### PR TITLE
Preserve attachment + image context across slash-skill / deep-research expansion

### DIFF
--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -132,6 +132,8 @@ from surogates.harness.loop_attachments import (
     _attachments_note,
     _attachments_note_from_data,
     _render_inlined_attachments,
+    build_user_message_dict,
+    fold_attachment_context,
 )
 from surogates.harness.loop_constants import (
     DEFAULT_PRESERVE_THINKING,
@@ -158,6 +160,7 @@ from surogates.harness.loop_messages import (
     _format_bytes,
     _initial_system_message,
     _last_assistant_message_excerpt,
+    _latest_user_event_data,
     _latest_user_event_text,
     _latest_user_message_text,
     _seconds_since,
@@ -986,9 +989,15 @@ class AgentHarness(
             )
             if deep_research_topic is not None:
                 if last_user is not None:
-                    last_user["content"] = build_deep_research_message(
-                        topic=deep_research_topic,
-                    )
+                    # Rebuild with the deep-research directive as the base so
+                    # this turn's attachment note / inlined files / image
+                    # blocks survive the rewrite (same fix as the slash path).
+                    last_user["content"] = build_user_message_dict(
+                        _latest_user_event_data(all_events),
+                        base_content=build_deep_research_message(
+                            topic=deep_research_topic,
+                        ),
+                    )["content"]
                 # The rewritten directive is the planning structure;
                 # skip the SELF-DISCOVER / thinking-gate scaffold.
                 self._skip_pre_llm_scaffold_for_turn = True
@@ -1011,7 +1020,15 @@ class AgentHarness(
                 )
                 if expansion is not None:
                     expanded_text, skill_name, staged_at, kind = expansion
-                    last_user["content"] = expanded_text
+                    # Rebuild with the skill body as the base so this turn's
+                    # attachment note, inlined file content, and image blocks
+                    # survive the rewrite.  Overwriting with the bare skill
+                    # body dropped them, leaving the agent unaware a file/image
+                    # was attached on a slash-skill turn.
+                    last_user["content"] = build_user_message_dict(
+                        _latest_user_event_data(all_events),
+                        base_content=expanded_text,
+                    )["content"]
                     # The skill body itself is the planning structure;
                     # don't pay for the thinking-gate + SELF-DISCOVER
                     # classifier pair on this turn.

--- a/surogates/harness/loop_attachments.py
+++ b/surogates/harness/loop_attachments.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from surogates.harness.loop_messages import _format_bytes
+from surogates.harness.loop_messages import (
+    _format_bytes,
+    _view_context_note_from_metadata,
+)
 from surogates.session.events import EventType
 
 _ATTACHMENT_SKIP_HINTS: dict[str, str] = {
@@ -138,3 +141,74 @@ def _render_inlined_attachments(
     if not blocks:
         return content
     return content + "\n\n" + "\n\n".join(blocks)
+
+
+def fold_attachment_context(text: str, data: Any) -> str:
+    """Fold a ``user.message`` event's attachment context into ``text``.
+
+    Mirrors what :meth:`AgentHarness._rebuild_messages` does for a normal
+    user turn: render inlined attachment blocks onto ``text`` and prepend
+    the view-context and attachments notes.  Used to preserve attachment
+    context when the rebuilt user content is replaced wholesale (e.g.
+    slash-skill expansion overwriting it with just the skill body), which
+    would otherwise drop the note and the inlined file content so the
+    agent acts as if no file was attached.
+
+    ``data`` is the ``user.message`` event's ``data`` dict.  Returns
+    ``text`` unchanged when there is no attachment/view context to fold.
+    """
+    if not isinstance(data, dict):
+        return text
+    out = _render_inlined_attachments(text, data.get("attachments"))
+    note_parts: list[str] = []
+    view_note = _view_context_note_from_metadata(data.get("metadata"))
+    if view_note:
+        note_parts.append(view_note)
+    attachments_note = _attachments_note_from_data(data)
+    if attachments_note:
+        note_parts.append(attachments_note)
+    if note_parts:
+        notes_block = "\n\n".join(note_parts)
+        out = f"{notes_block}\n\n{out}" if out else notes_block
+    return out
+
+
+def build_user_message_dict(
+    event_data: Any, base_content: str | None = None,
+) -> dict:
+    """Build the LLM user-message dict for a ``user.message`` event.
+
+    Single source of truth for per-user-message content construction:
+    folds the attachment note + inlined file content + view-context note
+    into the text (via :func:`fold_attachment_context`) and, when the
+    event carries images, assembles a multimodal ``content`` blocks list
+    (text + ``image_url`` parts) and shrinks oversized images.
+
+    ``base_content`` overrides the event's raw ``content`` as the text
+    base.  The slash-skill and ``/deep-research`` rewrite paths pass the
+    rewritten body here so the *current turn's* attachment note, inlined
+    file content, and image blocks survive the rewrite instead of being
+    clobbered.  Returns ``{"role": "user", "content": str | list}``.
+    """
+    data = event_data if isinstance(event_data, dict) else {}
+    base = data.get("content", "") if base_content is None else base_content
+    text = fold_attachment_context(base, data)
+
+    images = data.get("images")
+    if not images:
+        return {"role": "user", "content": text}
+
+    blocks: list[dict] = [{"type": "text", "text": text}]
+    for img in images:
+        data_url = img["data"]
+        if not data_url.startswith("data:"):
+            mime = img.get("mime_type", "image/png")
+            data_url = f"data:{mime};base64,{data_url}"
+        blocks.append({
+            "type": "image_url",
+            "image_url": {"url": data_url, "detail": "auto"},
+        })
+    msg = {"role": "user", "content": blocks}
+    from surogates.harness.image_shrink import shrink_image_parts_in_messages
+    shrink_image_parts_in_messages([msg])
+    return msg

--- a/surogates/harness/loop_context_replay.py
+++ b/surogates/harness/loop_context_replay.py
@@ -7,11 +7,7 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID
 
-from surogates.harness.loop_attachments import (
-    _attachments_note_from_data,
-    _render_inlined_attachments,
-)
-from surogates.harness.loop_messages import _view_context_note_from_metadata
+from surogates.harness.loop_attachments import build_user_message_dict
 from surogates.harness.loop_tool_recovery import collapse_repeated_tool_rounds
 from surogates.harness.sanitize import strip_budget_warnings
 from surogates.session.events import EventType
@@ -94,55 +90,16 @@ class ContextReplayMixin:
             etype = event.type
 
             if etype == EventType.USER_MESSAGE.value:
-                content = event.data.get("content", "")
-                content = _render_inlined_attachments(
-                    content, event.data.get("attachments"),
-                )
-                # Fold per-user ephemeral notes (view-context, non-inlined
-                # attachments) into the user content here so the bytes are
-                # determined entirely by the durable event payload.  This
-                # keeps the provider's implicit prefix cache stable across
-                # turns -- the previous design inserted the notes mid-array
-                # before the latest user message, which left them present
-                # in turn T's request but absent in turn T+1's prefix.
-                note_parts: list[str] = []
-                view_note = _view_context_note_from_metadata(
-                    event.data.get("metadata"),
-                )
-                if view_note:
-                    note_parts.append(view_note)
-                attachments_note = _attachments_note_from_data(event.data)
-                if attachments_note:
-                    note_parts.append(attachments_note)
-                if note_parts:
-                    notes_block = "\n\n".join(note_parts)
-                    content = (
-                        f"{notes_block}\n\n{content}" if content else notes_block
-                    )
-                images = event.data.get("images")
-                if images:
-                    logger.info(
-                        "User message has %d image(s), first mime: %s",
-                        len(images),
-                        images[0].get("mime_type", "?"),
-                    )
-                if images:
-                    blocks: list[dict] = [{"type": "text", "text": content}]
-                    for img in images:
-                        data_url = img["data"]
-                        if not data_url.startswith("data:"):
-                            mime = img.get("mime_type", "image/png")
-                            data_url = f"data:{mime};base64,{data_url}"
-                        blocks.append({
-                            "type": "image_url",
-                            "image_url": {"url": data_url, "detail": "auto"},
-                        })
-                    user_msg = {"role": "user", "content": blocks}
-                    from surogates.harness.image_shrink import shrink_image_parts_in_messages
-                    shrink_image_parts_in_messages([user_msg])
-                    messages.append(user_msg)
-                else:
-                    messages.append({"role": "user", "content": content})
+                # Single source of truth for per-user-message construction
+                # (attachment note + inlined file content + view-context note
+                # + image blocks).  Shared with the slash-skill and
+                # /deep-research rewrite paths in loop.py via
+                # build_user_message_dict so the two can't drift -- that drift
+                # was the original cause of slash turns dropping the current
+                # turn's attachment + image context.  Building from the durable
+                # event payload also keeps the request bytes (and the
+                # provider's implicit prefix cache) stable across turns.
+                messages.append(build_user_message_dict(event.data))
 
             elif etype == EventType.LLM_RESPONSE.value:
                 stored_message = event.data.get("message")

--- a/surogates/harness/loop_messages.py
+++ b/surogates/harness/loop_messages.py
@@ -141,6 +141,28 @@ def _latest_user_event_text(events: list[Any]) -> str:
             )
         return (raw or "").strip()
     return ""
+
+
+def _latest_user_event_data(events: list[Any]) -> dict:
+    """Return the ``data`` dict of the latest ``USER_MESSAGE`` event.
+
+    Companion to :func:`_latest_user_event_text` for callers that need the
+    full payload (attachments, metadata) rather than just the raw text --
+    e.g. re-folding attachment context after slash-skill expansion
+    overwrites the rebuilt user content.  Returns ``{}`` when no
+    ``USER_MESSAGE`` event exists or its ``data`` is malformed.
+    """
+    for event in reversed(events):
+        event_type = event.type
+        type_value = (
+            event_type.value if hasattr(event_type, "value") else event_type
+        )
+        if type_value != EventType.USER_MESSAGE.value:
+            continue
+        return event.data if isinstance(event.data, dict) else {}
+    return {}
+
+
 def _last_assistant_message_excerpt(
     messages: list[dict[str, Any]],
     limit: int = 500,

--- a/tests/harness/test_attachment_rendering.py
+++ b/tests/harness/test_attachment_rendering.py
@@ -356,3 +356,194 @@ def test_latest_user_event_text_returns_empty_when_no_user_event() -> None:
     from surogates.harness.loop import _latest_user_event_text
 
     assert _latest_user_event_text([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# fold_attachment_context: re-fold attachment notes + inlined blocks into a
+# replacement message body (used when slash-skill expansion overwrites the
+# rebuilt user content, which would otherwise drop the attachment context).
+# ---------------------------------------------------------------------------
+
+
+def test_fold_attachment_context_preserves_inlined_content() -> None:
+    from surogates.harness.loop import fold_attachment_context
+
+    out = fold_attachment_context(
+        "EXPANDED SKILL BODY",
+        {
+            "content": "/pdf-skill",
+            "attachments": [
+                {
+                    "path": "uploads/report.pdf",
+                    "filename": "report.pdf",
+                    "inlined_text": "INLINE BODY",
+                    "inlined_render_kind": "markdown",
+                }
+            ],
+        },
+    )
+    assert "EXPANDED SKILL BODY" in out
+    assert "**Attachment: report.pdf**" in out
+    assert "INLINE BODY" in out
+
+
+def test_fold_attachment_context_preserves_attachments_note_for_path_only() -> None:
+    from surogates.harness.loop import fold_attachment_context
+
+    out = fold_attachment_context(
+        "EXPANDED SKILL BODY",
+        {
+            "content": "/pdf-skill",
+            "attachments": [
+                {
+                    "path": "uploads/big.pdf",
+                    "filename": "big.pdf",
+                    "mime_type": "application/pdf",
+                    "size": 9_000_000,
+                },
+            ],
+        },
+    )
+    assert "EXPANDED SKILL BODY" in out
+    assert "big.pdf" in out  # the note lists the path-only file
+    # note is folded in as a prefix, before the (expanded) body
+    assert out.index("big.pdf") < out.index("EXPANDED SKILL BODY")
+
+
+def test_fold_attachment_context_is_noop_without_attachments() -> None:
+    from surogates.harness.loop import fold_attachment_context
+
+    assert fold_attachment_context("plain body", {"content": "/skill"}) == "plain body"
+    assert fold_attachment_context("plain body", {}) == "plain body"
+    assert fold_attachment_context("plain body", None) == "plain body"
+
+
+def test_fold_attachment_context_preserves_view_context_note() -> None:
+    from surogates.harness.loop import fold_attachment_context
+
+    out = fold_attachment_context(
+        "EXPANDED SKILL BODY",
+        {
+            "content": "/skill",
+            "metadata": {
+                "view_context": {"kind": "document", "id": "doc-42", "name": "Q3 plan"},
+            },
+        },
+    )
+    assert "EXPANDED SKILL BODY" in out
+    assert "currently viewing" in out
+    assert "doc-42" in out
+    assert out.index("currently viewing") < out.index("EXPANDED SKILL BODY")
+
+
+def test_latest_user_event_data_returns_latest_payload() -> None:
+    from types import SimpleNamespace
+    from surogates.harness.loop import _latest_user_event_data
+    from surogates.session.events import EventType
+
+    events = [
+        SimpleNamespace(
+            type=EventType.USER_MESSAGE.value, data={"content": "first"}, id=1,
+        ),
+        SimpleNamespace(
+            type=EventType.LLM_RESPONSE.value, data={"message": {}}, id=2,
+        ),
+        SimpleNamespace(
+            type=EventType.USER_MESSAGE.value,
+            data={
+                "content": "/skill",
+                "attachments": [{"path": "uploads/a.pdf", "filename": "a.pdf"}],
+            },
+            id=3,
+        ),
+    ]
+    data = _latest_user_event_data(events)
+    assert data["content"] == "/skill"
+    assert data["attachments"][0]["filename"] == "a.pdf"
+
+
+def test_latest_user_event_data_empty_when_no_user_event() -> None:
+    from surogates.harness.loop import _latest_user_event_data
+
+    assert _latest_user_event_data([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# build_user_message_dict: full user-message construction (text + attachment
+# notes + inlined files + image blocks). ``base_content`` overrides the
+# event's raw content (used by slash-skill / deep-research rewrite paths) so
+# the current turn's attachments AND images survive the rewrite.
+# ---------------------------------------------------------------------------
+
+
+def test_build_user_message_dict_preserves_image_blocks_with_base_content() -> None:
+    from surogates.harness.loop import build_user_message_dict
+
+    msg = build_user_message_dict(
+        {
+            "content": "/image-ocr",
+            "images": [{"data": "BASE64DATA", "mime_type": "image/jpeg"}],
+        },
+        base_content="SKILL_BODY_HERE",
+    )
+    assert msg["role"] == "user"
+    content = msg["content"]
+    # images present -> content is a multimodal blocks list, not a bare string
+    assert isinstance(content, list)
+    text_block = next(b for b in content if b.get("type") == "text")
+    assert "SKILL_BODY_HERE" in text_block["text"]
+    img_block = next(b for b in content if b.get("type") == "image_url")
+    assert img_block["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+def test_build_user_message_dict_preserves_attachments_with_base_content() -> None:
+    from surogates.harness.loop import build_user_message_dict
+
+    msg = build_user_message_dict(
+        {
+            "content": "/pdf-skill",
+            "attachments": [
+                {
+                    "path": "uploads/r.pdf", "filename": "r.pdf",
+                    "inlined_text": "INLINE BODY", "inlined_render_kind": "markdown",
+                }
+            ],
+        },
+        base_content="SKILL_BODY_HERE",
+    )
+    assert msg["role"] == "user"
+    # no images -> plain string content
+    assert isinstance(msg["content"], str)
+    assert "SKILL_BODY_HERE" in msg["content"]
+    assert "**Attachment: r.pdf**" in msg["content"]
+    assert "INLINE BODY" in msg["content"]
+
+
+def test_build_user_message_dict_plain_passthrough() -> None:
+    from surogates.harness.loop import build_user_message_dict
+
+    assert build_user_message_dict({"content": "just text"}) == {
+        "role": "user", "content": "just text",
+    }
+
+
+def test_build_user_message_dict_combines_attachment_and_image() -> None:
+    from surogates.harness.loop import build_user_message_dict
+
+    msg = build_user_message_dict(
+        {
+            "content": "/image-ocr",
+            "images": [{"data": "B64", "mime_type": "image/png"}],
+            "attachments": [
+                {"path": "uploads/big.pdf", "filename": "big.pdf",
+                 "mime_type": "application/pdf", "size": 9_000_000},
+            ],
+        },
+        base_content="SKILL_BODY",
+    )
+    content = msg["content"]
+    assert isinstance(content, list)
+    text_block = next(b for b in content if b.get("type") == "text")
+    assert "SKILL_BODY" in text_block["text"]
+    assert "big.pdf" in text_block["text"]  # attachments note folded into the text block
+    assert any(b.get("type") == "image_url" for b in content)


### PR DESCRIPTION
Problem
Invoking a slash skill (e.g. /pdf-skill) or /deep-research with a file or image attached made the agent act as if nothing was attached — it fell back to scanning the workspace and bound to stale files.

Root cause: on those turns the harness overwrote the rebuilt user-message content with just the rewritten body (last_user["content"] = expanded_text). But _rebuild_messages had folded the current turn's attachment note, inlined file content, and image blocks into that content, so the rewrite dropped all of it.

Fix
Extracted the per-user-message construction into a single helper build_user_message_dict(event_data, base_content=None) and routed all three call sites through it so they can't drift: _rebuild_messages (normal turns), the slash-skill path, and the /deep-research path (the rewrite paths pass their body as base_content, so the event's attachments + images are still folded in).

Verification
New unit tests for build_user_message_dict (image blocks preserved with a base body, attachments preserved, plain passthrough, combined image+attachment) plus the existing _rebuild_messages tests — 97 green. Live: /pdf-skill + PDF → agent reads the inlined PDF; /image-ocr + image → the image block now reaches the model.

Out of scope / follow-up
An image attached to a skill now reaches the model as a vision block, but OCR from a workspace file needs chat images written to the workspace (separate images-not-in-workspace work). Per-upload filename uniquification is also a separate follow-up.