### PR TITLE
api: parse inline attachments off the event loop

### DIFF
--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import logging
@@ -685,7 +686,15 @@ async def send_message(
         )
         storage = _get_storage(request)
 
+        # First pass (serial): validate each attachment, accumulate the
+        # cumulative byte budget, and materialise inline-parse inputs.
+        # We keep this serial because each step needs to fail fast with
+        # a precise per-attachment 422 and because ``total_bytes`` is
+        # an accumulator.
         resolved: list[dict] = []
+        # Parallel parse tasks indexed by their position in ``resolved``
+        # so we can stitch results back in order after gather.
+        inline_tasks: list[tuple[int, AttachmentRef, asyncio.Task]] = []
         total_bytes = 0
         for attachment in body.attachments:
             storage_key = prefixed_session_workspace_key(
@@ -730,14 +739,26 @@ async def send_message(
                     ),
                 )
 
+            attachment.size = real_size  # populate for the helper
+            entry: dict[str, Any] = {
+                "path": attachment.path,
+                "filename": attachment.filename,
+                "mime_type": attachment.mime_type,
+                "size": real_size,
+            }
+            resolved.append(entry)
+
             # ── Inline-attachment branch ─────────────────────────────
             # For files small enough and of a supported type, parse or
             # decode the content server-side and persist it on the event
             # so the LLM sees it directly without calling read_file.
