### PR TITLE
feat(sdk): redesign composer slash menu popover to match Figma

### DIFF
--- a/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
@@ -20,6 +20,7 @@ import {
   PlusIcon,
   SparklesIcon,
   TerminalIcon,
+  type LucideIcon,
 } from "lucide-react";
 import type { PromptInputMessage } from "../ai-elements/prompt-input";
 import { useProviderAttachments } from "../ai-elements/prompt-input";
@@ -70,12 +71,13 @@ import {
 } from "../ui/popover";
 import {
   Command,
-  CommandEmpty,
-  CommandInput,
   CommandItem,
   CommandList,
 } from "../ui/command";
-import { Skeleton } from "../ui/skeleton";
+import {
+  ComposerCommandMenu,
+  type ComposerMenuMode,
+} from "./composer-command-menu";
 
 // ── Slash command entry ──────────────────────────────────────────────
 
@@ -225,6 +227,35 @@ function formatBytes(n?: number): string {
   return `${n} B`;
 }
 
+// ── Expert-mode menu trigger ─────────────────────────────────────────
+//
+// The three buttons that open the slash menu in a pre-selected scope are
+// identical bar their icon, label and target mode, so they share one
+// presentational button.
+
+function ComposerMenuButton({
+  icon: Icon,
+  label,
+  onClick,
+}: {
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      size="sm"
+      className="rounded-sm -uppercase font-display bg-white dark:bg-accent border-2 border-accent cursor-pointer"
+      onClick={onClick}
+    >
+      <Icon />
+      {label}
+    </Button>
+  );
+}
+
 function AttachmentPreviewStrip() {
   const attachments = useProviderAttachments();
   if (attachments.files.length === 0) return null;
@@ -343,9 +374,7 @@ function ChatComposerInner({
   const [adapterCommands, setAdapterCommands] = useState<SlashCommand[]>([]);
   const [skillsLoading, setSkillsLoading] = useState(false);
   const [buttonMenuOpen, setButtonMenuOpen] = useState(false);
-  const [menuMode, setMenuMode] = useState<
-    "commands" | "skills" | "scheduled" | "all"
-  >("all");
+  const [menuMode, setMenuMode] = useState<ComposerMenuMode>("all");
   const [addMenuOpen, setAddMenuOpen] = useState(false);
   const [menuDismissed, setMenuDismissed] = useState(false);
   const showSlashMenu = !menuDismissed && (textInput.value.startsWith("/") || buttonMenuOpen);
@@ -532,6 +561,12 @@ function ChatComposerInner({
     });
   }, []);
 
+  const openMenu = useCallback((mode: ComposerMenuMode) => {
+    setMenuMode(mode);
+    setMenuDismissed(false);
+    setButtonMenuOpen(true);
+  }, []);
+
   const handleCommandSelect = useCallback(
     (commandValue: string) => {
       textInput.setInput(`${commandValue} `);
@@ -657,49 +692,22 @@ function ChatComposerInner({
       <AttachmentPreviewStrip />
       {viewMode === "expert" && !disabled && (
         <div className="flex flex-wrap items-center justify-end gap-2 px-1 pb-2">
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            className="rounded-sm -uppercase font-display bg-white dark:bg-accent border-2 border-accent cursor-pointer"
-            onClick={() => {
-              setMenuMode("commands");
-              setMenuDismissed(false);
-              setButtonMenuOpen(true);
-            }}
-          >
-            <TerminalIcon />
-            Commands
-          </Button>
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            className="rounded-sm -uppercase font-display bg-white dark:bg-accent border-2 border-accent cursor-pointer"
-            onClick={() => {
-              setMenuMode("skills");
-              setMenuDismissed(false);
-              setButtonMenuOpen(true);
-            }}
-          >
-            <SparklesIcon />
-            Skills
-          </Button>
+          <ComposerMenuButton
+            icon={TerminalIcon}
+            label="Commands"
+            onClick={() => openMenu("commands")}
+          />
+          <ComposerMenuButton
+            icon={SparklesIcon}
+            label="Skills"
+            onClick={() => openMenu("skills")}
+          />
           {loopsEnabled && (
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              className="rounded-sm -uppercase font-display bg-white dark:bg-accent border-2 border-accent cursor-pointer"
-              onClick={() => {
-                setMenuMode("scheduled");
-                setMenuDismissed(false);
-                setButtonMenuOpen(true);
-              }}
-            >
-              <ClockIcon />
-              Scheduled Tasks
-            </Button>
+            <ComposerMenuButton
+              icon={ClockIcon}
+              label="Scheduled Tasks"
+              onClick={() => openMenu("scheduled")}
+            />
           )}
         </div>
       )}
@@ -926,163 +934,17 @@ function ChatComposerInner({
           </PromptInputFooter>
         </PromptInput>
       </PopoverAnchor>
-      <PopoverContent
-        side="top"
-        align="start"
-        className="overflow-hidden rounded-xl p-0"
-        style={{ width: "var(--radix-popover-trigger-width)" }}
-        onCloseAutoFocus={(e) => e.preventDefault()}
-        onEscapeKeyDown={() => {
-          // Escape is the canonical "back out of the popup, keep
-          // typing in the chat" gesture.  Click-outside is
-          // deliberately NOT routed here — if the user clicked some
-          // other widget on the page they expect focus to land
-          // wherever they clicked, not snap back to the textarea.
-          focusTextareaAtEnd();
-        }}
-      >
-        {/*
-          Native shadcn / cmdk command palette: the CommandInput owns
-          focus while the popup is open, cmdk runs the filter
-          (matching ``value`` plus the ``keywords`` we pass per item,
-          so descriptions count toward matches), and cmdk handles
-          arrow keys / Enter / scroll-into-view itself.  The CommandInput
-          mirrors the textarea so the chat input still reflects the
-          query and sending the message still works the same way.
-        */}
-        <Command>
-          {menuMode === "skills" ? (
-            <CommandInput placeholder="Search skills..." />
-          ) : menuMode === "scheduled" ? (
-            <CommandInput placeholder="Search scheduled tasks..." />
-          ) : (
-            <CommandInput
-              placeholder="Type a command or search..."
-              value={searchQuery}
-              onValueChange={handleSearchChange}
-            />
-          )}
-          <CommandList>
-            {/*
-              While skills are still being fetched ``adapterCommands`` is
-              empty, so cmdk would otherwise flash "No skills found." until
-              the request resolves. Suppress the empty state and show
-              skeleton rows instead so the menu reads as "loading" on its
-              very first open rather than "empty".
-            */}
-            {!(
-              skillsLoading &&
-              (menuMode === "skills" || menuMode === "all")
-            ) && (
-              <CommandEmpty>
-                {menuMode === "skills"
-                  ? "No skills found."
-                  : menuMode === "scheduled"
-                  ? "No scheduled tasks found."
-                  : "No commands found."}
-              </CommandEmpty>
-            )}
-            {(menuMode === "skills" || menuMode === "all") &&
-              skillsLoading &&
-              adapterCommands.length === 0 &&
-              [0, 1, 2].map((i) => (
-                <div
-                  key={`skill-skeleton-${i}`}
-                  className="grid grid-cols-[12rem_1fr] items-baseline gap-3 px-2 py-2"
-                  aria-hidden="true"
-                >
-                  <Skeleton className="h-4 w-28" />
-                  <Skeleton className="h-3 w-full max-w-[16rem]" />
-                </div>
-              ))}
-            {menuMode === "scheduled" &&
-              scheduledExamples.map((cmd) => (
-                <CommandItem
-                  key={cmd.value}
-                  value={cmd.value}
-                  keywords={[cmd.description]}
-                  onSelect={() => handleCommandSelect(cmd.value)}
-                  className="grid grid-cols-[14rem_1fr] items-baseline gap-3 [&_svg]:hidden"
-                >
-                  <span
-                    className="font-mono font-semibold text-foreground truncate"
-                    title={cmd.label}
-                  >
-                    {cmd.label}
-                  </span>
-                  <span
-                    className="min-w-0 truncate text-sm text-muted-foreground"
-                    title={cmd.description}
-                  >
-                    {cmd.description}
-                  </span>
-                </CommandItem>
-              ))}
-            {(menuMode === "commands" || menuMode === "all") &&
-              builtinCommands.map((cmd) => (
-                <CommandItem
-                  key={cmd.value}
-                  value={cmd.value}
-                  keywords={[cmd.description]}
-                  onSelect={() => handleCommandSelect(cmd.value)}
-                  className="grid grid-cols-[12rem_1fr] items-baseline gap-3 [&_svg]:hidden"
-                >
-                  <span
-                    className="font-mono font-semibold text-foreground truncate"
-                    title={cmd.label}
-                  >
-                    {cmd.label}
-                  </span>
-                  <span
-                    className="min-w-0 truncate text-sm text-muted-foreground"
-                    title={cmd.description}
-                  >
-                    {cmd.description}
-                  </span>
-                </CommandItem>
-              ))}
-            {(menuMode === "skills" || menuMode === "all") &&
-              adapterCommands.map((cmd) => (
-                <CommandItem
-                  key={cmd.value}
-                  value={cmd.value}
-                  // Including "expert" as a fuzzy-match keyword lets the
-                  // user type "/expert" to list every specialist at once.
-                  keywords={
-                    cmd.isExpert
-                      ? [cmd.description, "expert"]
-                      : [cmd.description]
-                  }
-                  onSelect={() => handleCommandSelect(cmd.value)}
-                  className="grid grid-cols-[12rem_1fr] items-baseline gap-3 [&_svg]:hidden"
-                >
-                  <span
-                    className="inline-flex items-center gap-1.5 min-w-0 max-w-full"
-                    title={cmd.label}
-                  >
-                    <span className="font-mono font-semibold text-foreground truncate">
-                      {cmd.label}
-                    </span>
-                    {cmd.isExpert && (
-                      <span
-                        className="shrink-0 rounded-sm bg-primary/10 px-1 text-[9px] font-semibold uppercase tracking-wider text-primary"
-                        aria-label="Expert specialist"
-                      >
-                        expert
-                      </span>
-                    )}
-                  </span>
-                  <span
-                    className="min-w-0 truncate text-sm text-muted-foreground"
-                    title={cmd.description}
-                  >
-                    {cmd.description}
-                  </span>
-                </CommandItem>
-              ))}
-          </CommandList>
-        </Command>
-      </PopoverContent>
+      <ComposerCommandMenu
+        menuMode={menuMode}
+        searchQuery={searchQuery}
+        onSearchChange={handleSearchChange}
+        skillsLoading={skillsLoading}
+        builtinCommands={builtinCommands}
+        adapterCommands={adapterCommands}
+        scheduledExamples={scheduledExamples}
+        onCommandSelect={handleCommandSelect}
+        onEscapeDismiss={focusTextareaAtEnd}
+      />
     </Popover>
   );
 }

--- a/sdk/agent-chat-react/src/components/chat/composer-command-menu.tsx
+++ b/sdk/agent-chat-react/src/components/chat/composer-command-menu.tsx
@@ -1,0 +1,261 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+import { Command as CommandPrimitive } from "cmdk";
+import { SearchIcon } from "lucide-react";
+import type { AgentChatSlashCommand } from "../../types";
+import { PopoverContent } from "../ui/popover";
+import { Command, CommandEmpty, CommandItem, CommandList } from "../ui/command";
+import { Skeleton } from "../ui/skeleton";
+
+// ── Modes ────────────────────────────────────────────────────────────
+//
+// One panel backs every entry point into the slash menu: the three
+// expert-mode trigger buttons (``commands`` / ``skills`` / ``scheduled``)
+// and free-form ``/`` typing in the textarea (``all``).  Keeping them in
+// a single component means the search header, divider, list chrome and
+// keyboard affordances stay identical no matter how the menu was opened.
+
+export type ComposerMenuMode = "commands" | "skills" | "scheduled" | "all";
+
+const SEARCH_PLACEHOLDER: Record<ComposerMenuMode, string> = {
+  commands: "Search commands…",
+  skills: "Search skills…",
+  scheduled: "Search scheduled tasks…",
+  all: "Type a command or search…",
+};
+
+// Skills is the one mode that routinely renders an empty state, so its
+// hint is trimmed to the single gesture that still applies there; every
+// other mode is a navigable list and advertises the full set.
+const NAV_HINT = "↑↓ navigate   ·   Enter select   ·   Esc dismiss";
+const SEARCH_HINT: Record<ComposerMenuMode, string> = {
+  commands: NAV_HINT,
+  skills: "Esc dismiss",
+  scheduled: NAV_HINT,
+  all: NAV_HINT,
+};
+
+interface ComposerCommandMenuProps {
+  menuMode: ComposerMenuMode;
+  /** Mirrors the textarea query; only read in the controlled modes. */
+  searchQuery: string;
+  onSearchChange: (next: string) => void;
+  skillsLoading: boolean;
+  builtinCommands: AgentChatSlashCommand[];
+  adapterCommands: AgentChatSlashCommand[];
+  scheduledExamples: AgentChatSlashCommand[];
+  onCommandSelect: (value: string) => void;
+  /** Return focus to the textarea after an Escape dismissal. */
+  onEscapeDismiss: () => void;
+}
+
+// Shared row geometry: a fixed mono-name column + a flexible description,
+// matching the design's 120px / fill split.
+const ROW_CLASS =
+  "grid grid-cols-[120px_1fr] items-baseline gap-3 rounded-md px-3 py-[9px] data-[selected=true]:bg-foreground/[0.06] [&_svg]:hidden";
+
+export function ComposerCommandMenu({
+  menuMode,
+  searchQuery,
+  onSearchChange,
+  skillsLoading,
+  builtinCommands,
+  adapterCommands,
+  scheduledExamples,
+  onCommandSelect,
+  onEscapeDismiss,
+}: ComposerCommandMenuProps) {
+  // The query mirrors back into the textarea only when the menu was
+  // opened by typing ``/`` (``all``) or via the Commands button — the
+  // skills / scheduled scopes run cmdk's own uncontrolled filtering so a
+  // mirror write can't widen their scope back to "all".
+  const controlledSearch = menuMode === "commands" || menuMode === "all";
+  const showCommands = menuMode === "commands" || menuMode === "all";
+  const showSkills = menuMode === "skills" || menuMode === "all";
+
+  // Zero attached skills is a first-class state with its own call to
+  // action, distinct from "your search matched nothing" (cmdk's empty).
+  const skillsUnattached =
+    menuMode === "skills" && !skillsLoading && adapterCommands.length === 0;
+
+  return (
+    <PopoverContent
+      side="top"
+      align="start"
+      className="overflow-hidden rounded-xl p-0"
+      style={{ width: "var(--radix-popover-trigger-width)" }}
+      onCloseAutoFocus={(e) => e.preventDefault()}
+      onEscapeKeyDown={() => {
+        // Escape is the canonical "back out of the popup, keep typing in
+        // the chat" gesture.  Click-outside is deliberately NOT routed
+        // here — if the user clicked some other widget on the page they
+        // expect focus to land wherever they clicked.
+        onEscapeDismiss();
+      }}
+    >
+      {/*
+        Native cmdk command palette: the input owns focus while the popup
+        is open, cmdk runs the filter (matching ``value`` plus the
+        ``keywords`` we pass per item, so descriptions count toward
+        matches) and handles arrow keys / Enter / scroll-into-view itself.
+        In the controlled modes the input mirrors the textarea so the chat
+        input still reflects the query and sending the message still works.
+      */}
+      <Command>
+        {/* ── Search header ─────────────────────────────────────────── */}
+        <div className="flex items-center gap-2.5 px-4 py-[13px]">
+          <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
+          <CommandPrimitive.Input
+            data-slot="command-input"
+            placeholder={SEARCH_PLACEHOLDER[menuMode]}
+            className="min-w-0 flex-1 bg-transparent text-[13.5px] text-foreground outline-hidden placeholder:text-muted-foreground"
+            {...(controlledSearch
+              ? { value: searchQuery, onValueChange: onSearchChange }
+              : {})}
+          />
+          <span className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground">
+            {SEARCH_HINT[menuMode]}
+          </span>
+        </div>
+        <div className="h-px w-full bg-foreground/[0.07]" />
+
+        {/* ── Body ──────────────────────────────────────────────────── */}
+        {skillsUnattached ? (
+          <SkillsEmptyState />
+        ) : (
+          <CommandList className="p-2">
+            {/*
+              While skills are still being fetched ``adapterCommands`` is
+              empty, so cmdk would flash its empty message until the
+              request resolves. Suppress it and show skeleton rows so the
+              menu reads as "loading" on its very first open.
+            */}
+            {!(skillsLoading && showSkills) && (
+              <CommandEmpty className="px-3 py-8 text-center text-sm text-muted-foreground">
+                {menuMode === "skills"
+                  ? "No skills match your search."
+                  : menuMode === "scheduled"
+                    ? "No scheduled tasks found."
+                    : "No commands found."}
+              </CommandEmpty>
+            )}
+
+            {showSkills &&
+              skillsLoading &&
+              adapterCommands.length === 0 &&
+              [0, 1, 2].map((i) => (
+                <div
+                  key={`skill-skeleton-${i}`}
+                  className="grid grid-cols-[120px_1fr] items-baseline gap-3 px-3 py-[9px]"
+                  aria-hidden="true"
+                >
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-3 w-full max-w-[16rem]" />
+                </div>
+              ))}
+
+            {menuMode === "scheduled" &&
+              scheduledExamples.map((cmd) => (
+                <MenuRow
+                  key={cmd.value}
+                  cmd={cmd}
+                  onSelect={onCommandSelect}
+                />
+              ))}
+
+            {showCommands &&
+              builtinCommands.map((cmd) => (
+                <MenuRow
+                  key={cmd.value}
+                  cmd={cmd}
+                  onSelect={onCommandSelect}
+                />
+              ))}
+
+            {showSkills &&
+              adapterCommands.map((cmd) => (
+                <MenuRow
+                  key={cmd.value}
+                  cmd={cmd}
+                  // Including "expert" as a fuzzy-match keyword lets the
+                  // user type "/expert" to list every specialist at once.
+                  keywords={
+                    cmd.isExpert ? [cmd.description, "expert"] : undefined
+                  }
+                  badge={cmd.isExpert ? "expert" : undefined}
+                  onSelect={onCommandSelect}
+                />
+              ))}
+          </CommandList>
+        )}
+      </Command>
+    </PopoverContent>
+  );
+}
+
+// ── Command row ──────────────────────────────────────────────────────
+
+function MenuRow({
+  cmd,
+  keywords,
+  badge,
+  onSelect,
+}: {
+  cmd: AgentChatSlashCommand;
+  keywords?: string[];
+  badge?: string;
+  onSelect: (value: string) => void;
+}) {
+  return (
+    <CommandItem
+      value={cmd.value}
+      keywords={keywords ?? [cmd.description]}
+      onSelect={() => onSelect(cmd.value)}
+      className={ROW_CLASS}
+    >
+      <span
+        className="inline-flex min-w-0 max-w-full items-center gap-1.5"
+        title={cmd.label}
+      >
+        <span className="truncate font-mono text-[13px] font-medium text-amber-500">
+          {cmd.label}
+        </span>
+        {badge && (
+          <span
+            className="shrink-0 rounded-sm bg-amber-500/10 px-1 text-[9px] font-semibold uppercase tracking-wider text-amber-500"
+            aria-label="Expert specialist"
+          >
+            {badge}
+          </span>
+        )}
+      </span>
+      <span
+        className="min-w-0 truncate text-[12.5px] text-muted-foreground"
+        title={cmd.description}
+      >
+        {cmd.description}
+      </span>
+    </CommandItem>
+  );
+}
+
+// ── Skills empty state ───────────────────────────────────────────────
+
+function SkillsEmptyState() {
+  return (
+    <div className="flex flex-col items-center gap-2.5 px-6 py-[30px] text-center">
+      <span
+        className="text-2xl leading-none text-muted-foreground/70"
+        aria-hidden="true"
+      >
+        ✦
+      </span>
+      <p className="text-sm font-medium text-foreground">No skills attached</p>
+      <p className="text-[12.5px] text-muted-foreground">
+        Add them in{" "}
+        <span className="text-amber-500">Configure → Skills &amp; Tools</span>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
Extract the inline slash-menu panel into a reusable ComposerCommandMenu shared by every entry point — the Commands / Skills / Scheduled Tasks buttons and free-form "/" typing. The panel gains a Figma-matched search header (search icon, input, right-aligned keyboard hint) over a hairline divider, mono amber command rows on a fixed name column, and a dedicated "No skills attached" empty state distinct from cmdk's no-match message.

Also collapse the three near-identical trigger buttons into a single ComposerMenuButton helper driven by an openMenu(mode) callback.