### PR TITLE
feat(browser): add zoom controls to the VNC live view

### DIFF
--- a/sdk/agent-chat-react/src/components/browser/browser-live-view.tsx
+++ b/sdk/agent-chat-react/src/components/browser/browser-live-view.tsx
@@ -16,6 +16,23 @@ interface BrowserLiveViewProps {
 
 type ConnectionState = "connecting" | "connected" | "disconnected";
 
+// Zoom is driven through noVNC's own scaling, never a CSS transform: the RFB
+// pointer mapping is ``absX(x) = x / display.scale``, so a CSS-transformed
+// canvas would send clicks offset by the zoom factor. Instead we grow the RFB
+// target element to ``pane × zoom`` inside an overflow-auto scroller and leave
+// ``scaleViewport`` on — noVNC's ResizeObserver re-runs ``autoscale`` and
+// re-derives ``display.scale``, keeping rendering *and* clicks correct while
+// the scroller provides panning. Fit-to-pane is the floor (1×).
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 3;
+const ZOOM_STEP = 0.5;
+
+function clampZoom(zoom: number): number {
+  const bounded = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom));
+  // Round to avoid floating-point drift accumulating across steps.
+  return Math.round(bounded * 100) / 100;
+}
+
 // The live-view URL is an http(s) asset path; noVNC needs the ws(s) scheme.
 // Only http(s) is rewritten — an already-ws(s) URL is passed through so
 // ws: (local/non-SSL) is not forced to wss:.
