### PR TITLE
fix(web): declare @novnc/novnc dependency for the bundled SDK source

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,6 +20,7 @@
         "@huggingface/hub": "^2.9.0",
         "@invergent/agent-chat-react": "file:../sdk/agent-chat-react",
         "@langchain/core": "^1.1.27",
+        "@novnc/novnc": "^1.7.0",
         "@openrouter/sdk": "^0.11.2",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-label": "^2.1.8",
@@ -107,9 +108,10 @@
     },
     "../sdk/agent-chat-react": {
       "name": "@invergent/agent-chat-react",
-      "version": "1.6.0",
+      "version": "1.8.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@novnc/novnc": "^1.7.0",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
@@ -3007,7 +3009,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3028,7 +3029,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3049,7 +3049,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3070,7 +3069,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3091,7 +3089,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3112,7 +3109,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3133,7 +3129,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3154,7 +3149,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3175,7 +3169,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3196,7 +3189,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3217,7 +3209,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -3451,6 +3442,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@novnc/novnc": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.7.0.tgz",
+      "integrity": "sha512-ucEJOx4T2avIRCleodk7YobZj5O2Ga2AeLfQ69A/yjG9HHba2+PDgwSkN3FttrmG+70ZGx21sElNFouK13RzyA==",
+      "license": "MPL-2.0"
     },
     "node_modules/@open-draft/deferred-promise": {
       "version": "2.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -29,6 +29,7 @@
     "@huggingface/hub": "^2.9.0",
     "@invergent/agent-chat-react": "file:../sdk/agent-chat-react",
     "@langchain/core": "^1.1.27",
+    "@novnc/novnc": "^1.7.0",
     "@openrouter/sdk": "^0.11.2",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-label": "^2.1.8",


### PR DESCRIPTION
## What
The `surogates-api` image fails at the `web-build` stage:
`Rolldown failed to resolve import "@novnc/novnc" from sdk/agent-chat-react/src/components/browser/browser-live-view.tsx`.

The web SPA bundles agent-chat-react's **source** (vite alias `@invergent/agent-chat-react` → `../sdk/agent-chat-react/src`), and the image symlinks the SDK's `node_modules` to the web app's. So every runtime dep agent-chat-react's source imports must be declared in `web/package.json` — and **all 31 already are, except the newly-added `@novnc/novnc`**.

## Fix
Declare `@novnc/novnc` (`^1.7.0`, matching agent-chat-react) in `web/package.json` and refresh `web/package-lock.json`, restoring the invariant so `npm ci` installs it into the web build's `node_modules`.

## Verify
- `web/node_modules/@novnc/novnc/core/rfb.js` present after `npm ci`/install.
- `npx vite build` (the failing command) succeeds.