### PR TITLE
feat(experts): EXPERT badge in slash menu + filter inactive experts

### DIFF
--- a/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
@@ -865,15 +865,31 @@ function ChatComposerInner({
                 <CommandItem
                   key={cmd.value}
                   value={cmd.value}
-                  keywords={[cmd.description]}
+                  // Including "expert" as a fuzzy-match keyword lets the
+                  // user type "/expert" to list every specialist at once.
+                  keywords={
+                    cmd.isExpert
+                      ? [cmd.description, "expert"]
+                      : [cmd.description]
+                  }
                   onSelect={() => handleCommandSelect(cmd.value)}
                   className="grid grid-cols-[12rem_1fr] items-baseline gap-3 [&_svg]:hidden"
                 >
                   <span
-                    className="font-mono font-semibold text-foreground truncate"
+                    className="inline-flex items-center gap-1.5 min-w-0 max-w-full"
                     title={cmd.label}
                   >
-                    {cmd.label}
+                    <span className="font-mono font-semibold text-foreground truncate">
+                      {cmd.label}
+                    </span>
+                    {cmd.isExpert && (
+                      <span
+                        className="shrink-0 rounded-sm bg-primary/10 px-1 text-[9px] font-semibold uppercase tracking-wider text-primary"
+                        aria-label="Expert specialist"
+                      >
+                        expert
+                      </span>
+                    )}
                   </span>
                   <span
                     className="min-w-0 truncate text-sm text-muted-foreground"

--- a/sdk/agent-chat-react/src/types.ts
+++ b/sdk/agent-chat-react/src/types.ts
@@ -507,6 +507,13 @@ export interface AgentChatSlashCommand {
   value: string;
   label: string;
   description: string;
+  /**
+   * True when this entry is backed by an active expert model (consulted
+   * via the harness mini-loop) rather than a prompt-based skill. The UI
+   * shows an "EXPERT" badge so the user can distinguish a multi-second
+   * specialist consultation from a body-inline skill.
+   */
+  isExpert?: boolean;
 }
 
 export interface AgentChatWorkspaceEntry {

--- a/sdk/agent-chat-react/tests/agent-chat.test.tsx
+++ b/sdk/agent-chat-react/tests/agent-chat.test.tsx
@@ -235,6 +235,70 @@ describe("AgentChat", () => {
     expect(document.body.textContent).toContain("Review the current work");
   });
 
+  it("renders an EXPERT badge for expert-typed slash entries", async () => {
+    const stream = new FakeEventStream();
+    const baseAdapter = createAdapter(stream);
+    const adapter: AgentChatAdapter = {
+      ...baseAdapter,
+      async listSlashCommands() {
+        return [
+          {
+            value: "/sql_writer",
+            label: "/sql_writer",
+            description: "Writes PostgreSQL queries",
+            isExpert: true,
+          },
+          {
+            value: "/docx",
+            label: "/docx",
+            description: "Edit DOCX files",
+            // isExpert intentionally omitted to verify the badge is
+            // gated on the boolean rather than rendered for every
+            // adapter-provided entry.
+          },
+        ];
+      },
+    };
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<AgentChat adapter={adapter} sessionId="s-1" />);
+      await Promise.resolve();
+    });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("textarea not rendered");
+
+    await act(async () => {
+      setTextareaValue(textarea, "/");
+      // Two microtasks: one for the textarea controller to propagate,
+      // one for the listSlashCommands promise to resolve.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Both entries appear.
+    expect(document.body.textContent).toContain("/sql_writer");
+    expect(document.body.textContent).toContain("/docx");
+
+    // The badge sits next to the expert entry's label and carries an
+    // aria-label so screen readers announce it.
+    const badge = document.body.querySelector<HTMLElement>(
+      '[aria-label="Expert specialist"]',
+    );
+    if (badge === null) throw new Error("expert badge not rendered");
+    expect(badge.textContent?.toLowerCase()).toBe("expert");
+
+    // Only the expert entry gets a badge.
+    const badges = document.body.querySelectorAll(
+      '[aria-label="Expert specialist"]',
+    );
+    expect(badges.length).toBe(1);
+  });
+
   it("stops the active response before sending a submitted message while streaming", async () => {
     const stream = new FakeEventStream();
     const calls: string[] = [];

--- a/surogates/tools/builtin/skills.py
+++ b/surogates/tools/builtin/skills.py
@@ -197,6 +197,17 @@ async def _skills_list_handler(
     for s in skills:
         if category_filter and s.category != category_filter:
             continue
+        # Inactive experts (draft / collecting / retired) are hidden
+        # from this catalog.  The slash dispatcher would otherwise fall
+        # through to ``skill_view`` and inline the expert's system
+        # prompt as if it were a regular skill body — confusing UX.
+        # ``# Available Experts`` in the system prompt and the
+        # ``consult_expert`` tool already filter to active-only via
+        # ``get_active_experts``; this keeps the catalog tool aligned.
+        if getattr(s, "is_expert", False) and not getattr(
+            s, "is_active_expert", False,
+        ):
+            continue
         entry: dict[str, Any] = {
             "name": s.name,
             "description": s.description,

--- a/tests/test_expert.py
+++ b/tests/test_expert.py
@@ -429,6 +429,76 @@ class TestSkillsListExpertMetadata:
         assert "type: expert" in desc or "type=expert" in desc.replace(": ", "=")
         assert "consult_expert" in desc
 
+    @pytest.mark.asyncio
+    async def test_handler_hides_inactive_experts(self, monkeypatch):
+        """draft / collecting / retired experts must not appear in the catalog.
+
+        The slash dispatcher only routes active experts to the
+        mini-loop; inactive ones would fall through to ``skill_view``
+        and inline their system prompt as a skill body, which is the
+        wrong UX.  The ``# Available Experts`` system-prompt section
+        and ``consult_expert``'s active-expert resolver already enforce
+        the same invariant; this test keeps the catalog tool aligned.
+        """
+        import json
+        from types import SimpleNamespace
+        from uuid import uuid4
+
+        from surogates.tools.builtin.skills import _skills_list_handler
+        from surogates.tools.loader import SkillDef
+
+        active = SkillDef(
+            name="sql_writer",
+            description="Writes SQL",
+            content="body",
+            source="org",
+            type="expert",
+            expert_status="active",
+            expert_endpoint="http://expert:8000/v1",
+        )
+        draft = SkillDef(
+            name="draft_specialist",
+            description="Not yet active",
+            content="body",
+            source="org",
+            type="expert",
+            expert_status="draft",
+        )
+        retired = SkillDef(
+            name="retired_specialist",
+            description="Decommissioned",
+            content="body",
+            source="org",
+            type="expert",
+            expert_status="retired",
+        )
+        regular = SkillDef(
+            name="code_review",
+            description="Reviews code",
+            content="body",
+            source="org",
+            type="skill",
+        )
+
+        async def fake_loader(tenant, **kwargs):
+            return [active, draft, retired, regular]
+
+        monkeypatch.setattr(
+            "surogates.tools.builtin.skills._load_all_skills", fake_loader,
+        )
+
+        tenant = SimpleNamespace(org_id=uuid4())
+        out = await _skills_list_handler({}, tenant=tenant)
+        payload = json.loads(out)
+
+        names = [s["name"] for s in payload["skills"]]
+        assert "sql_writer" in names
+        assert "code_review" in names
+        assert "draft_specialist" not in names
+        assert "retired_specialist" not in names
+        # `count` mirrors the visible list, not the underlying catalog.
+        assert payload["count"] == 2
+
 
 # =========================================================================
 # consult_expert handler


### PR DESCRIPTION
## Summary
Three small UX polish items left over after PR #33 (voluntary expert consultation).

## Changes
1. **`AgentChatSlashCommand` gains `isExpert?: boolean`** ([types.ts](sdk/agent-chat-react/src/types.ts)). Adapters that distinguish skills from experts can now surface that signal to the composer.
2. **EXPERT badge in the chat composer slash menu** ([chat-composer.tsx](sdk/agent-chat-react/src/components/chat/chat-composer.tsx)). A small "EXPERT" tag next to the label so users can tell a multi-second specialist consultation apart from a body-inline skill. `"expert"` is also added as a fuzzy-match keyword so typing `/expert` lists every specialist at once.
3. **`skills_list` hides inactive experts** ([skills.py](surogates/tools/builtin/skills.py)). `draft` / `collecting` / `retired` experts no longer appear in the catalog tool. The slash dispatcher would otherwise fall through to `skill_view` and inline their system prompt as a skill body — confusing UX. Mirrors the active-only filter that `# Available Experts` in the system prompt already applies via `get_active_experts`.

## Tests
- 21 / 21 in `agent-chat.test.tsx` — new test verifies the badge renders for `isExpert: true` entries only and carries an `aria-label="Expert specialist"`.
- 146 pass across `test_expert.py`, `test_slash_expert.py`, `test_slash_skill.py`, `test_skills_config.py`, `test_skill_manager.py` — new `test_handler_hides_inactive_experts` confirms draft / retired experts are filtered while active experts and regular skills are kept.

## Follow-up (one-line, in surogate-ops)
After this lands, `skillToSlashCommand` in `frontend/src/features/work/work-agent-chat-adapter.ts` needs the obvious one-liner:
```ts
return { value: trigger, label: trigger, description: skill.description, isExpert: skill.is_expert };
```
to plumb `is_expert` from `AgentSkillSummary` through to the slash menu. That's a separate small PR in the ops repo.