### PR TITLE
Detect silent SSE drops in the web app with a fetch-based stream

### DIFF
--- a/sdk/agent-chat-react/src/index.ts
+++ b/sdk/agent-chat-react/src/index.ts
@@ -7,6 +7,8 @@ export {
   useAgentChatRuntime,
   useChatViewMode,
 } from "./runtime/use-agent-chat-runtime";
+export { FetchSseEventStream } from "./runtime/fetch-sse-stream";
+export type { FetchSseEventStreamOptions } from "./runtime/fetch-sse-stream";
 export { MessageResponse } from "./components/ai-elements/message";
 export { ComposioConnectCard } from "./components/connections/composio-connect-card";
 export type { ComposioConnectCardProps } from "./components/connections/composio-connect-card";

--- a/sdk/agent-chat-react/src/runtime/fetch-sse-stream.ts
+++ b/sdk/agent-chat-react/src/runtime/fetch-sse-stream.ts
@@ -1,0 +1,217 @@
+import type { AgentChatSseMessageEvent } from "../types";
+
+// The harness emits an SSE ``: ping`` comment every 15 seconds, so a
+// healthy stream is never byte-silent for long. A silent TCP drop
+// (laptop sleep/resume, Wi-Fi roam, NAT mapping expiry) leaves
+// ``reader.read()`` pending forever with NO error event — without a
+// watchdog the live feed freezes until a full page reload. Three
+// missed pings means the connection is dead.
+//
+// Native ``EventSource`` cannot implement this: browsers do not expose
+// SSE comment lines to JavaScript, so ping arrivals are invisible.
+// Reading the bytes ourselves through ``fetch()`` is what makes the
+// liveness signal observable at all.
+const STREAM_STALL_THRESHOLD_MS = 45_000;
+const STREAM_STALL_CHECK_INTERVAL_MS = 5_000;
+
+class StreamStallWatchdog {
+  private lastByteAt = Date.now();
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly onStall: () => void;
+  private readonly check = () => {
+    if (Date.now() - this.lastByteAt > STREAM_STALL_THRESHOLD_MS) {
+      this.onStall();
+    }
+  };
+
+  constructor(onStall: () => void) {
+    this.onStall = onStall;
+  }
+
+  start() {
+    this.lastByteAt = Date.now();
+    this.timer = setInterval(this.check, STREAM_STALL_CHECK_INTERVAL_MS);
+    // Instant re-check on tab refocus / network restore: browsers
+    // throttle interval timers in background tabs, but these events
+    // fire the moment the user is back in front of a possibly-dead
+    // stream, so recovery starts immediately instead of on the next
+    // (throttled) tick.
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", this.check);
+    }
+    if (typeof window !== "undefined") {
+      window.addEventListener("online", this.check);
+    }
+  }
+
+  touch() {
+    this.lastByteAt = Date.now();
+  }
+
+  stop() {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", this.check);
+    }
+    if (typeof window !== "undefined") {
+      window.removeEventListener("online", this.check);
+    }
+  }
+}
+
+export interface FetchSseEventStreamOptions {
+  /** Fetch implementation — pass the app's authenticated fetch wrapper. */
+  fetchFn?: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Promise<Response>;
+}
+
+/**
+ * SSE-over-fetch event stream with silent-drop detection.
+ *
+ * Structurally compatible with ``AgentChatEventStream`` (and the inbox
+ * stream contract): ``addEventListener``/``close``/``onerror``. Every
+ * failure mode — bad response, mid-stream error, clean server close,
+ * and watchdog-detected silent stall — funnels through a once-only
+ * guard, so consumers can treat ``onerror`` as "reconnect now" without
+ * risking a leaked second stream from double-firing.
+ */
+export class FetchSseEventStream {
+  private readonly abort = new AbortController();
+  private readonly decoder = new TextDecoder();
+  private readonly listeners = new Map<
+    string,
+    Set<(event: AgentChatSseMessageEvent) => void>
+  >();
+  private buffer = "";
+  private eventType = "";
+  private eventId = "";
+  private dataLines: string[] = [];
+  private readonly url: string;
+  private readonly fetchFn: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Promise<Response>;
+  private readonly watchdog = new StreamStallWatchdog(() => this.fail());
+  private errored = false;
+
+  onerror: (() => void) | null = null;
+
+  constructor(url: string, options: FetchSseEventStreamOptions = {}) {
+    this.url = url;
+    this.fetchFn = options.fetchFn ?? fetch;
+    queueMicrotask(() => void this.start());
+  }
+
+  addEventListener(
+    type: string,
+    listener: (event: AgentChatSseMessageEvent) => void,
+  ) {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  close() {
+    this.watchdog.stop();
+    this.abort.abort();
+  }
+
+  private fail() {
+    if (this.errored) return;
+    this.errored = true;
+    this.watchdog.stop();
+    this.onerror?.();
+  }
+
+  private async start() {
+    try {
+      const response = await this.fetchFn(this.url, {
+        signal: this.abort.signal,
+        headers: { Accept: "text/event-stream" },
+      });
+      if (!response.ok || !response.body) {
+        this.fail();
+        return;
+      }
+      this.watchdog.start();
+      const reader = response.body.getReader();
+      while (!this.abort.signal.aborted) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        this.watchdog.touch();
+        this.feed(this.decoder.decode(value, { stream: true }));
+      }
+      this.feed(this.decoder.decode());
+      this.flushEvent();
+      // Server closed the response. Signal onerror so the consumer's
+      // reconnect path runs — matches native EventSource semantics,
+      // where any close is surfaced as an error.
+      if (!this.abort.signal.aborted) {
+        this.fail();
+      }
+    } catch (error) {
+      if (!this.abort.signal.aborted) {
+        console.error("SSE stream failed:", error);
+        this.fail();
+      }
+    } finally {
+      this.watchdog.stop();
+    }
+  }
+
+  private feed(chunk: string) {
+    this.buffer += chunk;
+    for (;;) {
+      const newlineIndex = this.buffer.indexOf("\n");
+      if (newlineIndex < 0) return;
+      const line = this.buffer.slice(0, newlineIndex).replace(/\r$/, "");
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+      this.processLine(line);
+    }
+  }
+
+  private processLine(line: string) {
+    if (line === "") {
+      this.flushEvent();
+      return;
+    }
+    if (line.startsWith(":")) return;
+
+    const separator = line.indexOf(":");
+    const field = separator >= 0 ? line.slice(0, separator) : line;
+    const rawValue = separator >= 0 ? line.slice(separator + 1) : "";
+    const value = rawValue.startsWith(" ") ? rawValue.slice(1) : rawValue;
+
+    if (field === "event") {
+      this.eventType = value;
+    } else if (field === "id") {
+      this.eventId = value;
+    } else if (field === "data") {
+      this.dataLines.push(value);
+    }
+  }
+
+  private flushEvent() {
+    if (!this.eventType || this.dataLines.length === 0) {
+      this.dataLines = [];
+      return;
+    }
+    const listeners = this.listeners.get(this.eventType);
+    const event = {
+      data: this.dataLines.join("\n"),
+      lastEventId: this.eventId,
+    };
+    if (listeners) {
+      for (const listener of listeners) {
+        listener(event);
+      }
+    }
+    this.eventType = "";
+    this.dataLines = [];
+  }
+}

