### PR TITLE
sandbox: add on-disk cache to geesefs s3fs sidecar

### DIFF
--- a/images/s3fs/entrypoint.sh
+++ b/images/s3fs/entrypoint.sh
@@ -108,7 +108,19 @@ BUCKET_SPEC="${S3_BUCKET_PATH/:\//:}"
 # memory limit of 1000MB is unrealistic for our deployment shape.
 GEESEFS_MEMORY_LIMIT_MB="${GEESEFS_MEMORY_LIMIT_MB:-256}"
 
-echo "Mounting s3://${S3_BUCKET_PATH} at ${MOUNT_POINT} (endpoint: ${S3_ENDPOINT}, region: ${S3_REGION})"
+# On-disk data cache. Speeds up repeated reads and lets writes coalesce
+# locally before being flushed to S3. The path must be on a writable
+# volume *outside* the FUSE mount (which would be circular). The sandbox
+# pod manifest mounts an emptyDir at /var/cache/geesefs for this purpose;
+# set GEESEFS_CACHE_DIR="" to disable.
+GEESEFS_CACHE_DIR="${GEESEFS_CACHE_DIR-/var/cache/geesefs}"
+GEESEFS_CACHE_ARGS=()
+if [ -n "${GEESEFS_CACHE_DIR}" ]; then
+    mkdir -p "${GEESEFS_CACHE_DIR}"
+    GEESEFS_CACHE_ARGS=(--cache "${GEESEFS_CACHE_DIR}")
+fi
+
+echo "Mounting s3://${S3_BUCKET_PATH} at ${MOUNT_POINT} (endpoint: ${S3_ENDPOINT}, region: ${S3_REGION}, cache: ${GEESEFS_CACHE_DIR:-off})"
 
 # In legacy mode we exec geesefs so it owns PID 1 and Kubernetes signals
 # reach it directly. In fleet mode we need to write the .s3fs-mounted
@@ -126,6 +138,7 @@ if [ "${FLEET_MODE:-0}" = "1" ]; then
         --file-mode 0644 \
         --dir-mode 0755 \
         --memory-limit "${GEESEFS_MEMORY_LIMIT_MB}" \
+        "${GEESEFS_CACHE_ARGS[@]}" \
         -f \
         "${BUCKET_SPEC}" "${MOUNT_POINT}" &
     GEESEFS_PID=$!
@@ -164,5 +177,6 @@ exec geesefs \
     --file-mode 0644 \
     --dir-mode 0755 \
     --memory-limit "${GEESEFS_MEMORY_LIMIT_MB}" \
+    "${GEESEFS_CACHE_ARGS[@]}" \
     -f \
     "${BUCKET_SPEC}" "${MOUNT_POINT}"

--- a/surogates/browser/kubernetes.py
+++ b/surogates/browser/kubernetes.py
@@ -409,6 +409,16 @@ class K8sBrowserBackend:
                     empty_dir=client.V1EmptyDirVolumeSource(),
                 )
             )
+            # On-disk cache for the geesefs sidecar (see s3fs entrypoint).
+            # Bounded so a runaway session can't exhaust node ephemeral storage.
+            volumes.append(
+                client.V1Volume(
+                    name="geesefs-cache",
+                    empty_dir=client.V1EmptyDirVolumeSource(
+                        size_limit="2Gi",
+                    ),
+                )
+            )
         init_container = client.V1Container(
             name="browser-runtime-init",
             image=spec.image or self._image,
@@ -523,6 +533,10 @@ class K8sBrowserBackend:
                     name="workspace",
                     mount_path="/workspace",
                     mount_propagation="Bidirectional",
+                ),
+                client.V1VolumeMount(
+                    name="geesefs-cache",
+                    mount_path="/var/cache/geesefs",
                 ),
             ],
         )

--- a/surogates/sandbox/kubernetes.py
+++ b/surogates/sandbox/kubernetes.py
@@ -388,6 +388,10 @@ class K8sSandbox:
                     mount_path="/workspace",
                     mount_propagation="Bidirectional",
                 ),
+                client.V1VolumeMount(
+                    name="geesefs-cache",
+                    mount_path="/var/cache/geesefs",
+                ),
             ],
         )
 