@@ -40,11 +57,15 @@ export function BrowserLiveView({
   const onDisconnectRef = useRef(onDisconnect);
   onDisconnectRef.current = onDisconnect;
   const [state, setState] = useState<ConnectionState>("connecting");
+  const [zoom, setZoom] = useState(MIN_ZOOM);
 
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
     setState("connecting");
+    // A new session starts fit-to-pane; carrying a previous zoom over to an
+    // unrelated framebuffer would be disorienting.
+    setZoom(MIN_ZOOM);
 
     let rfb: NoVncClient | undefined;
     let disposed = false;
@@ -88,9 +109,60 @@ export function BrowserLiveView({
     };
   }, [src]);
 
+  // Keep pointer-down on the controls from blurring the RFB canvas, which would
+  // stop keyboard events from reaching the remote.
+  const keepCanvasFocus = (event: React.MouseEvent) => event.preventDefault();
+  const zoomTo = (next: number) => setZoom((current) => clampZoom(next || current));
+
   return (
     <div className="relative h-full w-full bg-black">
-      <div ref={containerRef} data-testid={testId} className="h-full w-full" />
+      <div className="absolute inset-0 overflow-auto">
+        <div
+          ref={containerRef}
+          data-testid={testId}
+          style={{ width: `${zoom * 100}%`, height: `${zoom * 100}%` }}
+        />
+      </div>
+      {state === "connected" && (
+        <div
+          data-testid="browser-rfb-zoom"
+          className="absolute bottom-3 right-3 flex items-center gap-0.5 rounded-md border border-line bg-card/90 p-0.5 text-muted-foreground shadow-sm backdrop-blur"
+        >
+          <button
+            type="button"
+            tabIndex={-1}
+            aria-label="Zoom out"
+            disabled={zoom <= MIN_ZOOM}
+            onMouseDown={keepCanvasFocus}
+            onClick={() => zoomTo(zoom - ZOOM_STEP)}
+            className="flex size-6 items-center justify-center rounded text-sm leading-none hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-40"
+          >
+            −
+          </button>
+          <button
+            type="button"
+            tabIndex={-1}
+            aria-label="Reset zoom"
+            disabled={zoom === MIN_ZOOM}
+            onMouseDown={keepCanvasFocus}
+            onClick={() => setZoom(MIN_ZOOM)}
+            className="min-w-10 rounded px-1 text-center text-xs tabular-nums hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none"
+          >
+            {Math.round(zoom * 100)}%
+          </button>
+          <button
+            type="button"
+            tabIndex={-1}
+            aria-label="Zoom in"
+            disabled={zoom >= MAX_ZOOM}
+            onMouseDown={keepCanvasFocus}
+            onClick={() => zoomTo(zoom + ZOOM_STEP)}
+            className="flex size-6 items-center justify-center rounded text-sm leading-none hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-40"
+          >
+            +
+          </button>
+        </div>
+      )}
       {state !== "connected" && (
         <div
           data-testid="browser-rfb-overlay"

--- a/sdk/agent-chat-react/tests/browser-live-view.test.tsx
+++ b/sdk/agent-chat-react/tests/browser-live-view.test.tsx
@@ -81,6 +81,51 @@ describe("BrowserLiveView", () => {
     expect(node.querySelector('[data-testid="browser-rfb"]')).not.toBeNull();
   });
 
+  it("zooms the viewport through noVNC scaling (sizing the target, not transforming it)", async () => {
+    const node = await renderView(<BrowserLiveView src={SRC} />);
+    // Zoom controls only appear once connected.
+    await act(async () => {
+      rfbMock.listeners.connect?.(new CustomEvent("connect"));
+    });
+
+    const target = node.querySelector(
+      '[data-testid="browser-rfb"]',
+    ) as HTMLElement;
+    const zoomOut = node.querySelector(
+      '[aria-label="Zoom out"]',
+    ) as HTMLButtonElement;
+    const zoomIn = node.querySelector(
+      '[aria-label="Zoom in"]',
+    ) as HTMLButtonElement;
+    const reset = node.querySelector(
+      '[aria-label="Reset zoom"]',
+    ) as HTMLButtonElement;
+
+    // Fit-to-pane floor: target is exactly the viewport and cannot zoom out.
+    expect(target.style.width).toBe("100%");
+    expect(target.style.height).toBe("100%");
+    expect(zoomOut.disabled).toBe(true);
+    expect(target.style.transform).toBe("");
+
+    await act(async () => zoomIn.click());
+    expect(target.style.width).toBe("150%");
+    expect(target.style.height).toBe("150%");
+    expect(zoomOut.disabled).toBe(false);
+
+    // Clamp at the 3× ceiling: 150 → 200 → 250 → 300, then no further.
+    await act(async () => zoomIn.click());
+    await act(async () => zoomIn.click());
+    await act(async () => zoomIn.click());
+    expect(target.style.width).toBe("300%");
+    expect(zoomIn.disabled).toBe(true);
+    await act(async () => zoomIn.click());
+    expect(target.style.width).toBe("300%");
+
+    await act(async () => reset.click());
+    expect(target.style.width).toBe("100%");
+    expect(zoomOut.disabled).toBe(true);
+  });
+
   it("calls onDisconnect and shows an overlay when the connection drops", async () => {
     const onDisconnect = vi.fn();
     const node = await renderView(


### PR DESCRIPTION
## What

Adds +/− zoom controls (with a percentage reset) to the browser live view, overlaid bottom-right and shown only while connected. Range 1×–3× in 0.5× steps; 1× is fit-to-pane.

## How — native noVNC scaling, not a CSS transform

noVNC has no built-in zoom widget, only three scaling modes (`scaleViewport` = fit, `clipViewport` = 1:1 + pan, `resizeSession` = remote resize). The trap is that a CSS-`transform` zoom **desyncs input**: noVNC maps pointers as `absX(x) = x / display.scale`, dividing by *its own* scale, not the on-screen ratio — so a CSS-scaled canvas sends every click offset by the zoom factor.

Instead this keeps `scaleViewport=true` and grows the RFB **target element** to `pane × zoom` inside an `overflow-auto` scroller. noVNC's `ResizeObserver` catches the resize, re-runs `autoscale`, and re-derives `display.scale` — so rendering **and** click-mapping stay correct, the scroller provides panning, and it's resize-safe with zero private-field access. Zoom changes only restyle the container; the RFB session is never torn down (the connect effect still depends solely on `src`). A new `src` resets to fit. Control buttons `preventDefault` on mousedown so they don't blur the canvas and cut keyboard input.

## Tests

Extended `browser-live-view.test.tsx`: zoom in sizes the target to 150%/300%, clamps at 3×, reset returns to 100%, the zoom-out button is disabled at the floor, and the target carries **no** `transform` (guards against a regression to CSS-transform zoom). Full SDK browser suite green (43 passed); typecheck clean.

> Frontend/SDK-only change — no backend or runtime-image rebuild. Ships with the next web build that bundles the SDK.