### PR TITLE
feat(agent-chat): upload prompt images to the workspace

### DIFF
--- a/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
@@ -30,6 +30,7 @@ import type {
   TokenUsage,
 } from "../../types";
 import { useAgentChatAdapterContext } from "../../adapter-context";
+import { splitComposerFiles } from "../../lib/split-composer-files";
 import {
   Context,
   ContextCacheUsage,
@@ -518,32 +519,13 @@ function ChatComposerInner({
       const text = message.text.trim();
       if (!text || disabled) return;
 
-      // Split incoming files by MIME bucket: images go through the
-      // existing vision-inline path (base64 data URL on the message
-      // body), everything else becomes a pending attachment uploaded
-      // to the workspace by the runtime.
-      const images: AgentChatImageAttachment[] = [];
-      const pending: AgentChatPendingAttachment[] = [];
-
-      for (const file of message.files) {
-        if (file.mediaType?.startsWith("image/") && file.url) {
-          images.push({ data: file.url, mimeType: file.mediaType });
-          continue;
-        }
-        if (!file.file) {
-          // Defensive: PromptInputProvider/local both stamp file: on
-          // each item. If a future consumer constructs a FileUIPart
-          // without it, drop the entry rather than pretending we can
-          // upload nothing.
-          continue;
-        }
-        pending.push({
-          file: file.file,
-          filename: file.filename ?? file.file.name,
-          mimeType: file.mediaType ?? file.file.type ?? undefined,
-          size: file.file.size,
-        });
-      }
+      // Split incoming files into the inline-vision image list and the
+      // workspace-upload pending list. Images appear in BOTH: the base64
+      // data URL still drives inline vision, and the same image is queued
+      // as a pending attachment so the runtime persists it to the
+      // workspace ``uploads/`` directory, exactly like a non-image file.
+      // Everything else becomes a pending attachment only.
+      const { images, pending } = splitComposerFiles(message.files);
 
       // Split-aware caps — the <PromptInput maxFiles/maxFileSize> caps
       // are a coarse first line that ignores the image/non-image

--- a/sdk/agent-chat-react/src/components/chat/chat-message.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-message.tsx
@@ -37,6 +37,13 @@ export const ChatMessage = memo(function ChatMessage({
   message,
   onFileSelect,
 }: ChatMessageProps) {
+  // Image attachments are rendered as inline previews via
+  // ``message.images`` (the composer routes each picked image into both
+  // the inline-vision list and the workspace-upload list). Skip them
+  // here so the same image does not also appear as a file chip.
+  const fileAttachments = (message.attachments ?? []).filter(
+    (a) => !a.mimeType?.startsWith("image/"),
+  );
   return (
     <Message from="user">
       <MessageContent>
@@ -53,9 +60,9 @@ export const ChatMessage = memo(function ChatMessage({
             ))}
           </div>
         )}
-        {message.attachments && message.attachments.length > 0 && (
+        {fileAttachments.length > 0 && (
           <div className="flex flex-wrap gap-2 mt-2">
-            {message.attachments.map((a, i) => (
+            {fileAttachments.map((a, i) => (
               <AttachmentChip
                 // Stable key across the optimistic → confirmed
                 // transition: the local chip starts without a path

--- a/sdk/agent-chat-react/src/lib/split-composer-files.ts
+++ b/sdk/agent-chat-react/src/lib/split-composer-files.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+import type {
+  AgentChatImageAttachment,
+  AgentChatPendingAttachment,
+} from "../types";
+
+/**
+ * Minimal shape of a composer file part needed to split it for sending.
+ * Mirrors the relevant fields of ``PromptInputFileUIPart`` without
+ * coupling this pure helper to the prompt-input module.
+ */
+export interface ComposerFilePart {
+  /** MIME type, e.g. "image/png". */
+  mediaType?: string;
+  /** Data URL (base64) for images; blob/HTTP URL otherwise. */
+  url?: string;
+  filename?: string;
+  /** Backing File, retained so the runtime can upload to the workspace. */
+  file?: File;
+}
+
+export interface SplitComposerFiles {
+  images: AgentChatImageAttachment[];
+  pending: AgentChatPendingAttachment[];
+}
+
+/**
+ * Split composer files into the inline-vision image list and the
+ * workspace-upload pending list.
+ *
+ * Images go to **both** buckets: the base64 ``url`` feeds the inline
+ * vision path so vision-capable models see the image on this turn, and —
+ * when the part carries its backing ``File`` — the same image is also
+ * queued as a pending attachment so the runtime persists it to the
+ * workspace ``uploads/`` directory, exactly like a non-image file.
+ * Non-image files only ever become pending attachments.
+ *
+ * A FileUIPart with no backing ``File`` (e.g. an inline image synthesised
+ * from an HTTP source) is still surfaced inline when it has a ``url`` but
+ * cannot be uploaded, so it is omitted from the pending list rather than
+ * pretending we can persist nothing.
+ */
+export function splitComposerFiles(
+  files: readonly ComposerFilePart[],
+): SplitComposerFiles {
+  const images: AgentChatImageAttachment[] = [];
+  const pending: AgentChatPendingAttachment[] = [];
+
+  for (const file of files) {
+    if (file.mediaType?.startsWith("image/") && file.url) {
+      images.push({ data: file.url, mimeType: file.mediaType });
+    }
+    if (!file.file) {
+      continue;
+    }
+    pending.push({
+      file: file.file,
+      filename: file.filename ?? file.file.name,
+      mimeType: file.mediaType ?? file.file.type ?? undefined,
+      size: file.file.size,
+    });
+  }
+
+  return { images, pending };
+}

--- a/sdk/agent-chat-react/tests/chat-message.test.tsx
+++ b/sdk/agent-chat-react/tests/chat-message.test.tsx
@@ -208,4 +208,40 @@ describe("ChatMessage — user bubble attachment chips", () => {
     expect(node.querySelectorAll("img")).toHaveLength(1);
     expect(node.querySelectorAll("button")).toHaveLength(1);
   });
+
+  it("does not render a chip for an image attachment (shown as an inline preview instead)", () => {
+    // The composer now uploads picked images to the workspace, so a sent
+    // image appears in BOTH message.images (inline preview) and
+    // message.attachments (workspace ref). The bubble must render it once,
+    // as the image preview — never also as a file chip.
+    const node = render(
+      <ChatMessage
+        message={userMessage({
+          images: [
+            { data: "data:image/png;base64,xxxx", mimeType: "image/png" },
+          ],
+          attachments: [
+            {
+              path: "uploads/1-0-shot.png",
+              filename: "shot.png",
+              mimeType: "image/png",
+              size: 1024,
+            },
+            {
+              path: "uploads/1-1-notes.txt",
+              filename: "notes.txt",
+              mimeType: "text/plain",
+              size: 42,
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(node.querySelectorAll("img")).toHaveLength(1);
+    // Only the non-image (notes.txt) attachment gets a chip button.
+    expect(node.querySelectorAll("button")).toHaveLength(1);
+    expect(node.textContent).toContain("notes.txt");
+    expect(node.textContent).not.toContain("shot.png");
+  });
 });

--- a/sdk/agent-chat-react/tests/split-composer-files.test.ts
+++ b/sdk/agent-chat-react/tests/split-composer-files.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  splitComposerFiles,
+  type ComposerFilePart,
+} from "../src/lib/split-composer-files";
+
+function imageFile(name = "shot.png"): File {
+  return new File([new Uint8Array([1, 2, 3])], name, { type: "image/png" });
+}
+
+function docFile(name = "report.pdf"): File {
+  return new File([new Uint8Array([4, 5, 6])], name, {
+    type: "application/pdf",
+  });
+}
+
+describe("splitComposerFiles", () => {
+  it("routes an image into BOTH the inline-vision list and the upload list", () => {
+    const file = imageFile();
+    const part: ComposerFilePart = {
+      mediaType: "image/png",
+      url: "data:image/png;base64,AAAA",
+      filename: "shot.png",
+      file,
+    };
+
+    const { images, pending } = splitComposerFiles([part]);
+
+    expect(images).toEqual([
+      { data: "data:image/png;base64,AAAA", mimeType: "image/png" },
+    ]);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({
+      file,
+      filename: "shot.png",
+      mimeType: "image/png",
+      size: file.size,
+    });
+  });
+
+  it("routes a non-image file into the upload list only", () => {
+    const file = docFile();
+    const part: ComposerFilePart = {
+      mediaType: "application/pdf",
+      filename: "report.pdf",
+      file,
+    };
+
+    const { images, pending } = splitComposerFiles([part]);
+
+    expect(images).toEqual([]);
+    expect(pending).toEqual([
+      {
+        file,
+        filename: "report.pdf",
+        mimeType: "application/pdf",
+        size: file.size,
+      },
+    ]);
+  });
+
+  it("surfaces an image inline but does not queue an upload when it has no backing File", () => {
+    const part: ComposerFilePart = {
+      mediaType: "image/jpeg",
+      url: "data:image/jpeg;base64,BBBB",
+      filename: "remote.jpg",
+    };
+
+    const { images, pending } = splitComposerFiles([part]);
+
+    expect(images).toEqual([
+      { data: "data:image/jpeg;base64,BBBB", mimeType: "image/jpeg" },
+    ]);
+    expect(pending).toEqual([]);
+  });
+
+  it("keeps a mixed batch separated, with the image in both buckets", () => {
+    const img = imageFile();
+    const doc = docFile();
+    const parts: ComposerFilePart[] = [
+      {
+        mediaType: "image/png",
+        url: "data:image/png;base64,CCCC",
+        filename: "shot.png",
+        file: img,
+      },
+      { mediaType: "application/pdf", filename: "report.pdf", file: doc },
+    ];
+
+    const { images, pending } = splitComposerFiles(parts);
+
+    expect(images).toHaveLength(1);
+    expect(pending).toHaveLength(2);
+    expect(pending.map((p) => p.filename)).toEqual(["shot.png", "report.pdf"]);
+  });
+
+  it("falls back to the File name and type when filename/mediaType are absent", () => {
+    const file = docFile("notes.txt");
+    const part: ComposerFilePart = { file };
+
+    const { pending } = splitComposerFiles([part]);
+
+    expect(pending[0]).toMatchObject({
+      filename: "notes.txt",
+      mimeType: "application/pdf",
+    });
+  });
+});


### PR DESCRIPTION
Picked images now upload to the session workspace (uploads/) like any other file attachment, while still being sent inline as base64 so vision-capable models see them on the turn. Previously images were inline-only and never persisted.

- Add splitComposerFiles helper routing images into both the inline-vision list and the workspace-upload pending list
- Skip image-mime attachment chips in the user bubble (the image is already shown as an inline preview) to avoid double-rendering