### PR TITLE
fix(experts): authenticate expert calls with the per-model proxy key

### DIFF
--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -1065,6 +1065,7 @@ class AgentHarness(
                     session_config=session.config,
                     session_store=self._store,
                     sandbox_pool=self._sandbox_pool,
+                    credential_vault=self._credential_vault,
                 )
                 if expansion is not None:
                     expanded_text, skill_name, staged_at, kind = expansion

--- a/surogates/harness/slash_skill.py
+++ b/surogates/harness/slash_skill.py
@@ -187,6 +187,7 @@ async def expand_slash_skill(
     session_config: dict[str, Any] | None = None,
     session_store: Any | None = None,
     sandbox_pool: Any | None = None,
+    credential_vault: Any | None = None,
 ) -> tuple[str, str, str | None, Literal["skill", "expert"]] | None:
     """Try to expand a ``/<name> args...`` user message.
 
@@ -233,6 +234,7 @@ async def expand_slash_skill(
             tool_registry=tools,
             session_store=session_store,
             sandbox_pool=sandbox_pool,
+            credential_vault=credential_vault,
         )
 
     return await _expand_skill(
@@ -310,6 +312,7 @@ async def _expand_expert(
     tool_registry: Any,
     session_store: Any | None,
     sandbox_pool: Any | None,
+    credential_vault: Any | None = None,
 ) -> tuple[str, str, str | None, Literal["skill", "expert"]] | None:
     """Run the expert mini-loop and inline the deliverable.
 
@@ -331,6 +334,7 @@ async def _expand_expert(
             tool_registry=tool_registry,
             session_store=session_store,
             sandbox_pool=sandbox_pool,
+            credential_vault=credential_vault,
         )
         outcome = await service.consult(expert=expert, task=args)
     except Exception:

