### PR TITLE
fix(harness): keep attachment binding when expanding slash-skills

### DIFF
--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -158,6 +158,7 @@ from surogates.harness.loop_messages import (
     _format_bytes,
     _initial_system_message,
     _last_assistant_message_excerpt,
+    _latest_user_event_data,
     _latest_user_event_text,
     _latest_user_message_text,
     _seconds_since,
@@ -207,7 +208,10 @@ from surogates.harness.loop_artifact_completion import ArtifactCompletionMixin
 from surogates.harness.loop_arbor import ArborHarvestMixin
 from surogates.harness.loop_board import BoardMixin
 from surogates.harness.loop_code_commands import CodeCommandMixin
-from surogates.harness.loop_context_replay import ContextReplayMixin
+from surogates.harness.loop_context_replay import (
+    ContextReplayMixin,
+    build_user_message_dict,
+)
 from surogates.harness.loop_iteration_summary import IterationSummaryMixin
 from surogates.harness.loop_outcome_commands import OutcomeCommandMixin
 
@@ -264,6 +268,30 @@ def _skill_invoked_event_data(
         if ov.get("candidate_id") is not None:
             data["candidate_id"] = ov["candidate_id"]
     return data
+
+
+def _rewrite_user_content_preserving_attachments(
+    last_user: dict | None,
+    all_events: list,
+    new_text: str,
+) -> None:
+    """Swap a rewritten directive into the latest user message in place,
+    keeping this turn's attachment note, inlined content, and image blocks.
+
+    The slash-skill and ``/deep-research`` paths replace the raw
+    ``/command`` text with an expanded body.  Assigning that body directly
+    drops the per-turn attachment binding that ``_rebuild_messages`` folds
+    into the user content, so the model loses track of which file the user
+    just attached and binds the request to an earlier upload still visible
+    in history.  Rebuilding via ``build_user_message_dict`` with the body as
+    ``base_content`` reattaches the binding.
+    """
+    if last_user is None:
+        return
+    data = _latest_user_event_data(all_events) or {}
+    last_user["content"] = build_user_message_dict(
+        data, base_content=new_text,
+    )["content"]
 
 
 # Reminder injected when the deep-research planner ends a turn with
@@ -985,10 +1013,11 @@ class AgentHarness(
                 last_user_content,
             )
             if deep_research_topic is not None:
-                if last_user is not None:
-                    last_user["content"] = build_deep_research_message(
-                        topic=deep_research_topic,
-                    )
+                _rewrite_user_content_preserving_attachments(
+                    last_user,
+                    all_events,
+                    build_deep_research_message(topic=deep_research_topic),
+                )
                 # The rewritten directive is the planning structure;
                 # skip the SELF-DISCOVER / thinking-gate scaffold.
                 self._skip_pre_llm_scaffold_for_turn = True
@@ -1011,7 +1040,9 @@ class AgentHarness(
                 )
                 if expansion is not None:
                     expanded_text, skill_name, staged_at, kind = expansion
-                    last_user["content"] = expanded_text
+                    _rewrite_user_content_preserving_attachments(
+                        last_user, all_events, expanded_text,
+                    )
                     # The skill body itself is the planning structure;
                     # don't pay for the thinking-gate + SELF-DISCOVER
                     # classifier pair on this turn.

--- a/surogates/harness/loop_context_replay.py
+++ b/surogates/harness/loop_context_replay.py
@@ -19,6 +19,68 @@ from surogates.session.events import EventType
 logger = logging.getLogger(__name__)
 
 
+def build_user_message_dict(
+    event_data: dict,
+    *,
+    base_content: str | None = None,
+) -> dict:
+    """Construct the replayed LLM user message for one ``user.message`` event.
+
+    Folds the per-turn ephemeral context — inlined attachment content,
+    view-context note, path-only attachment note, and image vision blocks —
+    onto the user's text, exactly as the conversation history is rebuilt.
+
+    ``base_content`` overrides the event's own ``content``.  The slash-skill
+    and ``/deep-research`` rewrite paths pass the expanded directive here so
+    the skill/delegation body replaces the raw ``/command`` text while the
+    attachment binding for *this* turn survives.  Without that, the rewrite
+    discarded the note/inlined content and the model bound the request to an
+    earlier upload still visible in history instead of the file the user just
+    attached.
+    """
+    content = base_content if base_content is not None else event_data.get("content", "")
+    content = _render_inlined_attachments(content, event_data.get("attachments"))
+    # Fold per-user ephemeral notes (view-context, non-inlined attachments)
+    # into the user content here so the bytes are determined entirely by the
+    # durable event payload.  This keeps the provider's implicit prefix cache
+    # stable across turns -- the previous design inserted the notes mid-array
+    # before the latest user message, which left them present in turn T's
+    # request but absent in turn T+1's prefix.
+    note_parts: list[str] = []
+    view_note = _view_context_note_from_metadata(event_data.get("metadata"))
+    if view_note:
+        note_parts.append(view_note)
+    attachments_note = _attachments_note_from_data(event_data)
+    if attachments_note:
+        note_parts.append(attachments_note)
+    if note_parts:
+        notes_block = "\n\n".join(note_parts)
+        content = f"{notes_block}\n\n{content}" if content else notes_block
+
+    images = event_data.get("images")
+    if images:
+        logger.info(
+            "User message has %d image(s), first mime: %s",
+            len(images),
+            images[0].get("mime_type", "?"),
+        )
+        blocks: list[dict] = [{"type": "text", "text": content}]
+        for img in images:
+            data_url = img["data"]
+            if not data_url.startswith("data:"):
+                mime = img.get("mime_type", "image/png")
+                data_url = f"data:{mime};base64,{data_url}"
+            blocks.append({
+                "type": "image_url",
+                "image_url": {"url": data_url, "detail": "auto"},
+            })
+        user_msg = {"role": "user", "content": blocks}
+        from surogates.harness.image_shrink import shrink_image_parts_in_messages
+        shrink_image_parts_in_messages([user_msg])
+        return user_msg
+    return {"role": "user", "content": content}
+
+
 class ContextReplayMixin:
     async def _prefetch_memory(self, session_id: UUID) -> str | None:
         """Prefetch user memory and snapshot it for the session.
@@ -94,55 +156,7 @@ class ContextReplayMixin:
             etype = event.type
 
             if etype == EventType.USER_MESSAGE.value:
-                content = event.data.get("content", "")
-                content = _render_inlined_attachments(
-                    content, event.data.get("attachments"),
-                )
-                # Fold per-user ephemeral notes (view-context, non-inlined
-                # attachments) into the user content here so the bytes are
-                # determined entirely by the durable event payload.  This
-                # keeps the provider's implicit prefix cache stable across
-                # turns -- the previous design inserted the notes mid-array
-                # before the latest user message, which left them present
-                # in turn T's request but absent in turn T+1's prefix.
-                note_parts: list[str] = []
-                view_note = _view_context_note_from_metadata(
-                    event.data.get("metadata"),
-                )
-                if view_note:
-                    note_parts.append(view_note)
-                attachments_note = _attachments_note_from_data(event.data)
-                if attachments_note:
-                    note_parts.append(attachments_note)
-                if note_parts:
-                    notes_block = "\n\n".join(note_parts)
-                    content = (
-                        f"{notes_block}\n\n{content}" if content else notes_block
-                    )
-                images = event.data.get("images")
-                if images:
-                    logger.info(
-                        "User message has %d image(s), first mime: %s",
-                        len(images),
-                        images[0].get("mime_type", "?"),
-                    )
-                if images:
-                    blocks: list[dict] = [{"type": "text", "text": content}]
-                    for img in images:
-                        data_url = img["data"]
-                        if not data_url.startswith("data:"):
-                            mime = img.get("mime_type", "image/png")
-                            data_url = f"data:{mime};base64,{data_url}"
-                        blocks.append({
-                            "type": "image_url",
-                            "image_url": {"url": data_url, "detail": "auto"},
-                        })
-                    user_msg = {"role": "user", "content": blocks}
-                    from surogates.harness.image_shrink import shrink_image_parts_in_messages
-                    shrink_image_parts_in_messages([user_msg])
-                    messages.append(user_msg)
-                else:
-                    messages.append({"role": "user", "content": content})
+                messages.append(build_user_message_dict(event.data))
 
             elif etype == EventType.LLM_RESPONSE.value:
                 stored_message = event.data.get("message")

--- a/surogates/harness/loop_messages.py
+++ b/surogates/harness/loop_messages.py
@@ -141,6 +141,30 @@ def _latest_user_event_text(events: list[Any]) -> str:
             )
         return (raw or "").strip()
     return ""
+
+
+def _latest_user_event_data(events: list[Any]) -> dict | None:
+    """Return the ``data`` payload of the latest ``USER_MESSAGE`` event.
+
+    Used by the slash-skill / ``/deep-research`` rewrite paths to refold the
+    current turn's attachment note, inlined content, and image blocks onto
+    the rewritten message body via
+    :func:`surogates.harness.loop_context_replay.build_user_message_dict`.
+
+    Returns ``None`` when no ``USER_MESSAGE`` event exists or its payload is
+    not a dict.
+    """
+    for event in reversed(events):
+        event_type = event.type
+        type_value = (
+            event_type.value if hasattr(event_type, "value") else event_type
+        )
+        if type_value != EventType.USER_MESSAGE.value:
+            continue
+        return event.data if isinstance(event.data, dict) else None
+    return None
+
+
 def _last_assistant_message_excerpt(
     messages: list[dict[str, Any]],
     limit: int = 500,

--- a/tests/test_skill_expansion_preserves_attachments.py
+++ b/tests/test_skill_expansion_preserves_attachments.py
@@ -1,0 +1,130 @@
+"""Slash-skill / deep-research expansion must keep the current turn's
+attachment binding.
+
+When the user attaches a file and invokes a skill (``/my-skill``) without
+naming the file, the harness rewrites the user message to the skill body.
+Historically that rewrite *replaced* the rebuilt user content outright,
+discarding the per-turn attachment note and inlined attachment content
+that ``_rebuild_messages`` folds in. The model was then left with no
+signal about which file was attached to *this* message and would bind to
+an earlier upload still visible in the conversation history.
+
+``build_user_message_dict`` is the shared seam: with ``base_content`` it
+swaps in the skill body while preserving the attachment note, inlined
+content, and image vision blocks.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from surogates.harness.loop import AgentHarness
+from surogates.harness.loop_context_replay import build_user_message_dict
+from surogates.harness.loop_messages import _latest_user_event_data
+from surogates.session.events import EventType
+
+
+def _user_event(data: dict, event_id: int = 1):
+    return SimpleNamespace(type=EventType.USER_MESSAGE.value, data=data, id=event_id)
+
+
+def test_base_content_override_keeps_path_only_attachment_note():
+    data = {
+        "content": "/holland-report",
+        "attachments": [
+            {
+                "path": "uploads/172-0-holland.pdf",
+                "filename": "holland.pdf",
+                "mime_type": "application/pdf",
+                "size": 4_200_000,
+            }
+        ],
+    }
+    skill_body = (
+        "The user invoked the `holland-report` skill.\n\n"
+        "Use the following skill to handle this request:\n---\n"
+        "Summarise the attached document.\n---"
+    )
+
+    msg = build_user_message_dict(data, base_content=skill_body)
+
+    assert isinstance(msg["content"], str)
+    # Skill body is present...
+    assert "Summarise the attached document." in msg["content"]
+    # ...and so is the binding to THIS turn's attachment.
+    assert "uploads/172-0-holland.pdf" in msg["content"]
+    assert "holland.pdf" in msg["content"]
+    # The raw slash command text is gone (replaced by the skill body).
+    assert "/holland-report" not in msg["content"]
+
+
+def test_base_content_override_keeps_inlined_attachment_content():
+    data = {
+        "content": "/summarize",
+        "attachments": [
+            {
+                "path": "uploads/1-0-notes.txt",
+                "filename": "notes.txt",
+                "mime_type": "text/plain",
+                "inlined_text": "HOLLAND QUARTERLY FIGURES",
+                "inlined_render_kind": "text",
+            }
+        ],
+    }
+
+    msg = build_user_message_dict(data, base_content="SKILL BODY HERE")
+
+    assert "SKILL BODY HERE" in msg["content"]
+    assert "HOLLAND QUARTERLY FIGURES" in msg["content"]
+
+
+def test_base_content_override_keeps_image_vision_blocks():
+    data = {
+        "content": "/describe",
+        "images": [
+            {"data": "data:image/png;base64,AAAA", "mime_type": "image/png"},
+        ],
+    }
+
+    msg = build_user_message_dict(data, base_content="SKILL BODY")
+
+    assert isinstance(msg["content"], list)
+    text_block = next(p for p in msg["content"] if p.get("type") == "text")
+    assert "SKILL BODY" in text_block["text"]
+    assert any(p.get("type") == "image_url" for p in msg["content"])
+
+
+def test_default_matches_rebuild_messages_for_a_single_user_event():
+    data = {
+        "content": "summarise this",
+        "attachments": [
+            {
+                "path": "uploads/x.pdf",
+                "filename": "x.pdf",
+                "mime_type": "application/pdf",
+                "size": 1234,
+            }
+        ],
+    }
+    event = _user_event(data)
+
+    rebuilt = AgentHarness._rebuild_messages(SimpleNamespace(), [event])
+    direct = build_user_message_dict(data)
+
+    assert rebuilt[0] == direct
+
+
+def test_latest_user_event_data_returns_latest_user_payload():
+    events = [
+        _user_event({"content": "first", "attachments": [{"path": "a"}]}, 1),
+        SimpleNamespace(type=EventType.LLM_RESPONSE.value, data={}, id=2),
+        _user_event({"content": "second", "attachments": [{"path": "b"}]}, 3),
+    ]
+    data = _latest_user_event_data(events)
+    assert data is not None
+    assert data["content"] == "second"
+    assert data["attachments"] == [{"path": "b"}]
+
+
+def test_latest_user_event_data_none_when_no_user_message():
+    assert _latest_user_event_data([]) is None


### PR DESCRIPTION
A slash-skill (and /deep-research) invocation rewrites the latest user message to the expanded skill body via last_user["content"] = expanded_text. That assignment discarded the per-turn attachment note, inlined attachment content, and image vision blocks that _rebuild_messages folds into the user content, so the model lost track of which file was attached to THIS message and bound the request to an earlier upload still visible in the conversation history.

Extract the per-user-message construction into build_user_message_dict (reused by _rebuild_messages) and refold the current turn's attachment context onto the rewritten body via _rewrite_user_content_preserving_attachments, so an unnamed 'run this skill' on a freshly attached file operates on that file.