### PR TITLE
fix(browser): gate live-view input on the effective user, not tenant.user_id

### DIFF
--- a/surogates/api/routes/browser.py
+++ b/surogates/api/routes/browser.py
@@ -509,10 +509,12 @@ async def proxy_live_view_ws(
                     # or coalesce RFB messages, so parse the client byte stream and
                     # drop KeyEvent/PointerEvent/ClientCutText when control is no
                     # longer held (e.g. after the control lease's TTL expires).
+                    # Key on ``effective`` (the live-view identity validated at
+                    # connect time) — NOT ``tenant.user_id``, which is None for the
+                    # ops proxy's service-account connection and would drop all
+                    # input, making the live view read-only.
                     input_allowed = (
-                        tenant.user_id is not None
-                        and await control.held_by(str(session_id))
-                        == str(tenant.user_id)
+                        await control.held_by(str(session_id)) == effective
                     )
                     for chunk in rfb_gate.filter_client_bytes(
                         frame,

--- a/tests/test_browser_route_ws.py
+++ b/tests/test_browser_route_ws.py
@@ -95,6 +95,8 @@ class TestLiveViewWebSocketFrameTypes:
 
 # --- Full-route coverage of proxy_live_view_ws (control-required + RFB proxy) ---
 
+import asyncio
+
 import pytest
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
@@ -137,6 +139,9 @@ class _FakeUpstream:
         async def _gen():
             for frame in self._sends:
                 yield frame
+            # Keep the read side open so the client->upstream pump has time to
+            # forward input before the connection is torn down.
+            await asyncio.Event().wait()
         return _gen()
 
     async def send(self, frame) -> None:
@@ -146,16 +151,18 @@ class _FakeUpstream:
         pass
 
 
-def _build_ws_app(monkeypatch, *, control_holder, upstream_sends):
+def _build_ws_app(
+    monkeypatch, *, control_holder, upstream_sends, tenant_user_id=USER_1, prefix=""
+):
     from fastapi import FastAPI
 
     app = FastAPI()
-    app.include_router(browser_mod.router)
+    app.include_router(browser_mod.router, prefix=prefix)
     app.state.browser_resolver = _FakeResolver(_FakeResolved("ws://browser:8080"))
     app.state.browser_control = _FakeControlHeld(control_holder)
 
     async def _fake_auth(_app, *, path, token, cookies, authorization):
-        return _tenant()
+        return _tenant(user_id=tenant_user_id)
 
     monkeypatch.setattr(browser_mod, "authenticate_websocket_tenant", _fake_auth)
 
@@ -190,3 +197,34 @@ def test_live_view_ws_proxies_rfb_for_holder(monkeypatch) -> None:
     with client.websocket_connect(f"/api/sessions/{_SID}/browser/live/?token=t") as ws:
         frame = ws.receive_bytes()
     assert frame.startswith(b"RFB 00")
+
+
+def test_service_account_holder_input_is_forwarded(monkeypatch) -> None:
+    # PROD "take control": the ops proxy connects to the runtime as a service
+    # account (tenant.user_id is None) on the /v1/api path and asserts the
+    # holder via ?owner_user_id=. Input must still be forwarded for that holder
+    # — the gate must key on the effective user, not tenant.user_id.
+    import time
+
+    app, upstream = _build_ws_app(
+        monkeypatch,
+        control_holder="owner-x",
+        upstream_sends=[],
+        tenant_user_id=None,
+        prefix="/v1",
+    )
+    client = TestClient(app)
+    url = f"/v1/api/sessions/{_SID}/browser/live/ws?owner_user_id=owner-x&token=t"
+    handshake = b"RFB 003.008\n\x01\x01"  # 14 client handshake bytes (forwarded raw)
+    pointer = b"\x05\x00\x00\x0a\x00\x0b"  # RFB PointerEvent (type 5) — input
+
+    with client.websocket_connect(url) as ws:
+        ws.send_bytes(handshake + pointer)
+        deadline = time.time() + 3
+        while time.time() < deadline and len(
+            b"".join(c for c in upstream.received if isinstance(c, bytes))
+        ) < len(handshake) + len(pointer):
+            time.sleep(0.02)
+
+    forwarded = b"".join(c for c in upstream.received if isinstance(c, bytes))
+    assert pointer in forwarded, "PointerEvent dropped — live view is read-only"


### PR DESCRIPTION
## Problem

After the VNC live-view transport switch, "take control" rendered the desktop but was **read-only** in PROD — clicks, scroll, selection, and keystrokes did nothing.

## Root cause

The ops server proxies the browser live-view WS to the runtime as a **service account** (`tenant.user_id is None`) over the `/v1/api/...` path, asserting the real holder via `?owner_user_id=`. `proxy_live_view_ws` correctly resolved the holder through `_effective_live_view_user(...)` for the **WS-open** check (so the screen rendered), but the **input gate** keyed on `tenant.user_id`:

```python
input_allowed = tenant.user_id is not None and await control.held_by(...) == str(tenant.user_id)
```

For the ops-proxied connection `tenant.user_id` is `None`, so `input_allowed` was always `False` → every RFB Key/Pointer/CutText message was dropped → read-only.

## Fix

Gate input on the same `effective` user that authorized the connection:

```python
input_allowed = await control.held_by(str(session_id)) == effective
```

## Tests

Added `test_service_account_holder_input_is_forwarded` — a service-account WS (`tenant.user_id=None`, `/v1/api` prefix, `?owner_user_id=`) must forward a PointerEvent to the upstream. Full browser suite green (74 passed).

> This is a runtime-image hotfix (`runtime-api`/`runtime-worker`) — rebuild + redeploy the runtime image after merge.