### PR TITLE
fix(agent-chat): self-contained noVNC type for cross-package builds

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,9 +111,6 @@ importers:
       '@types/node':
         specifier: ^24.10.1
         version: 24.12.2
-      '@types/novnc__novnc':
-        specifier: ^1.6.0
-        version: 1.6.0
       '@types/react':
         specifier: ^19.2.5
         version: 19.2.14
@@ -2016,9 +2013,6 @@ packages:
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
-
-  '@types/novnc__novnc@1.6.0':
-    resolution: {integrity: sha512-kIH/PQACbf9qj6whiSXRKECpyzgs6IFNVsW4wohyqQUZfQHdLhuGRMLi9XEhBiISSh0lKCSbBa7kScuPu9Gk+Q==}
 
   '@types/qs@6.15.0':
     resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
@@ -5637,8 +5631,6 @@ snapshots:
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
-
-  '@types/novnc__novnc@1.6.0': {}
 
   '@types/qs@6.15.0': {}
 

--- a/sdk/agent-chat-react/package.json
+++ b/sdk/agent-chat-react/package.json
@@ -80,7 +80,6 @@
   },
   "devDependencies": {
     "@types/node": "^24.10.1",
-    "@types/novnc__novnc": "^1.6.0",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "happy-dom": "^15.11.0",

--- a/sdk/agent-chat-react/src/components/browser/browser-live-view.tsx
+++ b/sdk/agent-chat-react/src/components/browser/browser-live-view.tsx
@@ -1,5 +1,6 @@
+/// <reference path="../../novnc.d.ts" />
 import { useEffect, useRef, useState } from "react";
-import type RFB from "@novnc/novnc";
+import type { NoVncClient } from "@novnc/novnc";
 
 interface BrowserLiveViewProps {
   src: string;
@@ -45,22 +46,23 @@ export function BrowserLiveView({
     if (!container) return;
     setState("connecting");
 
-    let rfb: RFB | undefined;
+    let rfb: NoVncClient | undefined;
     let disposed = false;
 
     const handleConnect = () => setState("connected");
-    const handleDisconnect = (event: CustomEvent<{ clean: boolean }>) => {
+    const handleDisconnect = (event: Event) => {
+      const detail = (event as CustomEvent<{ clean: boolean }>).detail;
       setState("disconnected");
-      onDisconnectRef.current?.(event.detail?.clean ?? false);
+      onDisconnectRef.current?.(detail?.clean ?? false);
     };
 
     // noVNC is browser-only (touches WebSocket/canvas at module load), so it is
     // imported lazily — the component stays safe to import in SSR/tests that do
     // not mount it.
     void import("@novnc/novnc")
-      .then(({ default: RFBImpl }) => {
+      .then((mod) => {
         if (disposed || !containerRef.current) return;
-        const instance = new RFBImpl(containerRef.current, toWsUrl(src), {
+        const instance = new mod.default(containerRef.current, toWsUrl(src), {
           wsProtocols: ["binary"],
         });
         instance.viewOnly = false;

--- a/sdk/agent-chat-react/src/novnc.d.ts
+++ b/sdk/agent-chat-react/src/novnc.d.ts
@@ -1,8 +1,24 @@
-/// <reference types="novnc__novnc" />
-// @novnc/novnc@1.7 exposes the RFB class at the bare specifier (its
-// package.json "exports" maps the package root to "./core/rfb.js"), while
-// @types/novnc__novnc still declares it at the legacy "@novnc/novnc/lib/rfb"
-// path. Bridge the runtime import path to the published typings.
+// @novnc/novnc@1.7 exposes the RFB class at the bare specifier (its package.json
+// "exports" maps the package root to "./core/rfb.js"). The published
+// @types/novnc__novnc only declares the legacy "@novnc/novnc/lib/rfb" subpath,
+// which does not match the bare runtime export — so we declare the small surface
+// of the RFB client we actually use here. This file is pulled in via a
+// triple-slash reference from browser-live-view.tsx so it resolves in every
+// package that compiles that source (e.g. example-chat-app), not just this one.
 declare module "@novnc/novnc" {
-  export { default } from "@novnc/novnc/lib/rfb";
+  export interface NoVncClient {
+    viewOnly: boolean;
+    scaleViewport: boolean;
+    addEventListener(type: string, listener: (event: Event) => void): void;
+    removeEventListener(type: string, listener: (event: Event) => void): void;
+    disconnect(): void;
+  }
+
+  const RFB: new (
+    target: Element,
+    url: string,
+    options?: { wsProtocols?: string[] },
+  ) => NoVncClient;
+
+  export default RFB;
 }


### PR DESCRIPTION
## What
After #77, `sdk/example-chat-app` fails to build with `TS2306: @types/novnc__novnc/index.d.ts is not a module`. It compiles `agent-chat-react`'s source via a path alias, so the package-local `novnc.d.ts` shim that bridged the bare `@novnc/novnc` import was out of scope — the import fell back to the ambient-only `@types` package (not a module).

## Fix
- Rewrote `novnc.d.ts` as a **self-contained** ambient declaration of the bare `@novnc/novnc` module (only the RFB surface we use) — no `@types` dependency.
- Added a **triple-slash reference** to it from `browser-live-view.tsx`, so it resolves in any package that compiles that source.
- Removed the unused `@types/novnc__novnc` devDependency.

## Verify
- `example-chat-app` build: ✓ built (was failing)
- `agent-chat-react`: `tsc --noEmit` clean, tsup build green, **385 tests pass** (vi.mock still intercepts the lazy `import()`).