@@ -411,6 +415,15 @@ class K8sSandbox:
                     client.V1Volume(
                         name="workspace",
                         empty_dir=client.V1EmptyDirVolumeSource(),
+                    ),
+                    # On-disk cache for the geesefs sidecar. Sized to bound
+                    # node ephemeral-storage pressure; if a session needs
+                    # more, the cache evicts LRU rather than failing writes.
+                    client.V1Volume(
+                        name="geesefs-cache",
+                        empty_dir=client.V1EmptyDirVolumeSource(
+                            size_limit="2Gi",
+                        ),
                     ),
                 ],
                 containers=[sandbox_container, s3fs_container],

--- a/tests/test_browser_kubernetes.py
+++ b/tests/test_browser_kubernetes.py
@@ -197,6 +197,7 @@ class TestBuildPodManifest:
         assert [(v.name, v.empty_dir is not None) for v in pod.spec.volumes] == [
             ("browser-runtime", True),
             ("workspace", True),
+            ("geesefs-cache", True),
         ]
         browser_container = pod.spec.containers[0]
         s3fs_container = pod.spec.containers[1]
@@ -228,7 +229,14 @@ class TestBuildPodManifest:
         assert [
             (mount.name, mount.mount_path, mount.mount_propagation)
             for mount in s3fs_container.volume_mounts
-        ] == [("workspace", "/workspace", "Bidirectional")]
+        ] == [
+            ("workspace", "/workspace", "Bidirectional"),
+            ("geesefs-cache", "/var/cache/geesefs", None),
+        ]
+        cache_volume = next(
+            v for v in pod.spec.volumes if v.name == "geesefs-cache"
+        )
+        assert cache_volume.empty_dir.size_limit == "2Gi"
 
     def test_pod_manifest_uses_backend_image_when_spec_image_blank(
         self,


### PR DESCRIPTION
## Summary

Adds a second `emptyDir` (sized 2 GiB) mounted at `/var/cache/geesefs` in both the sandbox and browser pod manifests, and passes it to geesefs via `--cache`. Overridable via `GEESEFS_CACHE_DIR` env var (set to `""` to disable).

This is the follow-up to #42 (goofys → geesefs swap) — same s3fs sidecar, now with read-through / write-back caching.

## Local validation against R2 (`surogate-workspaces-dev`)

| Scenario | Time | vs cold R2 |
|---|---|---|
| Cold R2 (no cache) | 0.94 s | 1× |
| Cold memory + warm disk cache (this PR) | 0.51 s | **2×** |
| Warm memory (existing `--memory-limit` behavior) | 0.015 s | 60× |

So the disk cache is incremental on top of the in-memory cache we already get — kicks in after memory eviction, for files >256 MB, or for re-reads after the in-memory entry has been GC'd. The big win is still the in-memory cache from #42; this is a safety net for larger workspaces.

Confirmed:
- Empty cache + existing R2 prefix → full listing visible, files readable.
- Cache populates on reads (full file) and on writes (chunked overflow buffering).
- Cache survives mount/unmount within the same pod lifetime.
- `GEESEFS_CACHE_DIR=""` cleanly disables (produces a 0-element flag list, safe under `set -u` on bash 5.2+).
- All 65 affected unit tests pass (`tests/test_browser_kubernetes.py`, `tests/test_k8s_sandbox.py`).

## Tradeoff

Writes can sit in the disk cache briefly before reaching R2 — saw 50 MB of a 300 MB write still buffered locally after sync returned. If the pod dies in that window, those bytes are lost. Acceptable for session-scoped sandbox workspaces where R2 is the source of truth; flagging because it's a real behavior change vs the previous passthrough.

Cost: +2 GiB node ephemeral storage budget per sandbox/browser pod.

## Test plan

- [x] Local unit tests pass.
- [x] geesefs `--cache` validated against R2 from local host.
- [ ] Build the surogates-s3fs image, deploy a sandbox pod in k3d, confirm `/var/cache/geesefs` is mounted and writable inside the s3fs container.
- [ ] Confirm `du -sh /var/cache/geesefs` grows during a representative agent workload and is bounded by the 2Gi `sizeLimit`.
- [ ] Smoke-test fleet mode the same way.
- [ ] Roll out to staging before prod.