--- a/sdk/agent-chat-react/tests/fetch-sse-stream.test.ts
+++ b/sdk/agent-chat-react/tests/fetch-sse-stream.test.ts
@@ -1,0 +1,210 @@
+// Silent-drop watchdog for the fetch-based SSE event stream.
+//
+// The harness emits an SSE ``: ping`` comment every 15s, so a healthy
+// stream is never byte-silent for long. A silent TCP drop (laptop
+// sleep, Wi-Fi roam, NAT mapping expiry) leaves ``reader.read()``
+// pending forever with no error event — without a watchdog the live
+// feed freezes until a full page reload. These tests pin the recovery
+// behavior: sustained byte silence must fire ``onerror`` (exactly
+// once) so the consumer's reconnect path takes over.
+//
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FetchSseEventStream } from "@/runtime/fetch-sse-stream";
+
+const STALL_MS = 45_000;
+
+function sseResponse(): {
+  response: Response;
+  push: (text: string) => void;
+  end: () => void;
+} {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  const encoder = new TextEncoder();
+  return {
+    response: new Response(body, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    }),
+    push: (text: string) => controller.enqueue(encoder.encode(text)),
+    end: () => controller.close(),
+  };
+}
+
+function openStream(response: Response) {
+  const fetchFn = vi.fn().mockResolvedValue(response);
+  const stream = new FetchSseEventStream("/api/v1/sessions/s1/events?after=0", {
+    fetchFn,
+  });
+  const onerror = vi.fn();
+  stream.onerror = onerror;
+  return { stream, onerror, fetchFn };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({
+    toFake: [
+      "setTimeout",
+      "clearTimeout",
+      "setInterval",
+      "clearInterval",
+      "Date",
+    ],
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("FetchSseEventStream event parsing", () => {
+  it("dispatches named events with id and data to listeners", async () => {
+    const upstream = sseResponse();
+    const { stream } = openStream(upstream.response);
+    const events: Array<{ data: string; lastEventId: string }> = [];
+    stream.addEventListener("llm.delta", (event) => events.push(event));
+
+    await vi.advanceTimersByTimeAsync(0);
+    upstream.push(': connected\n\nid: 7\nevent: llm.delta\ndata: {"a":1}\n\n');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(events).toEqual([{ data: '{"a":1}', lastEventId: "7" }]);
+    stream.close();
+  });
+
+  it("requests the stream with text/event-stream accept header", async () => {
+    const upstream = sseResponse();
+    const { stream, fetchFn } = openStream(upstream.response);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const [url, init] = fetchFn.mock.calls[0] ?? [];
+    expect(url).toBe("/api/v1/sessions/s1/events?after=0");
+    expect(new Headers(init?.headers).get("Accept")).toBe("text/event-stream");
+    stream.close();
+  });
+});
+
+describe("FetchSseEventStream stall watchdog", () => {
+  it("fires onerror exactly once after sustained byte silence", async () => {
+    const upstream = sseResponse();
+    const { stream, onerror } = openStream(upstream.response);
+    await vi.advanceTimersByTimeAsync(0);
+    upstream.push(": connected\n\n");
+
+    await vi.advanceTimersByTimeAsync(STALL_MS * 3);
+
+    expect(onerror).toHaveBeenCalledTimes(1);
+    stream.close();
+  });
+
+  it("does not fire while harness pings keep arriving", async () => {
+    const upstream = sseResponse();
+    const { stream, onerror } = openStream(upstream.response);
+    await vi.advanceTimersByTimeAsync(0);
+    upstream.push(": connected\n\n");
+
+    for (let i = 0; i < 8; i++) {
+      await vi.advanceTimersByTimeAsync(15_000);
+      upstream.push(`: ping ${i}\n\n`);
+    }
+
+    expect(onerror).not.toHaveBeenCalled();
+    stream.close();
+  });
+
+  it("re-checks staleness on tab refocus without waiting for the timer", async () => {
+    const upstream = sseResponse();
+    const { stream, onerror } = openStream(upstream.response);
+    await vi.advanceTimersByTimeAsync(0);
+    upstream.push(": connected\n\n");
+
+    // Jump the clock without running timer callbacks — exactly what a
+    // sleeping laptop / throttled background tab looks like.
+    vi.setSystemTime(Date.now() + STALL_MS * 2);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(onerror).toHaveBeenCalledTimes(1);
+    stream.close();
+  });
+
+  it("re-checks staleness when the browser reports network restored", async () => {
+    const upstream = sseResponse();
+    const { stream, onerror } = openStream(upstream.response);
+    await vi.advanceTimersByTimeAsync(0);
+    upstream.push(": connected\n\n");
+
+    vi.setSystemTime(Date.now() + STALL_MS * 2);
+    window.dispatchEvent(new Event("online"));
+
+    expect(onerror).toHaveBeenCalledTimes(1);
+    stream.close();
+  });
+
+  it("close() disarms the watchdog and its listeners", async () => {
+    const upstream = sseResponse();
+    const { stream, onerror } = openStream(upstream.response);
+    await vi.advanceTimersByTimeAsync(0);
+    upstream.push(": connected\n\n");
+
+    stream.close();
+    await vi.advanceTimersByTimeAsync(STALL_MS * 3);
+    vi.setSystemTime(Date.now() + STALL_MS);
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("online"));
+
+    expect(onerror).not.toHaveBeenCalled();
+  });
+});
+
+describe("FetchSseEventStream error funnel", () => {
+  it("fires onerror exactly once on clean server close", async () => {
+    const upstream = sseResponse();
+    const { stream, onerror } = openStream(upstream.response);
+    await vi.advanceTimersByTimeAsync(0);
+    upstream.push(": connected\n\n");
+    upstream.end();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onerror).toHaveBeenCalledTimes(1);
+
+    // The watchdog must not re-fire after the stream already ended.
+    await vi.advanceTimersByTimeAsync(STALL_MS * 3);
+    expect(onerror).toHaveBeenCalledTimes(1);
+    stream.close();
+  });
+
+  it("fires onerror once on a non-ok response", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(new Response("denied", { status: 401 }));
+    const stream = new FetchSseEventStream("/api/v1/inbox/stream", {
+      fetchFn,
+    });
+    const onerror = vi.fn();
+    stream.onerror = onerror;
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onerror).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(STALL_MS * 3);
+    expect(onerror).toHaveBeenCalledTimes(1);
+    stream.close();
+  });
+
+  it("does not fire onerror when closed by the consumer", async () => {
+    const upstream = sseResponse();
+    const { stream, onerror } = openStream(upstream.response);
+    await vi.advanceTimersByTimeAsync(0);
+    upstream.push(": connected\n\n");
+
+    stream.close();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onerror).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/features/chat/surogates-web-chat-adapter.ts
+++ b/web/src/features/chat/surogates-web-chat-adapter.ts
@@ -1,7 +1,7 @@
 import { getArtifact } from "@/api/artifacts";
 import * as codingAgentsApi from "@/api/coding-agents";
 import * as composioApi from "@/api/composio";
-import { refreshSession } from "@/api/auth";
+import { authFetch } from "@/api/auth";
 import { submitAskUserQuestionResponse as submitAskUserQuestionResponseApi } from "@/api/ask_user_question";
 import { submitTurnFeedback } from "@/api/feedback";
 import * as inboxApi from "@/api/inbox";
@@ -15,10 +15,9 @@ import type { ScheduledWorkItem, Session } from "@/types/session";
 // Copyright (c) 2026, Invergent SA, developed by Flavius Burca
 // SPDX-License-Identifier: AGPL-3.0-only
 //
+import { FetchSseEventStream } from "@invergent/agent-chat-react";
 import type {
   AgentChatAdapter,
-  AgentChatEventStream,
-  AgentChatEventType,
   AgentChatInboxEventStream,
   AgentChatInboxStreamEvent,
   AgentChatMissionSummary,
@@ -27,7 +26,6 @@ import type {
   AgentChatScheduledWorkItem,
   AgentChatSession,
   AgentChatSlashCommand,
-  AgentChatSseMessageEvent,
 } from "@invergent/agent-chat-react";
 
 const DEFAULT_OUTCOME_RUBRIC =
@@ -184,7 +182,7 @@ export const surogatesWebChatAdapter: AgentChatAdapter = {
   },
 
   openInboxStream() {
-    return openSelfRefreshingInboxStream();
+    return openSelfReopeningInboxStream();
   },
 
   async stopSession(input) {
@@ -293,14 +291,20 @@ export const surogatesWebChatAdapter: AgentChatAdapter = {
   },
 
   openEventStream(input) {
-    const token = getAuthToken();
-    const url = new URL(
-      `/api/v1/sessions/${input.sessionId}/events`,
-      window.location.origin,
+    // Fetch-based SSE instead of native EventSource: browsers hide SSE
+    // comment lines from EventSource consumers, so the harness's 15s
+    // ``: ping`` keepalives are invisible there and a silently-dropped
+    // connection (laptop sleep, Wi-Fi roam, NAT expiry) hangs forever.
+    // FetchSseEventStream reads the bytes itself and converts sustained
+    // silence into the normal onerror → reconnect path. Auth travels in
+    // the Authorization header via authFetch (no token in the URL).
+    const qs = new URLSearchParams({ after: String(input.after) });
+    const stream = new FetchSseEventStream(
+      `/api/v1/sessions/${input.sessionId}/events?${qs}`,
+      { fetchFn: authFetch },
     );
-    url.searchParams.set("after", String(input.after));
-    if (token) url.searchParams.set("token", token);
-    return wrapEventSource(new EventSource(url.toString()), input.sessionId);
+    attachTitleSideChannel(stream, input.sessionId);
+    return stream;
   },
 
   browserLiveViewUrl(sessionId) {
@@ -556,19 +560,16 @@ function deriveRunKind(
   return null;
 }
 
-function wrapEventSource(
-  source: EventSource,
+// Side-channel listener for ``session.title_updated``.  Sidebar/title state
+// lives in the zustand store, not in the AgentChat library, so we patch it
+// from here instead of plumbing a new event type through the chat protocol.
+function attachTitleSideChannel(
+  stream: FetchSseEventStream,
   sessionId: string,
-): AgentChatEventStream {
-  let errorHandler: (() => void) | null = null;
-
-  // Side-channel listener for ``session.title_updated``.  Sidebar/title state
-  // lives in the zustand store, not in the AgentChat library, so we patch it
-  // from here instead of plumbing a new event type through the chat protocol.
-  source.addEventListener("session.title_updated", (event) => {
-    const message = event as MessageEvent<string>;
+): void {
+  stream.addEventListener("session.title_updated", (event) => {
     try {
-      const payload = JSON.parse(message.data) as { title?: unknown };
+      const payload = JSON.parse(event.data) as { title?: unknown };
       if (typeof payload.title === "string" && payload.title.length > 0) {
         useAppStore.getState().updateSessionTitle(sessionId, payload.title);
       }
@@ -576,74 +577,47 @@ function wrapEventSource(
       // Malformed payload — ignore.
     }
   });
-
-  return {
-    addEventListener(
-      type: AgentChatEventType,
-      listener: (event: AgentChatSseMessageEvent) => void,
-    ) {
-      source.addEventListener(type, (event) => {
-        const message = event as MessageEvent<string>;
-        listener({
-          data: message.data,
-          lastEventId: message.lastEventId,
-        });
-      });
-    },
-    close() {
-      source.close();
-    },
-    get onerror() {
-      return errorHandler;
-    },
-    set onerror(handler: (() => void) | null) {
-      errorHandler = handler;
-      source.onerror = handler ? () => handler() : null;
-    },
-  };
 }
 
-// EventSource auto-reconnects on failure with the same URL — including
-// the same access token. When the token has expired the server returns
-// 401 forever, hammering at ~3s intervals. This wrapper intercepts the
-// failure, refreshes the token, and reopens with the new one. If the
-// refresh itself fails the wrapper surfaces the error and stops.
-function openSelfRefreshingInboxStream(): AgentChatInboxEventStream {
+// The SDK's inbox hook treats ``onerror`` as terminal ("Inbox stream
+// disconnected"), so this wrapper owns reconnection: it reopens the
+// stream on every failure — including watchdog-detected silent stalls —
+// and only surfaces ``onerror`` after several consecutive failures
+// with no event in between. authFetch refreshes an expired token
+// transparently, so a stale-token failure heals on the first reopen.
+function openSelfReopeningInboxStream(): AgentChatInboxEventStream {
   type InboxStreamType = "item" | "snapshot";
-  type RawHandler = (event: MessageEvent<string>) => void;
 
-  const handlers = new Map<InboxStreamType, Set<RawHandler>>();
-  let source: EventSource | null = null;
+  const handlers = new Map<
+    InboxStreamType,
+    Set<(event: AgentChatInboxStreamEvent) => void>
+  >();
+  let source: FetchSseEventStream | null = null;
   let closed = false;
   let consecutiveFailures = 0;
   let externalErrorHandler: (() => void) | null = null;
   const MAX_CONSECUTIVE_FAILURES = 3;
-
-  function buildUrl(): string {
-    const token = getAuthToken();
-    const url = new URL("/api/v1/inbox/stream", window.location.origin);
-    if (token) url.searchParams.set("token", token);
-    return url.toString();
-  }
+  const REOPEN_DELAY_MS = 3_000;
 
   function open(): void {
     if (closed) return;
-    const next = new EventSource(buildUrl());
+    const next = new FetchSseEventStream("/api/v1/inbox/stream", {
+      fetchFn: authFetch,
+    });
     source = next;
 
     for (const [type, set] of handlers.entries()) {
       for (const fn of set) {
-        next.addEventListener(type, fn as EventListener);
+        next.addEventListener(type, (event) => {
+          // Receiving any event proves the reopened stream is healthy.
+          consecutiveFailures = 0;
+          fn(event);
+        });
       }
     }
 
-    next.onopen = () => {
-      consecutiveFailures = 0;
-    };
     next.onerror = () => {
       if (closed) return;
-      // Close immediately — we don't want EventSource's automatic retry
-      // racing our refresh-then-reopen cycle.
       next.close();
       if (source === next) source = null;
 
@@ -652,15 +626,7 @@ function openSelfRefreshingInboxStream(): AgentChatInboxEventStream {
         externalErrorHandler?.();
         return;
       }
-
-      void refreshSession().then((ok) => {
-        if (closed) return;
-        if (!ok) {
-          externalErrorHandler?.();
-          return;
-        }
-        open();
-      });
+      setTimeout(open, REOPEN_DELAY_MS);
     };
   }
 
@@ -671,16 +637,13 @@ function openSelfRefreshingInboxStream(): AgentChatInboxEventStream {
       type: InboxStreamType,
       listener: (event: AgentChatInboxStreamEvent) => void,
     ) {
-      const wrapper: RawHandler = (event) => {
-        listener({
-          data: event.data,
-          lastEventId: event.lastEventId,
-        });
-      };
-      const set = handlers.get(type) ?? new Set<RawHandler>();
-      set.add(wrapper);
+      const set = handlers.get(type) ?? new Set();
+      set.add(listener);
       handlers.set(type, set);
-      source?.addEventListener(type, wrapper as EventListener);
+      source?.addEventListener(type, (event) => {
+        consecutiveFailures = 0;
+        listener(event);
+      });
     },
     close() {
       closed = true;


### PR DESCRIPTION
The web chat used native EventSource for the live session event stream. Browsers do not expose SSE comment lines to EventSource consumers, so the harness's 15s ': ping' keepalives were invisible — a silently dropped connection (laptop sleep/resume, Wi-Fi roam, NAT mapping expiry) produced no error event and left the chat frozen until a full page reload.

Add FetchSseEventStream to the agent-chat-react SDK: an SSE-over-fetch stream that reads the bytes itself, so ping arrival is observable, and a stall watchdog (45s of byte silence = three missed pings) converts a silent drop into the normal onerror path that consumers already treat as 'reconnect now'. visibilitychange/online listeners re-check staleness immediately on tab refocus or network restore instead of waiting out background-tab timer throttling. All failure modes funnel through a once-only guard so a reconnecting consumer cannot leak a second stream.

The web adapter now opens the chat stream through FetchSseEventStream with authFetch — auth moves from a ?token= query parameter to the Authorization header — and keeps the session.title_updated zustand side-channel. The inbox stream switches to the same transport inside its self-reopening wrapper; authFetch refreshes expired tokens transparently, replacing the EventSource-specific refresh-then-reopen machinery.