### PR TITLE
Agent-aware Open session from the cross-agent inbox

### DIFF
--- a/docs/superpowers/plans/2026-06-18-inbox-cross-agent-open-session-revision.md
+++ b/docs/superpowers/plans/2026-06-18-inbox-cross-agent-open-session-revision.md
@@ -1,0 +1,220 @@
+# Cross-agent inbox "Open session" — REVISION Plan (slug-based, cross-repo)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Why this revision:** Local testing showed `api_web_url` in the runtime config is **never populated** (no code path writes it into the runtime-config blob; null for every agent), so the original new-tab path (using `agent_web_url`) can never fire. The agent's hosted page is **slug-based**: `https://<slug>.<domain>/chat/<id>` (confirmed in prod, e.g. `https://pdf-reader-2u6vbt.cloud.surogate.ai/chat/<id>`), where `<slug>` is `agent.name`. This revision sources the URL from the agent slug instead.
+
+**What stays (already built, unchanged):** Task 2 (`/auth/config` returns `agent_id`), Task 4 (`SessionTreePanel` list/tree decoupling), and the SDK callback change + `agentId` field. Only the URL-source pieces change: `agent_web_url` → `agent_slug`, plus a new ops field and web URL construction.
+
+**Spec:** `docs/superpowers/specs/2026-06-18-inbox-cross-agent-open-session-design.md` (revised).
+
+## Global Constraints
+
+- **Branches (cross-repo):** `surogates` → `fix/inbox-cross-agent-open-session` (off `master`, current). `surogate-ops` → `fix/inbox-cross-agent-open-session` (off `main`, already created). Do not switch/create other branches.
+- **No AI mentions** in any commit/PR/GitHub text; no `Co-Authored-By`/"Generated with" trailers. Conventional, technical messages.
+- **Node 22** for the frontends: prefix npm/npx with `PATH="$HOME/.local/node/bin:$PATH"`.
+- **Python tests** via `uv run pytest`.
+- Backward compatible: all new fields optional; localhost / non-`<slug>.<domain>` hosts fall back to in-place.
+
+---
+
+## Task 1: ops — expose the agent slug in the runtime config
+
+**Repo:** `surogate-ops` (work from `/home/monica/invergent/surogate-ops`, branch `fix/inbox-cross-agent-open-session`).
+
+**Files:**
+- Modify: `surogate_ops/server/models/agent_runtime.py` (response model)
+- Modify: `surogate_ops/server/routes/agent_runtime.py` (handler)
+- Test: the existing agent_runtime endpoint test (find it under `tests/`), or add a focused one.
+
+**Interfaces:**
+- Produces: `AgentRuntimeConfigResponse.slug: Optional[str]` in the runtime-config JSON, set to `agent.name`.
+
+- [ ] **Step 1: Write the failing test.** Find the existing test for the agent-runtime config endpoint (search `tests/` for `agent_runtime` / the runtime-config route). Add/extend a test asserting the response includes `slug` equal to the agent's `name`. If there is genuinely no endpoint test to extend, add a focused unit test that calls the handler (or constructs `AgentRuntimeConfigResponse`) and asserts `slug == agent.name`. Follow the existing ops test conventions in that file.
+
+- [ ] **Step 2: Run it, verify it fails** (no `slug` field yet). Use the repo's pytest invocation (e.g. `uv run pytest <path> -v` or the ops standard).
+
+- [ ] **Step 3: Add the field to the model.** In `surogate_ops/server/models/agent_runtime.py`, add to `AgentRuntimeConfigResponse` (next to `api_web_url`):
+
+```python
+    slug: Optional[str] = None
+```
+
+- [ ] **Step 4: Set it in the handler.** In `surogate_ops/server/routes/agent_runtime.py`, the handler already loads `agent` (the `Agent` row). In the `return AgentRuntimeConfigResponse(...)`, add:
+
+```python
+        slug=agent.name,
+```
+
+(`agent.name` doubles as the DNS slug — see the `Agent` model docstring.)
+
+- [ ] **Step 5: Run the test, verify it passes.**
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add surogate_ops/server/models/agent_runtime.py surogate_ops/server/routes/agent_runtime.py <test file>
+git commit -m "feat(agent-runtime): expose agent slug (name) in the runtime config"
+```
+
+---
+
+## Task 2: surogates — stamp `agent_slug` on inbox items (replace `agent_web_url`)
+
+**Repo:** `surogates` (work from `/home/monica/invergent/surogates`, branch `fix/inbox-cross-agent-open-session`).
+
+**Files:**
+- Modify: `surogates/api/routes/inbox.py` (`_resolve_agent_fields`, `_serialize_item`)
+- Test: `tests/test_inbox_serialize.py`
+
+**Interfaces:**
+- Consumes: the runtime-config payload now has `slug` (Task 1). `payload = await runtime_config_cache.get(agent_id)` → `payload.get("slug")`.
+- Produces: serialized inbox item has `agent_id` + **`agent_slug`** (no more `agent_web_url`). `_resolve_agent_fields` returns `{session_id: {"agent_id", "agent_slug"}}`.
+
+- [ ] **Step 1: Update the failing tests.** In `tests/test_inbox_serialize.py`, replace `agent_web_url` with `agent_slug` and make the fake cache return a slug. Specifically:
+  - `test_serialize_item_includes_agent_fields`: pass `{"agent_id": "agent-x", "agent_slug": "agent-x-slug"}`; assert `out["agent_slug"] == "agent-x-slug"` (and `out["agent_id"] == "agent-x"`).
+  - `test_serialize_item_defaults_agent_fields_to_none`: assert `out["agent_slug"] is None` (and `agent_id is None`).
+  - `_FakeCache.get` returns `{"slug": self._urls[agent_id]}` (rename the attr if you like); the two `_resolve_agent_fields` tests assert `fields[sid] == {"agent_id": "agent-x", "agent_slug": "agent-x-slug"}` and the cache-miss case `{"agent_id": "agent-x", "agent_slug": None}`.
+
+- [ ] **Step 2: Run, verify it fails.** `uv run pytest tests/test_inbox_serialize.py -v`.
+
+- [ ] **Step 3: Update `_resolve_agent_fields`** in `surogates/api/routes/inbox.py`: read the slug instead of the url, and key the result as `agent_slug`:
+
+```python
+    for sid, agent_id in agent_by_session.items():
+        if agent_id not in slug_by_agent:
+            slug = None
+            if cache is not None:
+                try:
+                    payload = await cache.get(agent_id)
+                    slug = payload.get("slug")
+                except LookupError:
+                    slug = None
+            slug_by_agent[agent_id] = slug
+        out[sid] = {"agent_id": agent_id, "agent_slug": slug_by_agent[agent_id]}
+    return out
+```
+
+(Rename the local `url_by_agent` → `slug_by_agent` and update the docstring to say `agent_slug` is best-effort.)
+
+- [ ] **Step 4: Update `_serialize_item`** — replace the `agent_web_url` line with:
+
+```python
+        "agent_slug": fields.get("agent_slug"),
+```
+
+(Keep `"agent_id": fields.get("agent_id"),`.)
+
+- [ ] **Step 5: Run the tests, verify they pass.** `uv run pytest tests/test_inbox_serialize.py -v`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add surogates/api/routes/inbox.py tests/test_inbox_serialize.py
+git commit -m "feat(inbox): stamp owner agent_slug (was agent_web_url) on inbox items"
+```
+
+---
+
+## Task 3: SDK — `agentSlug` field (replace `agentWebUrl`) + web mapper
+
+**Repo:** `surogates`. **Files:**
+- Modify: `sdk/agent-chat-react/src/types.ts`
+- Modify: `web/src/api/inbox.ts`
+- Test: `sdk/agent-chat-react/tests/inbox-panel.test.tsx`
+
+**Interfaces:**
+- Produces: `AgentChatInboxItem.agentSlug?: string | null` (replaces `agentWebUrl`). Web `toInboxItem` maps `agentSlug: item.agent_slug ?? null`.
+
+- [ ] **Step 1: Update the test.** In `sdk/agent-chat-react/tests/inbox-panel.test.tsx`, the test that asserts the item passes to `onSessionSelect`: set `items[0].agentSlug = "other-agent"` (instead of `agentWebUrl`), and assert the passed item's `agentSlug` is `"other-agent"` (keep asserting `agentId`). If a test references `agentWebUrl` anywhere, update it.
+
+- [ ] **Step 2: Run, verify it fails.** `PATH="$HOME/.local/node/bin:$PATH" npm test --prefix sdk/agent-chat-react -- inbox-panel`.
+
+- [ ] **Step 3: Rename the type field.** In `sdk/agent-chat-react/src/types.ts`, in `AgentChatInboxItem`, replace `agentWebUrl?: string | null;` with:
+
+```ts
+  agentSlug?: string | null;
+```
+
+(Keep `agentId?: string | null;`.)
+
+- [ ] **Step 4: Update the web mapper.** In `web/src/api/inbox.ts`: in `InboxItemResponse` replace `agent_web_url?: string | null;` with `agent_slug?: string | null;`; in `toInboxItem` replace the `agentWebUrl` mapping with `agentSlug: item.agent_slug ?? null,` (keep `agentId`).
+
+- [ ] **Step 5: Run the SDK test, verify it passes.** `PATH="$HOME/.local/node/bin:$PATH" npm test --prefix sdk/agent-chat-react -- inbox-panel`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add sdk/agent-chat-react/src/types.ts web/src/api/inbox.ts sdk/agent-chat-react/tests/inbox-panel.test.tsx
+git commit -m "feat(agent-chat): inbox item carries agentSlug (was agentWebUrl)"
+```
+
+---
+
+## Task 4: web — build the cross-agent URL from the current host + slug
+
+**Repo:** `surogates`. **Files:**
+- Modify: `web/src/features/inbox/inbox-page.tsx`
+
+**Interfaces:**
+- Consumes: `item.agentSlug`, `currentAgentId` (from the capabilities store, unchanged).
+
+> No web test harness — verify with `PATH="$HOME/.local/node/bin:$PATH" npm run typecheck --prefix web` (must exit 0) + the local manual check.
+
+- [ ] **Step 1: Replace the routing in `handleSessionSelect`.** In `web/src/features/inbox/inbox-page.tsx`, add a host-derivation helper and use the slug:
+
+```ts
+// Build the owning agent's hosted-page URL from THIS app's host: prod serves
+// each agent at <slug>.<domain> (e.g. agent.cloud.surogate.ai), so swap the
+// current first label for the owner's slug. Returns null when the host has no
+// derivable domain (e.g. localhost:5174 in dev) — caller falls back to in-place.
+function crossAgentChatUrl(agentSlug: string, sessionId: string): string | null {
+  const { protocol, host } = window.location;
+  const dot = host.indexOf(".");
+  if (dot <= 0) return null; // localhost / single-label host → not derivable
+  const domain = host.slice(dot + 1);
+  return `${protocol}//${agentSlug}.${domain}/chat/${sessionId}`;
+}
+```
+
+And the handler:
+
+```ts
+  function handleSessionSelect(sessionId: string, item?: AgentChatInboxItem) {
+    if (
+      item?.agentId &&
+      currentAgentId &&
+      item.agentId !== currentAgentId &&
+      item.agentSlug
+    ) {
+      const url = crossAgentChatUrl(item.agentSlug, sessionId);
+      if (url) {
+        window.open(url, "_blank", "noopener");
+        return;
+      }
+    }
+    setActiveSession(sessionId);
+    void navigate({ to: "/chat/$sessionId", params: { sessionId } });
+  }
+```
+
+(Remove the old `agentWebUrl`-based branch.)
+
+- [ ] **Step 2: Typecheck.** `PATH="$HOME/.local/node/bin:$PATH" npm run typecheck --prefix web` → exit 0.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add web/src/features/inbox/inbox-page.tsx
+git commit -m "feat(web): build cross-agent inbox URL from host + owner slug"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** ops slug (Task 1) → surogates stamps `agent_slug` (Task 2) → SDK `agentSlug` + web mapper (Task 3) → web builds `<slug>.<domain>/chat/<id>` (Task 4). `/auth/config` agent_id + list/tree decoupling already built. Edge cases: missing slug / non-derivable domain → in-place (Task 4 guard).
+
+**Placeholder scan:** R1's test step references "the existing test" because the ops test file must be located first — the assertion (response `slug == agent.name`) is concrete. All other steps have exact code.
+
+**Type consistency:** ops `slug` (response) → `payload.get("slug")` (Task 2) → serialized `agent_slug` (snake) → `agentSlug` (camel, SDK + web mapper + web handler). `crossAgentChatUrl(agentSlug, sessionId)` used by `handleSessionSelect`. `agentId`/`currentAgentId` unchanged from the original Task 5.

--- a/docs/superpowers/plans/2026-06-18-inbox-cross-agent-open-session.md
+++ b/docs/superpowers/plans/2026-06-18-inbox-cross-agent-open-session.md
@@ -1,0 +1,587 @@
+# Cross-agent inbox "Open session" — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** From the web app's user-scoped (cross-agent) inbox, "Open session" opens a different agent's session in that agent's app (new tab) and a same-agent session in place; and the session list never blanks when the active session's tree fetch fails.
+
+**Architecture:** Backend stamps each inbox item with its owner `agent_id` + `agent_web_url` and exposes the current agent id via `/auth/config`; the SDK carries those fields and passes the item to `onSessionSelect`; the web compares the item's agent to its own and routes (new tab vs in place). Separately, `SessionTreePanel` decouples its list fetch from the active-session tree fetch so a failed tree doesn't discard the list.
+
+**Tech Stack:** Python/FastAPI + SQLAlchemy (surogates runtime), React + TypeScript SDK (`agent-chat-react`, vitest), React web app (`web`, Vite, Node 22).
+
+**Spec:** `docs/superpowers/specs/2026-06-18-inbox-cross-agent-open-session-design.md`
+
+## Global Constraints
+
+- **Branch:** `fix/inbox-cross-agent-open-session` (already created off `master`). Do not switch branches.
+- **No AI mentions in any commit/PR/GitHub text.** Technical content only; no `Co-Authored-By`/"Generated with" trailers.
+- **Backward compatible:** all new inbox-item fields are optional; `onSessionSelect`'s new arg is optional; ops and pre-deploy items keep working (in-place). Do not change the inbox endpoint's user-scoped contract (no agent resolution added there).
+- **Node 22 for the frontends:** prefix npm/npx with `PATH="$HOME/.local/node/bin:$PATH"` (system node is 18).
+- **Commit messages:** Conventional, technical, no attribution.
+
+## File structure
+
+- `surogates/session/store.py` — add `get_agent_ids_for_sessions` (batch session→agent_id).
+- `surogates/api/routes/inbox.py` — `_resolve_agent_fields` helper; `_serialize_item` gains optional agent fields; wire all 5 serialize sites.
+- `surogates/api/routes/auth.py` — `AuthConfigResponse` gains `agent_id`.
+- `tests/test_inbox_serialize.py` (new, unit) — serializer + helper.
+- `tests/integration/test_inbox_api.py` — assert listed items carry `agent_id`.
+- `sdk/agent-chat-react/src/types.ts` — `AgentChatInboxItem` gains `agentId?`, `agentWebUrl?`.
+- `sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx` — pass item to `onSessionSelect`.
+- `sdk/agent-chat-react/src/components/sessions/session-tree-panel.tsx` — decouple list/tree fetch.
+- `web/src/api/inbox.ts`, `surogate-ops/frontend/src/api/inbox.ts` — map the new fields.
+- `web/src/api/auth.ts`, `web/src/stores/capabilities-slice.ts` — read + store current `agentId`.
+- `web/src/features/inbox/inbox-page.tsx` — agent-aware routing.
+- `sdk/agent-chat-react/tests/inbox-panel.test.tsx`, `tests/session-tree-panel.test.tsx` — SDK tests.
+
+---
+
+## Task 1: Backend — stamp owner `agent_id` + `agent_web_url` on inbox items
+
+**Files:**
+- Modify: `surogates/session/store.py`
+- Modify: `surogates/api/routes/inbox.py`
+- Test: `tests/test_inbox_serialize.py` (new, unit — no DB)
+
+**Interfaces:**
+- Produces: `SessionStore.get_agent_ids_for_sessions(session_ids: list[UUID]) -> dict[UUID, str]`; `_serialize_item(item, agent_fields: dict | None = None) -> dict` where the dict gains `"agent_id"` and `"agent_web_url"`; `async _resolve_agent_fields(request, session_ids) -> dict[UUID, dict]`.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `tests/test_inbox_serialize.py`:
+
+```python
+# Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+# SPDX-License-Identifier: AGPL-3.0-only
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from surogates.api.routes.inbox import _resolve_agent_fields, _serialize_item
+
+
+def _item(session_id):
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        id=1, org_id=uuid.uuid4(), user_id=uuid.uuid4(), session_id=session_id,
+        source_event_id=1, kind="task_complete", status="pending",
+        title="t", body=None, payload={}, action_ref=None,
+        created_at=now, updated_at=now, read_at=None, responded_at=None,
+    )
+
+
+def test_serialize_item_includes_agent_fields():
+    sid = uuid.uuid4()
+    out = _serialize_item(_item(sid), {"agent_id": "agent-x", "agent_web_url": "https://x.example"})
+    assert out["agent_id"] == "agent-x"
+    assert out["agent_web_url"] == "https://x.example"
+
+
+def test_serialize_item_defaults_agent_fields_to_none():
+    out = _serialize_item(_item(uuid.uuid4()))
+    assert out["agent_id"] is None
+    assert out["agent_web_url"] is None
+
+
+class _FakeStore:
+    def __init__(self, mapping):
+        self._mapping = mapping
+    async def get_agent_ids_for_sessions(self, session_ids):
+        return {s: self._mapping[s] for s in session_ids if s in self._mapping}
+
+
+class _FakeCache:
+    def __init__(self, urls):
+        self._urls = urls
+    async def get(self, agent_id):
+        if agent_id not in self._urls:
+            raise LookupError(agent_id)
+        return {"api_web_url": self._urls[agent_id]}
+
+
+def _request(store, cache):
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(
+        session_store=store, runtime_config_cache=cache)))
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_fields_maps_owner_and_url():
+    sid = uuid.uuid4()
+    req = _request(_FakeStore({sid: "agent-x"}), _FakeCache({"agent-x": "https://x.example"}))
+    fields = await _resolve_agent_fields(req, [sid])
+    assert fields[sid] == {"agent_id": "agent-x", "agent_web_url": "https://x.example"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_fields_url_none_on_cache_miss():
+    sid = uuid.uuid4()
+    req = _request(_FakeStore({sid: "agent-x"}), _FakeCache({}))
+    fields = await _resolve_agent_fields(req, [sid])
+    assert fields[sid] == {"agent_id": "agent-x", "agent_web_url": None}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run pytest tests/test_inbox_serialize.py -v`
+Expected: FAIL — `_resolve_agent_fields` not importable / `_serialize_item` missing agent fields.
+
+- [ ] **Step 3: Add the store batch helper**
+
+In `surogates/session/store.py`, add a method to the `SessionStore` class (near `get_session`, ~line 174). Confirm `Session` is already imported in this module (it is — `list_inbox` returns `InboxItem` and the file imports the models):
+
+```python
+    async def get_agent_ids_for_sessions(
+        self, session_ids: list[UUID]
+    ) -> dict[UUID, str]:
+        """Map each session id to its owning agent id (one query)."""
+        if not session_ids:
+            return {}
+        async with self._sf() as db:
+            result = await db.execute(
+                select(Session.id, Session.agent_id).where(
+                    Session.id.in_(session_ids)
+                )
+            )
+            return {row.id: str(row.agent_id) for row in result.all()}
+```
+
+- [ ] **Step 4: Add the resolver + extend the serializer in `inbox.py`**
+
+In `surogates/api/routes/inbox.py`, add `from fastapi import Request` if not already imported (it is — the routes use `request: Request`). Add the helper above `_serialize_item`:
+
+```python
+async def _resolve_agent_fields(
+    request: Request, session_ids: list[UUID]
+) -> dict:
+    """Map session_id -> {"agent_id", "agent_web_url"} for serialization.
+
+    `agent_web_url` is best-effort: a runtime-config cache miss leaves it
+    None so the item still serializes (the web then falls back to in-place).
+    """
+    store = request.app.state.session_store
+    agent_by_session = await store.get_agent_ids_for_sessions(list(session_ids))
+    cache = getattr(request.app.state, "runtime_config_cache", None)
+    url_by_agent: dict[str, str | None] = {}
+    out: dict = {}
+    for sid, agent_id in agent_by_session.items():
+        if agent_id not in url_by_agent:
+            web_url = None
+            if cache is not None:
+                try:
+                    payload = await cache.get(agent_id)
+                    web_url = payload.get("api_web_url")
+                except LookupError:
+                    web_url = None
+            url_by_agent[agent_id] = web_url
+        out[sid] = {"agent_id": agent_id, "agent_web_url": url_by_agent[agent_id]}
+    return out
+```
+
+Change `_serialize_item` (line 67) to accept optional agent fields and add them to the dict:
+
+```python
+def _serialize_item(item, agent_fields: dict | None = None) -> dict:
+    fields = agent_fields or {}
+    return {
+        "id": item.id,
+        "org_id": str(item.org_id),
+        "user_id": str(item.user_id),
+        "session_id": str(item.session_id),
+        "source_event_id": item.source_event_id,
+        "kind": item.kind,
+        "status": item.status,
+        "title": item.title,
+        "body": item.body,
+        "payload": item.payload,
+        "action_ref": item.action_ref,
+        "created_at": item.created_at.isoformat(),
+        "updated_at": item.updated_at.isoformat(),
+        "read_at": item.read_at.isoformat() if item.read_at else None,
+        "responded_at": item.responded_at.isoformat()
+        if item.responded_at
+        else None,
+        "agent_id": fields.get("agent_id"),
+        "agent_web_url": fields.get("agent_web_url"),
+    }
+```
+
+- [ ] **Step 5: Run the unit test to verify it passes**
+
+Run: `uv run pytest tests/test_inbox_serialize.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Wire the 5 serialize call sites**
+
+In `inbox.py`, update each serialize site to resolve and pass agent fields. The LIST handler (line ~125) — replace the return:
+
+```python
+    agent_fields = await _resolve_agent_fields(
+        request, [item.session_id for item in items]
+    )
+    return {
+        "items": [
+            _serialize_item(item, agent_fields.get(item.session_id))
+            for item in items
+        ],
+        "next_cursor": next_cursor,
+    }
+```
+
+For each single-item return (`return _serialize_item(item)` at ~208, ~226, ~259, ~354), replace with:
+
+```python
+    agent_fields = await _resolve_agent_fields(request, [item.session_id])
+    return _serialize_item(item, agent_fields.get(item.session_id))
+```
+
+If any of those four handlers does not already have `request: Request` in its signature, add it (FastAPI injects it). Verify by reading each handler's signature first.
+
+- [ ] **Step 7: Run the full inbox test module + typecheck the module**
+
+Run: `uv run pytest tests/test_inbox_serialize.py -v`
+Expected: PASS.
+Run: `uv run python -c "import surogates.api.routes.inbox, surogates.session.store"`
+Expected: no import error.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add surogates/session/store.py surogates/api/routes/inbox.py tests/test_inbox_serialize.py
+git commit -m "feat(inbox): stamp owner agent_id and agent_web_url on inbox items"
+```
+
+---
+
+## Task 2: Backend — expose the current agent id via `/auth/config`
+
+**Files:**
+- Modify: `surogates/api/routes/auth.py`
+- Test: `tests/integration/test_inbox_api.py` (add one assertion) OR a focused unit test if the auth route is unit-testable; integration preferred since the route depends on `agent_runtime_context_dep`.
+
+**Interfaces:**
+- Produces: `AuthConfigResponse.agent_id: str` in the `GET /v1/auth/config` JSON.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/integration/test_inbox_api.py` (it already builds the app + client; reuse its fixtures). If `/auth/config` requires an agent context the existing harness can't supply, instead assert at the unit level by constructing `AuthConfigResponse` — but prefer the integration assertion. Add:
+
+```python
+async def test_auth_config_returns_current_agent_id(client, session_factory, session_store):
+    # /auth/config resolves the agent via agent_runtime_context_dep; supply
+    # the agent the same way the runtime expects (e.g. ?agent_id=<id>).
+    # Use whatever agent the harness configures; assert the field is present
+    # and equals that agent id.
+    response = await client.get("/v1/auth/config?agent_id=test-agent")
+    assert response.status_code == 200, response.text
+    assert response.json()["agent_id"] == "test-agent"
+```
+
+If the harness cannot resolve `test-agent` (runtime-config cache miss → 404), adjust to the agent id the harness does configure, or seed the runtime-config cache in a fixture; the assertion is that the response includes `agent_id` equal to the resolved agent.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run pytest tests/integration/test_inbox_api.py::test_auth_config_returns_current_agent_id -v`
+Expected: FAIL — response JSON has no `agent_id` key.
+
+- [ ] **Step 3: Add `agent_id` to the response**
+
+In `surogates/api/routes/auth.py`, add the field to `AuthConfigResponse` (line ~81):
+
+```python
+class AuthConfigResponse(BaseModel):
+    """Runtime auth shape exposed by ``GET /v1/auth/config``."""
+
+    agent_id: str
+    self_registration_enabled: bool
+    firebase: FirebaseWebConfig | None = None
+    slash_commands: list[str] = Field(default_factory=list)
+```
+
+In the `auth_config` handler, set `agent_id=agent_runtime.agent_id` in all three `AuthConfigResponse(...)` constructions (the two early returns and the final return).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/integration/test_inbox_api.py::test_auth_config_returns_current_agent_id -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add surogates/api/routes/auth.py tests/integration/test_inbox_api.py
+git commit -m "feat(auth): return current agent_id from /auth/config"
+```
+
+---
+
+## Task 3: SDK — carry agent fields + pass the item to `onSessionSelect`
+
+**Files:**
+- Modify: `sdk/agent-chat-react/src/types.ts`
+- Modify: `sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx`
+- Modify: `web/src/api/inbox.ts`, `surogate-ops/frontend/src/api/inbox.ts`
+- Test: `sdk/agent-chat-react/tests/inbox-panel.test.tsx`
+
+**Interfaces:**
+- Consumes: backend items now include `agent_id`, `agent_web_url`.
+- Produces: `AgentChatInboxItem.agentId?: string | null`, `.agentWebUrl?: string | null`; `InboxPanelProps.onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `sdk/agent-chat-react/tests/inbox-panel.test.tsx`, add a test that asserts the item is passed as the 2nd arg. Use the file's existing `createAdapter`/`inboxItem` helpers and render harness:
+
+```tsx
+it("passes the inbox item to onSessionSelect", async () => {
+  const calls: Array<{ id: string; agentId?: string | null }> = [];
+  const items = [inboxItem({ id: 1, title: "Done" })];
+  items[0].agentId = "other-agent";
+  items[0].agentWebUrl = "https://other.example";
+  const adapter = createAdapter(items);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      <InboxPanel
+        adapter={adapter}
+        onSessionSelect={(sessionId, item) =>
+          calls.push({ id: sessionId, agentId: item?.agentId })
+        }
+      />,
+    );
+    await Promise.resolve();
+  });
+  // select the item, then click "Open session"
+  const row = container.querySelector<HTMLButtonElement>('button[aria-label^="Open inbox item"]');
+  await act(async () => { row?.click(); await Promise.resolve(); });
+  const openBtn = container.querySelector<HTMLButtonElement>('button[aria-label="Open session"]');
+  await act(async () => { openBtn?.click(); await Promise.resolve(); });
+  expect(calls).toEqual([{ id: "session-1", agentId: "other-agent" }]);
+});
+```
+
+(If `inboxItem`/`createAdapter` don't yet allow `agentId`, set it on the item object as above after construction.)
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `PATH="$HOME/.local/node/bin:$PATH" npm test --prefix sdk/agent-chat-react -- inbox-panel`
+Expected: FAIL — `item` is `undefined` (only `sessionId` passed), so `agentId` is undefined and the assertion mismatches.
+
+- [ ] **Step 3: Add the type fields**
+
+In `sdk/agent-chat-react/src/types.ts`, in `interface AgentChatInboxItem` (line ~431), add after `respondedAt`:
+
+```ts
+  agentId?: string | null;
+  agentWebUrl?: string | null;
+```
+
+- [ ] **Step 4: Pass the item from the button**
+
+In `sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx`:
+- Change the prop type (line ~42): `onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;`
+- Change the button handler (line ~204): `onClick={() => onSessionSelect?.(item.sessionId, item)}`
+
+- [ ] **Step 5: Map the fields in the API layers**
+
+In `web/src/api/inbox.ts` `toInboxItem` (line ~37), add to the returned object:
+
+```ts
+    agentId: item.agent_id ?? null,
+    agentWebUrl: item.agent_web_url ?? null,
+```
+
+And add `agent_id?: string | null; agent_web_url?: string | null;` to that file's `InboxItemResponse` interface. Do the same in `surogate-ops/frontend/src/api/inbox.ts` (so ops compiles; ops will simply carry nulls).
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `PATH="$HOME/.local/node/bin:$PATH" npm test --prefix sdk/agent-chat-react -- inbox-panel`
+Expected: PASS, including the existing inbox-panel tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add sdk/agent-chat-react/src/types.ts sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx web/src/api/inbox.ts surogate-ops/frontend/src/api/inbox.ts sdk/agent-chat-react/tests/inbox-panel.test.tsx
+git commit -m "feat(agent-chat): pass inbox item (with owner agent) to onSessionSelect"
+```
+
+---
+
+## Task 4: SDK — decouple session list from the active-session tree fetch
+
+**Files:**
+- Modify: `sdk/agent-chat-react/src/components/sessions/session-tree-panel.tsx`
+- Test: `sdk/agent-chat-react/tests/session-tree-panel.test.tsx`
+
+**Interfaces:**
+- No public API change; `refetch` no longer discards the list when `getSessionTree` rejects.
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/session-tree-panel.test.tsx`, add (using the file's `createAdapter`/`session` helpers):
+
+```tsx
+it("keeps the list when the active session's tree fetch fails", async () => {
+  const sessions = [session({ id: "s-1", title: "First session", agentId: "agent-1" })];
+  const adapter: AgentChatAdapter = {
+    ...createAdapter(sessions),
+    async listSessions() { return { sessions, total: sessions.length }; },
+    async getSessionTree() { throw new Error("404 not found"); },
+  };
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      <SessionTreePanel adapter={adapter} loadList sessionId="foreign-session" activeSessionId="foreign-session" />,
+    );
+    await Promise.resolve();
+  });
+  expect(container.textContent).toContain("First session");
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `PATH="$HOME/.local/node/bin:$PATH" npm test --prefix sdk/agent-chat-react -- session-tree-panel`
+Expected: FAIL — `Promise.all` rejects on the tree 404, the panel renders `null`, "First session" is absent.
+
+- [ ] **Step 3: Decouple the two fetches in `refetch`**
+
+In `session-tree-panel.tsx`, replace the `Promise.all` block (lines ~391-410) so a failed tree doesn't discard the list:
+
+```ts
+        const [listResult, treeResult] = await Promise.allSettled([
+          sessionListPromise,
+          sessionTreePromise,
+        ]);
+        if (!mounted.current || currentRequestId !== requestId.current) return;
+        // The list is the panel's backbone; only a list failure is fatal.
+        if (loadList && adapter.listSessions && listResult.status === "rejected") {
+          throw listResult.reason;
+        }
+        const sessionList =
+          listResult.status === "fulfilled" ? listResult.value : null;
+        const sessionTree =
+          treeResult.status === "fulfilled" ? treeResult.value : null;
+        let nextNodes = mergeTreeNodes([
+          sessionList?.sessions.map(sessionToTreeNode) ?? [],
+          sessionTree?.nodes ?? [],
+        ]);
+```
+
+The rest of the `try` (pendingDelete filtering, fingerprint, `setNodes`, `setError(null)`, `setHasEverLoaded(true)`) stays as-is. The existing `catch` now only triggers when the list itself fails.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `PATH="$HOME/.local/node/bin:$PATH" npm test --prefix sdk/agent-chat-react -- session-tree-panel`
+Expected: PASS (this test plus the existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/agent-chat-react/src/components/sessions/session-tree-panel.tsx sdk/agent-chat-react/tests/session-tree-panel.test.tsx
+git commit -m "fix(agent-chat): keep session list when active session tree fetch fails"
+```
+
+---
+
+## Task 5: Web — store current agent id + route by agent
+
+**Files:**
+- Modify: `web/src/api/auth.ts` (read `agent_id` from `/auth/config`)
+- Modify: `web/src/stores/capabilities-slice.ts` (store `agentId`)
+- Modify: `web/src/features/inbox/inbox-page.tsx` (route)
+
+**Interfaces:**
+- Consumes: `/auth/config` now returns `agent_id`; inbox items now carry `agentId`/`agentWebUrl`.
+- Produces: app store exposes `agentId: string | null`.
+
+> No component test harness exists in `web` (confirmed). Verify via `typecheck` + the local manual repro (the :5174 image/pdf-agent setup). The routing logic is covered by intent here; the SDK tests cover the callback contract.
+
+- [ ] **Step 1: Read `agent_id` in the auth/config client**
+
+In `web/src/api/auth.ts`, where `/api/v1/auth/config` is fetched (line ~176), include `agent_id` in the parsed result type and return it (the response now has it). Ensure the returned config object exposes `agent_id: string`.
+
+- [ ] **Step 2: Store `agentId` in the capabilities slice**
+
+In `web/src/stores/capabilities-slice.ts`: add `agentId: string | null` to the slice state (default `null`), and in `fetchCapabilities` (line ~30) extend the `set` call:
+
+```ts
+    set({ slashCommands: config.slash_commands ?? null, agentId: config.agent_id ?? null });
+```
+
+- [ ] **Step 3: Route by agent in the inbox page**
+
+In `web/src/features/inbox/inbox-page.tsx`, read `agentId` from the store and change `handleSessionSelect` to accept the item and branch:
+
+```tsx
+  const currentAgentId = useAppStore((s) => s.agentId);
+
+  function handleSessionSelect(sessionId: string, item?: AgentChatInboxItem) {
+    if (item?.agentId && item.agentId !== currentAgentId && item.agentWebUrl) {
+      window.open(`${item.agentWebUrl}/chat/${sessionId}`, "_blank", "noopener");
+      return;
+    }
+    setActiveSession(sessionId);
+    void navigate({ to: "/chat/$sessionId", params: { sessionId } });
+  }
+```
+
+Import the `AgentChatInboxItem` type from `@invergent/agent-chat-react`. Ensure `InboxPage` still fetches capabilities (it calls `fetchUser`/`fetchSessions`; add `fetchCapabilities` to its mount effect if not already present so `agentId` is populated — check first).
+
+- [ ] **Step 4: Typecheck the web app**
+
+Run: `PATH="$HOME/.local/node/bin:$PATH" npm run typecheck --prefix web`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/api/auth.ts web/src/stores/capabilities-slice.ts web/src/features/inbox/inbox-page.tsx
+git commit -m "feat(web): open cross-agent inbox sessions in the owning agent's app"
+```
+
+---
+
+## Task 6: Verify — full builds + backward compatibility
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: SDK test suite**
+
+Run: `PATH="$HOME/.local/node/bin:$PATH" npm test --prefix sdk/agent-chat-react`
+Expected: all SDK tests pass (inbox-panel, session-tree-panel, others).
+
+- [ ] **Step 2: Backend inbox tests**
+
+Run: `uv run pytest tests/test_inbox_serialize.py tests/integration/test_inbox_api.py -m "not browser_e2e and not browser_e2e_k8s and not live" -v`
+Expected: pass (integration tests require the test DB per conftest; if unavailable, at minimum `tests/test_inbox_serialize.py` passes and you note the integration run was skipped).
+
+- [ ] **Step 3: Web typecheck**
+
+Run: `PATH="$HOME/.local/node/bin:$PATH" npm run typecheck --prefix web`
+Expected: no errors.
+
+- [ ] **Step 4: Confirm ops backward-compatibility**
+
+Ops consumes the *published* SDK, not this local checkout, so no ops build runs here. Confirm by inspection that the SDK changes are backward compatible: `onSessionSelect`'s new 2nd arg is optional (ops's `(sessionId) => …` handler stays valid), and the new `AgentChatInboxItem` fields are optional. Note in the PR that ops needs no code change and will pick up the fix on the next SDK version bump.
+
+- [ ] **Step 5: Manual local verification (web)**
+
+With the local stack up and `web/.env.local` pointed at an agent that has a cross-agent inbox item: open `:5174` → Inbox → "Open session" on a different-agent item. Confirm it calls `window.open` with `<agent_web_url>/chat/<sessionId>` (the new tab won't load on localhost — see spec caveat) and that a same-agent item still opens in place. Confirm the session list no longer blanks.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Backend stamps `agent_id` + `agent_web_url` → Task 1. Current agent via `/auth/config` → Task 2.
+- SDK carries fields + passes item → Task 3. List/tree decoupling → Task 4.
+- Web stores current agent + routes (new tab vs in place) → Task 5.
+- Edge cases (missing url / absent fields → in-place) → Task 5 branch condition (`item.agentId && item.agentId !== currentAgentId && item.agentWebUrl`).
+- Ops verify-only / backward compat → Task 6 Step 4.
+
+**Placeholder scan:** none — every step has concrete code/commands. The one judgment call (which agent id the auth-config integration test can resolve) is called out explicitly in Task 2 Step 1 with the fallback.
+
+**Type consistency:** `agent_id`/`agent_web_url` (snake, backend + API JSON) map to `agentId`/`agentWebUrl` (camel, SDK type + web/ops mappers + web handler). `onSessionSelect(sessionId, item?)` signature is identical in the SDK prop type (Task 3), the button call (Task 3), and the web handler (Task 5). `get_agent_ids_for_sessions` returns `dict[UUID, str]`, consumed by `_resolve_agent_fields` (Task 1). `AuthConfigResponse.agent_id` (Task 2) → `config.agent_id` (Task 5 Step 1-2).

--- a/docs/superpowers/plans/2026-06-18-inbox-cross-agent-open-session.md
+++ b/docs/superpowers/plans/2026-06-18-inbox-cross-agent-open-session.md
@@ -28,7 +28,7 @@
 - `sdk/agent-chat-react/src/types.ts` — `AgentChatInboxItem` gains `agentId?`, `agentWebUrl?`.
 - `sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx` — pass item to `onSessionSelect`.
 - `sdk/agent-chat-react/src/components/sessions/session-tree-panel.tsx` — decouple list/tree fetch.
-- `web/src/api/inbox.ts`, `surogate-ops/frontend/src/api/inbox.ts` — map the new fields.
+- `web/src/api/inbox.ts` — map the new fields. (ops is a separate repo on the published SDK and is verify-only; no ops change.)
 - `web/src/api/auth.ts`, `web/src/stores/capabilities-slice.ts` — read + store current `agentId`.
 - `web/src/features/inbox/inbox-page.tsx` — agent-aware routing.
 - `sdk/agent-chat-react/tests/inbox-panel.test.tsx`, `tests/session-tree-panel.test.tsx` — SDK tests.
@@ -319,7 +319,7 @@ git commit -m "feat(auth): return current agent_id from /auth/config"
 **Files:**
 - Modify: `sdk/agent-chat-react/src/types.ts`
 - Modify: `sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx`
-- Modify: `web/src/api/inbox.ts`, `surogate-ops/frontend/src/api/inbox.ts`
+- Modify: `web/src/api/inbox.ts`
 - Test: `sdk/agent-chat-react/tests/inbox-panel.test.tsx`
 
 **Interfaces:**
@@ -391,7 +391,7 @@ In `web/src/api/inbox.ts` `toInboxItem` (line ~37), add to the returned object:
     agentWebUrl: item.agent_web_url ?? null,
 ```
 
-And add `agent_id?: string | null; agent_web_url?: string | null;` to that file's `InboxItemResponse` interface. Do the same in `surogate-ops/frontend/src/api/inbox.ts` (so ops compiles; ops will simply carry nulls).
+And add `agent_id?: string | null; agent_web_url?: string | null;` to that file's `InboxItemResponse` interface. Do NOT touch the ops repo: `surogate-ops` is a separate repo on the published SDK; the optional fields require no ops mapper change and ops's inbox is per-agent (verify-only).
 
 - [ ] **Step 6: Run the test to verify it passes**
 
@@ -401,7 +401,7 @@ Expected: PASS, including the existing inbox-panel tests.
 - [ ] **Step 7: Commit**
 
 ```bash
-git add sdk/agent-chat-react/src/types.ts sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx web/src/api/inbox.ts surogate-ops/frontend/src/api/inbox.ts sdk/agent-chat-react/tests/inbox-panel.test.tsx
+git add sdk/agent-chat-react/src/types.ts sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx web/src/api/inbox.ts sdk/agent-chat-react/tests/inbox-panel.test.tsx
 git commit -m "feat(agent-chat): pass inbox item (with owner agent) to onSessionSelect"
 ```
 

--- a/docs/superpowers/specs/2026-06-18-inbox-cross-agent-open-session-design.md
+++ b/docs/superpowers/specs/2026-06-18-inbox-cross-agent-open-session-design.md
@@ -1,0 +1,132 @@
+# Agent-aware "Open session" from the cross-agent inbox
+
+**Date:** 2026-06-18
+**Status:** Approved, ready for planning
+**Scope:** surogates only — backend runtime + SDK (`agent-chat-react`) + web app. Ops/Studio is verify-only.
+**Branch:** `fix/inbox-cross-agent-open-session` (off `master`).
+
+## Problem
+
+The agent web app's inbox is **per-user and cross-agent**: `store.list_inbox` filters by
+`user_id` only (`surogates/session/store.py:921`), so a user with accounts on several
+agents sees inbox items from all of them in whichever agent's web app they're viewing.
+
+When you click **Open session** on an item that belongs to a *different* agent, three
+things go wrong (all reproduced locally on 2026-06-18):
+
+1. **Wrong agent context** — it loads in the current agent's app instead of the owning agent's.
+2. **Same window** — it navigates in place; it should open the owning agent's app in a new tab.
+3. **Session list empties** — the left list goes blank until you open a session that belongs
+   to the current agent.
+
+### Confirmed root cause
+
+- **No agent identity on inbox items, at any layer.** The runtime serializer
+  `_serialize_item` (`surogates/api/routes/inbox.py:67-85`) emits `session_id` but no
+  `agent_id`/slug/url; the SDK type `AgentChatInboxItem`
+  (`sdk/agent-chat-react/src/types.ts:431`) and the web mapping `toInboxItem`
+  (`web/src/api/inbox.ts:37`) carry none. The SDK "Open session" button passes only
+  `item.sessionId` to `onSessionSelect` (`sdk/.../components/inbox/inbox-panel.tsx:204`),
+  and the web handler unconditionally does `setActiveSession` + `navigate("/chat/$sessionId")`
+  (`web/src/features/inbox/inbox-page.tsx:25-28`). The web frontend doesn't even track its
+  own agent (resolved server-side from Host/`?agent_id`, `surogates/runtime/resolver.py:136-159`).
+  → symptoms #1 and #2.
+- **Symptom #3** is a downstream effect: a foreign session is unloadable in the current
+  agent's scope by design — `_get_session_for_tenant` 404s when `session.agent_id != agent_id`
+  ("callers cannot probe session existence across scopes", `surogates/api/routes/sessions.py:531-562`).
+  The SDK `SessionTreePanel.refetch` fetches the list and the active session's tree together in
+  one `Promise.all` (`sdk/.../components/sessions/session-tree-panel.tsx:402-405`); the foreign
+  tree's 404 rejects the whole call, the `catch` never sets `nodes`/`hasEverLoaded`, and the
+  render guards return `null` — discarding the *successful* list fetch and blanking the panel.
+
+### Why ops is not affected
+
+Ops/Studio's inbox is **per-agent**: its backend query joins the session and filters
+`SessionRow.agent_id == agent_id` (`surogate-ops/.../core/surogates_client.py:1770`), so an
+ops agent inbox only ever lists that agent's items. "Open session" there always targets the
+correct agent. Ops is touched only to stay compatible with the SDK change (verify-only).
+
+## Goals
+
+- A different-agent inbox session opens in that agent's app, in a new browser tab.
+- A same-agent inbox session opens in place (unchanged from today).
+- The session list never blanks because the *active* session's tree fetch failed.
+- Backward compatible: ops and any pre-deploy items keep working (in-place) with no change.
+
+## Non-goals
+
+- No change to ops behavior (its per-agent inbox is already correct).
+- No change to inbox scoping (the cross-agent, user-scoped inbox is intended).
+- No new "agent switcher" UI; we only fix the Open-session target.
+
+## Design
+
+### 1. Backend — stamp agent identity on inbox items
+`_serialize_item` (`surogates/api/routes/inbox.py`) gains three fields, all derivable
+server-side:
+- `agent_id` — the owner, from the item's `session.agent_id`.
+- `agent_web_url` — the owner agent's `api_web_url`, read from that agent's runtime config
+  (`AgentRuntimeContext.api_web_url`, populated from the platform payload; same value the
+  Slack channel uses). Resolved via the runtime-config cache keyed by `agent_id`.
+- `is_current` — `session.agent_id == <request's resolved agent_id>` (the runtime already
+  resolves the request's agent via `agent_runtime_context_dep`).
+
+The serializer currently takes only `item`; it will need the request's resolved agent id and
+a way to resolve `agent_id -> (api_web_url)` and `agent_id -> session.agent_id`. The list
+endpoint already has `request` (hence the runtime-config cache) and loads items; the plan
+will thread the resolved agent id and look up each owner agent's config (batched/cached).
+
+### 2. SDK — carry the fields and pass the item to the handler
+- Add optional `agentId?: string | null`, `agentWebUrl?: string | null`,
+  `isCurrent?: boolean` to `AgentChatInboxItem` (`types.ts`); map them in the web and ops
+  `api/inbox.ts` response mappers (ops may leave them undefined).
+- `InboxPanel`'s Open-session button calls `onSessionSelect?.(item.sessionId, item)` —
+  adding the full item as an **optional second argument**. The `onSessionSelect` prop type
+  becomes `(sessionId: string, item?: AgentChatInboxItem) => void`. This is backward
+  compatible: an existing `(sessionId) => …` handler (ops) remains assignable and untouched.
+
+### 3. Web — route based on the item
+`handleSessionSelect` (`web/src/features/inbox/inbox-page.tsx`) becomes
+`(sessionId, item?)`:
+- If `item?.isCurrent === false && item.agentWebUrl` → `window.open(\`${item.agentWebUrl}/chat/${sessionId}\`, "_blank", "noopener")` (new tab, owner's app).
+- Otherwise (same agent, or fields absent) → today's in-place behavior:
+  `setActiveSession(sessionId)` + `navigate({ to: "/chat/$sessionId" })`.
+
+### 4. Secondary hardening — decouple list from tree (SDK)
+In `SessionTreePanel.refetch` (`sdk/.../components/sessions/session-tree-panel.tsx`), stop
+letting a failed `getSessionTree` discard the list. Run the two fetches independently
+(`Promise.allSettled`, or await each in its own try/catch): build `nodes` from whichever
+results succeeded, and only surface an error / withhold `hasEverLoaded` when the *list*
+fetch itself fails. A failed active-session tree must not blank the list.
+
+## Error handling / edge cases
+
+- Different agent but `agent_web_url` missing/null → fall back to in-place (never worse than today).
+- `is_current` / item fields absent (ops, pre-deploy items) → in-place. Fully backward compatible.
+- `window.open` blocked by a popup blocker → acceptable; it fires from a direct user click, so
+  browsers normally allow it. No special handling planned.
+
+## Testing
+
+- **Backend:** `_serialize_item` includes `agent_id`, `agent_web_url`, `is_current`; an item
+  whose session belongs to another agent serializes `is_current=false` with that agent's
+  `agent_web_url`; a same-agent item serializes `is_current=true`.
+- **SDK:** `InboxPanel` passes the item as the 2nd arg to `onSessionSelect`;
+  `SessionTreePanel` still renders the list when `getSessionTree` rejects (list 200, tree
+  404 → list shown, no blank).
+- **Web:** the handler calls `window.open` with `\`${agentWebUrl}/chat/${sessionId}\`` for a
+  different-agent item and navigates in place for a same-agent item; falls back to in-place
+  when `agentWebUrl` is absent.
+
+## Local testing caveat
+
+`agent_web_url` points at the cluster/prod host, so the *new tab itself* will not load on
+localhost. Locally we verify the logic (correct branch + the URL passed to `window.open`);
+the real cross-agent tab is confirmed in a prod-like environment.
+
+## Cross-repo note
+
+Per the standing rule, chat-menu / SDK / adapter changes are checked in both ops and the web
+app. Here the SDK `InboxPanel` and `AgentChatInboxItem` changes are backward compatible, ops's
+inbox is per-agent (no cross-agent case), and ops's `onSessionSelect` handler stays valid — so
+ops needs verification only, not a behavioral change.

--- a/docs/superpowers/specs/2026-06-18-inbox-cross-agent-open-session-design.md
+++ b/docs/superpowers/specs/2026-06-18-inbox-cross-agent-open-session-design.md
@@ -61,36 +61,44 @@ correct agent. Ops is touched only to stay compatible with the SDK change (verif
 
 ## Design
 
-### 1. Backend — stamp agent identity on inbox items
-`_serialize_item` (`surogates/api/routes/inbox.py`) gains three fields, all derivable
-server-side:
-- `agent_id` — the owner, from the item's `session.agent_id`.
-- `agent_web_url` — the owner agent's `api_web_url`, read from that agent's runtime config
-  (`AgentRuntimeContext.api_web_url`, populated from the platform payload; same value the
-  Slack channel uses). Resolved via the runtime-config cache keyed by `agent_id`.
-- `is_current` — `session.agent_id == <request's resolved agent_id>` (the runtime already
-  resolves the request's agent via `agent_runtime_context_dep`).
+> **Refinement (during planning):** the same/different-agent decision is made **client-side
+> by comparing agent ids**, not by a backend `is_current` flag. Computing `is_current` on the
+> inbox item would force the user-scoped inbox endpoint to resolve an agent (it currently does
+> not, and its integration tests call it with no agent), breaking that contract. Instead the
+> backend stamps each item with its owner `agent_id` + `agent_web_url`, and exposes the
+> **current** agent id via the already-agent-resolved `/auth/config`. Behavior is identical.
 
-The serializer currently takes only `item`; it will need the request's resolved agent id and
-a way to resolve `agent_id -> (api_web_url)` and `agent_id -> session.agent_id`. The list
-endpoint already has `request` (hence the runtime-config cache) and loads items; the plan
-will thread the resolved agent id and look up each owner agent's config (batched/cached).
+### 1. Backend — stamp owner agent on inbox items + expose current agent
+Two additive, non-breaking changes:
+
+- **Inbox items** (`surogates/api/routes/inbox.py`): serialize `agent_id` (owner, from the
+  item's `session.agent_id`) and `agent_web_url` (owner agent's `api_web_url`, read from that
+  agent's runtime config via the runtime-config cache keyed by `agent_id`). The serializer
+  currently takes only `item`; the list path batches `session_id -> agent_id` (one query) and
+  dedupes the per-owner-agent `api_web_url` cache lookups; single-item paths resolve one each.
+  The endpoint stays **user-scoped** — no agent resolution added, no contract change.
+- **Current agent** (`surogates/api/routes/auth.py`): add `agent_id` to `AuthConfigResponse`
+  (the `/auth/config` handler already resolves the agent via `agent_runtime_context_dep`, so
+  `agent_runtime.agent_id` is in hand). This is how the web learns its own agent id.
 
 ### 2. SDK — carry the fields and pass the item to the handler
-- Add optional `agentId?: string | null`, `agentWebUrl?: string | null`,
-  `isCurrent?: boolean` to `AgentChatInboxItem` (`types.ts`); map them in the web and ops
-  `api/inbox.ts` response mappers (ops may leave them undefined).
+- Add optional `agentId?: string | null`, `agentWebUrl?: string | null` to
+  `AgentChatInboxItem` (`types.ts`); map them in the web and ops `api/inbox.ts` response
+  mappers (ops may leave them undefined).
 - `InboxPanel`'s Open-session button calls `onSessionSelect?.(item.sessionId, item)` —
   adding the full item as an **optional second argument**. The `onSessionSelect` prop type
   becomes `(sessionId: string, item?: AgentChatInboxItem) => void`. This is backward
   compatible: an existing `(sessionId) => …` handler (ops) remains assignable and untouched.
 
-### 3. Web — route based on the item
-`handleSessionSelect` (`web/src/features/inbox/inbox-page.tsx`) becomes
-`(sessionId, item?)`:
-- If `item?.isCurrent === false && item.agentWebUrl` → `window.open(\`${item.agentWebUrl}/chat/${sessionId}\`, "_blank", "noopener")` (new tab, owner's app).
-- Otherwise (same agent, or fields absent) → today's in-place behavior:
-  `setActiveSession(sessionId)` + `navigate({ to: "/chat/$sessionId" })`.
+### 3. Web — route by comparing the item's agent to the current agent
+- The web stores its **current agent id** from `/auth/config` (the capabilities fetch it
+  already makes on load).
+- `handleSessionSelect` (`web/src/features/inbox/inbox-page.tsx`) becomes `(sessionId, item?)`:
+  - If `item?.agentId && item.agentId !== currentAgentId && item.agentWebUrl` →
+    `window.open(\`${item.agentWebUrl}/chat/${sessionId}\`, "_blank", "noopener")` (new tab,
+    owner's app).
+  - Otherwise (same agent, or fields absent) → today's in-place behavior:
+    `setActiveSession(sessionId)` + `navigate({ to: "/chat/$sessionId" })`.
 
 ### 4. Secondary hardening — decouple list from tree (SDK)
 In `SessionTreePanel.refetch` (`sdk/.../components/sessions/session-tree-panel.tsx`), stop
@@ -102,15 +110,16 @@ fetch itself fails. A failed active-session tree must not blank the list.
 ## Error handling / edge cases
 
 - Different agent but `agent_web_url` missing/null → fall back to in-place (never worse than today).
-- `is_current` / item fields absent (ops, pre-deploy items) → in-place. Fully backward compatible.
+- Item agent fields absent, or current agent id unknown (ops, pre-deploy items) → in-place.
+  Fully backward compatible.
 - `window.open` blocked by a popup blocker → acceptable; it fires from a direct user click, so
   browsers normally allow it. No special handling planned.
 
 ## Testing
 
-- **Backend:** `_serialize_item` includes `agent_id`, `agent_web_url`, `is_current`; an item
-  whose session belongs to another agent serializes `is_current=false` with that agent's
-  `agent_web_url`; a same-agent item serializes `is_current=true`.
+- **Backend:** the inbox serializer includes `agent_id` + `agent_web_url` (owner) on items;
+  an item whose session belongs to another agent serializes that agent's id + `agent_web_url`.
+  `/auth/config` returns the current `agent_id`.
 - **SDK:** `InboxPanel` passes the item as the 2nd arg to `onSessionSelect`;
   `SessionTreePanel` still renders the list when `getSessionTree` rejects (list 200, tree
   404 → list shown, no blank).

--- a/docs/superpowers/specs/2026-06-18-inbox-cross-agent-open-session-design.md
+++ b/docs/superpowers/specs/2026-06-18-inbox-cross-agent-open-session-design.md
@@ -2,8 +2,8 @@
 
 **Date:** 2026-06-18
 **Status:** Approved, ready for planning
-**Scope:** surogates only — backend runtime + SDK (`agent-chat-react`) + web app. Ops/Studio is verify-only.
-**Branch:** `fix/inbox-cross-agent-open-session` (off `master`).
+**Scope:** cross-repo — `surogates` (runtime inbox + SDK `agent-chat-react` + web app) and a one-field `surogate-ops` backend change (expose the agent slug in the runtime config). Ops *frontend* is verify-only.
+**Branches:** `surogates` `fix/inbox-cross-agent-open-session` (off `master`); `surogate-ops` `fix/inbox-cross-agent-open-session` (off `main`).
 
 ## Problem
 
@@ -61,43 +61,50 @@ correct agent. Ops is touched only to stay compatible with the SDK change (verif
 
 ## Design
 
-> **Refinement (during planning):** the same/different-agent decision is made **client-side
-> by comparing agent ids**, not by a backend `is_current` flag. Computing `is_current` on the
-> inbox item would force the user-scoped inbox endpoint to resolve an agent (it currently does
-> not, and its integration tests call it with no agent), breaking that contract. Instead the
-> backend stamps each item with its owner `agent_id` + `agent_web_url`, and exposes the
-> **current** agent id via the already-agent-resolved `/auth/config`. Behavior is identical.
+> **Revision (2026-06-18, after local testing):** the cross-agent URL is built from the
+> owning agent's **slug** (`agent.name`), NOT from `api_web_url`. Investigation (DB + code)
+> showed `api_web_url` in the runtime config is **never populated** — no code path writes it
+> into the runtime-config blob, and it is null for every agent — so the originally-specced
+> new-tab path (using `agent_web_url`) could never fire, in any environment. The agent's
+> hosted page is slug-based: `https://<slug>.<domain>/chat/<id>` (confirmed in prod, e.g.
+> `https://pdf-reader-2u6vbt.cloud.surogate.ai/chat/<id>`). The same/different-agent decision
+> is still made client-side by comparing agent ids (via `/auth/config`'s `agent_id`).
+> **Unaffected by this revision (already built):** `/auth/config` returning `agent_id`
+> (Design 2 below) and the list/tree decoupling (Design 4).
 
-### 1. Backend — stamp owner agent on inbox items + expose current agent
-Two additive, non-breaking changes:
+### 1. Backend — expose the owner agent's slug + stamp it on inbox items
+Cross-repo: the slug lives in **ops** (`agent.name`); the surogates runtime only knows the
+agent id, so ops must surface the slug in the runtime config it serves.
 
-- **Inbox items** (`surogates/api/routes/inbox.py`): serialize `agent_id` (owner, from the
-  item's `session.agent_id`) and `agent_web_url` (owner agent's `api_web_url`, read from that
-  agent's runtime config via the runtime-config cache keyed by `agent_id`). The serializer
-  currently takes only `item`; the list path batches `session_id -> agent_id` (one query) and
-  dedupes the per-owner-agent `api_web_url` cache lookups; single-item paths resolve one each.
-  The endpoint stays **user-scoped** — no agent resolution added, no contract change.
-- **Current agent** (`surogates/api/routes/auth.py`): add `agent_id` to `AuthConfigResponse`
-  (the `/auth/config` handler already resolves the agent via `agent_runtime_context_dep`, so
-  `agent_runtime.agent_id` is in hand). This is how the web learns its own agent id.
+- **ops** (`surogate_ops/server/routes/agent_runtime.py`): add the agent's slug (`agent.name`)
+  to the runtime-config response (`AgentRuntimeConfigResponse`). The handler already loads the
+  `Agent` row, so it is a one-field addition. This lets the surogates runtime learn an agent's
+  slug from its (cached) runtime config.
+- **surogates** (`surogates/api/routes/inbox.py`): the runtime-config payload now carries the
+  slug; stamp `agent_slug` (owner, from that agent's runtime-config payload, best-effort/None
+  on cache miss) on each inbox item alongside `agent_id`. (Replaces the always-null
+  `agent_web_url`.) The list path still batches `session_id -> agent_id` and dedupes the
+  per-owner-agent slug lookups. The inbox endpoint stays **user-scoped**.
+- **Current agent** (`surogates/api/routes/auth.py`): `/auth/config` returns `agent_id` —
+  DONE, unchanged by this revision.
 
 ### 2. SDK — carry the fields and pass the item to the handler
-- Add optional `agentId?: string | null`, `agentWebUrl?: string | null` to
-  `AgentChatInboxItem` (`types.ts`); map them in the web and ops `api/inbox.ts` response
-  mappers (ops may leave them undefined).
-- `InboxPanel`'s Open-session button calls `onSessionSelect?.(item.sessionId, item)` —
-  adding the full item as an **optional second argument**. The `onSessionSelect` prop type
-  becomes `(sessionId: string, item?: AgentChatInboxItem) => void`. This is backward
-  compatible: an existing `(sessionId) => …` handler (ops) remains assignable and untouched.
+- Add optional `agentId?: string | null` and **`agentSlug?: string | null`** to
+  `AgentChatInboxItem` (`types.ts`); map them in the **web** `api/inbox.ts` response mapper.
+  (ops frontend is a separate repo on the published SDK — verify-only, no ops mapper change.)
+- `InboxPanel`'s Open-session button calls `onSessionSelect?.(item.sessionId, item)` (item as
+  an optional 2nd arg) — DONE for `agentId` + the callback; this revision swaps the
+  `agentWebUrl` field for `agentSlug`.
 
-### 3. Web — route by comparing the item's agent to the current agent
-- The web stores its **current agent id** from `/auth/config` (the capabilities fetch it
-  already makes on load).
-- `handleSessionSelect` (`web/src/features/inbox/inbox-page.tsx`) becomes `(sessionId, item?)`:
-  - If `item?.agentId && item.agentId !== currentAgentId && item.agentWebUrl` →
-    `window.open(\`${item.agentWebUrl}/chat/${sessionId}\`, "_blank", "noopener")` (new tab,
-    owner's app).
-  - Otherwise (same agent, or fields absent) → today's in-place behavior:
+### 3. Web — build the owner's URL from the current host + slug
+- The web stores its **current agent id** from `/auth/config` (DONE).
+- `handleSessionSelect(sessionId, item?)`:
+  - If `item?.agentId && currentAgentId && item.agentId !== currentAgentId && item.agentSlug`
+    AND the current host is a `<slug>.<domain>` form (has a parseable multi-label domain, not
+    `localhost`): derive `domain` from `window.location.host` (drop the current first label),
+    then `window.open(\`${protocol}//${item.agentSlug}.${domain}/chat/${sessionId}\`, "_blank",
+    "noopener")`.
+  - Otherwise (same agent, missing slug, or no derivable domain — e.g. localhost) → in-place
     `setActiveSession(sessionId)` + `navigate({ to: "/chat/$sessionId" })`.
 
 ### 4. Secondary hardening — decouple list from tree (SDK)
@@ -109,33 +116,40 @@ fetch itself fails. A failed active-session tree must not blank the list.
 
 ## Error handling / edge cases
 
-- Different agent but `agent_web_url` missing/null → fall back to in-place (never worse than today).
-- Item agent fields absent, or current agent id unknown (ops, pre-deploy items) → in-place.
+- Different agent but `agent_slug` missing/null, OR no derivable domain (e.g. `localhost`,
+  single-label host) → fall back to in-place (never worse than today).
+- Item agent fields absent, or current agent id unknown (pre-deploy items) → in-place.
   Fully backward compatible.
 - `window.open` blocked by a popup blocker → acceptable; it fires from a direct user click, so
   browsers normally allow it. No special handling planned.
 
 ## Testing
 
-- **Backend:** the inbox serializer includes `agent_id` + `agent_web_url` (owner) on items;
-  an item whose session belongs to another agent serializes that agent's id + `agent_web_url`.
-  `/auth/config` returns the current `agent_id`.
-- **SDK:** `InboxPanel` passes the item as the 2nd arg to `onSessionSelect`;
-  `SessionTreePanel` still renders the list when `getSessionTree` rejects (list 200, tree
-  404 → list shown, no blank).
-- **Web:** the handler calls `window.open` with `\`${agentWebUrl}/chat/${sessionId}\`` for a
-  different-agent item and navigates in place for a same-agent item; falls back to in-place
-  when `agentWebUrl` is absent.
+- **ops:** the runtime-config response includes the agent's slug (`name`).
+- **surogates backend:** the inbox serializer includes `agent_id` + `agent_slug` (owner) on
+  items; an item whose session belongs to another agent serializes that agent's id + slug.
+  `/auth/config` returns the current `agent_id` (done).
+- **SDK:** `InboxPanel` passes the item as the 2nd arg to `onSessionSelect` (done);
+  `AgentChatInboxItem` carries `agentSlug`; `SessionTreePanel` still renders the list when
+  `getSessionTree` rejects (done).
+- **Web:** no component test harness — verify by typecheck + manual. Handler builds
+  `<protocol>//<agentSlug>.<domain>/chat/<sessionId>` from `window.location` for a
+  different-agent item (when a domain is derivable), navigates in place for a same-agent item,
+  and falls back to in-place when the slug or domain is unavailable.
 
 ## Local testing caveat
 
-`agent_web_url` points at the cluster/prod host, so the *new tab itself* will not load on
-localhost. Locally we verify the logic (correct branch + the URL passed to `window.open`);
-the real cross-agent tab is confirmed in a prod-like environment.
+The web app runs at `localhost:5174` locally (no `<slug>.<domain>` host), so the domain is not
+derivable and a cross-agent click correctly falls back to **in-place** — the new tab cannot be
+exercised locally. The cross-agent tab is confirmed in a prod-like environment (web served at
+`<slug>.cloud.surogate.ai`). Locally, verify: cross-agent detection (agent ids differ), the
+in-place fallback, and the list-no-blank fix.
 
 ## Cross-repo note
 
-Per the standing rule, chat-menu / SDK / adapter changes are checked in both ops and the web
-app. Here the SDK `InboxPanel` and `AgentChatInboxItem` changes are backward compatible, ops's
-inbox is per-agent (no cross-agent case), and ops's `onSessionSelect` handler stays valid — so
-ops needs verification only, not a behavioral change.
+This revision touches **two repos**: `surogate-ops` (expose the agent slug in the runtime
+config) and `surogates` (carry the slug through the inbox + build the URL in web). Per the
+standing rule, the shared SDK change is backward compatible; the ops *frontend* inbox is
+per-agent (no cross-agent case) and stays verify-only — the only ops change is the backend
+runtime-config field. Branches: `surogates` off `master`, `surogate-ops` off `main` (both
+`fix/inbox-cross-agent-open-session`).

--- a/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
+++ b/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
@@ -39,7 +39,7 @@ export interface InboxPanelProps {
   title?: string;
   selectedId?: number | null;
   onSelectedIdChange?: (itemId: number | null) => void;
-  onSessionSelect?: (sessionId: string) => void;
+  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
   hideHeader?: boolean;
   limit?: number;
 }
@@ -181,7 +181,7 @@ function InboxDetailActions({
   item: AgentChatInboxItem;
   adapter: InboxAdapter;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string) => void;
+  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
   children?: ReactNode;
 }) {
   const [deleting, setDeleting] = useState(false);
@@ -201,7 +201,7 @@ function InboxDetailActions({
       <Button
         type="button"
         size="sm"
-        onClick={() => onSessionSelect?.(item.sessionId)}
+        onClick={() => onSessionSelect?.(item.sessionId, item)}
         aria-label="Open session"
       >
         <ExternalLinkIcon className="size-3.5" />
@@ -237,7 +237,7 @@ function InputRequiredDetail({
   adapter: InboxAdapter;
   onUpdated: (item: AgentChatInboxItem) => void;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string) => void;
+  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
 }) {
   const questions = Array.isArray(item.payload.questions)
     ? (item.payload.questions as Array<{
@@ -342,7 +342,7 @@ function AckDetail({
   adapter: InboxAdapter;
   onUpdated: (item: AgentChatInboxItem) => void;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string) => void;
+  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
 }) {
   async function acknowledge() {
     onUpdated(await adapter.acknowledgeInboxItem({ itemId: item.id }));
@@ -399,7 +399,7 @@ function GovernanceDetail({
   adapter: InboxAdapter;
   onUpdated: (item: AgentChatInboxItem) => void;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string) => void;
+  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
 }) {
   async function decide(decision: "approve" | "reject") {
     onUpdated(
@@ -467,7 +467,7 @@ function ActionRequiredDetail({
   adapter: InboxAdapter;
   onUpdated: (item: AgentChatInboxItem) => void;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string) => void;
+  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
 }) {
   const [submitting, setSubmitting] = useState(false);
   const actionType =
@@ -530,7 +530,7 @@ function ProgressDetail({
   adapter: InboxAdapter;
   onUpdated: (item: AgentChatInboxItem) => void;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string) => void;
+  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
 }) {
   async function acknowledge() {
     onUpdated(await adapter.acknowledgeInboxItem({ itemId: item.id }));
@@ -591,7 +591,7 @@ function InboxDetail({
   adapter: InboxAdapter;
   onUpdated: (item: AgentChatInboxItem) => void;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string) => void;
+  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
 }) {
   const Icon = kindIcon(item.kind);
 

--- a/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
+++ b/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
@@ -34,12 +34,14 @@ import type {
   AgentChatInboxList,
 } from "../../types";
 
+type OnSessionSelect = (sessionId: string, item?: AgentChatInboxItem) => void;
+
 export interface InboxPanelProps {
   adapter: AgentChatAdapter;
   title?: string;
   selectedId?: number | null;
   onSelectedIdChange?: (itemId: number | null) => void;
-  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
+  onSessionSelect?: OnSessionSelect;
   hideHeader?: boolean;
   limit?: number;
 }
@@ -181,7 +183,7 @@ function InboxDetailActions({
   item: AgentChatInboxItem;
   adapter: InboxAdapter;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
+  onSessionSelect?: OnSessionSelect;
   children?: ReactNode;
 }) {
   const [deleting, setDeleting] = useState(false);
@@ -237,7 +239,7 @@ function InputRequiredDetail({
   adapter: InboxAdapter;
   onUpdated: (item: AgentChatInboxItem) => void;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
+  onSessionSelect?: OnSessionSelect;
 }) {
   const questions = Array.isArray(item.payload.questions)
     ? (item.payload.questions as Array<{
@@ -342,7 +344,7 @@ function AckDetail({
   adapter: InboxAdapter;
   onUpdated: (item: AgentChatInboxItem) => void;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
+  onSessionSelect?: OnSessionSelect;
 }) {
   async function acknowledge() {
     onUpdated(await adapter.acknowledgeInboxItem({ itemId: item.id }));
@@ -399,7 +401,7 @@ function GovernanceDetail({
   adapter: InboxAdapter;
   onUpdated: (item: AgentChatInboxItem) => void;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
+  onSessionSelect?: OnSessionSelect;
 }) {
   async function decide(decision: "approve" | "reject") {
     onUpdated(
@@ -467,7 +469,7 @@ function ActionRequiredDetail({
   adapter: InboxAdapter;
   onUpdated: (item: AgentChatInboxItem) => void;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
+  onSessionSelect?: OnSessionSelect;
 }) {
   const [submitting, setSubmitting] = useState(false);
   const actionType =
@@ -530,7 +532,7 @@ function ProgressDetail({
   adapter: InboxAdapter;
   onUpdated: (item: AgentChatInboxItem) => void;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
+  onSessionSelect?: OnSessionSelect;
 }) {
   async function acknowledge() {
     onUpdated(await adapter.acknowledgeInboxItem({ itemId: item.id }));
@@ -591,7 +593,7 @@ function InboxDetail({
   adapter: InboxAdapter;
   onUpdated: (item: AgentChatInboxItem) => void;
   onDeleted: (itemId: number) => Promise<void>;
-  onSessionSelect?: (sessionId: string, item?: AgentChatInboxItem) => void;
+  onSessionSelect?: OnSessionSelect;
 }) {
   const Icon = kindIcon(item.kind);
 

--- a/sdk/agent-chat-react/src/components/sessions/session-tree-panel.tsx
+++ b/sdk/agent-chat-react/src/components/sessions/session-tree-panel.tsx
@@ -405,7 +405,7 @@ export function SessionTreePanel({
         ]);
         if (!mounted.current || currentRequestId !== requestId.current) return;
         // The list is the panel's backbone; only a list failure is fatal.
-        if (loadList && adapter.listSessions && listResult.status === "rejected") {
+        if (loadList && listResult.status === "rejected") {
           throw listResult.reason;
         }
         const sessionList =

--- a/sdk/agent-chat-react/src/components/sessions/session-tree-panel.tsx
+++ b/sdk/agent-chat-react/src/components/sessions/session-tree-panel.tsx
@@ -399,11 +399,19 @@ export function SessionTreePanel({
           sessionId && adapter.getSessionTree
             ? adapter.getSessionTree({ sessionId })
             : Promise.resolve(null);
-        const [sessionList, sessionTree] = await Promise.all([
+        const [listResult, treeResult] = await Promise.allSettled([
           sessionListPromise,
           sessionTreePromise,
         ]);
         if (!mounted.current || currentRequestId !== requestId.current) return;
+        // The list is the panel's backbone; only a list failure is fatal.
+        if (loadList && adapter.listSessions && listResult.status === "rejected") {
+          throw listResult.reason;
+        }
+        const sessionList =
+          listResult.status === "fulfilled" ? listResult.value : null;
+        const sessionTree =
+          treeResult.status === "fulfilled" ? treeResult.value : null;
         let nextNodes = mergeTreeNodes([
           sessionList?.sessions.map(sessionToTreeNode) ?? [],
           sessionTree?.nodes ?? [],

--- a/sdk/agent-chat-react/src/types.ts
+++ b/sdk/agent-chat-react/src/types.ts
@@ -445,7 +445,7 @@ export interface AgentChatInboxItem {
   readAt: string | null;
   respondedAt: string | null;
   agentId?: string | null;
-  agentWebUrl?: string | null;
+  agentSlug?: string | null;
 }
 
 export interface AgentChatInboxList {

--- a/sdk/agent-chat-react/src/types.ts
+++ b/sdk/agent-chat-react/src/types.ts
@@ -444,6 +444,8 @@ export interface AgentChatInboxItem {
   updatedAt: string;
   readAt: string | null;
   respondedAt: string | null;
+  agentId?: string | null;
+  agentWebUrl?: string | null;
 }
 
 export interface AgentChatInboxList {

--- a/sdk/agent-chat-react/tests/inbox-panel.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel.test.tsx
@@ -566,10 +566,10 @@ describe("InboxPanel", () => {
   });
 
   it("passes the inbox item to onSessionSelect", async () => {
-    const calls: Array<{ id: string; agentId?: string | null }> = [];
+    const calls: Array<{ id: string; agentId?: string | null; agentSlug?: string | null }> = [];
     const items = [inboxItem({ id: 1, title: "Done" })];
     items[0].agentId = "other-agent";
-    items[0].agentWebUrl = "https://other.example";
+    items[0].agentSlug = "other-agent";
     const adapter = createAdapter(items);
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -579,7 +579,7 @@ describe("InboxPanel", () => {
         <InboxPanel
           adapter={adapter}
           onSessionSelect={(sessionId, item) =>
-            calls.push({ id: sessionId, agentId: item?.agentId })
+            calls.push({ id: sessionId, agentId: item?.agentId, agentSlug: item?.agentSlug })
           }
         />,
       );
@@ -590,7 +590,7 @@ describe("InboxPanel", () => {
     await act(async () => { row?.click(); await Promise.resolve(); });
     const openBtn = container.querySelector<HTMLButtonElement>('button[aria-label="Open session"]');
     await act(async () => { openBtn?.click(); await Promise.resolve(); });
-    expect(calls).toEqual([{ id: "session-1", agentId: "other-agent" }]);
+    expect(calls).toEqual([{ id: "session-1", agentId: "other-agent", agentSlug: "other-agent" }]);
   });
 
   it("deletes the selected inbox item and clears the detail pane", async () => {

--- a/sdk/agent-chat-react/tests/inbox-panel.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel.test.tsx
@@ -565,6 +565,34 @@ describe("InboxPanel", () => {
     expect(container.textContent).toContain("Responded");
   });
 
+  it("passes the inbox item to onSessionSelect", async () => {
+    const calls: Array<{ id: string; agentId?: string | null }> = [];
+    const items = [inboxItem({ id: 1, title: "Done" })];
+    items[0].agentId = "other-agent";
+    items[0].agentWebUrl = "https://other.example";
+    const adapter = createAdapter(items);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        <InboxPanel
+          adapter={adapter}
+          onSessionSelect={(sessionId, item) =>
+            calls.push({ id: sessionId, agentId: item?.agentId })
+          }
+        />,
+      );
+      await Promise.resolve();
+    });
+    // select the item, then click "Open session"
+    const row = container.querySelector<HTMLButtonElement>('button[aria-label^="Open inbox item"]');
+    await act(async () => { row?.click(); await Promise.resolve(); });
+    const openBtn = container.querySelector<HTMLButtonElement>('button[aria-label="Open session"]');
+    await act(async () => { openBtn?.click(); await Promise.resolve(); });
+    expect(calls).toEqual([{ id: "session-1", agentId: "other-agent" }]);
+  });
+
   it("deletes the selected inbox item and clears the detail pane", async () => {
     const deleted: number[] = [];
     const items = [

--- a/sdk/agent-chat-react/tests/inbox-panel.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel.test.tsx
@@ -569,7 +569,7 @@ describe("InboxPanel", () => {
     const calls: Array<{ id: string; agentId?: string | null; agentSlug?: string | null }> = [];
     const items = [inboxItem({ id: 1, title: "Done" })];
     items[0].agentId = "other-agent";
-    items[0].agentSlug = "other-agent";
+    items[0].agentSlug = "other-agent-slug";
     const adapter = createAdapter(items);
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -590,7 +590,7 @@ describe("InboxPanel", () => {
     await act(async () => { row?.click(); await Promise.resolve(); });
     const openBtn = container.querySelector<HTMLButtonElement>('button[aria-label="Open session"]');
     await act(async () => { openBtn?.click(); await Promise.resolve(); });
-    expect(calls).toEqual([{ id: "session-1", agentId: "other-agent", agentSlug: "other-agent" }]);
+    expect(calls).toEqual([{ id: "session-1", agentId: "other-agent", agentSlug: "other-agent-slug" }]);
   });
 
   it("deletes the selected inbox item and clears the detail pane", async () => {

--- a/sdk/agent-chat-react/tests/session-tree-panel.test.tsx
+++ b/sdk/agent-chat-react/tests/session-tree-panel.test.tsx
@@ -915,6 +915,25 @@ describe("SessionTreePanel", () => {
     expect(container.textContent).not.toContain("Child session");
   });
 
+  it("keeps the list when the active session's tree fetch fails", async () => {
+    const sessions = [session({ id: "s-1", title: "First session", agentId: "agent-1" })];
+    const adapter: AgentChatAdapter = {
+      ...createAdapter(sessions),
+      async listSessions() { return { sessions, total: sessions.length }; },
+      async getSessionTree() { throw new Error("404 not found"); },
+    };
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(
+        <SessionTreePanel adapter={adapter} loadList sessionId="foreign-session" activeSessionId="foreign-session" />,
+      );
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("First session");
+  });
+
   it("removes a deleted session before the delete refetch completes", async () => {
     const sessions = [
       session({ id: "s-1", title: "First session", agentId: "agent-1" }),

--- a/surogates/api/routes/auth.py
+++ b/surogates/api/routes/auth.py
@@ -81,6 +81,7 @@ class FirebaseWebConfig(BaseModel):
 class AuthConfigResponse(BaseModel):
     """Runtime auth shape exposed by ``GET /v1/auth/config``."""
 
+    agent_id: str
     self_registration_enabled: bool
     firebase: FirebaseWebConfig | None = None
     # Enabled built-in slash commands for this agent, as canonical
@@ -117,6 +118,7 @@ async def auth_config(
     project_id = getattr(agent_runtime, "project_id", None)
     if cache is None or not project_id:
         return AuthConfigResponse(
+            agent_id=agent_runtime.agent_id,
             self_registration_enabled=False,
             firebase=None,
             slash_commands=slash_commands,
@@ -125,11 +127,13 @@ async def auth_config(
         fb = await cache.get(project_id)
     except LookupError:
         return AuthConfigResponse(
+            agent_id=agent_runtime.agent_id,
             self_registration_enabled=False,
             firebase=None,
             slash_commands=slash_commands,
         )
     return AuthConfigResponse(
+        agent_id=agent_runtime.agent_id,
         self_registration_enabled=True,
         slash_commands=slash_commands,
         firebase=FirebaseWebConfig(

--- a/surogates/api/routes/inbox.py
+++ b/surogates/api/routes/inbox.py
@@ -69,30 +69,35 @@ async def _resolve_agent_fields(
 ) -> dict:
     """Map session_id -> {"agent_id", "agent_slug"} for serialization.
 
-    `agent_slug` is best-effort: an absent cache or any per-agent lookup
-    failure leaves it None so the item still serializes (the web then falls
-    back to in-place). The distinct per-owner-agent lookups run concurrently.
+    `agent_slug` is best-effort: an absent cache or a cache miss (LookupError)
+    leaves it None so the item still serializes (the web then falls back to
+    in-place). Other errors propagate, matching the cache's other callers, so
+    a real management-plane failure is not silently masked. The distinct
+    per-owner-agent lookups run concurrently.
     """
     store = request.app.state.session_store
     agent_by_session = await store.get_agent_ids_for_sessions(session_ids)
     cache = getattr(request.app.state, "runtime_config_cache", None)
     distinct_agents = list(dict.fromkeys(agent_by_session.values()))
-    slug_by_agent: dict[str, str | None] = dict.fromkeys(distinct_agents)
-    if cache is not None and distinct_agents:
-        payloads = await asyncio.gather(
-            *(cache.get(agent_id) for agent_id in distinct_agents),
-            return_exceptions=True,
-        )
-        for agent_id, payload in zip(distinct_agents, payloads):
-            if isinstance(payload, dict):
-                slug_by_agent[agent_id] = payload.get("slug")
+
+    async def _slug(agent_id: str) -> str | None:
+        if cache is None:
+            return None
+        try:
+            payload = await cache.get(agent_id)
+        except LookupError:
+            return None
+        return payload.get("slug")
+
+    slugs = await asyncio.gather(*(_slug(agent_id) for agent_id in distinct_agents))
+    slug_by_agent = dict(zip(distinct_agents, slugs))
     return {
         sid: {"agent_id": agent_id, "agent_slug": slug_by_agent.get(agent_id)}
         for sid, agent_id in agent_by_session.items()
     }
 
 
-async def _agent_fields_for(request: Request, session_id) -> dict:
+async def _agent_fields_for(request: Request, session_id: UUID) -> dict:
     """Agent fields for one inbox item's session (single-item serialize path)."""
     fields = await _resolve_agent_fields(request, [session_id])
     return fields.get(session_id, {})

--- a/surogates/api/routes/inbox.py
+++ b/surogates/api/routes/inbox.py
@@ -67,27 +67,27 @@ def _decode_cursor(cursor: str | None) -> tuple[datetime, int] | None:
 async def _resolve_agent_fields(
     request: Request, session_ids: list[UUID]
 ) -> dict:
-    """Map session_id -> {"agent_id", "agent_web_url"} for serialization.
+    """Map session_id -> {"agent_id", "agent_slug"} for serialization.
 
-    `agent_web_url` is best-effort: a runtime-config cache miss leaves it
+    `agent_slug` is best-effort: a runtime-config cache miss leaves it
     None so the item still serializes (the web then falls back to in-place).
     """
     store = request.app.state.session_store
     agent_by_session = await store.get_agent_ids_for_sessions(list(session_ids))
     cache = getattr(request.app.state, "runtime_config_cache", None)
-    url_by_agent: dict[str, str | None] = {}
+    slug_by_agent: dict[str, str | None] = {}
     out: dict = {}
     for sid, agent_id in agent_by_session.items():
-        if agent_id not in url_by_agent:
-            web_url = None
+        if agent_id not in slug_by_agent:
+            slug = None
             if cache is not None:
                 try:
                     payload = await cache.get(agent_id)
-                    web_url = payload.get("api_web_url")
+                    slug = payload.get("slug")
                 except LookupError:
-                    web_url = None
-            url_by_agent[agent_id] = web_url
-        out[sid] = {"agent_id": agent_id, "agent_web_url": url_by_agent[agent_id]}
+                    slug = None
+            slug_by_agent[agent_id] = slug
+        out[sid] = {"agent_id": agent_id, "agent_slug": slug_by_agent[agent_id]}
     return out
 
 
@@ -112,7 +112,7 @@ def _serialize_item(item, agent_fields: dict | None = None) -> dict:
         if item.responded_at
         else None,
         "agent_id": fields.get("agent_id"),
-        "agent_web_url": fields.get("agent_web_url"),
+        "agent_slug": fields.get("agent_slug"),
     }
 
 

--- a/surogates/api/routes/inbox.py
+++ b/surogates/api/routes/inbox.py
@@ -69,26 +69,33 @@ async def _resolve_agent_fields(
 ) -> dict:
     """Map session_id -> {"agent_id", "agent_slug"} for serialization.
 
-    `agent_slug` is best-effort: a runtime-config cache miss leaves it
-    None so the item still serializes (the web then falls back to in-place).
+    `agent_slug` is best-effort: an absent cache or any per-agent lookup
+    failure leaves it None so the item still serializes (the web then falls
+    back to in-place). The distinct per-owner-agent lookups run concurrently.
     """
     store = request.app.state.session_store
-    agent_by_session = await store.get_agent_ids_for_sessions(list(session_ids))
+    agent_by_session = await store.get_agent_ids_for_sessions(session_ids)
     cache = getattr(request.app.state, "runtime_config_cache", None)
-    slug_by_agent: dict[str, str | None] = {}
-    out: dict = {}
-    for sid, agent_id in agent_by_session.items():
-        if agent_id not in slug_by_agent:
-            slug = None
-            if cache is not None:
-                try:
-                    payload = await cache.get(agent_id)
-                    slug = payload.get("slug")
-                except LookupError:
-                    slug = None
-            slug_by_agent[agent_id] = slug
-        out[sid] = {"agent_id": agent_id, "agent_slug": slug_by_agent[agent_id]}
-    return out
+    distinct_agents = list(dict.fromkeys(agent_by_session.values()))
+    slug_by_agent: dict[str, str | None] = dict.fromkeys(distinct_agents)
+    if cache is not None and distinct_agents:
+        payloads = await asyncio.gather(
+            *(cache.get(agent_id) for agent_id in distinct_agents),
+            return_exceptions=True,
+        )
+        for agent_id, payload in zip(distinct_agents, payloads):
+            if isinstance(payload, dict):
+                slug_by_agent[agent_id] = payload.get("slug")
+    return {
+        sid: {"agent_id": agent_id, "agent_slug": slug_by_agent.get(agent_id)}
+        for sid, agent_id in agent_by_session.items()
+    }
+
+
+async def _agent_fields_for(request: Request, session_id) -> dict:
+    """Agent fields for one inbox item's session (single-item serialize path)."""
+    fields = await _resolve_agent_fields(request, [session_id])
+    return fields.get(session_id, {})
 
 
 def _serialize_item(item, agent_fields: dict | None = None) -> dict:
@@ -241,8 +248,7 @@ async def get_inbox_item(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Inbox item not found.",
         )
-    agent_fields = await _resolve_agent_fields(request, [item.session_id])
-    return _serialize_item(item, agent_fields.get(item.session_id))
+    return _serialize_item(item, await _agent_fields_for(request, item.session_id))
 
 
 @router.post("/{item_id}/read")
@@ -260,8 +266,7 @@ async def mark_inbox_item_read(
             detail="Inbox item not found.",
         )
     item = await store.mark_inbox_read(item_id=item_id, user_id=tenant.user_id)
-    agent_fields = await _resolve_agent_fields(request, [item.session_id])
-    return _serialize_item(item, agent_fields.get(item.session_id))
+    return _serialize_item(item, await _agent_fields_for(request, item.session_id))
 
 
 @router.post("/{item_id}/ack")
@@ -294,8 +299,7 @@ async def acknowledge_inbox_item(
             status_code=status.HTTP_409_CONFLICT,
             detail=str(exc),
         ) from exc
-    agent_fields = await _resolve_agent_fields(request, [item.session_id])
-    return _serialize_item(item, agent_fields.get(item.session_id))
+    return _serialize_item(item, await _agent_fields_for(request, item.session_id))
 
 
 @router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -390,5 +394,4 @@ async def respond_to_inbox_item(
             detail=str(exc),
         ) from exc
     await _wake_session_from_request(request, item.session_id)
-    agent_fields = await _resolve_agent_fields(request, [item.session_id])
-    return _serialize_item(item, agent_fields.get(item.session_id))
+    return _serialize_item(item, await _agent_fields_for(request, item.session_id))

--- a/surogates/api/routes/inbox.py
+++ b/surogates/api/routes/inbox.py
@@ -64,7 +64,35 @@ def _decode_cursor(cursor: str | None) -> tuple[datetime, int] | None:
         ) from exc
 
 
-def _serialize_item(item) -> dict:
+async def _resolve_agent_fields(
+    request: Request, session_ids: list[UUID]
+) -> dict:
+    """Map session_id -> {"agent_id", "agent_web_url"} for serialization.
+
+    `agent_web_url` is best-effort: a runtime-config cache miss leaves it
+    None so the item still serializes (the web then falls back to in-place).
+    """
+    store = request.app.state.session_store
+    agent_by_session = await store.get_agent_ids_for_sessions(list(session_ids))
+    cache = getattr(request.app.state, "runtime_config_cache", None)
+    url_by_agent: dict[str, str | None] = {}
+    out: dict = {}
+    for sid, agent_id in agent_by_session.items():
+        if agent_id not in url_by_agent:
+            web_url = None
+            if cache is not None:
+                try:
+                    payload = await cache.get(agent_id)
+                    web_url = payload.get("api_web_url")
+                except LookupError:
+                    web_url = None
+            url_by_agent[agent_id] = web_url
+        out[sid] = {"agent_id": agent_id, "agent_web_url": url_by_agent[agent_id]}
+    return out
+
+
+def _serialize_item(item, agent_fields: dict | None = None) -> dict:
+    fields = agent_fields or {}
     return {
         "id": item.id,
         "org_id": str(item.org_id),
@@ -83,6 +111,8 @@ def _serialize_item(item) -> dict:
         "responded_at": item.responded_at.isoformat()
         if item.responded_at
         else None,
+        "agent_id": fields.get("agent_id"),
+        "agent_web_url": fields.get("agent_web_url"),
     }
 
 
@@ -121,8 +151,14 @@ async def list_inbox(
         if len(items) == limit
         else None
     )
+    agent_fields = await _resolve_agent_fields(
+        request, [item.session_id for item in items]
+    )
     return {
-        "items": [_serialize_item(item) for item in items],
+        "items": [
+            _serialize_item(item, agent_fields.get(item.session_id))
+            for item in items
+        ],
         "next_cursor": next_cursor,
     }
 
@@ -205,7 +241,8 @@ async def get_inbox_item(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Inbox item not found.",
         )
-    return _serialize_item(item)
+    agent_fields = await _resolve_agent_fields(request, [item.session_id])
+    return _serialize_item(item, agent_fields.get(item.session_id))
 
 
 @router.post("/{item_id}/read")
@@ -223,7 +260,8 @@ async def mark_inbox_item_read(
             detail="Inbox item not found.",
         )
     item = await store.mark_inbox_read(item_id=item_id, user_id=tenant.user_id)
-    return _serialize_item(item)
+    agent_fields = await _resolve_agent_fields(request, [item.session_id])
+    return _serialize_item(item, agent_fields.get(item.session_id))
 
 
 @router.post("/{item_id}/ack")
@@ -256,7 +294,8 @@ async def acknowledge_inbox_item(
             status_code=status.HTTP_409_CONFLICT,
             detail=str(exc),
         ) from exc
-    return _serialize_item(item)
+    agent_fields = await _resolve_agent_fields(request, [item.session_id])
+    return _serialize_item(item, agent_fields.get(item.session_id))
 
 
 @router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -351,4 +390,5 @@ async def respond_to_inbox_item(
             detail=str(exc),
         ) from exc
     await _wake_session_from_request(request, item.session_id)
-    return _serialize_item(item)
+    agent_fields = await _resolve_agent_fields(request, [item.session_id])
+    return _serialize_item(item, agent_fields.get(item.session_id))

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -182,6 +182,20 @@ class SessionStore:
             raise SessionNotFoundError(f"session {session_id} not found")
         return Session.model_validate(row)
 
+    async def get_agent_ids_for_sessions(
+        self, session_ids: list[UUID]
+    ) -> dict[UUID, str]:
+        """Map each session id to its owning agent id (one query)."""
+        if not session_ids:
+            return {}
+        async with self._sf() as db:
+            result = await db.execute(
+                select(SessionRow.id, SessionRow.agent_id).where(
+                    SessionRow.id.in_(session_ids)
+                )
+            )
+            return {row.id: str(row.agent_id) for row in result.all()}
+
     async def update_session_status(self, session_id: UUID, status: str) -> None:
         """Set a session's status and touch ``updated_at``."""
         async with self._sf() as db:

--- a/tests/integration/test_auth_firebase_self_registration.py
+++ b/tests/integration/test_auth_firebase_self_registration.py
@@ -153,10 +153,9 @@ async def test_auth_config_hides_firebase_when_self_registration_disabled(
     response = await auth_client.get("/v1/auth/config")
 
     assert response.status_code == 200
-    assert response.json() == {
-        "self_registration_enabled": False,
-        "firebase": None,
-    }
+    body = response.json()
+    assert body["self_registration_enabled"] is False
+    assert body["firebase"] is None
 
 
 async def test_auth_config_exposes_firebase_when_enabled(auth_client, auth_app):

--- a/tests/integration/test_inbox_api.py
+++ b/tests/integration/test_inbox_api.py
@@ -521,6 +521,41 @@ async def test_sse_stream_emits_snapshot_and_nudge_for_new_item(
     assert "task_complete" in response.text
 
 
+class _FakeRuntimeCache:
+    """Minimal stand-in for ``app.state.runtime_config_cache``.
+
+    Returns a valid runtime-config payload for ``agent_id`` and raises
+    ``LookupError`` for everything else, mirroring the real cache's
+    contract.
+    """
+
+    def __init__(self, agent_id: str) -> None:
+        self._agent_id = agent_id
+
+    async def get(self, agent_id: str) -> dict:
+        if agent_id != self._agent_id:
+            raise LookupError(agent_id)
+        return {
+            "agent_id": agent_id,
+            "org_id": "00000000-0000-0000-0000-000000000000",
+            "project_id": "test-project",
+            "enabled": True,
+            "version": 1,
+            "storage_key_prefix": "",
+        }
+
+
+async def test_auth_config_returns_current_agent_id(client, app):
+    # Seed the runtime-config cache so agent_runtime_context_dep can resolve
+    # "test-agent" without a live management-plane connection.
+    app.state.runtime_config_cache = _FakeRuntimeCache("test-agent")
+
+    response = await client.get("/v1/auth/config?agent_id=test-agent")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["agent_id"] == "test-agent"
+
+
 async def test_ask_user_question_response_flips_inbox_to_responded(
     client,
     session_factory,

--- a/tests/integration/test_inbox_api.py
+++ b/tests/integration/test_inbox_api.py
@@ -548,9 +548,12 @@ class _FakeRuntimeCache:
 async def test_auth_config_returns_current_agent_id(client, app):
     # Seed the runtime-config cache so agent_runtime_context_dep can resolve
     # "test-agent" without a live management-plane connection.
+    original = getattr(app.state, "runtime_config_cache", None)
     app.state.runtime_config_cache = _FakeRuntimeCache("test-agent")
-
-    response = await client.get("/v1/auth/config?agent_id=test-agent")
+    try:
+        response = await client.get("/v1/auth/config?agent_id=test-agent")
+    finally:
+        app.state.runtime_config_cache = original
 
     assert response.status_code == 200, response.text
     assert response.json()["agent_id"] == "test-agent"

--- a/tests/test_inbox_serialize.py
+++ b/tests/test_inbox_serialize.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+# SPDX-License-Identifier: AGPL-3.0-only
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from surogates.api.routes.inbox import _resolve_agent_fields, _serialize_item
+
+
+def _item(session_id):
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        id=1, org_id=uuid.uuid4(), user_id=uuid.uuid4(), session_id=session_id,
+        source_event_id=1, kind="task_complete", status="pending",
+        title="t", body=None, payload={}, action_ref=None,
+        created_at=now, updated_at=now, read_at=None, responded_at=None,
+    )
+
+
+def test_serialize_item_includes_agent_fields():
+    sid = uuid.uuid4()
+    out = _serialize_item(_item(sid), {"agent_id": "agent-x", "agent_web_url": "https://x.example"})
+    assert out["agent_id"] == "agent-x"
+    assert out["agent_web_url"] == "https://x.example"
+
+
+def test_serialize_item_defaults_agent_fields_to_none():
+    out = _serialize_item(_item(uuid.uuid4()))
+    assert out["agent_id"] is None
+    assert out["agent_web_url"] is None
+
+
+class _FakeStore:
+    def __init__(self, mapping):
+        self._mapping = mapping
+    async def get_agent_ids_for_sessions(self, session_ids):
+        return {s: self._mapping[s] for s in session_ids if s in self._mapping}
+
+
+class _FakeCache:
+    def __init__(self, urls):
+        self._urls = urls
+    async def get(self, agent_id):
+        if agent_id not in self._urls:
+            raise LookupError(agent_id)
+        return {"api_web_url": self._urls[agent_id]}
+
+
+def _request(store, cache):
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(
+        session_store=store, runtime_config_cache=cache)))
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_fields_maps_owner_and_url():
+    sid = uuid.uuid4()
+    req = _request(_FakeStore({sid: "agent-x"}), _FakeCache({"agent-x": "https://x.example"}))
+    fields = await _resolve_agent_fields(req, [sid])
+    assert fields[sid] == {"agent_id": "agent-x", "agent_web_url": "https://x.example"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_fields_url_none_on_cache_miss():
+    sid = uuid.uuid4()
+    req = _request(_FakeStore({sid: "agent-x"}), _FakeCache({}))
+    fields = await _resolve_agent_fields(req, [sid])
+    assert fields[sid] == {"agent_id": "agent-x", "agent_web_url": None}

--- a/tests/test_inbox_serialize.py
+++ b/tests/test_inbox_serialize.py
@@ -21,15 +21,15 @@ def _item(session_id):
 
 def test_serialize_item_includes_agent_fields():
     sid = uuid.uuid4()
-    out = _serialize_item(_item(sid), {"agent_id": "agent-x", "agent_web_url": "https://x.example"})
+    out = _serialize_item(_item(sid), {"agent_id": "agent-x", "agent_slug": "agent-x-slug"})
     assert out["agent_id"] == "agent-x"
-    assert out["agent_web_url"] == "https://x.example"
+    assert out["agent_slug"] == "agent-x-slug"
 
 
 def test_serialize_item_defaults_agent_fields_to_none():
     out = _serialize_item(_item(uuid.uuid4()))
     assert out["agent_id"] is None
-    assert out["agent_web_url"] is None
+    assert out["agent_slug"] is None
 
 
 class _FakeStore:
@@ -40,12 +40,12 @@ class _FakeStore:
 
 
 class _FakeCache:
-    def __init__(self, urls):
-        self._urls = urls
+    def __init__(self, slugs):
+        self._slugs = slugs
     async def get(self, agent_id):
-        if agent_id not in self._urls:
+        if agent_id not in self._slugs:
             raise LookupError(agent_id)
-        return {"api_web_url": self._urls[agent_id]}
+        return {"slug": self._slugs[agent_id]}
 
 
 def _request(store, cache):
@@ -54,16 +54,16 @@ def _request(store, cache):
 
 
 @pytest.mark.asyncio
-async def test_resolve_agent_fields_maps_owner_and_url():
+async def test_resolve_agent_fields_maps_owner_and_slug():
     sid = uuid.uuid4()
-    req = _request(_FakeStore({sid: "agent-x"}), _FakeCache({"agent-x": "https://x.example"}))
+    req = _request(_FakeStore({sid: "agent-x"}), _FakeCache({"agent-x": "agent-x-slug"}))
     fields = await _resolve_agent_fields(req, [sid])
-    assert fields[sid] == {"agent_id": "agent-x", "agent_web_url": "https://x.example"}
+    assert fields[sid] == {"agent_id": "agent-x", "agent_slug": "agent-x-slug"}
 
 
 @pytest.mark.asyncio
-async def test_resolve_agent_fields_url_none_on_cache_miss():
+async def test_resolve_agent_fields_slug_none_on_cache_miss():
     sid = uuid.uuid4()
     req = _request(_FakeStore({sid: "agent-x"}), _FakeCache({}))
     fields = await _resolve_agent_fields(req, [sid])
-    assert fields[sid] == {"agent_id": "agent-x", "agent_web_url": None}
+    assert fields[sid] == {"agent_id": "agent-x", "agent_slug": None}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -107,7 +107,7 @@
     },
     "../sdk/agent-chat-react": {
       "name": "@invergent/agent-chat-react",
-      "version": "1.6.0",
+      "version": "1.8.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -167,6 +167,9 @@ export interface AuthConfigResponse {
   // "loop", "deep-research"). Absent on a fetch error or an older backend
   // — consumers treat "absent" as "unknown" and fail open (show all).
   slash_commands?: string[];
+  // The agent this deployment serves, echoed from the runtime config.
+  // Absent on older backends — consumers treat "absent" as null.
+  agent_id?: string;
 }
 
 /** Fetch the runtime auth config. Falls back to "disabled" on any error

--- a/web/src/api/inbox.ts
+++ b/web/src/api/inbox.ts
@@ -27,6 +27,8 @@ interface InboxItemResponse {
   updated_at: string;
   read_at: string | null;
   responded_at: string | null;
+  agent_id?: string | null;
+  agent_web_url?: string | null;
 }
 
 interface InboxListResponse {
@@ -51,6 +53,8 @@ function toInboxItem(item: InboxItemResponse): AgentChatInboxItem {
     updatedAt: item.updated_at,
     readAt: item.read_at,
     respondedAt: item.responded_at,
+    agentId: item.agent_id ?? null,
+    agentWebUrl: item.agent_web_url ?? null,
   };
 }
 

--- a/web/src/api/inbox.ts
+++ b/web/src/api/inbox.ts
@@ -28,7 +28,7 @@ interface InboxItemResponse {
   read_at: string | null;
   responded_at: string | null;
   agent_id?: string | null;
-  agent_web_url?: string | null;
+  agent_slug?: string | null;
 }
 
 interface InboxListResponse {
@@ -54,7 +54,7 @@ function toInboxItem(item: InboxItemResponse): AgentChatInboxItem {
     readAt: item.read_at,
     respondedAt: item.responded_at,
     agentId: item.agent_id ?? null,
-    agentWebUrl: item.agent_web_url ?? null,
+    agentSlug: item.agent_slug ?? null,
   };
 }
 

--- a/web/src/features/inbox/inbox-page.tsx
+++ b/web/src/features/inbox/inbox-page.tsx
@@ -18,6 +18,9 @@ function crossAgentChatUrl(agentSlug: string, sessionId: string): string | null 
   const { protocol, host } = window.location;
   const dot = host.indexOf(".");
   if (dot <= 0) return null; // localhost / single-label host → not derivable
+  // IPv4 host (e.g. LAN dev at 192.168.x.x:5174) has dots but no real domain
+  // to subdomain — fall back to in-place like localhost.
+  if (/^\d{1,3}(\.\d{1,3}){3}(:\d+)?$/.test(host)) return null;
   const domain = host.slice(dot + 1);
   return `${protocol}//${agentSlug}.${domain}/chat/${sessionId}`;
 }

--- a/web/src/features/inbox/inbox-page.tsx
+++ b/web/src/features/inbox/inbox-page.tsx
@@ -26,7 +26,7 @@ export function InboxPage() {
   }, [fetchSessions, fetchUser, fetchCapabilities]);
 
   function handleSessionSelect(sessionId: string, item?: AgentChatInboxItem) {
-    if (item?.agentId && item.agentId !== currentAgentId && item.agentWebUrl) {
+    if (item?.agentId && currentAgentId && item.agentId !== currentAgentId && item.agentWebUrl) {
       window.open(`${item.agentWebUrl}/chat/${sessionId}`, "_blank", "noopener");
       return;
     }

--- a/web/src/features/inbox/inbox-page.tsx
+++ b/web/src/features/inbox/inbox-page.tsx
@@ -26,8 +26,8 @@ export function InboxPage() {
   }, [fetchSessions, fetchUser, fetchCapabilities]);
 
   function handleSessionSelect(sessionId: string, item?: AgentChatInboxItem) {
-    if (item?.agentId && currentAgentId && item.agentId !== currentAgentId && item.agentWebUrl) {
-      window.open(`${item.agentWebUrl}/chat/${sessionId}`, "_blank", "noopener");
+    if (item?.agentId && currentAgentId && item.agentId !== currentAgentId && item.agentSlug) {
+      window.open(`/${item.agentSlug}/chat/${sessionId}`, "_blank", "noopener");
       return;
     }
     setActiveSession(sessionId);

--- a/web/src/features/inbox/inbox-page.tsx
+++ b/web/src/features/inbox/inbox-page.tsx
@@ -10,6 +10,18 @@ import { SessionSidebar } from "@/components/navbar";
 import { surogatesWebChatAdapter } from "@/features/chat";
 import { useAppStore } from "@/stores/app-store";
 
+// Build the owning agent's hosted-page URL from THIS app's host: prod serves
+// each agent at <slug>.<domain> (e.g. agent.cloud.surogate.ai), so swap the
+// current first label for the owner's slug. Returns null when the host has no
+// derivable domain (e.g. localhost:5174 in dev) — caller falls back to in-place.
+function crossAgentChatUrl(agentSlug: string, sessionId: string): string | null {
+  const { protocol, host } = window.location;
+  const dot = host.indexOf(".");
+  if (dot <= 0) return null; // localhost / single-label host → not derivable
+  const domain = host.slice(dot + 1);
+  return `${protocol}//${agentSlug}.${domain}/chat/${sessionId}`;
+}
+
 export function InboxPage() {
   const navigate = useNavigate();
   const fetchSessions = useAppStore((state) => state.fetchSessions);
@@ -26,9 +38,17 @@ export function InboxPage() {
   }, [fetchSessions, fetchUser, fetchCapabilities]);
 
   function handleSessionSelect(sessionId: string, item?: AgentChatInboxItem) {
-    if (item?.agentId && currentAgentId && item.agentId !== currentAgentId && item.agentSlug) {
-      window.open(`/${item.agentSlug}/chat/${sessionId}`, "_blank", "noopener");
-      return;
+    if (
+      item?.agentId &&
+      currentAgentId &&
+      item.agentId !== currentAgentId &&
+      item.agentSlug
+    ) {
+      const url = crossAgentChatUrl(item.agentSlug, sessionId);
+      if (url) {
+        window.open(url, "_blank", "noopener");
+        return;
+      }
     }
     setActiveSession(sessionId);
     void navigate({ to: "/chat/$sessionId", params: { sessionId } });

--- a/web/src/features/inbox/inbox-page.tsx
+++ b/web/src/features/inbox/inbox-page.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026, Invergent SA, developed by Flavius Burca
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { InboxPanel } from "@invergent/agent-chat-react";
+import { type AgentChatInboxItem, InboxPanel } from "@invergent/agent-chat-react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useEffect } from "react";
 
@@ -14,15 +14,22 @@ export function InboxPage() {
   const navigate = useNavigate();
   const fetchSessions = useAppStore((state) => state.fetchSessions);
   const fetchUser = useAppStore((state) => state.fetchUser);
+  const fetchCapabilities = useAppStore((state) => state.fetchCapabilities);
   const setActiveSession = useAppStore((state) => state.setActiveSession);
+  const currentAgentId = useAppStore((s) => s.agentId);
   const search = useSearch({ strict: false }) as { item?: number };
 
   useEffect(() => {
     void fetchSessions();
     void fetchUser();
-  }, [fetchSessions, fetchUser]);
+    void fetchCapabilities();
+  }, [fetchSessions, fetchUser, fetchCapabilities]);
 
-  function handleSessionSelect(sessionId: string) {
+  function handleSessionSelect(sessionId: string, item?: AgentChatInboxItem) {
+    if (item?.agentId && item.agentId !== currentAgentId && item.agentWebUrl) {
+      window.open(`${item.agentWebUrl}/chat/${sessionId}`, "_blank", "noopener");
+      return;
+    }
     setActiveSession(sessionId);
     void navigate({ to: "/chat/$sessionId", params: { sessionId } });
   }

--- a/web/src/stores/capabilities-slice.ts
+++ b/web/src/stores/capabilities-slice.ts
@@ -15,6 +15,7 @@ import { fetchAuthConfig } from "@/api/auth";
 // "clear") is the authoritative enabled set.
 export type CapabilitiesSlice = {
   slashCommands: string[] | null;
+  agentId: string | null;
 
   fetchCapabilities: () => Promise<void>;
 };
@@ -26,12 +27,13 @@ export const createCapabilitiesSlice: StateCreator<
   CapabilitiesSlice
 > = (set) => ({
   slashCommands: null,
+  agentId: null,
 
   fetchCapabilities: async () => {
     // ``fetchAuthConfig`` already degrades to a safe fallback on error
-    // (no ``slash_commands`` field), which maps to ``null`` here.
+    // (no ``slash_commands`` / ``agent_id`` fields), which map to ``null``.
     const config = await fetchAuthConfig();
-    set({ slashCommands: config.slash_commands ?? null });
+    set({ slashCommands: config.slash_commands ?? null, agentId: config.agent_id ?? null });
   },
 });
 


### PR DESCRIPTION
## Problem
The agent web app's inbox is per-user and cross-agent (`list_inbox` filters by `user_id` only), so a user sees inbox items from every agent they have an account on. Clicking **Open session** on an item owned by a *different* agent had three problems:
1. It loaded in the current agent's app instead of the owning agent's.
2. It navigated in place instead of opening the owning agent's app in a new tab.
3. The left session list went blank until a same-agent session was opened.

## Root cause
- Inbox items carried no agent identity at any layer (serializer, SDK type, web mapper), and the web app didn't track its own agent — symptoms #1/#2.
- `SessionTreePanel.refetch` fetched the session list and the active session's tree in one `Promise.all`; a foreign session's tree 404 (cross-scope access is 404'd by design) rejected the whole call and discarded the successful list — symptom #3.

## Changes
- **Backend** (`inbox.py`): stamp owner `agent_id` + `agent_slug` on each inbox item (slug resolved from the owner agent's runtime config, best-effort; per-owner lookups deduped and run concurrently, cache miss leaves slug null). Inbox stays user-scoped. `store.get_agent_ids_for_sessions` batches the session to agent_id lookup.
- **Backend** (`auth.py`): `/auth/config` returns the current `agent_id` so the web can compare.
- **SDK** (`agent-chat-react`): `AgentChatInboxItem` carries `agentId`/`agentSlug`; the Open-session button passes the item to `onSessionSelect`; `SessionTreePanel` decouples list from tree (`Promise.allSettled`) so a failed active-session tree no longer blanks the list.
- **Web**: stores the current agent id; for a cross-agent item it opens `<protocol>//<agentSlug>.<domain>/chat/<sessionId>` in a new tab, falling back to in-place when same-agent or no domain is derivable (e.g. localhost / IPv4 host).

## Dependency
Requires invergent-ai/surogate-ops#174 (exposes the agent `slug` in the runtime config).

## Testing
- Backend: inbox serializer stamps `agent_id`+`agent_slug` (incl. the cross-agent case); `/auth/config` returns `agent_id`; inbox + auth suites green.
- SDK: 383/383; `InboxPanel` passes the item to `onSessionSelect`; `SessionTreePanel` renders the list when the tree fetch rejects.
- Web: typecheck clean (no component test harness).

## Notes
- All new fields are optional; pre-deploy items and the ops per-agent inbox keep working in place. Backward compatible.
- The new tab is only exercisable in a `<slug>.<domain>` deployment; locally (`localhost:5174`) a cross-agent click correctly falls back to in-place. Verified locally: cross-agent detection, in-place fallback, and the list-no-blank fix.
