### PR TITLE
Website widget: self-mounting drop-in chat UI + agentId

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,10 @@ importers:
         version: 2.1.9(@types/node@24.12.2)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   sdk/website-widget:
+    dependencies:
+      preact:
+        specifier: ^10.25.4
+        version: 10.29.2
     devDependencies:
       '@ag-ui/client':
         specifier: ^0.0.52
@@ -656,30 +660,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.100':
     resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
     resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.100':
     resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.100':
     resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
     resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
@@ -1498,36 +1507,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -1592,66 +1607,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1796,24 +1824,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -2859,24 +2891,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3265,6 +3301,9 @@ packages:
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
@@ -7204,6 +7243,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact@10.29.2: {}
 
   property-information@7.1.0: {}
 

--- a/sdk/website-widget/README.md
+++ b/sdk/website-widget/README.md
@@ -46,29 +46,57 @@ pnpm add @invergent/website-widget @ag-ui/client @ag-ui/core rxjs
 
 `@ag-ui/client`, `@ag-ui/core`, and `rxjs` are **peer dependencies** -- they likely already exist in your app's bundle (especially if you're using CopilotKit or another AG-UI consumer), so we don't duplicate them.
 
-### CDN / `<script>` tag
+### Drop-in widget (`<script>` tag)
 
-For plain HTML sites without a bundler, use the IIFE build from a CDN. It bundles AG-UI and RxJS:
+For plain HTML sites without a bundler, load the IIFE build from a CDN and
+call `mount()`. One call renders a complete, self-contained chat widget — a
+floating launcher button that opens a streaming chat panel, fully isolated in
+a Shadow DOM so it can't collide with your site's CSS. The bundle includes
+AG-UI, RxJS, and the UI:
 
 ```html
-<script src="https://cdn.surogates.com/widget/v1/surogates-widget.global.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@invergent/website-widget@2/dist/surogates-widget.global.js"></script>
 <script>
-  const agent = new SurogatesWidget.WebsiteAgent({
+  SurogatesWidget.mount({
     apiUrl: 'https://agent.acme.com',
     publishableKey: 'surg_wk_...',
+    // Optional appearance:
+    // title: 'Acme Support',
+    // accentColor: '#4f46e5',
+    // welcomeMessage: 'Hi! How can I help?',
+    // position: 'bottom-right',
   });
-
-  agent.subscribe({
-    onTextMessageContentEvent: ({ event }) => document.body.append(event.delta),
-    onRunFinishedEvent: () => console.log('done'),
-  });
-
-  agent.addMessage({ role: 'user', content: 'hello' });
-  agent.runAgent();
 </script>
 ```
 
-The IIFE exposes `WebsiteAgent`, `EventType`, `AbstractAgent`, the error classes, and the `Translator` on `window.SurogatesWidget`.
+`mount(config)` returns a `WidgetHandle` — `{ open(), close(), toggle(),
+destroy(), agent }` — for programmatic control.
+
+| Option | Type | Notes |
+|---|---|---|
+| `apiUrl` | string, required | Base URL of the Surogates API. |
+| `publishableKey` | string, required | `surg_wk_...` key. Safe to embed in browser JS. |
+| `title` | string | Header label. Defaults to the deployed agent's name. |
+| `accentColor` | string | Brand colour (hex) for the launcher/header/bubbles. |
+| `welcomeMessage` | string | Greeting shown before the first turn (Markdown). |
+| `position` | `'bottom-right'` \| `'bottom-left'` | Launcher corner. Default `bottom-right`. |
+| `target` | `HTMLElement` | Host element. Defaults to `document.body`. |
+| `inline` | boolean | Render the panel inline (no floating launcher). |
+| `openByDefault` | boolean | Open the panel on load. |
+
+The IIFE also exposes the headless `WebsiteAgent`, `EventType`,
+`AbstractAgent`, the error classes, and the `Translator` on
+`window.SurogatesWidget` for hosts that want to build their own UI.
+
+#### Bundler consumers
+
+If you build your own React/Vue app, import the headless client from the
+package root, or the self-mounting UI from the `./ui` subpath:
+
+```ts
+import { mount } from '@invergent/website-widget/ui';
+mount({ apiUrl: 'https://agent.acme.com', publishableKey: 'surg_wk_...' });
+```
 
 ## API
 
@@ -160,11 +188,15 @@ Measured on the current build:
 
 | Target | Raw | Gzipped |
 |---|---|---|
-| ESM (`dist/index.js`) | 21 KB | **6 KB** |
-| CJS (`dist/index.cjs`) | 22 KB | **6 KB** |
-| IIFE (`dist/surogates-widget.global.js`) | 285 KB | **66 KB** |
+| ESM headless (`dist/index.js` + chunk) | ~23 KB | **~6 KB** |
+| ESM widget UI (`dist/ui.js`) | 16 KB | **~5 KB** |
+| IIFE (`dist/surogates-widget.global.js`) | 178 KB | **~49 KB** |
 
-The npm/ESM numbers exclude AG-UI, RxJS, and zod (peer deps). The IIFE bundles everything for script-tag users.
+The npm headless numbers exclude AG-UI, RxJS, and zod (peer deps); the headless
+entry stays Preact-free. The `./ui` build bundles Preact (peers still external).
+The IIFE bundles everything (AG-UI + RxJS + Preact + UI) for script-tag users and
+is built with `platform: 'browser'` so transitive deps resolve to their
+Web-Crypto variants rather than Node's `require('crypto')`.
 
 ## Versioning
 

