### PR TITLE
fix(harness): keep browser alive across turns within a session

### DIFF
--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -537,14 +537,12 @@ class ArtifactCompletionMixin:
             except Exception:
                 logger.debug("Sandbox cleanup failed for %s", session.id, exc_info=True)
 
-        # Close any browser session the agent opened this turn. Best
-        # effort — a leaked browser pod is worse than a failed cleanup,
-        # so swallow errors and never block completion on it.
-        if self._browser_pool is not None:
-            try:
-                await self._browser_pool.destroy_for_session(str(session.id))
-            except Exception:
-                logger.debug("Browser cleanup failed for %s", session.id, exc_info=True)
+        # The browser is intentionally NOT torn down here. A turn end is
+        # not a session end: an agent driving a multi-step browser flow
+        # (e.g. logging into a site across several user interactions)
+        # needs cookies and page state to survive between turns. The
+        # browser persists in the session-keyed pool and is reclaimed on
+        # reprovision, explicit browser_close, or worker shutdown.
 
         # Notify memory manager of session end.
         if self._memory_manager is not None:

--- a/tests/test_turn_summary_emit.py
+++ b/tests/test_turn_summary_emit.py
@@ -409,68 +409,25 @@ async def test_complete_session_skips_drain_without_summarizer() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _complete_session closes the session's browser, like the sandbox
+# _complete_session must NOT close the session's browser. A turn end is
+# not a session end — the browser persists so cookies and page state
+# survive across turns (e.g. a multi-step login driven over several
+# user interactions).
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_complete_session_closes_browser() -> None:
+async def test_complete_session_keeps_browser_alive() -> None:
     store = AsyncMock()
     store.emit_event = AsyncMock()
     store.get_events = AsyncMock(return_value=[])
     store.update_session_status = AsyncMock()
     harness = _make_loop_harness(session_store=store, turn_summarizer=None)
     harness._browser_pool = AsyncMock()
-
-    session = await _call_complete_session(
-        harness, reason="completed", turn_id="t-1",
-    )
-
-    harness._browser_pool.destroy_for_session.assert_awaited_once_with(
-        str(session.id),
-    )
-
-
-@pytest.mark.asyncio
-async def test_complete_session_closes_browser_on_failure_reason() -> None:
-    """A leaked browser pod is worse than a failed turn — cleanup must
-    run regardless of the completion reason, not just on success."""
-    store = AsyncMock()
-    store.emit_event = AsyncMock()
-    store.get_events = AsyncMock(return_value=[])
-    store.update_session_status = AsyncMock()
-    harness = _make_loop_harness(session_store=store, turn_summarizer=None)
-    harness._browser_pool = AsyncMock()
-
-    session = await _call_complete_session(
-        harness, reason="invalid_tool_calls", turn_id="t-1",
-    )
-
-    harness._browser_pool.destroy_for_session.assert_awaited_once_with(
-        str(session.id),
-    )
-
-
-@pytest.mark.asyncio
-async def test_complete_session_swallows_browser_cleanup_error() -> None:
-    """Browser cleanup is best effort — a backend failure must not
-    abort completion (SESSION_COMPLETE still emitted)."""
-    store = AsyncMock()
-    store.emit_event = AsyncMock()
-    store.get_events = AsyncMock(return_value=[])
-    store.update_session_status = AsyncMock()
-    harness = _make_loop_harness(session_store=store, turn_summarizer=None)
-    harness._browser_pool = AsyncMock()
-    harness._browser_pool.destroy_for_session = AsyncMock(
-        side_effect=RuntimeError("backend down"),
-    )
 
     await _call_complete_session(harness, reason="completed", turn_id="t-1")
 
-    assert any(
-        c.args[1] == EventType.SESSION_COMPLETE
-        for c in store.emit_event.await_args_list
-    )
+    harness._browser_pool.destroy_for_session.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
_complete_session destroyed the session's browser on every turn end, which wiped cookies and page state between interactions. A multi-step browser flow (e.g. logging into LinkedIn across several user messages) got a fresh blank browser each turn and could never persist a login.

A turn end is not a session end. Stop tearing the browser down here; it lives in the session-keyed pool and is reclaimed on reprovision, explicit browser_close, or worker shutdown. Update tests accordingly.