--- a/surogates/tools/builtin/expert.py
+++ b/surogates/tools/builtin/expert.py
@@ -146,6 +146,7 @@ async def _consult_expert_handler(
         session_store=session_store,
         tool_router=tool_router,
         sandbox_pool=kwargs.get("sandbox_pool"),
+        credential_vault=kwargs.get("credential_vault"),
     )
     result = await service.consult(
         expert=expert,

--- a/surogates/tools/builtin/expert_loop.py
+++ b/surogates/tools/builtin/expert_loop.py
@@ -65,6 +65,7 @@ async def run_expert_loop(
     tenant: Any,
     session_id: UUID,
     session_store: Any | None = None,
+    api_key: str | None = None,
 ) -> tuple[str, int]:
     """Run a scoped agent loop using the expert's configured model.
 
@@ -128,7 +129,7 @@ async def run_expert_loop(
     server_base_url = getattr(load_settings(), "platform_api_url", None)
     client = AsyncOpenAI(
         base_url=_absolute_endpoint(expert.expert_endpoint, server_base_url),
-        api_key=_resolve_api_key(tenant, expert),
+        api_key=api_key or _resolve_api_key(tenant, expert),
     )
 
     gen_kwargs, gen_extra = _generation_kwargs(expert.expert_generation)

--- a/surogates/tools/builtin/expert_service.py
+++ b/surogates/tools/builtin/expert_service.py
@@ -16,6 +16,50 @@ from surogates.tools.loader import SkillDef
 logger = logging.getLogger(__name__)
 
 
+def _model_id_from_endpoint(endpoint: str | None) -> str | None:
+    """Extract the deployed-model id from a ``/proxy/services/_model/{id}`` path.
+
+    Experts served through the platform proxy carry an endpoint like
+    ``/proxy/services/_model/<uuid>/v1``; the per-model credential the
+    proxy expects is keyed by that ``<uuid>``.  Returns ``None`` for any
+    other endpoint shape (self-hosted, dstack legacy) so the caller falls
+    back to its default credential.
+    """
+    if not endpoint:
+        return None
+    marker = "/_model/"
+    idx = endpoint.find(marker)
+    if idx == -1:
+        return None
+    return endpoint[idx + len(marker):].split("/", 1)[0] or None
+
+
+async def resolve_expert_api_key(
+    credential_vault: Any, tenant: Any, expert: SkillDef,
+) -> str | None:
+    """Resolve the platform credential scoped to the expert's model.
+
+    The expert mini-loop calls ``/proxy/services/_model/{id}``, which the
+    proxy gates on an ``sk-agent`` key scoped to that model — the same
+    ``vault://byo_model_{id}_key`` credential the platform mints when a
+    model is served.  Resolve it from the vault; return ``None`` on any
+    miss so the loop falls back to its existing behaviour.
+    """
+    model_id = _model_id_from_endpoint(expert.expert_endpoint)
+    org_id = getattr(tenant, "org_id", None)
+    if credential_vault is None or model_id is None or org_id is None:
+        return None
+    try:
+        return await credential_vault.resolve_ref(
+            f"vault://byo_model_{model_id}_key", org_id=org_id,
+        )
+    except Exception:
+        logger.debug(
+            "expert key resolution failed for model %s", model_id, exc_info=True,
+        )
+        return None
+
+
 @dataclass(frozen=True, slots=True)
 class ExpertConsultationResult:
     """Result returned from an expert consultation."""
@@ -39,6 +83,7 @@ class ExpertConsultationService:
         session_store: Any | None = None,
         tool_router: Any | None = None,
         sandbox_pool: Any | None = None,
+        credential_vault: Any | None = None,
     ) -> None:
         self._tenant = tenant
         self._session_id = session_id
@@ -46,6 +91,7 @@ class ExpertConsultationService:
         self._session_store = session_store
         self._tool_router = tool_router
         self._sandbox_pool = sandbox_pool
+        self._credential_vault = credential_vault
 
     async def consult(
         self,
@@ -74,6 +120,9 @@ class ExpertConsultationService:
             )
 
         try:
+            api_key = await resolve_expert_api_key(
+                self._credential_vault, self._tenant, expert,
+            )
             result, iterations_used = await run_expert_loop(
                 expert=expert,
                 task=task,
@@ -83,6 +132,7 @@ class ExpertConsultationService:
                 tenant=self._tenant,
                 session_id=self._session_id,
                 session_store=self._session_store,
+                api_key=api_key,
             )
             await record_expert_outcome(
                 session_store=self._session_store,

--- a/tests/test_expert_key_resolution.py
+++ b/tests/test_expert_key_resolution.py
@@ -1,0 +1,83 @@
+"""Expert calls must carry the per-model proxy credential, not a placeholder.
+
+Experts route through ``/proxy/services/_model/{id}``, which the platform
+proxy gates on an ``sk-agent`` key scoped to that model — the same
+``vault://byo_model_{id}_key`` minted when the model is served.  These tests
+pin the endpoint→model-id parsing and the vault resolution, including the
+graceful fallbacks that leave the loop on its existing default.
+"""
+
+from __future__ import annotations
+
+import types
+import uuid
+
+import pytest
+
+from surogates.tools.builtin.expert_service import (
+    _model_id_from_endpoint,
+    resolve_expert_api_key,
+)
+from surogates.tools.loader import SkillDef
+
+
+def _expert(endpoint: str | None) -> SkillDef:
+    return SkillDef(
+        name="libra-ytd", description="d", content="", source="x", builtin=False,
+        type="expert", category=None, tags=[], platforms=[], fallback_for_tools=[],
+        requires_tools=[], trigger=None, expert_model="m", expert_endpoint=endpoint,
+        expert_adapter=None, expert_max_iterations=1, expert_status="active",
+        expert_tools=[], expert_generation=None, category_description=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "endpoint, expected",
+    [
+        ("/proxy/services/_model/27a20181-aaaa/v1", "27a20181-aaaa"),
+        ("/proxy/services/_model/abc", "abc"),
+        ("https://host/proxy/services/_model/xyz/v1/chat", "xyz"),
+        ("/proxy/services/default/r6b689116", None),  # legacy dstack shape
+        (None, None),
+    ],
+)
+def test_model_id_from_endpoint(endpoint, expected):
+    assert _model_id_from_endpoint(endpoint) == expected
+
+
+class _FakeVault:
+    def __init__(self) -> None:
+        self.asked: dict = {}
+
+    async def resolve_ref(self, ref, *, org_id, user_id=None):
+        self.asked = {"ref": ref, "org_id": org_id}
+        return "sk-agent-real-for-expert-model"
+
+
+async def test_resolves_per_model_key_from_vault():
+    org = uuid.uuid4()
+    vault = _FakeVault()
+    key = await resolve_expert_api_key(
+        vault, types.SimpleNamespace(org_id=org),
+        _expert("/proxy/services/_model/27a20181-aaaa/v1"),
+    )
+    assert key == "sk-agent-real-for-expert-model"
+    assert vault.asked["ref"] == "vault://byo_model_27a20181-aaaa_key"
+    assert vault.asked["org_id"] == org
+
+
+async def test_falls_back_to_none_when_unresolvable():
+    org = uuid.uuid4()
+    vault = _FakeVault()
+    # no vault wired
+    assert await resolve_expert_api_key(
+        None, types.SimpleNamespace(org_id=org), _expert("/proxy/services/_model/x")
+    ) is None
+    # legacy / non-_model endpoint
+    assert await resolve_expert_api_key(
+        vault, types.SimpleNamespace(org_id=org), _expert("/proxy/services/default/run")
+    ) is None
+    # missing org
+    assert await resolve_expert_api_key(
+        vault, types.SimpleNamespace(org_id=None), _expert("/proxy/services/_model/x")
+    ) is None


### PR DESCRIPTION
Expert consultations route through /proxy/services/_model/{id}, which the platform proxy gates on an sk-agent key scoped to that model. The mini-loop was sending a placeholder ("not-needed"), so every consultation 401'd with "Invalid token payload" once serving moved behind the authenticated _model route (Modal/dstack/on-prem alike). It "worked" before only because the old dstack route left auth off.

Resolve the model's own credential from the vault — the same vault://byo_model_{id}_key the platform mints when a model is served — and feed it into run_expert_loop:

- expert_loop.run_expert_loop: accept api_key, prefer it over the fallback
- expert_service: resolve_expert_api_key() parses the model id from the expert's _model/{id} endpoint and resolves byo_model_{id}_key from the vault; ExpertConsultationService takes the credential_vault and uses it
- consult_expert tool + slash /expert path: thread the credential_vault

Falls back to the prior behaviour when the endpoint isn't a _model path or the key can't be resolved. Paired with ops minting the key at serve time.