-            attachment.size = real_size  # populate for the helper
-            inlined_text: str | None = None
-            inlined_kind: str | None = None
-            skip_reason: str | None = None
+            # The expensive parse step (markitdown / python-docx /
+            # pymupdf4llm) runs as an asyncio.Task here and is awaited
+            # in parallel below via asyncio.gather, so an N-attachment
+            # message takes roughly max(parse_i) wall-clock instead of
+            # sum(parse_i) — and the per-parse work itself runs in a
+            # subprocess pool (see file_ops._parse_document_to_markdown)
+            # so the API event loop is never GIL-blocked.
             inline_kind = _inline_extension_kind(attachment.filename)
             if (
                 real_size <= _INLINE_MAX_BYTES
@@ -774,30 +795,44 @@ async def send_message(
                             modified=modified,
                             suffix=suffix,
                         )
-                inlined_text, inlined_kind, skip_reason = (
-                    await _try_inline_attachment(
+                task = asyncio.create_task(
+                    _try_inline_attachment(
                         attachment, raw_bytes, document_path,
                     )
                 )
+                inline_tasks.append((len(resolved) - 1, attachment, task))
 
-            entry: dict[str, Any] = {
-                "path": attachment.path,
-                "filename": attachment.filename,
-                "mime_type": attachment.mime_type,
-                "size": real_size,
-            }
-            if inlined_text is not None:
-                entry["inlined_text"] = inlined_text
-                entry["inlined_render_kind"] = inlined_kind
-                logger.info(
-                    "event=attachment.inline result=ok kind=%s "
-                    "filename=%s bytes=%d rendered_chars=%d",
-                    inlined_kind, attachment.filename, real_size,
-                    len(inlined_text),
-                )
-            elif skip_reason is not None:
-                entry["inline_skip_reason"] = skip_reason
-            resolved.append(entry)
+        # Drive all inline parses in parallel.  ``return_exceptions``
+        # keeps a single bad attachment from cancelling its siblings —
+        # we surface the failure on that attachment's entry rather than
+        # failing the whole message.
+        if inline_tasks:
+            results = await asyncio.gather(
+                *(t for _, _, t in inline_tasks), return_exceptions=True,
+            )
+            for (idx, attachment, _task), result in zip(
+                inline_tasks, results, strict=True,
+            ):
+                if isinstance(result, BaseException):
+                    logger.warning(
+                        "event=attachment.inline result=error "
+                        "filename=%s err=%s",
+                        attachment.filename, result,
+                    )
+                    resolved[idx]["inline_skip_reason"] = "parse_error"
+                    continue
+                inlined_text, inlined_kind, skip_reason = result
+                if inlined_text is not None:
+                    resolved[idx]["inlined_text"] = inlined_text
+                    resolved[idx]["inlined_render_kind"] = inlined_kind
+                    logger.info(
+                        "event=attachment.inline result=ok kind=%s "
+                        "filename=%s bytes=%d rendered_chars=%d",
+                        inlined_kind, attachment.filename,
+                        resolved[idx]["size"], len(inlined_text),
+                    )
+                elif skip_reason is not None:
+                    resolved[idx]["inline_skip_reason"] = skip_reason
         attachments_payload = resolved
 
     # Emit the user message event.

--- a/surogates/tools/builtin/file_ops.py
+++ b/surogates/tools/builtin/file_ops.py
@@ -17,6 +17,7 @@ import re
 import shutil
 import subprocess
 import threading
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -33,8 +34,51 @@ _EXPECTED_WRITE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS}
 
 # Wall-clock cap for markitdown conversions.  Set high enough for large
 # PDFs but low enough that a misbehaving document doesn't stall the
-# tool loop.
-_DOCUMENT_PARSE_TIMEOUT_S: float = 30.0
+# tool loop.  Tunable via env so PROD can shorten it without a release
+# when health probes are tight.
+_DOCUMENT_PARSE_TIMEOUT_S: float = float(
+    os.environ.get("SUROGATES_DOCUMENT_PARSE_TIMEOUT_S", "10.0")
+)
+
+# Subprocess pool used for ``_convert_to_markdown_sync``.  markitdown
+# and python-docx do pure-Python text processing that holds the GIL,
+# so running the conversion via ``asyncio.to_thread`` starves the
+# event loop on a CPU-limited container.  Running it in a separate
+# process gives the conversion its own GIL.  Pool size is bounded
+# (default 2) so a burst of attachments can't fork-bomb the API
+# container.
+#
+# Disable via ``SUROGATES_DOCUMENT_PARSE_USE_SUBPROCESS=0`` to fall
+# back to a thread (useful for tests that monkeypatch internal
+# loader symbols — subprocess workers re-import this module fresh and
+# can't see the patches).
+_PARSE_POOL_MAX_WORKERS: int = int(
+    os.environ.get("SUROGATES_DOCUMENT_PARSE_WORKERS", "2")
+)
+_USE_SUBPROCESS_PARSE: bool = (
+    os.environ.get("SUROGATES_DOCUMENT_PARSE_USE_SUBPROCESS", "1") == "1"
+)
+_parse_pool: ProcessPoolExecutor | None = None
+_parse_pool_lock = threading.Lock()
+
+
+def _get_parse_pool() -> ProcessPoolExecutor:
+    """Lazy-initialise the parse subprocess pool.
+
+    The pool is shared process-wide; workers are reused across
+    conversions to amortise interpreter startup.  Initialised lazily so
+    importing :mod:`file_ops` (which the harness does eagerly for tool
+    schema registration) does not fork off Python subprocesses at
+    import time.
+    """
+    global _parse_pool
+    if _parse_pool is None:
+        with _parse_pool_lock:
+            if _parse_pool is None:
+                _parse_pool = ProcessPoolExecutor(
+                    max_workers=_PARSE_POOL_MAX_WORKERS,
+                )
+    return _parse_pool
 
 
 class DocumentParseError(Exception):
@@ -97,17 +141,46 @@ def _convert_to_markdown_sync(path: Path) -> str:
 async def _parse_document_to_markdown(path: Path) -> str:
     """Convert a document to markdown via markitdown.
 
-    Wrapped in ``asyncio.to_thread`` because markitdown is synchronous
-    and PDF parsing can take seconds.  Bounded by
-    ``_DOCUMENT_PARSE_TIMEOUT_S`` wall-clock; any exception, including
-    timeout, is normalised to :class:`DocumentParseError`.
+    Runs in a :class:`ProcessPoolExecutor` rather than a thread because
+    markitdown / python-docx / openpyxl are pure-Python text processing
+    that holds the GIL.  In the API process (FastAPI on a 1-2 vCPU
+    container with aggressive liveness probes) a thread-based parse
+    starves the asyncio event loop and trips the kubelet's health
+    checks.  A subprocess has its own GIL, so the event loop keeps
+    scheduling.
+
+    Bounded by ``_DOCUMENT_PARSE_TIMEOUT_S`` wall-clock; any exception,
+    including timeout, is normalised to :class:`DocumentParseError`.
+    Note: we cancel the future on timeout but the subprocess worker
+    may still complete the parse in the background — that's fine, the
+    result is just discarded.
     """
+    if _USE_SUBPROCESS_PARSE:
+        loop = asyncio.get_running_loop()
+        future = loop.run_in_executor(
+            _get_parse_pool(), _convert_to_markdown_sync, path,
+        )
+        awaitable: asyncio.Future | asyncio.Task = asyncio.shield(future)
+        on_timeout_cancel = future
+    else:
+        # Thread-based fallback (tests, or explicit opt-out).  GIL
+        # contention is acceptable here because the test environment
+        # isn't on the critical liveness-probe path.
+        awaitable = asyncio.create_task(
+            asyncio.to_thread(_convert_to_markdown_sync, path),
+        )
+        on_timeout_cancel = awaitable
+
     try:
         return await asyncio.wait_for(
-            asyncio.to_thread(_convert_to_markdown_sync, path),
-            timeout=_DOCUMENT_PARSE_TIMEOUT_S,
+            awaitable, timeout=_DOCUMENT_PARSE_TIMEOUT_S,
         )
     except asyncio.TimeoutError as exc:
+        # Explicitly cancel so the executor slot / thread is released.
+        # ProcessPoolExecutor.cancel() succeeds only if the job hasn't
+        # started yet — a started job will finish on its own and its
+        # result is dropped.
+        on_timeout_cancel.cancel()
         raise DocumentParseError(
             path,
             f"parse timeout after {_DOCUMENT_PARSE_TIMEOUT_S}s",

--- a/surogates/tools/utils/document_cache.py
+++ b/surogates/tools/utils/document_cache.py
@@ -10,7 +10,6 @@ executors from racing on the same entry.
 
 from __future__ import annotations
 
-import asyncio
 import fcntl
 import hashlib
 import logging
@@ -45,7 +44,6 @@ class DocumentCache:
         self._max_entries = max_entries
         self._max_entry_bytes = max_entry_bytes
         self._root.mkdir(parents=True, exist_ok=True)
-        self._inflight_lock = asyncio.Lock()
 
     def _key(self, source: Path) -> str:
         st = source.stat()
@@ -87,21 +85,19 @@ class DocumentCache:
             except OSError as exc:
                 logger.debug("cache read failed for %s: %s", entry, exc)
 
-        # Miss — parse, then persist if small enough.  The in-process
-        # lock prevents two coroutines in the same process from parsing
-        # the same file in parallel.
-        async with self._inflight_lock:
-            # Double-check after acquiring the lock; another coroutine
-            # may have populated the file while we waited.
-            if entry.exists():
-                try:
-                    return entry.read_text(encoding="utf-8")
-                except OSError:
-                    pass
-
-            markdown = await parse(source)
-            self._maybe_store(key, markdown)
-            return markdown
+        # Miss — parse and persist if small enough.  We deliberately do
+        # NOT take a global lock here: an earlier version held an
+        # asyncio.Lock around the parse to deduplicate concurrent
+        # requests for the same file, but that lock also serialised
+        # parses of *different* files, which starved the API event
+        # loop when a user sent multiple attachments at once.  Same-key
+        # races are rare in practice (the cache file appears the
+        # moment the first parse finishes) and harmless when they do
+        # happen — the second parse just overwrites the first via the
+        # fcntl-locked rename in ``_maybe_store``.
+        markdown = await parse(source)
+        self._maybe_store(key, markdown)
+        return markdown
 
     def _maybe_store(self, key: str, markdown: str) -> None:
         encoded = markdown.encode("utf-8")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,14 @@ from surogates.tenant.context import TenantContext
 # ---------------------------------------------------------------------------
 os.environ.setdefault("SUROGATES_JWT_SECRET", "test-secret-key-for-unit-tests")
 
+# ---------------------------------------------------------------------------
+# Run document parsing in-thread for tests so that monkeypatched
+# ``_load_markitdown`` / ``_load_pymupdf4llm`` symbols are visible.
+# Production defaults to the subprocess pool (see
+# ``surogates.tools.builtin.file_ops``).
+# ---------------------------------------------------------------------------
+os.environ.setdefault("SUROGATES_DOCUMENT_PARSE_USE_SUBPROCESS", "0")
+
 
 # ---------------------------------------------------------------------------
 # Fixtures


### PR DESCRIPTION
## Summary

Move the per-message inline-attachment markdown extraction (markitdown / python-docx / pymupdf4llm) off the FastAPI event loop.  On a CPU-limited API container the previous \`asyncio.to_thread\` path starved the asyncio loop long enough to miss kubelet liveness probes and get the pod killed mid-request when a user sent multi-attachment messages.

- \`_parse_document_to_markdown\` now runs in a \`ProcessPoolExecutor\` (each parse gets its own GIL).  Subprocess use is on by default; tests opt out via env var because subprocess workers re-import the module and can't see monkeypatched loader symbols.
- Per-message attachment loop in \`api/routes/sessions.py\` now runs parses concurrently via \`asyncio.gather\`; one failed parse no longer cancels its siblings.
- Removed the global \`asyncio.Lock\` in \`DocumentCache\` that was serializing parses of *different* files.  The \`fcntl\`-locked rename in \`_maybe_store\` remains the source of truth for the persisted cache.
- Per-parse timeout tightened 30s → 10s (override via \`SUROGATES_DOCUMENT_PARSE_TIMEOUT_S\`).

## Symptom this fixes

PROD agent \`evergent\` became unresponsive when a user uploaded 5 office documents (~3 MB total, including a 1.6 MB .docx) and invoked a skill.  The API pod's CPU saturated at the 1-vCPU limit while parsing the attachments sequentially in the message handler; health probes timed out (\`context deadline exceeded\`) and the kubelet killed the pod.  Logs showed \`inline_skip_reason: parse_timeout\` and \`events_session_id_fkey\` violations from the dispatcher retrying against the resulting deleted session.

The companion change in \`surogate-ops\` raises the API container CPU limit (\`1\` → \`4\`) and relaxes the liveness/readiness probe budgets to give parsing room.  This PR addresses the root cause; the chart change is a defense-in-depth.

## Test plan

- [x] \`pytest tests/api tests/tools tests/harness/test_attachment_rendering.py\` — 76 passed
- [ ] Smoke test in PROD-like env: upload 5 office documents to a session, send a message, observe API CPU stays well under limit and health probes never miss
- [ ] Confirm subprocess pool is reused (no fork-per-call) and exits cleanly on API shutdown