--- a/sdk/website-widget/package.json
+++ b/sdk/website-widget/package.json
@@ -32,6 +32,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./ui": {
+      "types": "./dist/ui.d.ts",
+      "import": "./dist/ui.js",
+      "require": "./dist/ui.cjs"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -50,6 +55,9 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "pnpm run typecheck && pnpm run build"
+  },
+  "dependencies": {
+    "preact": "^10.25.4"
   },
   "peerDependencies": {
     "@ag-ui/client": "^0.0.52",

--- a/sdk/website-widget/src/agent.ts
+++ b/sdk/website-widget/src/agent.ts
@@ -119,7 +119,11 @@ export class WebsiteAgent extends AbstractAgent {
    */
   async ensureBootstrapped(): Promise<BootstrapResult> {
     if (this.bootstrapResult) return this.bootstrapResult;
-    this.bootstrapResult = await bootstrap(this.apiUrl, this.publishableKey);
+    this.bootstrapResult = await bootstrap(
+      this.apiUrl,
+      this.publishableKey,
+      this.agentId,
+    );
     return this.bootstrapResult;
   }
 
@@ -136,7 +140,7 @@ export class WebsiteAgent extends AbstractAgent {
     if (!current) return;
     this.bootstrapResult = undefined;
     this.cursor = 0;
-    await endSession(this.apiUrl, current.sessionId, current.csrfToken);
+    await endSession(this.apiUrl, current.sessionId, current.csrfToken, this.agentId);
   }
 
   /**
@@ -275,7 +279,7 @@ export class WebsiteAgent extends AbstractAgent {
     input: RunAgentInput,
   ): void {
     closeEventSource(ctx.source);
-    const source = openEventStream(this.apiUrl, sessionId, after);
+    const source = openEventStream(this.apiUrl, sessionId, after, this.agentId);
     ctx.source = source;
     this.attachStreamListeners(source, translator, subscriber, input, ctx);
   }
@@ -298,7 +302,7 @@ export class WebsiteAgent extends AbstractAgent {
     onRebootstrap: (fresh: BootstrapResult) => void,
   ): Promise<void> {
     try {
-      await sendMessage(this.apiUrl, boot.sessionId, boot.csrfToken, content);
+      await sendMessage(this.apiUrl, boot.sessionId, boot.csrfToken, content, this.agentId);
       return;
     } catch (err) {
       if (!(err instanceof SurogatesAuthError)) throw err;
@@ -306,7 +310,7 @@ export class WebsiteAgent extends AbstractAgent {
       this.cursor = 0;
       const fresh = await this.ensureBootstrapped();
       onRebootstrap(fresh);
-      await sendMessage(this.apiUrl, fresh.sessionId, fresh.csrfToken, content);
+      await sendMessage(this.apiUrl, fresh.sessionId, fresh.csrfToken, content, this.agentId);
     }
   }
 

--- a/sdk/website-widget/src/global.ts
+++ b/sdk/website-widget/src/global.ts
@@ -1,0 +1,13 @@
+/**
+ * IIFE entry point for the ``<script>``-tag / CDN build.
+ *
+ * The npm entry (``src/index.ts``) stays headless so AG-UI consumers
+ * who only want the client keep their lean, Preact-free bundle.  This
+ * module is the IIFE-only superset: it re-exports the entire headless
+ * surface **plus** the self-mounting ``mount()`` UI, so a single
+ * ``<script>`` tag puts both ``SurogatesWidget.WebsiteAgent`` and
+ * ``SurogatesWidget.mount`` on ``window``.
+ */
+export * from './index.js';
+export { mount } from './ui/mount.js';
+export type { MountConfig, WidgetHandle, WidgetAppearance } from './ui/types.js';

--- a/sdk/website-widget/src/protocol.ts
+++ b/sdk/website-widget/src/protocol.ts
@@ -40,6 +40,27 @@ export interface BootstrapResult {
 }
 
 /**
+ * Append ``?agent_id=`` (or ``&agent_id=``) when an explicit id is set.
+ *
+ * Per-agent deployments resolve the agent from the request ``Host``
+ * subdomain on every call, so the embed never needs this.  Shared/
+ * multi-tenant runtimes (and the Studio preview) aren't reached through
+ * the per-agent host, and the server resolves the agent on *every*
+ * website request (the rate limiter depends on the agent context), not
+ * just bootstrap -- so the id must ride on all four endpoints.
+ *
+ * BRIDGE (not the long-term design): the publishable key already scopes to
+ * one agent, so the deeper fix is server-side resolution of the agent from
+ * the key (a key->agent registry), after which shared mode would need no
+ * query param at all. Until that lands, every endpoint must thread the id.
+ */
+function withAgentId(path: string, agentId?: string): string {
+  if (!agentId) return path;
+  const sep = path.includes('?') ? '&' : '?';
+  return `${path}${sep}agent_id=${encodeURIComponent(agentId)}`;
+}
+
+/**
  * Shape the website channel returns from ``POST /v1/website/sessions``.
  * Mirrors the pydantic ``BootstrapResponse`` server-side; kept separate
  * from :class:`BootstrapResult` (camelCase) so future protocol drift
@@ -119,12 +140,21 @@ async function raiseForStatus(response: Response, action: string): Promise<never
   });
 }
 
-/** ``POST /v1/website/sessions`` with a publishable key. */
+/** ``POST /v1/website/sessions`` with a publishable key.
+ *
+ * ``agentId`` is optional.  In a per-agent deployment the server resolves
+ * the agent from the request ``Host`` subdomain, so the embed never needs
+ * it.  Shared/multi-tenant runtimes (and the Studio live preview) that
+ * aren't reached through the per-agent host can pass it explicitly; it is
+ * appended as the ``?agent_id=`` query param the server's resolver accepts.
+ * Only the bootstrap needs it -- subsequent calls are cookie-bound.
+ */
 export async function bootstrap(
   apiUrl: string,
   publishableKey: string,
+  agentId?: string,
 ): Promise<BootstrapResult> {
-  const response = await doFetch(apiUrl + PATH_BOOTSTRAP, {
+  const response = await doFetch(apiUrl + withAgentId(PATH_BOOTSTRAP, agentId), {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${publishableKey}`,
@@ -161,8 +191,9 @@ export async function sendMessage(
   sessionId: string,
   csrfToken: string,
   content: string,
+  agentId?: string,
 ): Promise<{ eventId: number }> {
-  const response = await doFetch(apiUrl + PATH_MESSAGES(sessionId), {
+  const response = await doFetch(apiUrl + withAgentId(PATH_MESSAGES(sessionId), agentId), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -184,9 +215,10 @@ export async function endSession(
   apiUrl: string,
   sessionId: string,
   csrfToken: string,
+  agentId?: string,
 ): Promise<void> {
   try {
-    await doFetch(apiUrl + PATH_END(sessionId), {
+    await doFetch(apiUrl + withAgentId(PATH_END(sessionId), agentId), {
       method: 'POST',
       headers: { [CSRF_HEADER]: csrfToken },
     });
@@ -201,8 +233,9 @@ export function openEventStream(
   apiUrl: string,
   sessionId: string,
   cursor: number,
+  agentId?: string,
 ): EventSource {
-  const url = apiUrl + PATH_EVENTS(sessionId, cursor);
+  const url = apiUrl + withAgentId(PATH_EVENTS(sessionId, cursor), agentId);
   // ``withCredentials`` is the non-obvious flag that makes EventSource
   // send the session cookie cross-origin.  Without it the server sees
   // an unauthenticated request and returns 401, and the EventSource

--- a/sdk/website-widget/src/ui/markdown.ts
+++ b/sdk/website-widget/src/ui/markdown.ts
@@ -1,0 +1,106 @@
+/**
+ * Minimal, dependency-free Markdown → HTML renderer for assistant text.
+ *
+ * Assistant output is *semi-trusted* (it comes from the agent, not the
+ * visitor), but the widget renders into a Shadow DOM via
+ * ``dangerouslySetInnerHTML``, so a careless renderer would still be an
+ * XSS vector if the model ever echoed attacker-supplied HTML.  The
+ * contract here is therefore: **escape first, then re-introduce only the
+ * small, known-safe subset of HTML the formatter produces.**  No raw
+ * HTML from the source string ever survives — every ``<`` in the input
+ * is entity-escaped before any tag is emitted.
+ *
+ * Supported: fenced code blocks, inline code, bold, italic, links
+ * (http/https/mailto only), unordered + ordered lists, and paragraphs
+ * with line breaks.  Everything else degrades to escaped plain text.
+ */
+
+const ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ESCAPE_MAP[c] ?? c);
+}
+
+/** Allow only links the browser can't be tricked into executing. */
+function safeHref(raw: string): string | undefined {
+  const url = raw.trim();
+  if (/^(https?:|mailto:)/i.test(url)) return url;
+  return undefined;
+}
+
+/**
+ * Apply inline formatting to an *already HTML-escaped* fragment.  Order
+ * matters: links before emphasis so ``[a](b)`` brackets aren't eaten by
+ * the italic rule, and bold (``**``) before italic (``*``).
+ */
+function renderInline(escaped: string): string {
+  let out = escaped;
+
+  // Inline code first — its contents must not be touched by later rules.
+  // The buffer is already escaped, so the captured group is literal text.
+  out = out.replace(/`([^`]+)`/g, (_m, code: string) => `<code>${code}</code>`);
+
+  // Links: [text](href).  ``href`` is validated; bad schemes render as
+  // the original (escaped) text without an anchor.
+  out = out.replace(
+    /\[([^\]]+)\]\(([^)\s]+)\)/g,
+    (_m, text: string, href: string) => {
+      const safe = safeHref(href);
+      if (!safe) return `${text}`;
+      return `<a href="${safe}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+    },
+  );
+
+  out = out.replace(/\*\*([^*]+)\*\*/g, (_m, t: string) => `<strong>${t}</strong>`);
+  out = out.replace(/(^|[^*])\*([^*\n]+)\*/g, (_m, pre: string, t: string) => `${pre}<em>${t}</em>`);
+
+  return out;
+}
+
+/**
+ * Render ``src`` Markdown to a safe HTML string.  Splits on fenced code
+ * blocks so their bodies bypass inline formatting entirely, then groups
+ * the remaining text into list and paragraph blocks.
+ */
+export function renderMarkdown(src: string): string {
+  const parts = src.split(/```/);
+  const html: string[] = [];
+
+  parts.forEach((part, index) => {
+    const isCodeFence = index % 2 === 1;
+    if (isCodeFence) {
+      // Drop an optional language hint on the first line.
+      const body = part.replace(/^[^\n]*\n/, (m) => (part.includes('\n') ? '' : m));
+      html.push(`<pre><code>${escapeHtml(body.replace(/\n$/, ''))}</code></pre>`);
+      return;
+    }
+
+    const blocks = part.split(/\n{2,}/);
+    for (const block of blocks) {
+      const lines = block.split('\n').filter((l) => l.trim().length > 0);
+      if (lines.length === 0) continue;
+
+      const isUnordered = lines.every((l) => /^\s*[-*]\s+/.test(l));
+      const isOrdered = lines.every((l) => /^\s*\d+\.\s+/.test(l));
+      if (isUnordered || isOrdered) {
+        const items = lines
+          .map((l) => l.replace(/^\s*(?:[-*]|\d+\.)\s+/, ''))
+          .map((l) => `<li>${renderInline(escapeHtml(l))}</li>`)
+          .join('');
+        html.push(isOrdered ? `<ol>${items}</ol>` : `<ul>${items}</ul>`);
+        continue;
+      }
+
+      const paragraph = lines.map((l) => renderInline(escapeHtml(l))).join('<br>');
+      html.push(`<p>${paragraph}</p>`);
+    }
+  });
+
+  return html.join('');
+}

--- a/sdk/website-widget/src/ui/mount.tsx
+++ b/sdk/website-widget/src/ui/mount.tsx
@@ -1,0 +1,132 @@
+/**
+ * ``mount()`` — the drop-in entry point.
+ *
+ * A single call stands up a complete chat widget: it creates a host
+ * element, isolates the UI in a Shadow DOM (so neither the host page's
+ * CSS nor the widget's styles can bleed across), instantiates the
+ * headless :class:`WebsiteAgent`, and renders the Preact UI into the
+ * shadow root.  Returns an imperative :type:`WidgetHandle` for hosts
+ * that want to open/close/destroy the widget programmatically.
+ *
+ * This is what the ``<script>``-tag embed and the Studio live preview
+ * both call.  Everything cosmetic is optional; ``apiUrl`` and
+ * ``publishableKey`` are the only required fields.
+ */
+import { render } from 'preact';
+
+import { WebsiteAgent } from '../agent.js';
+import { WIDGET_STYLES } from './styles.js';
+import type { MountConfig, WidgetHandle } from './types.js';
+import { Widget } from './widget.js';
+
+export type { MountConfig, WidgetHandle, WidgetAppearance } from './types.js';
+
+const DEFAULT_ACCENT = '#4f46e5';
+
+/**
+ * Pick a readable foreground (near-black vs white) for text/icons that
+ * sit on the accent colour, using an sRGB luminance approximation.  A
+ * pale accent gets dark text; a saturated one gets white.
+ */
+function accentForeground(hex: string): string {
+  const v = hex.replace('#', '');
+  const full = v.length === 3 ? v.split('').map((c) => c + c).join('') : v;
+  if (full.length !== 6 || /[^0-9a-f]/i.test(full)) return '#ffffff';
+  const r = parseInt(full.slice(0, 2), 16);
+  const g = parseInt(full.slice(2, 4), 16);
+  const b = parseInt(full.slice(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.62 ? '#0f172a' : '#ffffff';
+}
+
+export function mount(config: MountConfig): WidgetHandle {
+  if (!config || !config.apiUrl || !config.publishableKey) {
+    throw new Error(
+      'SurogatesWidget.mount: "apiUrl" and "publishableKey" are required.',
+    );
+  }
+
+  const target = config.target ?? document.body;
+  const accent = config.accentColor ?? DEFAULT_ACCENT;
+
+  // Host element + Shadow DOM: total style isolation in both directions.
+  const host = document.createElement('div');
+  host.setAttribute('data-surogates-widget', '');
+  const shadow = host.attachShadow({ mode: 'open' });
+
+  const style = document.createElement('style');
+  style.textContent = WIDGET_STYLES;
+  shadow.appendChild(style);
+
+  const root = document.createElement('div');
+  root.className = 'surg-root';
+  shadow.appendChild(root);
+
+  // Accent drives CSS custom properties on the root, so it can be re-applied
+  // on update() without re-rendering anything else.
+  const applyAccent = (accentColor?: string) => {
+    const a = accentColor ?? DEFAULT_ACCENT;
+    root.style.setProperty('--surg-accent', a);
+    root.style.setProperty('--surg-accent-fg', accentForeground(a));
+  };
+  applyAccent(accent);
+  target.appendChild(host);
+
+  const agent = new WebsiteAgent(config);
+
+  let setOpen: ((open: boolean) => void) | undefined;
+  let isOpen = config.inline || !!config.openByDefault;
+
+  // Stable callbacks so re-rendering on update() doesn't re-fire the
+  // component's open-control / open-change effects.
+  const registerOpenControl = (fn: (open: boolean) => void) => {
+    setOpen = fn;
+  };
+  const onOpenChange = (o: boolean) => {
+    isOpen = o;
+  };
+
+  // Current config is mutable so update() can re-render appearance without
+  // tearing down the agent (no re-bootstrap, no lost conversation).
+  let current: MountConfig = config;
+  const renderWidget = () => {
+    render(
+      <Widget
+        agent={agent}
+        config={current}
+        registerOpenControl={registerOpenControl}
+        onOpenChange={onOpenChange}
+      />,
+      root,
+    );
+  };
+  renderWidget();
+
+  // Best-effort session close when the visitor navigates away.
+  const endOnUnload = () => {
+    void agent.end();
+  };
+  window.addEventListener('beforeunload', endOnUnload);
+
+  let destroyed = false;
+  return {
+    agent,
+    open: () => setOpen?.(true),
+    close: () => setOpen?.(false),
+    toggle: () => setOpen?.(!isOpen),
+    update: (partial) => {
+      if (destroyed) return;
+      current = { ...current, ...partial };
+      if ('accentColor' in partial) applyAccent(current.accentColor);
+      renderWidget();
+    },
+    destroy: () => {
+      if (destroyed) return;
+      destroyed = true;
+      window.removeEventListener('beforeunload', endOnUnload);
+      void agent.end();
+      render(null, root);
+      host.remove();
+    },
+  };
+}

--- a/sdk/website-widget/src/ui/mount.tsx
+++ b/sdk/website-widget/src/ui/mount.tsx
@@ -46,8 +46,8 @@ export function mount(config: MountConfig): WidgetHandle {
     );
   }
 
-  const target = config.target ?? document.body;
   const accent = config.accentColor ?? DEFAULT_ACCENT;
+  let destroyed = false;
 
   // Host element + Shadow DOM: total style isolation in both directions.
   const host = document.createElement('div');
@@ -70,7 +70,21 @@ export function mount(config: MountConfig): WidgetHandle {
     root.style.setProperty('--surg-accent-fg', accentForeground(a));
   };
   applyAccent(accent);
-  target.appendChild(host);
+
+  // Attach to the page. Drop-in embeds are often placed in <head>, where
+  // document.body doesn't exist yet — defer the append until the DOM is ready.
+  const attach = () => (config.target ?? document.body)?.appendChild(host);
+  if (config.target || document.body) {
+    attach();
+  } else {
+    document.addEventListener(
+      "DOMContentLoaded",
+      () => {
+        if (!destroyed) attach();
+      },
+      { once: true },
+    );
+  }
 
   const agent = new WebsiteAgent(config);
 
@@ -108,7 +122,6 @@ export function mount(config: MountConfig): WidgetHandle {
   };
   window.addEventListener('beforeunload', endOnUnload);
 
-  let destroyed = false;
   return {
     agent,
     open: () => setOpen?.(true),

--- a/sdk/website-widget/src/ui/next-action.ts
+++ b/sdk/website-widget/src/ui/next-action.ts
@@ -1,0 +1,36 @@
+/**
+ * Strip the per-turn ``<next_action>`` footer from assistant text.
+ *
+ * The harness instructs the assistant to end every final response with a
+ * ``<next_action complexity="..." summary="...">...</next_action>`` block
+ * (see ``surogates/harness/prompts/guidance/next_action.md``).  It is
+ * harness/UI metadata, not user-facing content — by design the *client*
+ * strips it: the full chat console does so in
+ * ``agent-chat-react/src/lib/next-action.ts``, and messaging channels
+ * strip it server-side.  This widget streams raw ``llm.delta`` frames, so
+ * it must strip it too or the XML footer flashes in the bubble.
+ *
+ * We only need the stripping half here (the console additionally parses
+ * the block into a status pill).  Streaming-safe: a dangling, not-yet-
+ * closed footer is hidden the moment its opener appears so partial tags
+ * never flicker.
+ */
+
+// Complete ``<next_action ...>...</next_action>`` blocks (+ trailing ws).
+const NEXT_ACTION_RE = /<next_action([^>]*)>([\s\S]*?)<\/next_action>\s*/gi;
+
+// A trailing, still-streaming footer: any prefix of the literal
+// ``<next_action`` token at the start of a line through end-of-text,
+// then everything after the whole word arrives (attributes + partial
+// body, closing tag not yet seen).  Anchored to start-of-line so a stray
+// ``<`` mid-sentence is never mistaken for the footer.
+const PARTIAL_FOOTER_RE =
+  /(?:^|\n)\s*<(?:n(?:e(?:x(?:t(?:_(?:a(?:c(?:t(?:i(?:o(?:n[\s\S]*)?)?)?)?)?)?)?)?)?)?)?$/i;
+
+/** Return *text* with every (complete or streaming-partial) footer removed. */
+export function stripNextAction(text: string): string {
+  if (!text) return text;
+  const withoutBlocks = text.replace(NEXT_ACTION_RE, '').trimEnd();
+  const match = PARTIAL_FOOTER_RE.exec(withoutBlocks);
+  return match ? withoutBlocks.slice(0, match.index).trimEnd() : withoutBlocks;
+}

--- a/sdk/website-widget/src/ui/styles.ts
+++ b/sdk/website-widget/src/ui/styles.ts
@@ -1,0 +1,222 @@
+/**
+ * Scoped CSS for the chat widget, injected into the Shadow DOM root so
+ * it can neither leak into nor be overridden by the host page.  All
+ * colours derive from two custom properties (``--surg-accent`` and its
+ * readable foreground) set at mount time from the caller's
+ * ``accentColor`` so theming is a one-line change.
+ *
+ * Returned as a string (rather than a constructable stylesheet) because
+ * a ``<style>`` element in the shadow root is the most broadly supported
+ * path across the browsers a public embed has to serve.
+ */
+export const WIDGET_STYLES = `
+:host { all: initial; }
+* { box-sizing: border-box; }
+
+.surg-root {
+  --surg-radius: 16px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #0f172a;
+}
+
+.surg-launcher {
+  position: fixed;
+  bottom: 20px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  background: var(--surg-accent);
+  color: var(--surg-accent-fg);
+  box-shadow: 0 6px 24px rgba(15, 23, 42, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  z-index: 2147483000;
+}
+.surg-launcher:hover { transform: scale(1.06); box-shadow: 0 8px 28px rgba(15, 23, 42, 0.3); }
+.surg-launcher svg { width: 26px; height: 26px; }
+.surg-pos-bottom-right { right: 20px; }
+.surg-pos-bottom-left { left: 20px; }
+
+.surg-panel {
+  position: fixed;
+  bottom: 88px;
+  width: 380px;
+  max-width: calc(100vw - 40px);
+  height: 560px;
+  max-height: calc(100vh - 120px);
+  background: #ffffff;
+  border-radius: var(--surg-radius);
+  box-shadow: 0 12px 48px rgba(15, 23, 42, 0.28);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 2147483000;
+  animation: surg-rise 0.18s ease;
+}
+@keyframes surg-rise { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+
+.surg-inline {
+  position: relative;
+  bottom: auto; right: auto; left: auto;
+  width: 100%;
+  height: 100%;
+  box-shadow: none;
+  border: 1px solid #e2e8f0;
+  animation: none;
+}
+
+.surg-header {
+  background: var(--surg-accent);
+  color: var(--surg-accent-fg);
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+.surg-header-id { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.surg-header-text { display: flex; flex-direction: column; line-height: 1.25; min-width: 0; }
+.surg-title { font-weight: 600; font-size: 15px; }
+.surg-subtitle { font-size: 11px; font-weight: 400; opacity: 0.85; }
+.surg-logo {
+  width: 32px; height: 32px; border-radius: 50%; object-fit: cover;
+  background: rgba(255, 255, 255, 0.2); flex-shrink: 0;
+}
+.surg-launcher-logo {
+  width: 32px; height: 32px; border-radius: 50%; object-fit: cover;
+}
+.surg-close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.85;
+  padding: 4px;
+  display: flex;
+  border-radius: 6px;
+}
+.surg-close:hover { opacity: 1; background: rgba(255, 255, 255, 0.18); }
+
+.surg-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: #f8fafc;
+}
+
+.surg-bubble {
+  max-width: 82%;
+  padding: 9px 13px;
+  border-radius: 14px;
+  word-wrap: break-word;
+  white-space: normal;
+}
+.surg-bubble p { margin: 0 0 8px; }
+.surg-bubble p:last-child { margin-bottom: 0; }
+.surg-bubble ul, .surg-bubble ol { margin: 4px 0; padding-left: 20px; }
+.surg-bubble code {
+  background: rgba(15, 23, 42, 0.08);
+  padding: 1px 5px;
+  border-radius: 5px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9em;
+}
+.surg-bubble pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  overflow-x: auto;
+  margin: 6px 0;
+}
+.surg-bubble pre code { background: transparent; padding: 0; color: inherit; }
+.surg-bubble a { color: var(--surg-accent); }
+
+.surg-user {
+  align-self: flex-end;
+  background: var(--surg-accent);
+  color: var(--surg-accent-fg);
+  border-bottom-right-radius: 4px;
+  white-space: pre-wrap;
+}
+.surg-user a { color: var(--surg-accent-fg); text-decoration: underline; }
+.surg-assistant {
+  align-self: flex-start;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-bottom-left-radius: 4px;
+}
+
+.surg-typing { display: flex; gap: 4px; padding: 4px 2px; }
+.surg-typing span {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: #94a3b8;
+  animation: surg-blink 1.2s infinite ease-in-out;
+}
+.surg-typing span:nth-child(2) { animation-delay: 0.2s; }
+.surg-typing span:nth-child(3) { animation-delay: 0.4s; }
+@keyframes surg-blink { 0%, 60%, 100% { opacity: 0.3; } 30% { opacity: 1; } }
+
+.surg-error {
+  margin: 0 16px;
+  padding: 8px 12px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #b91c1c;
+  border-radius: 10px;
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.surg-composer {
+  display: flex;
+  gap: 8px;
+  padding: 12px;
+  border-top: 1px solid #e2e8f0;
+  background: #ffffff;
+  flex-shrink: 0;
+}
+.surg-input {
+  flex: 1;
+  resize: none;
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  padding: 9px 12px;
+  font: inherit;
+  color: inherit;
+  max-height: 120px;
+  outline: none;
+}
+.surg-input:focus { border-color: var(--surg-accent); }
+.surg-send {
+  border: none;
+  background: var(--surg-accent);
+  color: var(--surg-accent-fg);
+  border-radius: 12px;
+  width: 40px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.surg-send:disabled { opacity: 0.5; cursor: not-allowed; }
+.surg-send svg { width: 18px; height: 18px; }
+
+.surg-powered {
+  text-align: center;
+  font-size: 11px;
+  color: #94a3b8;
+  padding: 0 0 8px;
+  background: #ffffff;
+}
+`;

--- a/sdk/website-widget/src/ui/types.ts
+++ b/sdk/website-widget/src/ui/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Public types for the self-mounting widget UI.  Kept in their own
+ * module so ``widget.tsx`` and ``mount.tsx`` share them without an
+ * import cycle, and so consumers importing from
+ * ``@invergent/website-widget/ui`` get a clean surface.
+ */
+import type { WebsiteAgent, WebsiteAgentConfig } from '../agent.js';
+
+/** Purely cosmetic, client-side options.  None of these reach the server. */
+export interface WidgetAppearance {
+  /** Header label.  Defaults to the bootstrapped ``agentName``. */
+  title?: string;
+  /** Small line under the title (e.g. "Typically replies in a minute"). */
+  subtitle?: string;
+  /**
+   * Logo/avatar shown in the header and launcher.  Any browser-loadable
+   * image URL — a public ``https://`` URL or a ``data:`` URI (so a host
+   * can inline a small logo without hosting it).  Falls back to a chat
+   * glyph when unset.
+   */
+  logoUrl?: string;
+  /** Brand colour for the launcher, header, user bubbles, and send button. */
+  accentColor?: string;
+  /** Optional greeting shown as an assistant bubble before the first turn. */
+  welcomeMessage?: string;
+  /** Which corner the floating launcher docks to.  Default ``bottom-right``. */
+  position?: 'bottom-right' | 'bottom-left';
+}
+
+/** Argument to :func:`mount`. */
+export interface MountConfig extends WebsiteAgentConfig, WidgetAppearance {
+  /** Where to attach the widget host element.  Defaults to ``document.body``. */
+  target?: HTMLElement;
+  /**
+   * Render the chat panel inline (filling ``target``) with no floating
+   * launcher.  Used by hosts that embed the chat in their own layout —
+   * e.g. the Studio live preview.
+   */
+  inline?: boolean;
+  /** Open the panel immediately on mount (ignored when ``inline``). */
+  openByDefault?: boolean;
+}
+
+/** Imperative handle returned by :func:`mount`. */
+export interface WidgetHandle {
+  /** Open the chat panel. */
+  open(): void;
+  /** Close the chat panel (no-op in ``inline`` mode). */
+  close(): void;
+  /** Toggle the chat panel. */
+  toggle(): void;
+  /**
+   * Update appearance (title/subtitle/logo/accent/welcome/position) in place,
+   * without tearing down the agent — no re-bootstrap, no lost conversation.
+   * Used by hosts with a live config editor (e.g. the Studio preview).
+   */
+  update(config: Partial<WidgetAppearance>): void;
+  /** Unmount the widget, end the session, and remove the host element. */
+  destroy(): void;
+  /** The underlying headless agent, for advanced host integrations. */
+  readonly agent: WebsiteAgent;
+}

--- a/sdk/website-widget/src/ui/widget.tsx
+++ b/sdk/website-widget/src/ui/widget.tsx
@@ -57,13 +57,16 @@ function friendlyError(err: { code?: string; message?: string } | unknown): stri
   if (err instanceof SurogatesRateLimitError) {
     return 'You’re sending messages too quickly. Please wait a moment and try again.';
   }
-  const code = (err as { code?: string }).code;
-  if (code === 'auth') {
-    return 'This chat isn’t accepting messages from this site yet. The site owner needs to allow this origin.';
+  if (err && typeof err === 'object') {
+    const code = (err as { code?: string }).code;
+    if (code === 'auth') {
+      return 'This chat isn’t accepting messages from this site yet. The site owner needs to allow this origin.';
+    }
+    if (code === 'sse_closed') return 'Connection lost. Please send your message again.';
+    const message = (err as { message?: string }).message;
+    if (message && message.length < 160) return message;
   }
-  if (code === 'sse_closed') return 'Connection lost. Please send your message again.';
-  const message = (err as { message?: string }).message;
-  return message && message.length < 160 ? message : 'Something went wrong. Please try again.';
+  return 'Something went wrong. Please try again.';
 }
 
 const ICON_CHAT = (
@@ -131,7 +134,11 @@ export function Widget({ agent, config, registerOpenControl, onOpenChange }: Wid
       .then((res) => {
         if (res.agentName) setAgentName(res.agentName);
       })
-      .catch((err) => setError(friendlyError(err)));
+      .catch((err) => {
+        // Allow a retry the next time the panel opens (transient network, etc.).
+        bootstrapStarted.current = false;
+        setError(friendlyError(err));
+      });
   }, [open, agent]);
 
   // Keep the transcript pinned to the latest message.

--- a/sdk/website-widget/src/ui/widget.tsx
+++ b/sdk/website-widget/src/ui/widget.tsx
@@ -1,0 +1,258 @@
+/**
+ * The Preact chat UI rendered inside the widget's Shadow DOM.
+ *
+ * It is a thin presentation layer over the headless :class:`WebsiteAgent`:
+ * all transport, auth, and streaming live in the agent; this component
+ * only subscribes to the AG-UI event stream, mirrors ``agent.messages``
+ * into local state, and drives ``runAgent`` from the composer.
+ */
+import { useEffect, useRef, useState } from 'preact/hooks';
+
+import type { WebsiteAgent } from '../agent.js';
+import { SurogatesAuthError, SurogatesRateLimitError } from '../errors.js';
+import { renderMarkdown } from './markdown.js';
+import { stripNextAction } from './next-action.js';
+import type { MountConfig } from './types.js';
+
+// Shown when the operator hasn't set their own. Kept friendly and
+// provider-neutral so an unconfigured widget still looks finished.
+const DEFAULT_SUBTITLE = 'Typically replies instantly';
+const DEFAULT_WELCOME = 'Hi! 👋 How can I help you today?';
+
+interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface WidgetProps {
+  agent: WebsiteAgent;
+  config: MountConfig;
+  /** Lets the imperative handle in ``mount`` drive the open/closed state. */
+  registerOpenControl: (setOpen: (open: boolean) => void) => void;
+  /** Reports open-state changes back so ``mount``'s ``toggle()`` stays in sync. */
+  onOpenChange?: (open: boolean) => void;
+}
+
+function uid(): string {
+  return `u-${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
+}
+
+/** Project ``agent.messages`` down to the renderable user/assistant turns. */
+function snapshot(messages: ReadonlyArray<{ id?: string; role?: string; content?: unknown }>): ChatMessage[] {
+  const out: ChatMessage[] = [];
+  for (const m of messages) {
+    if (m.role !== 'user' && m.role !== 'assistant') continue;
+    const content = typeof m.content === 'string' ? m.content : '';
+    out.push({ id: m.id ?? uid(), role: m.role, content });
+  }
+  return out;
+}
+
+/** Map an SDK error (thrown or via RUN_ERROR) to visitor-facing copy. */
+function friendlyError(err: { code?: string; message?: string } | unknown): string {
+  if (err instanceof SurogatesAuthError) {
+    return 'This chat isn’t accepting messages from this site yet. The site owner needs to allow this origin.';
+  }
+  if (err instanceof SurogatesRateLimitError) {
+    return 'You’re sending messages too quickly. Please wait a moment and try again.';
+  }
+  const code = (err as { code?: string }).code;
+  if (code === 'auth') {
+    return 'This chat isn’t accepting messages from this site yet. The site owner needs to allow this origin.';
+  }
+  if (code === 'sse_closed') return 'Connection lost. Please send your message again.';
+  const message = (err as { message?: string }).message;
+  return message && message.length < 160 ? message : 'Something went wrong. Please try again.';
+}
+
+const ICON_CHAT = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+  </svg>
+);
+const ICON_CLOSE = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+);
+const ICON_SEND = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="22" y1="2" x2="11" y2="13" /><polygon points="22 2 15 22 11 13 2 9 22 2" />
+  </svg>
+);
+
+export function Widget({ agent, config, registerOpenControl, onOpenChange }: WidgetProps) {
+  const inline = !!config.inline;
+  const [open, setOpen] = useState(inline || !!config.openByDefault);
+  const [messages, setMessages] = useState<ChatMessage[]>(() => snapshot(agent.messages));
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [input, setInput] = useState('');
+  // Only the async input is state; the title is derived at render so a
+  // configured title (incl. live handle.update()) always wins, falling back
+  // to the bootstrapped agent name, then a generic label.
+  const [agentName, setAgentName] = useState('');
+  const title = config.title || agentName || 'Assistant';
+
+  const listRef = useRef<HTMLDivElement>(null);
+  const bootstrapStarted = useRef(false);
+
+  // Expose the open setter to the mount() imperative handle.
+  useEffect(() => registerOpenControl(setOpen), [registerOpenControl]);
+  useEffect(() => onOpenChange?.(open), [open, onOpenChange]);
+
+  // Mirror the agent's event stream into local UI state.
+  useEffect(() => {
+    const sub = agent.subscribe({
+      onMessagesChanged: () => setMessages(snapshot(agent.messages)),
+      onRunStartedEvent: () => {
+        setRunning(true);
+        setError(null);
+      },
+      onRunFinishedEvent: () => setRunning(false),
+      onRunErrorEvent: ({ event }) => {
+        setRunning(false);
+        setError(friendlyError(event));
+      },
+    });
+    return () => sub.unsubscribe();
+  }, [agent]);
+
+  // Validate config + resolve the header title the first time the panel
+  // is opened.  Eager bootstrap on open (not page-load) means visitors
+  // who never open the chat don't create server sessions; opening is a
+  // clear intent signal and surfaces misconfiguration immediately.
+  useEffect(() => {
+    if (!open || bootstrapStarted.current) return;
+    bootstrapStarted.current = true;
+    agent
+      .ensureBootstrapped()
+      .then((res) => {
+        if (res.agentName) setAgentName(res.agentName);
+      })
+      .catch((err) => setError(friendlyError(err)));
+  }, [open, agent]);
+
+  // Keep the transcript pinned to the latest message.
+  useEffect(() => {
+    const el = listRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages, running]);
+
+  const send = () => {
+    const content = input.trim();
+    if (!content || running) return;
+    setInput('');
+    agent.addMessage({ id: uid(), role: 'user', content } as never);
+    setMessages(snapshot(agent.messages));
+    void agent.runAgent().catch(() => {
+      /* Failures surface through onRunErrorEvent; swallow the rejection. */
+    });
+  };
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  };
+
+  // An unconfigured widget always shows sensible default copy: a missing
+  // subtitle/welcome falls back to the defaults. Note Studio/the embed omit
+  // empty fields, so *clearing* the field in Studio is indistinguishable from
+  // never setting it — both show the default. There is intentionally no
+  // "show nothing" state today; if suppression is ever needed, add an explicit
+  // sentinel rather than relying on empty string.
+  const subtitle = config.subtitle ?? DEFAULT_SUBTITLE;
+  const welcomeText = config.welcomeMessage ?? DEFAULT_WELCOME;
+  const hasAssistant = messages.some((m) => m.role === 'assistant');
+  const showWelcome = !!welcomeText && !hasAssistant;
+  const showTyping = running && messages[messages.length - 1]?.role !== 'assistant';
+
+  if (!inline && !open) {
+    return (
+      <button
+        type="button"
+        class={`surg-launcher surg-pos-${config.position ?? 'bottom-right'}`}
+        aria-label="Open chat"
+        onClick={() => setOpen(true)}
+      >
+        {config.logoUrl ? (
+          <img class="surg-launcher-logo" src={config.logoUrl} alt="" />
+        ) : (
+          ICON_CHAT
+        )}
+      </button>
+    );
+  }
+
+  const panelClass = inline
+    ? 'surg-panel surg-inline'
+    : `surg-panel surg-pos-${config.position ?? 'bottom-right'}`;
+
+  return (
+    <div class={panelClass} role="dialog" aria-label={title}>
+      <div class="surg-header">
+        <div class="surg-header-id">
+          {config.logoUrl && <img class="surg-logo" src={config.logoUrl} alt="" />}
+          <div class="surg-header-text">
+            <span class="surg-title">{title}</span>
+            {subtitle && <span class="surg-subtitle">{subtitle}</span>}
+          </div>
+        </div>
+        {!inline && (
+          <button type="button" class="surg-close" aria-label="Close chat" onClick={() => setOpen(false)}>
+            {ICON_CLOSE}
+          </button>
+        )}
+      </div>
+
+      <div class="surg-messages" ref={listRef}>
+        {showWelcome && (
+          <div
+            class="surg-bubble surg-assistant"
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(welcomeText) }}
+          />
+        )}
+        {messages.map((m) =>
+          m.role === 'assistant' ? (
+            <div
+              key={m.id}
+              class="surg-bubble surg-assistant"
+              dangerouslySetInnerHTML={{ __html: renderMarkdown(stripNextAction(m.content)) }}
+            />
+          ) : (
+            <div key={m.id} class="surg-bubble surg-user">
+              {m.content}
+            </div>
+          ),
+        )}
+        {showTyping && (
+          <div class="surg-bubble surg-assistant surg-typing">
+            <span /><span /><span />
+          </div>
+        )}
+      </div>
+
+      {error && <div class="surg-error">{error}</div>}
+
+      <div class="surg-composer">
+        <textarea
+          class="surg-input"
+          rows={1}
+          placeholder="Type a message…"
+          value={input}
+          disabled={running}
+          onInput={(e) => setInput((e.target as HTMLTextAreaElement).value)}
+          onKeyDown={onKeyDown}
+        />
+        <button type="button" class="surg-send" aria-label="Send" disabled={running || !input.trim()} onClick={send}>
+          {ICON_SEND}
+        </button>
+      </div>
+      <div class="surg-powered">Powered by Surogate</div>
+    </div>
+  );
+}

--- a/sdk/website-widget/tests/mount.test.ts
+++ b/sdk/website-widget/tests/mount.test.ts
@@ -1,0 +1,232 @@
+/**
+ * UI smoke tests for :func:`mount` — the self-mounting widget.
+ *
+ * These exercise the real :class:`WebsiteAgent` (with ``fetch`` +
+ * ``EventSource`` stubbed exactly as in ``agent.test.ts``) rendered
+ * through the Preact UI in a happy-dom Shadow DOM.  They lock down the
+ * three things a "drop a script tag" embed has to get right: the host
+ * element + shadow root materialise, the panel opens, and a sent
+ * message round-trips into a streamed assistant bubble.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SURG_EVENT } from '../src/constants.js';
+import { mount } from '../src/ui/mount.js';
+
+// --- Test doubles (mirrors agent.test.ts) ----------------------------------
+
+class FakeEventSource {
+  static lastInstance: FakeEventSource | undefined;
+  readonly url: string;
+  readyState = 1;
+  onerror: ((ev: Event) => void) | null = null;
+  private readonly listeners = new Map<string, Set<(ev: MessageEvent) => void>>();
+
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.lastInstance = this;
+  }
+  addEventListener(type: string, fn: (ev: MessageEvent) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) this.listeners.set(type, (set = new Set()));
+    set.add(fn);
+  }
+  removeEventListener(type: string, fn: (ev: MessageEvent) => void): void {
+    this.listeners.get(type)?.delete(fn);
+  }
+  close(): void {
+    this.readyState = 2;
+  }
+  emit(eventName: string, data: unknown, id: number): void {
+    if (this.readyState === 2) return;
+    const set = this.listeners.get(eventName);
+    if (!set) return;
+    const ev = new MessageEvent(eventName, { data: JSON.stringify(data), lastEventId: String(id) });
+    for (const fn of Array.from(set)) fn(ev);
+  }
+  static reset(): void {
+    FakeEventSource.lastInstance = undefined;
+  }
+}
+
+function makeResponse(status: number, body: unknown): Response {
+  return new Response(typeof body === 'string' ? body : JSON.stringify(body), { status });
+}
+
+/** Bootstrap-then-send fetch stub: 201 on bootstrap, 202 on messages. */
+function happyFetch() {
+  return vi.fn(async (url: unknown, init: RequestInit | undefined) => {
+    if (init?.method === 'POST' && !String(url).includes('/messages')) {
+      return makeResponse(201, {
+        session_id: 'sess-1',
+        csrf_token: 'csrf-1',
+        expires_at: Date.now() / 1000 + 3600,
+        agent_name: 'Acme Support',
+      });
+    }
+    return makeResponse(202, { event_id: 1 });
+  }) as unknown as typeof fetch;
+}
+
+async function waitFor(predicate: () => boolean, attempts = 200): Promise<void> {
+  for (let i = 0; i < attempts; i++) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  throw new Error('waitFor predicate never became true');
+}
+
+const originalFetch = globalThis.fetch;
+const originalEventSource = globalThis.EventSource;
+
+beforeEach(() => {
+  FakeEventSource.reset();
+  document.body.innerHTML = '';
+  (globalThis as unknown as { EventSource: typeof FakeEventSource }).EventSource = FakeEventSource;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  (globalThis as unknown as { EventSource: typeof EventSource }).EventSource = originalEventSource;
+});
+
+function shadowOf(): ShadowRoot {
+  const host = document.querySelector('[data-surogates-widget]');
+  if (!host || !(host as HTMLElement & { shadowRoot: ShadowRoot | null }).shadowRoot) {
+    throw new Error('widget host / shadow root not found');
+  }
+  return (host as HTMLElement).shadowRoot as ShadowRoot;
+}
+
+// --- Tests ------------------------------------------------------------------
+
+describe('mount() — config + lifecycle', () => {
+  it('requires apiUrl and publishableKey', () => {
+    expect(() => mount({ apiUrl: '', publishableKey: 'surg_wk_x' })).toThrow(/required/);
+    expect(() => mount({ apiUrl: 'https://a.test', publishableKey: '' })).toThrow(/required/);
+  });
+
+  it('renders a launcher (closed) by default, opens on click', async () => {
+    globalThis.fetch = happyFetch();
+    const handle = mount({ apiUrl: 'https://a.test', publishableKey: 'surg_wk_x' });
+
+    const sr = shadowOf();
+    expect(sr.querySelector('.surg-launcher')).toBeTruthy();
+    expect(sr.querySelector('.surg-panel')).toBeNull();
+
+    (sr.querySelector('.surg-launcher') as HTMLButtonElement).click();
+    await waitFor(() => !!sr.querySelector('.surg-panel'));
+    expect(sr.querySelector('.surg-panel')).toBeTruthy();
+    handle.destroy();
+  });
+
+  it('inline mode renders the panel immediately with no launcher', () => {
+    globalThis.fetch = happyFetch();
+    const handle = mount({ apiUrl: 'https://a.test', publishableKey: 'surg_wk_x', inline: true });
+    const sr = shadowOf();
+    expect(sr.querySelector('.surg-launcher')).toBeNull();
+    expect(sr.querySelector('.surg-panel')).toBeTruthy();
+    handle.destroy();
+  });
+
+  it('applies accent colour and renders the welcome message as markdown', () => {
+    globalThis.fetch = happyFetch();
+    const handle = mount({
+      apiUrl: 'https://a.test',
+      publishableKey: 'surg_wk_x',
+      inline: true,
+      accentColor: '#0ea5e9',
+      welcomeMessage: 'Hi! **Ask me** anything.',
+    });
+    const sr = shadowOf();
+    const root = sr.querySelector('.surg-root') as HTMLElement;
+    expect(root.style.getPropertyValue('--surg-accent')).toBe('#0ea5e9');
+    expect(sr.querySelector('.surg-assistant strong')?.textContent).toBe('Ask me');
+    expect(sr.querySelector('.surg-powered')?.textContent).toBe('Powered by Surogate');
+    handle.destroy();
+  });
+
+  it('renders a logo + subtitle when provided', () => {
+    globalThis.fetch = happyFetch();
+    const handle = mount({
+      apiUrl: 'https://a.test',
+      publishableKey: 'surg_wk_x',
+      inline: true,
+      title: 'Acme',
+      subtitle: 'Replies in a minute',
+      logoUrl: 'data:image/png;base64,iVBORw0KGgo=',
+    });
+    const sr = shadowOf();
+    const logo = sr.querySelector('.surg-logo') as HTMLImageElement | null;
+    expect(logo?.getAttribute('src')).toBe('data:image/png;base64,iVBORw0KGgo=');
+    expect(sr.querySelector('.surg-subtitle')?.textContent).toBe('Replies in a minute');
+    handle.destroy();
+  });
+
+  it('shows default subtitle + welcome when not configured', () => {
+    globalThis.fetch = happyFetch();
+    const handle = mount({ apiUrl: 'https://a.test', publishableKey: 'surg_wk_x', inline: true });
+    const sr = shadowOf();
+    expect(sr.querySelector('.surg-subtitle')?.textContent).toBe('Typically replies instantly');
+    expect(sr.querySelector('.surg-assistant')?.textContent).toContain('How can I help you today');
+    handle.destroy();
+  });
+
+  it('update() changes appearance in place without re-mounting', async () => {
+    globalThis.fetch = happyFetch();
+    const handle = mount({ apiUrl: 'https://a.test', publishableKey: 'surg_wk_x', inline: true, title: 'Old' });
+    const sr = shadowOf();
+    expect(sr.querySelector('.surg-title')?.textContent).toBe('Old');
+    handle.update({ title: 'New Co', accentColor: '#123456', subtitle: 'Here to help' });
+    const root = sr.querySelector('.surg-root') as HTMLElement;
+    // Subtitle + accent are direct reads — apply on the synchronous re-render.
+    expect(sr.querySelector('.surg-subtitle')?.textContent).toBe('Here to help');
+    expect(root.style.getPropertyValue('--surg-accent')).toBe('#123456');
+    // Title is synced via an effect — settles on the next tick.
+    await waitFor(() => sr.querySelector('.surg-title')?.textContent === 'New Co');
+    // Same host element — not torn down and recreated.
+    expect(document.querySelectorAll('[data-surogates-widget]').length).toBe(1);
+    handle.destroy();
+  });
+
+  it('destroy() removes the host element', () => {
+    globalThis.fetch = happyFetch();
+    const handle = mount({ apiUrl: 'https://a.test', publishableKey: 'surg_wk_x', inline: true });
+    expect(document.querySelector('[data-surogates-widget]')).toBeTruthy();
+    handle.destroy();
+    expect(document.querySelector('[data-surogates-widget]')).toBeNull();
+  });
+});
+
+describe('mount() — send and stream', () => {
+  it('sends a message and renders the streamed assistant reply', async () => {
+    globalThis.fetch = happyFetch();
+    const handle = mount({ apiUrl: 'https://a.test', publishableKey: 'surg_wk_x', inline: true });
+    const sr = shadowOf();
+
+    const input = sr.querySelector('.surg-input') as HTMLTextAreaElement;
+    input.value = 'How do I reset my password?';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    // The send button is disabled until the input-state rerender lands;
+    // wait for it to enable so the click isn't dropped on a disabled button.
+    const sendBtn = sr.querySelector('.surg-send') as HTMLButtonElement;
+    await waitFor(() => !sendBtn.disabled);
+    sendBtn.click();
+
+    // User bubble echoes immediately.
+    await waitFor(() => !!sr.querySelector('.surg-user'));
+    expect(sr.querySelector('.surg-user')?.textContent).toContain('reset my password');
+
+    // The agent opens an SSE stream for the run; drive a minimal turn.
+    await waitFor(() => FakeEventSource.lastInstance !== undefined);
+    const src = FakeEventSource.lastInstance as FakeEventSource;
+    src.emit(SURG_EVENT.LLM_DELTA, { delta: 'Click ' }, 1);
+    src.emit(SURG_EVENT.LLM_DELTA, { delta: '“Forgot password”.' }, 2);
+    src.emit(SURG_EVENT.LLM_RESPONSE, { content: 'Click “Forgot password”.', finish_reason: 'stop' }, 3);
+
+    await waitFor(() => /Forgot password/.test(sr.querySelector('.surg-assistant')?.textContent ?? ''));
+    expect(sr.querySelector('.surg-assistant')?.textContent).toContain('Forgot password');
+    handle.destroy();
+  });
+});

--- a/sdk/website-widget/tests/next-action.test.ts
+++ b/sdk/website-widget/tests/next-action.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { stripNextAction } from '../src/ui/next-action.js';
+
+describe('stripNextAction', () => {
+  it('removes a complete footer block', () => {
+    const text =
+      'Hello! How can I help you today?\n\n<next_action complexity="low" summary="hide">\ndone\n</next_action>';
+    expect(stripNextAction(text)).toBe('Hello! How can I help you today?');
+  });
+
+  it('removes multiple blocks', () => {
+    const text =
+      'First answer.\n<next_action complexity="low">x</next_action>\nMore.\n<next_action summary="show">y</next_action>';
+    const out = stripNextAction(text);
+    expect(out).not.toContain('next_action');
+    expect(out).toContain('First answer.');
+    expect(out).toContain('More.');
+  });
+
+  it('hides a streaming partial footer (opener only, no close yet)', () => {
+    expect(stripNextAction('All set.\n<next_action complexity="low"')).toBe('All set.');
+    expect(stripNextAction('All set.\n<next_a')).toBe('All set.');
+    expect(stripNextAction('All set.\n<')).toBe('All set.');
+  });
+
+  it('leaves ordinary text and mid-sentence < untouched', () => {
+    expect(stripNextAction('2 < 3 and 5 > 4')).toBe('2 < 3 and 5 > 4');
+    expect(stripNextAction('Hello there')).toBe('Hello there');
+  });
+
+  it('handles empty input', () => {
+    expect(stripNextAction('')).toBe('');
+  });
+});

--- a/sdk/website-widget/tsconfig.json
+++ b/sdk/website-widget/tsconfig.json
@@ -4,6 +4,8 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,

--- a/sdk/website-widget/tsup.config.ts
+++ b/sdk/website-widget/tsup.config.ts
@@ -1,21 +1,25 @@
 import { defineConfig } from 'tsup';
 
-// Two build targets, each with a different dependency strategy.
+// Three build targets, each with a different dependency strategy.
 //
-// * **npm/ESM+CJS** — AG-UI, RxJS, and friends are ``peerDependencies``
-//   on the consumer's end, so we mark them ``external``.  Application
-//   bundlers (Vite, webpack, Next) dedupe them against the consumer's
-//   own copies and our package stays <5 KB of glue.
+// * **npm/ESM+CJS (headless)** — ``index`` exports only the AG-UI
+//   ``WebsiteAgent``.  AG-UI, RxJS, and friends are ``peerDependencies``
+//   on the consumer's end, so we mark them ``external``; application
+//   bundlers dedupe them and the headless package stays ~6 KB of glue.
+//   Preact is *not* imported by this entry, so it never lands here.
+//
+// * **npm/ESM+CJS (``ui`` subpath)** — the self-mounting widget.  Preact
+//   is bundled (not external) so bundler consumers don't have to install
+//   it; AG-UI stays external like the headless entry.
 //
 // * **IIFE (CDN)** — ``<script>`` users can't run ``npm install``, so we
-//   bundle AG-UI and RxJS right into the IIFE and expose the whole kit
-//   on ``window.SurogatesWidget``.  This is the "drop a tag into your
-//   CMS" path; expect ~80 KB gzipped.
+//   bundle everything (AG-UI + RxJS + Preact + the UI) and expose
+//   ``WebsiteAgent`` *and* ``mount`` on ``window.SurogatesWidget``.
 const externalPeers = ['@ag-ui/client', '@ag-ui/core', 'rxjs'];
 
 export default defineConfig([
   {
-    entry: { index: 'src/index.ts' },
+    entry: { index: 'src/index.ts', ui: 'src/ui/mount.tsx' },
     format: ['esm', 'cjs'],
     dts: true,
     sourcemap: true,
@@ -26,7 +30,7 @@ export default defineConfig([
     external: externalPeers,
   },
   {
-    entry: { 'surogates-widget': 'src/index.ts' },
+    entry: { 'surogates-widget': 'src/global.ts' },
     format: ['iife'],
     globalName: 'SurogatesWidget',
     sourcemap: true,
@@ -34,6 +38,12 @@ export default defineConfig([
     minify: true,
     target: 'es2020',
     outDir: 'dist',
-    // Deliberately no ``external`` -- AG-UI + RxJS bake into the IIFE.
+    // ``platform: 'browser'`` is load-bearing: transitive deps (uuid,
+    // nanoid via AG-UI) ship CJS variants that ``require('crypto')`` at
+    // module-eval time.  Under the default node platform esbuild bundles
+    // those, and the IIFE throws "Dynamic require of crypto" on load in
+    // a real browser.  Browser resolution picks their Web-Crypto builds.
+    platform: 'browser',
+    // Deliberately no ``external`` -- AG-UI + RxJS + Preact bake in.
   },
 ]);


### PR DESCRIPTION
## What

Turns `@invergent/website-widget` from a headless AG-UI client into a real drop-in chat widget: a single `<script>` + `SurogatesWidget.mount({ apiUrl, publishableKey, ...appearance })` renders a floating chat bubble (Preact, isolated in a Shadow DOM) wrapping the existing `WebsiteAgent`.

## Highlights

- **`mount()` UI** with launcher → streaming chat panel; appearance: `title`/`subtitle`/`logoUrl`/`welcomeMessage`/`accentColor`/`position`, with sensible defaults. `handle.update()` applies look changes in place (no re-bootstrap).
- **Headless stays lean:** the npm `.` entry is unchanged (Preact only in the new `./ui` subpath and the IIFE); `src/global.ts` is the IIFE entry exposing both `WebsiteAgent` and `mount`.
- **IIFE crypto fix:** built with `platform:'browser'` so transitive deps (uuid/nanoid) resolve to their Web-Crypto builds — the previously published IIFE crashed on load with `Dynamic require of "crypto"`.
- **`<next_action>` footer** stripped client-side (mirrors `agent-chat-react`).
- **`agentId`** is threaded as `?agent_id=` onto every website call so shared runtimes / the Studio preview (not reached via the per-agent Host) resolve the agent. Documented as a bridge; the deeper fix is server-side key→agent resolution.

## Tests
45 unit tests (added `mount()` + `next-action` strip coverage); typecheck clean; verified end-to-end in a real browser against a live agent.

## Rollout
`mount()` is additive (minor bump). After this merges, tag a release so jsdelivr `@2` serves the fixed build — the current published `2.7.x` lacks `mount()` and crashes on load. The companion **surogate-ops** PR points the Studio embed at this widget.