### PR TITLE
feat(browser-profiles): harness backend (model, store, capture/inject, routes)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-browser-profiles.md
+++ b/docs/superpowers/plans/2026-06-19-browser-profiles.md
@@ -8,8 +8,8 @@
 - [x] **Task 2** — `BrowserProfileStore`
 - [x] **Task 3** — `KernelBrowserClient` storage_state helpers
 - [x] **Task 4** — inject storage_state at provision in `BrowserPool.ensure()`
-- [ ] **Task 5** — resolve `profile_id` → spec.storage_state at the tool layer _(in progress)_
-- [ ] **Task 6** — harness `/v1/api/browser-profiles` CRUD router
+- [x] **Task 5** — resolve `profile_id` → spec.storage_state at the tool layer
+- [ ] **Task 6** — harness `/v1/api/browser-profiles` CRUD router _(in progress)_
 - [ ] **Task 7** — harness setup-session route + `browser_setup` channel
 - [ ] **Task 8** — harness capture route
 - [ ] **Task 9** — ops `/api/browser-profiles` proxy
@@ -750,9 +750,19 @@ git commit -m "feat(browser-profiles): inject storage_state at provision before 
 
 ## Task 5: Resolve `profile_id` → spec.storage_state at the tool layer
 
+> **Implementation note (deviation):** `browser_pool`/`browser_control` are threaded
+> as params through the entire `worker → loop → streaming_executor → tool_exec → router`
+> chain (~13 hops). Rather than thread a new `browser_profile_store` param the same way
+> (fragile, ~20 edits), the store is attached to the `BrowserPool` instance
+> (`pool.browser_profile_store`, built in `worker.py` beside the pool), and
+> `_resolve_session_browser` reads it off the `browser_pool` it already receives. The
+> function keeps an optional `browser_profile_store` param that overrides the pool's, used
+> only by tests.
+
 **Files:**
-- Modify: `surogates/tools/builtin/browser.py` (`_resolve_session_browser`)
-- Modify: `surogates/api/app.py` and the harness tool-dispatch wiring to pass `browser_profile_store`
+- Modify: `surogates/tools/builtin/browser.py` (`_resolve_session_browser` reads the store off the pool)
+- Modify: `surogates/browser/pool.py` (`BrowserPool.browser_profile_store` attribute)
+- Modify: `surogates/orchestrator/worker.py` (build the store, pass to the pool)
 - Test: `tests/test_browser_tools_profile_inject.py`
 
 **Interfaces:**

--- a/docs/superpowers/plans/2026-06-19-browser-profiles.md
+++ b/docs/superpowers/plans/2026-06-19-browser-profiles.md
@@ -14,11 +14,18 @@
 - [x] **Task 8** — harness capture route
 - [x] **Task 9** — ops `/api/browser-profiles` proxy
 - [x] **Task 10** — ops session-create accepts `browser_profile_id`
-- [x] **Task 11** — SDK adapter `listBrowserProfiles` + `BrowserLiveView` export _(ops work-adapter impl pending on the ops branch)_
+- [x] **Task 11** — SDK adapter `listBrowserProfiles` + `BrowserLiveView` export (+ ops work-adapter impl)
 - [x] **Task 12** — SDK chat-composer profile selector popover
-- [ ] **Task 13** — Studio `api/browser-profiles.ts` client _(in progress)_
-- [ ] **Task 14** — Studio "Browser Profiles" manager section
-- [ ] **Task 15** — Studio "Set up authentication" dialog
+- [x] **Task 13** — Studio `api/browser-profiles.ts` client
+- [x] **Task 14** — Studio "Browser Profiles" manager section
+- [x] **Task 15** — Studio "Set up authentication" dialog
+
+**Post-plan extensions (to make the feature reachable end-to-end):**
+
+- [x] **E1** — Harness routes **dual-mounted** (`/v1` + `/v1/api`) so the web app (`/v1/browser-profiles`, its proxy strips `/api`) and the ops proxy (`/v1/api/browser-profiles`) both resolve.
+- [x] **E2** — SDK **prop forwarding**: `AgentChat` → `ChatThread` → `ChatComposer` thread `browserProfileId`/`onSelectBrowserProfile` (the selector was otherwise unreachable in any host).
+- [x] **E3** — **Studio work surface** wired: profile state → `AgentChat` selector props + `browser_profile_id` into ops session-create.
+- [x] **E4** — **Agent web app** (`/work/surogates/web`) wired: adapter `listBrowserProfiles`, composer selector + `config.browser.profile_id` on session-create, and a "Browser Profiles" settings tab with the live-view setup dialog.
 
 **Goal:** Let a user save a browser's login/cookie state under a named, private "profile" and reuse it across agent tasks, capturing auth by logging in by hand over the CDP-free VNC live view.
 

--- a/docs/superpowers/plans/2026-06-19-browser-profiles.md
+++ b/docs/superpowers/plans/2026-06-19-browser-profiles.md
@@ -7,8 +7,8 @@
 - [x] **Task 1** — `BrowserProfile` model
 - [x] **Task 2** — `BrowserProfileStore`
 - [x] **Task 3** — `KernelBrowserClient` storage_state helpers
-- [ ] **Task 4** — inject storage_state at provision in `BrowserPool.ensure()` _(in progress)_
-- [ ] **Task 5** — resolve `profile_id` → spec.storage_state at the tool layer
+- [x] **Task 4** — inject storage_state at provision in `BrowserPool.ensure()`
+- [ ] **Task 5** — resolve `profile_id` → spec.storage_state at the tool layer _(in progress)_
 - [ ] **Task 6** — harness `/v1/api/browser-profiles` CRUD router
 - [ ] **Task 7** — harness setup-session route + `browser_setup` channel
 - [ ] **Task 8** — harness capture route

--- a/docs/superpowers/plans/2026-06-19-browser-profiles.md
+++ b/docs/superpowers/plans/2026-06-19-browser-profiles.md
@@ -9,8 +9,8 @@
 - [x] **Task 3** — `KernelBrowserClient` storage_state helpers
 - [x] **Task 4** — inject storage_state at provision in `BrowserPool.ensure()`
 - [x] **Task 5** — resolve `profile_id` → spec.storage_state at the tool layer
-- [ ] **Task 6** — harness `/v1/api/browser-profiles` CRUD router _(in progress)_
-- [ ] **Task 7** — harness setup-session route + `browser_setup` channel
+- [x] **Task 6** — harness `/v1/api/browser-profiles` CRUD router
+- [ ] **Task 7** — harness setup-session route + `browser_setup` channel _(in progress)_
 - [ ] **Task 8** — harness capture route
 - [ ] **Task 9** — ops `/api/browser-profiles` proxy
 - [ ] **Task 10** — ops session-create accepts `browser_profile_id`

--- a/docs/superpowers/plans/2026-06-19-browser-profiles.md
+++ b/docs/superpowers/plans/2026-06-19-browser-profiles.md
@@ -11,8 +11,8 @@
 - [x] **Task 5** — resolve `profile_id` → spec.storage_state at the tool layer
 - [x] **Task 6** — harness `/v1/api/browser-profiles` CRUD router
 - [x] **Task 7** — harness setup-session route + `browser_setup` channel
-- [ ] **Task 8** — harness capture route _(in progress)_
-- [ ] **Task 9** — ops `/api/browser-profiles` proxy
+- [x] **Task 8** — harness capture route
+- [ ] **Task 9** — ops `/api/browser-profiles` proxy _(in progress)_
 - [ ] **Task 10** — ops session-create accepts `browser_profile_id`
 - [ ] **Task 11** — SDK adapter `listBrowserProfiles` + create wiring
 - [ ] **Task 12** — SDK chat-composer profile selector popover

--- a/docs/superpowers/plans/2026-06-19-browser-profiles.md
+++ b/docs/superpowers/plans/2026-06-19-browser-profiles.md
@@ -2,6 +2,24 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+## Implementation Progress
+
+- [x] **Task 1** — `BrowserProfile` model
+- [ ] **Task 2** — `BrowserProfileStore` _(in progress)_
+- [ ] **Task 3** — `KernelBrowserClient` storage_state helpers
+- [ ] **Task 4** — inject storage_state at provision in `BrowserPool.ensure()`
+- [ ] **Task 5** — resolve `profile_id` → spec.storage_state at the tool layer
+- [ ] **Task 6** — harness `/v1/api/browser-profiles` CRUD router
+- [ ] **Task 7** — harness setup-session route + `browser_setup` channel
+- [ ] **Task 8** — harness capture route
+- [ ] **Task 9** — ops `/api/browser-profiles` proxy
+- [ ] **Task 10** — ops session-create accepts `browser_profile_id`
+- [ ] **Task 11** — SDK adapter `listBrowserProfiles` + create wiring
+- [ ] **Task 12** — SDK chat-composer profile selector popover
+- [ ] **Task 13** — Studio `api/browser-profiles.ts` client
+- [ ] **Task 14** — Studio "Browser Profiles" manager section
+- [ ] **Task 15** — Studio "Set up authentication" dialog
+
 **Goal:** Let a user save a browser's login/cookie state under a named, private "profile" and reuse it across agent tasks, capturing auth by logging in by hand over the CDP-free VNC live view.
 
 **Architecture:** The surogates harness owns a `browser_profiles` table (surogates DB) plus capture/inject and a standalone `browser_setup` session; `surogate-ops` is a thin per-user-service-account proxy; the SDK adds a profile selector to the chat composer; Studio settings get a profile manager. Capture exports Playwright `storage_state` after a human login; inject applies it into a fresh context at browser-provision time, before registry publish / `browser.provisioned` / first navigation.

--- a/docs/superpowers/plans/2026-06-19-browser-profiles.md
+++ b/docs/superpowers/plans/2026-06-19-browser-profiles.md
@@ -10,8 +10,8 @@
 - [x] **Task 4** — inject storage_state at provision in `BrowserPool.ensure()`
 - [x] **Task 5** — resolve `profile_id` → spec.storage_state at the tool layer
 - [x] **Task 6** — harness `/v1/api/browser-profiles` CRUD router
-- [ ] **Task 7** — harness setup-session route + `browser_setup` channel _(in progress)_
-- [ ] **Task 8** — harness capture route
+- [x] **Task 7** — harness setup-session route + `browser_setup` channel
+- [ ] **Task 8** — harness capture route _(in progress)_
 - [ ] **Task 9** — ops `/api/browser-profiles` proxy
 - [ ] **Task 10** — ops session-create accepts `browser_profile_id`
 - [ ] **Task 11** — SDK adapter `listBrowserProfiles` + create wiring

--- a/docs/superpowers/plans/2026-06-19-browser-profiles.md
+++ b/docs/superpowers/plans/2026-06-19-browser-profiles.md
@@ -12,9 +12,9 @@
 - [x] **Task 6** — harness `/v1/api/browser-profiles` CRUD router
 - [x] **Task 7** — harness setup-session route + `browser_setup` channel
 - [x] **Task 8** — harness capture route
-- [ ] **Task 9** — ops `/api/browser-profiles` proxy _(in progress)_
-- [ ] **Task 10** — ops session-create accepts `browser_profile_id`
-- [ ] **Task 11** — SDK adapter `listBrowserProfiles` + create wiring
+- [x] **Task 9** — ops `/api/browser-profiles` proxy
+- [x] **Task 10** — ops session-create accepts `browser_profile_id`
+- [ ] **Task 11** — SDK adapter `listBrowserProfiles` + `BrowserLiveView` export _(in progress)_
 - [ ] **Task 12** — SDK chat-composer profile selector popover
 - [ ] **Task 13** — Studio `api/browser-profiles.ts` client
 - [ ] **Task 14** — Studio "Browser Profiles" manager section

--- a/docs/superpowers/plans/2026-06-19-browser-profiles.md
+++ b/docs/superpowers/plans/2026-06-19-browser-profiles.md
@@ -6,8 +6,8 @@
 
 - [x] **Task 1** — `BrowserProfile` model
 - [x] **Task 2** — `BrowserProfileStore`
-- [ ] **Task 3** — `KernelBrowserClient` storage_state helpers _(in progress)_
-- [ ] **Task 4** — inject storage_state at provision in `BrowserPool.ensure()`
+- [x] **Task 3** — `KernelBrowserClient` storage_state helpers
+- [ ] **Task 4** — inject storage_state at provision in `BrowserPool.ensure()` _(in progress)_
 - [ ] **Task 5** — resolve `profile_id` → spec.storage_state at the tool layer
 - [ ] **Task 6** — harness `/v1/api/browser-profiles` CRUD router
 - [ ] **Task 7** — harness setup-session route + `browser_setup` channel

--- a/docs/superpowers/plans/2026-06-19-browser-profiles.md
+++ b/docs/superpowers/plans/2026-06-19-browser-profiles.md
@@ -5,8 +5,8 @@
 ## Implementation Progress
 
 - [x] **Task 1** — `BrowserProfile` model
-- [ ] **Task 2** — `BrowserProfileStore` _(in progress)_
-- [ ] **Task 3** — `KernelBrowserClient` storage_state helpers
+- [x] **Task 2** — `BrowserProfileStore`
+- [ ] **Task 3** — `KernelBrowserClient` storage_state helpers _(in progress)_
 - [ ] **Task 4** — inject storage_state at provision in `BrowserPool.ensure()`
 - [ ] **Task 5** — resolve `profile_id` → spec.storage_state at the tool layer
 - [ ] **Task 6** — harness `/v1/api/browser-profiles` CRUD router

--- a/docs/superpowers/plans/2026-06-19-browser-profiles.md
+++ b/docs/superpowers/plans/2026-06-19-browser-profiles.md
@@ -14,9 +14,9 @@
 - [x] **Task 8** — harness capture route
 - [x] **Task 9** — ops `/api/browser-profiles` proxy
 - [x] **Task 10** — ops session-create accepts `browser_profile_id`
-- [ ] **Task 11** — SDK adapter `listBrowserProfiles` + `BrowserLiveView` export _(in progress)_
-- [ ] **Task 12** — SDK chat-composer profile selector popover
-- [ ] **Task 13** — Studio `api/browser-profiles.ts` client
+- [x] **Task 11** — SDK adapter `listBrowserProfiles` + `BrowserLiveView` export _(ops work-adapter impl pending on the ops branch)_
+- [x] **Task 12** — SDK chat-composer profile selector popover
+- [ ] **Task 13** — Studio `api/browser-profiles.ts` client _(in progress)_
 - [ ] **Task 14** — Studio "Browser Profiles" manager section
 - [ ] **Task 15** — Studio "Set up authentication" dialog
 

--- a/sdk/agent-chat-react/src/agent-chat.tsx
+++ b/sdk/agent-chat-react/src/agent-chat.tsx
@@ -31,6 +31,13 @@ export interface AgentChatProps {
    */
   onComposerError?: (err: ChatComposerError) => void;
   /**
+   * Browser-profile selection (host-managed). When ``onSelectBrowserProfile``
+   * is provided and the browser is available, the composer shows a profile
+   * picker; the host threads the chosen id into session creation.
+   */
+  browserProfileId?: string | null;
+  onSelectBrowserProfile?: (id: string | null) => void;
+  /**
    * Per-agent capability flag.  When true, the composer surfaces the
    * ``/deep-research`` slash command in its builtin menu.  Off by
    * default; the host (Studio) reads it from the agent record and
@@ -90,6 +97,8 @@ export function AgentChat({
   onMessagesChange,
   disabled,
   onComposerError,
+  browserProfileId,
+  onSelectBrowserProfile,
   deepResearchEnabled = false,
   researchEnabled = false,
   codeAgentsEnabled = false,
@@ -284,6 +293,8 @@ export function AgentChat({
               tokenUsage={runtime.tokenUsage}
               retryIndicator={runtime.retryIndicator}
               onComposerError={onComposerError}
+              browserProfileId={browserProfileId}
+              onSelectBrowserProfile={onSelectBrowserProfile}
               showBrowser={showBrowser}
               onToggleBrowser={handleToggleBrowser}
               showWorkspace={showWorkspace}

--- a/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
@@ -16,6 +16,7 @@ import {
   FolderIcon,
   GlobeIcon,
   HardDriveIcon,
+  IdCardIcon,
   PaperclipIcon,
   PlusIcon,
   SparklesIcon,
@@ -25,6 +26,7 @@ import {
 import type { PromptInputMessage } from "../ai-elements/prompt-input";
 import { useProviderAttachments } from "../ai-elements/prompt-input";
 import type {
+  AgentChatBrowserProfile,
   AgentChatImageAttachment,
   AgentChatPendingAttachment,
   AgentChatSlashCommand,
@@ -133,6 +135,10 @@ interface ChatComposerProps {
   onToggleWorkspace?: () => void;
   /** When false (default), the browser toggle button is omitted entirely. */
   canShowBrowser?: boolean;
+  /** Currently-selected browser profile id (drives the active style). */
+  browserProfileId?: string | null;
+  /** When provided (with ``canShowBrowser``), renders the profile selector. */
+  onSelectBrowserProfile?: (id: string | null) => void;
   /** When false (default), the workspace toggle button is omitted entirely. */
   canShowWorkspace?: boolean;
 
@@ -355,6 +361,8 @@ function ChatComposerInner({
   showWorkspace = false,
   onToggleWorkspace,
   canShowBrowser = false,
+  browserProfileId,
+  onSelectBrowserProfile,
   canShowWorkspace = false,
   deepResearchEnabled = false,
   researchEnabled = false,
@@ -367,6 +375,25 @@ function ChatComposerInner({
   onViewModeChange,
 }: ChatComposerProps) {
   const { adapter } = useAgentChatAdapterContext();
+  const [profileMenuOpen, setProfileMenuOpen] = useState(false);
+  const [browserProfiles, setBrowserProfiles] = useState<
+    AgentChatBrowserProfile[]
+  >([]);
+  useEffect(() => {
+    if (!profileMenuOpen || !adapter.listBrowserProfiles) return;
+    let cancelled = false;
+    void adapter
+      .listBrowserProfiles()
+      .then((p) => {
+        if (!cancelled) setBrowserProfiles(p);
+      })
+      .catch(() => {
+        if (!cancelled) setBrowserProfiles([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [profileMenuOpen, adapter]);
   const { textInput, attachments } = usePromptInputController();
   const status = isRunning ? "streaming" : disabled ? "error" : "ready";
 
@@ -796,6 +823,64 @@ function ChatComposerInner({
                   <GlobeIcon className="size-4" />
                 </PromptInputButton>
               )}
+              {canShowBrowser &&
+                onSelectBrowserProfile &&
+                adapter.listBrowserProfiles && (
+                  <Popover
+                    open={profileMenuOpen}
+                    onOpenChange={setProfileMenuOpen}
+                  >
+                    <PopoverTrigger asChild>
+                      <PromptInputButton
+                        aria-label="Select browser profile"
+                        aria-pressed={!!browserProfileId}
+                        className={
+                          browserProfileId
+                            ? "bg-accent text-foreground"
+                            : undefined
+                        }
+                      >
+                        <IdCardIcon className="size-4" />
+                      </PromptInputButton>
+                    </PopoverTrigger>
+                    <PopoverContent
+                      side="top"
+                      align="start"
+                      className="w-64 overflow-hidden rounded-xl p-1"
+                    >
+                      <Command>
+                        <CommandList>
+                          <CommandItem
+                            onSelect={() => {
+                              setProfileMenuOpen(false);
+                              onSelectBrowserProfile(null);
+                            }}
+                            className="gap-3 rounded-md px-3 py-2"
+                          >
+                            No profile
+                          </CommandItem>
+                          {browserProfiles.map((p) => (
+                            <CommandItem
+                              key={p.id}
+                              onSelect={() => {
+                                setProfileMenuOpen(false);
+                                onSelectBrowserProfile(p.id);
+                              }}
+                              className="gap-3 rounded-md px-3 py-2"
+                            >
+                              {p.name}
+                              {browserProfileId === p.id && (
+                                <span className="ml-auto text-xs text-muted-foreground">
+                                  Active
+                                </span>
+                              )}
+                            </CommandItem>
+                          ))}
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
+                )}
               {canShowWorkspace && onToggleWorkspace && (
                 <PromptInputButton
                   aria-label={

--- a/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
@@ -123,6 +123,8 @@ interface ChatThreadProps {
   showWorkspace?: boolean;
   onToggleWorkspace?: () => void;
   canShowBrowser?: boolean;
+  browserProfileId?: string | null;
+  onSelectBrowserProfile?: (id: string | null) => void;
   canShowWorkspace?: boolean;
   // Simple/Expert view-mode toggle — also threaded into AssistantGroup
   // in B9 to gate the actual render path. When omitted, the composer
@@ -2119,6 +2121,8 @@ export function ChatThread({
   showWorkspace = false,
   onToggleWorkspace,
   canShowBrowser = false,
+  browserProfileId,
+  onSelectBrowserProfile,
   canShowWorkspace = false,
   viewMode = "simple",
   onViewModeChange,
@@ -2228,6 +2232,8 @@ export function ChatThread({
         showWorkspace={showWorkspace}
         onToggleWorkspace={onToggleWorkspace}
         canShowBrowser={canShowBrowser}
+        browserProfileId={browserProfileId}
+        onSelectBrowserProfile={onSelectBrowserProfile}
         canShowWorkspace={canShowWorkspace}
         viewMode={viewMode}
         onViewModeChange={onViewModeChange}

--- a/sdk/agent-chat-react/src/index.ts
+++ b/sdk/agent-chat-react/src/index.ts
@@ -10,6 +10,7 @@ export {
 export { FetchSseEventStream } from "./runtime/fetch-sse-stream";
 export type { FetchSseEventStreamOptions } from "./runtime/fetch-sse-stream";
 export { MessageResponse } from "./components/ai-elements/message";
+export { BrowserLiveView } from "./components/browser/browser-live-view";
 export { ComposioConnectCard } from "./components/connections/composio-connect-card";
 export type { ComposioConnectCardProps } from "./components/connections/composio-connect-card";
 export { IntegrationsBand } from "./components/connections/integrations-band";
@@ -74,6 +75,7 @@ export type {
   AgentChatArtifactMeta,
   AgentChatArtifactKind,
   AgentChatArtifactPayload,
+  AgentChatBrowserProfile,
   AgentChatChartArtifactSpec,
   CodingAgentConnection,
   AgentChatAskUserQuestionArgs,

--- a/sdk/agent-chat-react/src/types.ts
+++ b/sdk/agent-chat-react/src/types.ts
@@ -525,6 +525,15 @@ export interface AgentChatBrowserState {
   controlOwner: string | null;
 }
 
+export interface AgentChatBrowserProfile {
+  id: string;
+  name: string;
+  cookieDomains: string[];
+  hasState: boolean;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
 export interface AgentChatBrowserPreviewSnapshot {
   src: string;
   capturedAt?: string;
@@ -949,6 +958,8 @@ export interface AgentChatAdapter {
   acquireBrowserControl(sessionId: string): Promise<AgentChatBrowserControlResponse>;
   releaseBrowserControl(sessionId: string): Promise<void>;
   browserLiveViewUrl(sessionId: string): string;
+  /** List the caller's saved browser profiles (optional capability). */
+  listBrowserProfiles?(): Promise<AgentChatBrowserProfile[]>;
   /**
    * Permanently terminate the session's browser sandbox (destroys the
    * pod / container, drops the registry entry). Optional — when

--- a/sdk/agent-chat-react/tests/browser-profile-selector.test.tsx
+++ b/sdk/agent-chat-react/tests/browser-profile-selector.test.tsx
@@ -1,0 +1,90 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AgentChatAdapterProvider,
+  NO_BROWSER_ADAPTER,
+} from "../src/adapter-context";
+import { ChatComposer } from "../src/components/chat/chat-composer";
+import type { AgentChatAdapter } from "../src/types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+async function renderComposer(
+  onSelectBrowserProfile: (id: string | null) => void,
+) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const adapter = {
+    ...NO_BROWSER_ADAPTER,
+    async listBrowserProfiles() {
+      return [
+        {
+          id: "p1",
+          name: "Personal",
+          cookieDomains: [],
+          hasState: true,
+          createdAt: "",
+          lastUsedAt: null,
+        },
+        {
+          id: "p2",
+          name: "Work",
+          cookieDomains: [],
+          hasState: false,
+          createdAt: "",
+          lastUsedAt: null,
+        },
+      ];
+    },
+  } as unknown as AgentChatAdapter;
+  await act(async () => {
+    root?.render(
+      <AgentChatAdapterProvider value={{ adapter, sessionId: "s-1" }}>
+        <ChatComposer
+          onSend={vi.fn()}
+          onStop={vi.fn()}
+          isRunning={false}
+          canShowBrowser
+          onSelectBrowserProfile={onSelectBrowserProfile}
+        />
+      </AgentChatAdapterProvider>,
+    );
+  });
+  return container;
+}
+
+describe("browser profile selector", () => {
+  it("lists profiles and selects one", async () => {
+    const onSelect = vi.fn();
+    const node = await renderComposer(onSelect);
+    const trigger = node.querySelector(
+      '[aria-label="Select browser profile"]',
+    ) as HTMLElement;
+    await act(async () => trigger.click());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // PopoverContent portals to document.body, so query the document.
+    expect(document.body.textContent).toContain("Personal");
+    expect(document.body.textContent).toContain("Work");
+    const work = [...document.querySelectorAll("[cmdk-item]")].find((el) =>
+      el.textContent?.includes("Work"),
+    ) as HTMLElement;
+    await act(async () => work.click());
+    expect(onSelect).toHaveBeenCalledWith("p2");
+  });
+});

--- a/surogates/api/app.py
+++ b/surogates/api/app.py
@@ -18,6 +18,7 @@ from surogates.db.engine import async_engine_from_settings, async_session_factor
 from surogates.harness.prompt_library import default_library as default_prompt_library
 from surogates.session.store import SessionStore
 from surogates.storage.backend import create_backend
+from surogates.browser.profiles import BrowserProfileStore
 from surogates.tenant.credentials import CredentialVault
 
 logger = logging.getLogger(__name__)
@@ -134,6 +135,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.credential_vault = _build_vault(
         settings.encryption_key,
         app.state.session_factory,
+    )
+    app.state.browser_profile_store = (
+        BrowserProfileStore(
+            app.state.session_factory,
+            encryption_key=settings.encryption_key.encode("utf-8"),
+        )
+        if settings.encryption_key
+        else None
     )
 
     from surogates.channels.pairing import PairingStore

--- a/surogates/api/app.py
+++ b/surogates/api/app.py
@@ -657,6 +657,7 @@ def create_app() -> FastAPI:
         auth,
         board,
         browser,
+        browser_profiles,
         coding_agents,
         composio,
         events,
@@ -715,6 +716,9 @@ def create_app() -> FastAPI:
     app.include_router(workspace.router, prefix="/v1", tags=["workspace"])
     app.include_router(artifacts.router, prefix="/v1", tags=["artifacts"])
     app.include_router(browser.router, prefix="/v1", tags=["browser"])
+    app.include_router(
+        browser_profiles.router, prefix="/v1", tags=["browser-profiles"]
+    )
     app.include_router(
         ask_user_question.router, prefix="/v1", tags=["ask_user_question"],
     )

--- a/surogates/api/app.py
+++ b/surogates/api/app.py
@@ -716,8 +716,15 @@ def create_app() -> FastAPI:
     app.include_router(workspace.router, prefix="/v1", tags=["workspace"])
     app.include_router(artifacts.router, prefix="/v1", tags=["artifacts"])
     app.include_router(browser.router, prefix="/v1", tags=["browser"])
+    # Dual-mount like the feedback router: the web app reaches these as
+    # ``/api/v1/browser-profiles`` (its dev proxy strips the leading ``/api`` →
+    # ``/v1/browser-profiles``), while the ops proxy uses the SA-token path
+    # ``/v1/api/browser-profiles``.
     app.include_router(
         browser_profiles.router, prefix="/v1", tags=["browser-profiles"]
+    )
+    app.include_router(
+        browser_profiles.router, prefix="/v1/api", tags=["browser-profiles"]
     )
     app.include_router(
         ask_user_question.router, prefix="/v1", tags=["ask_user_question"],

--- a/surogates/api/app.py
+++ b/surogates/api/app.py
@@ -150,6 +150,19 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.pairing_store = PairingStore(redis=app.state.redis)
     _install_browser_api_dependencies(app, settings)
 
+    # Read-only ops DB connection so the browser-minutes credit guard works on
+    # the API side too — the browser_setup pre-check returns a clean 402 instead
+    # of the worker silently failing to provision. Skipped when unconfigured
+    # (OSS/self-hosted), same as the worker.
+    if settings.ops_db.url:
+        from surogates.db.ops_engine import init_ops_engine
+
+        init_ops_engine(
+            settings.ops_db.url,
+            pool_size=settings.ops_db.pool_size,
+            pool_overflow=settings.ops_db.pool_overflow,
+        )
+
     # Per-request resolution goes through ``agent_runtime_context_dep``
     # which reads the caches wired below.
     _install_shared_runtime_plumbing(app, settings)

--- a/surogates/api/routes/browser_profiles.py
+++ b/surogates/api/routes/browser_profiles.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from surogates.browser.base import BrowserCreditsExhaustedError, BrowserSpec
+from surogates.browser.client import KernelBrowserClient
 from surogates.browser.profiles import BrowserProfileRow
 from surogates.session.provisioning import create_agent_session
 from surogates.tenant.auth.middleware import get_current_tenant
@@ -203,3 +204,68 @@ async def create_setup_session(
 
     expires_at = datetime.now(timezone.utc) + timedelta(seconds=_SETUP_TTL_SECONDS)
     return {"session_id": sid, "expires_at": expires_at.isoformat()}
+
+
+class CaptureRequest(BaseModel):
+    owner_user_id: str | None = None
+
+
+@router.post("/api/browser-profiles/{profile_id}/capture")
+async def capture_profile(
+    profile_id: UUID,
+    session_id: UUID,
+    body: CaptureRequest,
+    request: Request,
+    tenant: TenantContext = Depends(get_current_tenant),
+) -> BrowserProfileOut:
+    user_id, sa_id = _principal(tenant)
+    store = _store(request)
+
+    owner = body.owner_user_id or (
+        str(tenant.user_id) if tenant.user_id else None
+    )
+    if not owner:
+        raise HTTPException(
+            status_code=403, detail="Capture requires an owner user id."
+        )
+
+    session = await request.app.state.session_store.get_session(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    # Capture is restricted to the dedicated setup session bound to this
+    # profile — it cannot export an arbitrary agent session even if the caller
+    # transiently holds its control lease.
+    if session.channel != "browser_setup":
+        raise HTTPException(status_code=409, detail="Not a browser-setup session.")
+    bound = str((session.config or {}).get("browser", {}).get("profile_id"))
+    if bound != str(profile_id):
+        raise HTTPException(
+            status_code=409, detail="Session is not bound to this profile."
+        )
+
+    holder = await request.app.state.browser_control.held_by(str(session_id))
+    if holder != owner:
+        raise HTTPException(status_code=403, detail="Caller does not hold control.")
+
+    resolved = await request.app.state.browser_resolver.resolve(
+        str(session_id), expected_org_id=str(tenant.org_id)
+    )
+    if resolved is None:
+        raise HTTPException(status_code=404, detail="No browser for session")
+
+    # The only CDP call permitted while a user-control lease is held: export the
+    # post-login cookies + storage the human just established.
+    client = KernelBrowserClient(resolved.endpoint.rest_url)
+    try:
+        state = await client.storage_state()
+    finally:
+        await client.close()
+
+    row = await store.save_capture(
+        profile_id,
+        tenant.org_id,
+        user_id=user_id,
+        service_account_id=sa_id,
+        storage_state=state,
+    )
+    return BrowserProfileOut.of(row)

--- a/surogates/api/routes/browser_profiles.py
+++ b/surogates/api/routes/browser_profiles.py
@@ -1,4 +1,9 @@
-"""Browser-profile CRUD + setup/capture routes (mounted under ``/v1``)."""
+"""Browser-profile CRUD + setup/capture routes.
+
+The router is dual-mounted (``/v1`` and ``/v1/api``) so both the web app
+(``/v1/browser-profiles`` after its proxy strips ``/api``) and the ops proxy
+(``/v1/api/browser-profiles``) resolve, mirroring the feedback router.
+"""
 
 from __future__ import annotations
 
@@ -73,7 +78,7 @@ def _store(request: Request):
     return store
 
 
-@router.get("/api/browser-profiles")
+@router.get("/browser-profiles")
 async def list_profiles(
     request: Request, tenant: TenantContext = Depends(get_current_tenant)
 ) -> list[BrowserProfileOut]:
@@ -84,7 +89,7 @@ async def list_profiles(
     return [BrowserProfileOut.of(r) for r in rows]
 
 
-@router.post("/api/browser-profiles", status_code=201)
+@router.post("/browser-profiles", status_code=201)
 async def create_profile(
     body: CreateProfileRequest,
     request: Request,
@@ -100,7 +105,7 @@ async def create_profile(
     return BrowserProfileOut.of(row)
 
 
-@router.patch("/api/browser-profiles/{profile_id}")
+@router.patch("/browser-profiles/{profile_id}")
 async def rename_profile(
     profile_id: UUID,
     body: RenameProfileRequest,
@@ -120,7 +125,7 @@ async def rename_profile(
     return {"renamed": True}
 
 
-@router.delete("/api/browser-profiles/{profile_id}", status_code=204)
+@router.delete("/browser-profiles/{profile_id}", status_code=204)
 async def delete_profile(
     profile_id: UUID,
     request: Request,
@@ -138,7 +143,7 @@ class SetupSessionRequest(BaseModel):
     setup_spec: dict | None = None
 
 
-@router.post("/api/browser-profiles/{profile_id}/setup-session")
+@router.post("/browser-profiles/{profile_id}/setup-session")
 async def create_setup_session(
     profile_id: UUID,
     body: SetupSessionRequest,
@@ -210,7 +215,7 @@ class CaptureRequest(BaseModel):
     owner_user_id: str | None = None
 
 
-@router.post("/api/browser-profiles/{profile_id}/capture")
+@router.post("/browser-profiles/{profile_id}/capture")
 async def capture_profile(
     profile_id: UUID,
     session_id: UUID,

--- a/surogates/api/routes/browser_profiles.py
+++ b/surogates/api/routes/browser_profiles.py
@@ -2,16 +2,24 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
+from surogates.browser.base import BrowserCreditsExhaustedError, BrowserSpec
 from surogates.browser.profiles import BrowserProfileRow
+from surogates.session.provisioning import create_agent_session
 from surogates.tenant.auth.middleware import get_current_tenant
 from surogates.tenant.context import TenantContext
 
 router = APIRouter()
+
+# A browser-setup session is interactive-only: the user logs in by hand and
+# saves. The pod self-terminates at this deadline; nothing persists without an
+# explicit capture.
+_SETUP_TTL_SECONDS = 15 * 60
 
 
 class CreateProfileRequest(BaseModel):
@@ -121,3 +129,77 @@ async def delete_profile(
     await _store(request).delete(
         profile_id, tenant.org_id, user_id=user_id, service_account_id=sa_id
     )
+
+
+class SetupSessionRequest(BaseModel):
+    owner_user_id: str | None = None
+    agent_id: str | None = None
+    setup_spec: dict | None = None
+
+
+@router.post("/api/browser-profiles/{profile_id}/setup-session")
+async def create_setup_session(
+    profile_id: UUID,
+    body: SetupSessionRequest,
+    request: Request,
+    tenant: TenantContext = Depends(get_current_tenant),
+) -> dict[str, str]:
+    user_id, sa_id = _principal(tenant)
+    store = _store(request)
+
+    # The profile must exist and belong to the caller before we burn a pod.
+    rows = await store.list(tenant.org_id, user_id=user_id, service_account_id=sa_id)
+    if not any(r.id == profile_id for r in rows):
+        raise HTTPException(status_code=404, detail="Profile not found")
+
+    owner = body.owner_user_id or (
+        str(tenant.user_id) if tenant.user_id else None
+    )
+    if not owner:
+        raise HTTPException(
+            status_code=403, detail="Setup requires an owner user id."
+        )
+
+    setup_spec = body.setup_spec or {}
+    if setup_spec.get("proxy") is not None:
+        raise HTTPException(
+            status_code=400, detail="Egress proxy is not yet supported."
+        )
+
+    # Create a browser-only session: no harness wake is enqueued, so the agent
+    # loop never runs — the human drives the browser through the live view.
+    settings = request.app.state.settings
+    session = await create_agent_session(
+        store=request.app.state.session_store,
+        storage=request.app.state.storage,
+        settings=settings,
+        org_id=tenant.org_id,
+        user_id=user_id,
+        agent_id=body.agent_id or "browser-setup",
+        channel="browser_setup",
+        model=settings.llm.model,
+        config={
+            "browser": {"profile_id": str(profile_id), "setup_spec": setup_spec}
+        },
+        service_account_id=sa_id,
+    )
+    sid = str(session.id)
+
+    pool = request.app.state.browser_pool
+    try:
+        await pool.ensure(
+            session_id=sid,
+            org_id=str(tenant.org_id),
+            user_id=owner,
+            spec=BrowserSpec(active_deadline_seconds=_SETUP_TTL_SECONDS),
+        )
+    except BrowserCreditsExhaustedError as exc:
+        # ``ensure`` runs the browser-minutes credit guard before provisioning,
+        # so a setup browser meters minutes like any live browser. Surface a
+        # top-up signal instead of a 500.
+        raise HTTPException(status_code=402, detail=str(exc)) from exc
+
+    await request.app.state.browser_control.acquire(sid, owner)
+
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=_SETUP_TTL_SECONDS)
+    return {"session_id": sid, "expires_at": expires_at.isoformat()}

--- a/surogates/api/routes/browser_profiles.py
+++ b/surogates/api/routes/browser_profiles.py
@@ -15,8 +15,10 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 
+from surogates.browser.base import BrowserCreditsExhaustedError
 from surogates.browser.client import KernelBrowserClient
 from surogates.browser.profiles import BrowserProfileRow
+from surogates.db.ops_credits import assert_browser_minutes_available
 from surogates.session.provisioning import create_agent_session
 from surogates.session.store import SessionNotFoundError
 from surogates.tenant.auth.middleware import get_current_tenant
@@ -180,6 +182,14 @@ async def create_setup_session(
         raise HTTPException(
             status_code=400, detail="Egress proxy is not yet supported."
         )
+
+    # Pre-check browser-minutes so the user gets a clean 402 instead of the
+    # worker silently failing to provision (the live view would never connect).
+    # No-ops when the ops DB isn't configured.
+    try:
+        await assert_browser_minutes_available(str(tenant.org_id))
+    except BrowserCreditsExhaustedError as exc:
+        raise HTTPException(status_code=402, detail=str(exc)) from exc
 
     # Create the browser_setup session and wake it. Provisioning + the control
     # grant happen in the **worker** — the only process that owns a BrowserPool

--- a/surogates/api/routes/browser_profiles.py
+++ b/surogates/api/routes/browser_profiles.py
@@ -1,0 +1,123 @@
+"""Browser-profile CRUD + setup/capture routes (mounted under ``/v1``)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from surogates.browser.profiles import BrowserProfileRow
+from surogates.tenant.auth.middleware import get_current_tenant
+from surogates.tenant.context import TenantContext
+
+router = APIRouter()
+
+
+class CreateProfileRequest(BaseModel):
+    name: str | None = None
+
+
+class RenameProfileRequest(BaseModel):
+    name: str
+
+
+class BrowserProfileOut(BaseModel):
+    id: str
+    name: str
+    source: str
+    cookie_domains: list[str]
+    created_at: str
+    last_used_at: str | None
+    has_state: bool
+
+    @classmethod
+    def of(cls, row: BrowserProfileRow) -> "BrowserProfileOut":
+        return cls(
+            id=str(row.id),
+            name=row.name,
+            source=row.source,
+            cookie_domains=row.cookie_domains,
+            created_at=row.created_at.isoformat(),
+            last_used_at=(
+                row.last_used_at.isoformat() if row.last_used_at else None
+            ),
+            has_state=row.has_state,
+        )
+
+
+def _principal(tenant: TenantContext) -> tuple[UUID | None, UUID | None]:
+    """Resolve ``(user_id, service_account_id)`` — exactly one is non-null."""
+    if tenant.user_id is not None:
+        return tenant.user_id, None
+    if tenant.service_account_id is not None:
+        return None, tenant.service_account_id
+    raise HTTPException(
+        status_code=403, detail="Browser profiles require a user principal."
+    )
+
+
+def _store(request: Request):
+    store = getattr(request.app.state, "browser_profile_store", None)
+    if store is None:
+        raise HTTPException(status_code=503, detail="Browser profiles unavailable.")
+    return store
+
+
+@router.get("/api/browser-profiles")
+async def list_profiles(
+    request: Request, tenant: TenantContext = Depends(get_current_tenant)
+) -> list[BrowserProfileOut]:
+    user_id, sa_id = _principal(tenant)
+    rows = await _store(request).list(
+        tenant.org_id, user_id=user_id, service_account_id=sa_id
+    )
+    return [BrowserProfileOut.of(r) for r in rows]
+
+
+@router.post("/api/browser-profiles", status_code=201)
+async def create_profile(
+    body: CreateProfileRequest,
+    request: Request,
+    tenant: TenantContext = Depends(get_current_tenant),
+) -> BrowserProfileOut:
+    user_id, sa_id = _principal(tenant)
+    row = await _store(request).create(
+        tenant.org_id,
+        user_id=user_id,
+        service_account_id=sa_id,
+        name=(body.name or "Profile").strip() or "Profile",
+    )
+    return BrowserProfileOut.of(row)
+
+
+@router.patch("/api/browser-profiles/{profile_id}")
+async def rename_profile(
+    profile_id: UUID,
+    body: RenameProfileRequest,
+    request: Request,
+    tenant: TenantContext = Depends(get_current_tenant),
+) -> dict[str, bool]:
+    user_id, sa_id = _principal(tenant)
+    ok = await _store(request).rename(
+        profile_id,
+        tenant.org_id,
+        user_id=user_id,
+        service_account_id=sa_id,
+        name=body.name.strip(),
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return {"renamed": True}
+
+
+@router.delete("/api/browser-profiles/{profile_id}", status_code=204)
+async def delete_profile(
+    profile_id: UUID,
+    request: Request,
+    tenant: TenantContext = Depends(get_current_tenant),
+) -> None:
+    user_id, sa_id = _principal(tenant)
+    await _store(request).delete(
+        profile_id, tenant.org_id, user_id=user_id, service_account_id=sa_id
+    )

--- a/surogates/api/routes/browser_profiles.py
+++ b/surogates/api/routes/browser_profiles.py
@@ -7,18 +7,22 @@ The router is dual-mounted (``/v1`` and ``/v1/api``) so both the web app
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 
-from surogates.browser.base import BrowserCreditsExhaustedError, BrowserSpec
 from surogates.browser.client import KernelBrowserClient
 from surogates.browser.profiles import BrowserProfileRow
 from surogates.session.provisioning import create_agent_session
+from surogates.session.store import SessionNotFoundError
 from surogates.tenant.auth.middleware import get_current_tenant
 from surogates.tenant.context import TenantContext
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -96,12 +100,17 @@ async def create_profile(
     tenant: TenantContext = Depends(get_current_tenant),
 ) -> BrowserProfileOut:
     user_id, sa_id = _principal(tenant)
-    row = await _store(request).create(
-        tenant.org_id,
-        user_id=user_id,
-        service_account_id=sa_id,
-        name=(body.name or "Profile").strip() or "Profile",
-    )
+    try:
+        row = await _store(request).create(
+            tenant.org_id,
+            user_id=user_id,
+            service_account_id=sa_id,
+            name=(body.name or "Profile").strip() or "Profile",
+        )
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=409, detail="A profile with that name already exists."
+        ) from exc
     return BrowserProfileOut.of(row)
 
 
@@ -172,8 +181,11 @@ async def create_setup_session(
             status_code=400, detail="Egress proxy is not yet supported."
         )
 
-    # Create a browser-only session: no harness wake is enqueued, so the agent
-    # loop never runs — the human drives the browser through the live view.
+    # Create the browser_setup session and wake it. Provisioning + the control
+    # grant happen in the **worker** — the only process that owns a BrowserPool
+    # and the fleet credentials — whose loop short-circuits browser_setup
+    # sessions (provision + grant control, no agent loop). The owner travels in
+    # the config so the worker can grant control to the right user.
     settings = request.app.state.settings
     session = await create_agent_session(
         store=request.app.state.session_store,
@@ -185,27 +197,17 @@ async def create_setup_session(
         channel="browser_setup",
         model=settings.llm.model,
         config={
-            "browser": {"profile_id": str(profile_id), "setup_spec": setup_spec}
+            "browser": {
+                "profile_id": str(profile_id),
+                "setup_spec": setup_spec,
+                "setup_owner_user_id": owner,
+                "setup_ttl_seconds": _SETUP_TTL_SECONDS,
+            }
         },
         service_account_id=sa_id,
     )
     sid = str(session.id)
-
-    pool = request.app.state.browser_pool
-    try:
-        await pool.ensure(
-            session_id=sid,
-            org_id=str(tenant.org_id),
-            user_id=owner,
-            spec=BrowserSpec(active_deadline_seconds=_SETUP_TTL_SECONDS),
-        )
-    except BrowserCreditsExhaustedError as exc:
-        # ``ensure`` runs the browser-minutes credit guard before provisioning,
-        # so a setup browser meters minutes like any live browser. Surface a
-        # top-up signal instead of a 500.
-        raise HTTPException(status_code=402, detail=str(exc)) from exc
-
-    await request.app.state.browser_control.acquire(sid, owner)
+    await request.app.state.session_wake(sid)
 
     expires_at = datetime.now(timezone.utc) + timedelta(seconds=_SETUP_TTL_SECONDS)
     return {"session_id": sid, "expires_at": expires_at.isoformat()}
@@ -234,9 +236,10 @@ async def capture_profile(
             status_code=403, detail="Capture requires an owner user id."
         )
 
-    session = await request.app.state.session_store.get_session(session_id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+    try:
+        session = await request.app.state.session_store.get_session(session_id)
+    except SessionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
     # Capture is restricted to the dedicated setup session bound to this
     # profile — it cannot export an arbitrary agent session even if the caller
     # transiently holds its control lease.
@@ -273,4 +276,18 @@ async def capture_profile(
         service_account_id=sa_id,
         storage_state=state,
     )
+
+    # Release the setup browser promptly: flip the session terminal and re-wake
+    # so the worker (which owns the pool) destroys it instead of letting it idle
+    # to its pod deadline. Best-effort — the pod TTL is the backstop.
+    try:
+        await request.app.state.session_store.update_session_status(
+            session_id, "completed"
+        )
+        await request.app.state.session_wake(str(session_id))
+    except Exception:
+        logger.warning(
+            "browser_setup teardown wake failed for %s", session_id, exc_info=True
+        )
+
     return BrowserProfileOut.of(row)

--- a/surogates/browser/base.py
+++ b/surogates/browser/base.py
@@ -106,6 +106,9 @@ class BrowserSpec:
     workspace_path: str | None = None
     workspace_source_ref: str | None = None
     env: dict[str, str] = field(default_factory=dict)
+    # When set, the pool injects this Playwright storage_state into the fresh
+    # context at provision time (before registry publish / navigation).
+    storage_state: dict | None = None
 
 
 class BrowserBackend(Protocol):

--- a/surogates/browser/client.py
+++ b/surogates/browser/client.py
@@ -181,9 +181,18 @@ return {
     async def apply_storage_state(self, state: dict[str, Any]) -> None:
         """Inject cookies (and best-effort localStorage) into the live context.
 
-        Cookies are applied directly to the existing context. localStorage is
-        seeded per origin (best effort): a fresh context cannot be created on an
-        already-running browser, so we navigate to each origin and set its items.
+        Cookies are applied first, in one ``addCookies`` call — they are the
+        primary auth carrier and land atomically. localStorage can only be
+        written while the page is on the matching origin, and a fresh context
+        can't be created on an already-running browser, so each origin is seeded
+        by navigating to it and writing its items.
+
+        Those per-origin navigations run **sequentially** inside the single
+        ``_playwright_execute`` call, which shares one 60s budget — a profile
+        spanning many origins can approach that timeout. Cookies are already in
+        place by then, so a partial localStorage seed degrades gracefully rather
+        than losing the session; per-origin failures (origins that block
+        navigation) are swallowed for the same reason.
         """
 
         cookies_json = json.dumps(state.get("cookies", []) or [])

--- a/surogates/browser/client.py
+++ b/surogates/browser/client.py
@@ -171,6 +171,39 @@ return {
         self._invalidate_snapshot_cache()
         return result
 
+    async def storage_state(self) -> dict[str, Any]:
+        """Export the live context's cookies + per-origin localStorage."""
+
+        code = "return await page.context().storageState();"
+        result = await self._playwright_execute(code)
+        return result or {"cookies": [], "origins": []}
+
+    async def apply_storage_state(self, state: dict[str, Any]) -> None:
+        """Inject cookies (and best-effort localStorage) into the live context.
+
+        Cookies are applied directly to the existing context. localStorage is
+        seeded per origin (best effort): a fresh context cannot be created on an
+        already-running browser, so we navigate to each origin and set its items.
+        """
+
+        cookies_json = json.dumps(state.get("cookies", []) or [])
+        origins_json = json.dumps(state.get("origins", []) or [])
+        code = (
+            "const context = page.context();\n"
+            f"await context.addCookies({cookies_json});\n"
+            f"for (const o of {origins_json}) {{\n"
+            "  try {\n"
+            "    await page.goto(o.origin, {waitUntil: 'domcontentloaded'});\n"
+            "    await page.evaluate((items) => {\n"
+            "      for (const it of items) localStorage.setItem(it.name, it.value);\n"
+            "    }, o.localStorage || []);\n"
+            "  } catch (e) { /* best-effort per origin */ }\n"
+            "}\n"
+            "return true;"
+        )
+        await self._playwright_execute(code)
+        self._invalidate_snapshot_cache()
+
     async def get_state(
         self,
         *,

--- a/surogates/browser/pool.py
+++ b/surogates/browser/pool.py
@@ -52,11 +52,16 @@ class BrowserPool:
         registry: BrowserRegistry,
         event_emitter: EventEmitter | None = None,
         credit_guard: CreditGuard | None = None,
+        browser_profile_store: Any | None = None,
     ) -> None:
         self._backend = backend
         self._registry = registry
         self._emit = event_emitter
         self._credit_guard = credit_guard
+        # Read by the browser tool layer to inject a session's saved login
+        # state at provision; public so handlers reach it via the pool they
+        # already hold (avoids threading the store through the executor chain).
+        self.browser_profile_store = browser_profile_store
         self._mapping: dict[str, _Slot] = {}
         self._locks: dict[str, asyncio.Lock] = {}
         self._global_lock = asyncio.Lock()

--- a/surogates/browser/pool.py
+++ b/surogates/browser/pool.py
@@ -14,6 +14,7 @@ from surogates.browser.base import (
     BrowserSpec,
     BrowserStatus,
 )
+from surogates.browser.client import KernelBrowserClient
 from surogates.browser.registry import BrowserEntry, BrowserRegistry
 from surogates.session.events import EventType
 
@@ -112,6 +113,15 @@ class BrowserPool:
                 org_id=org_id,
                 user_id=user_id,
             )
+            # Inject saved login state into the fresh context *before* the
+            # registry publish and the provisioned event, so the agent's first
+            # navigation already sees the cookies. Only runs on a new provision.
+            if spec.storage_state:
+                client = KernelBrowserClient(endpoint.rest_url)
+                try:
+                    await client.apply_storage_state(spec.storage_state)
+                finally:
+                    await client.close()
             slot = _Slot(browser_id=browser_id, endpoint=endpoint, snapshot_cache={})
             self._mapping[session_id] = slot
             await self._registry.set(

--- a/surogates/browser/profiles.py
+++ b/surogates/browser/profiles.py
@@ -1,0 +1,213 @@
+"""Encrypted, principal-scoped browser login profiles."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from uuid import UUID
+
+from cryptography.fernet import Fernet, InvalidToken
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from surogates.db.models import BrowserProfile
+
+
+@dataclass(slots=True)
+class BrowserProfileRow:
+    id: UUID
+    name: str
+    source: str
+    cookie_domains: list[str]
+    created_at: datetime
+    last_used_at: datetime | None
+    has_state: bool
+
+
+def _row(p: BrowserProfile) -> BrowserProfileRow:
+    return BrowserProfileRow(
+        id=p.id,
+        name=p.name,
+        source=p.source,
+        cookie_domains=list(p.cookie_domains or []),
+        created_at=p.created_at,
+        last_used_at=p.last_used_at,
+        has_state=p.storage_state_enc is not None,
+    )
+
+
+def _cookie_domains(storage_state: dict) -> list[str]:
+    seen: dict[str, None] = {}
+    for cookie in storage_state.get("cookies", []) or []:
+        domain = str(cookie.get("domain", "")).lstrip(".")
+        if domain:
+            seen.setdefault(domain, None)
+    return sorted(seen)
+
+
+class BrowserProfileStore:
+    """CRUD + encrypted capture/inject for browser profiles.
+
+    Every method takes ``(org_id, user_id, service_account_id)`` and filters on
+    the exact principal so a profile is unreadable cross-principal even with a
+    guessed id.
+    """
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker,
+        encryption_key: bytes,
+    ) -> None:
+        self._session_factory = session_factory
+        self._fernet = Fernet(encryption_key)
+
+    @staticmethod
+    def _principal_clause(user_id: UUID | None, service_account_id: UUID | None):
+        if (user_id is None) == (service_account_id is None):
+            raise ValueError(
+                "exactly one of user_id / service_account_id required"
+            )
+        if user_id is not None:
+            return BrowserProfile.user_id == user_id
+        return BrowserProfile.service_account_id == service_account_id
+
+    async def create(
+        self,
+        org_id: UUID,
+        *,
+        user_id: UUID | None,
+        service_account_id: UUID | None,
+        name: str,
+    ) -> BrowserProfileRow:
+        self._principal_clause(user_id, service_account_id)
+        profile = BrowserProfile(
+            org_id=org_id,
+            user_id=user_id,
+            service_account_id=service_account_id,
+            name=name,
+        )
+        async with self._session_factory() as s:
+            async with s.begin():
+                s.add(profile)
+            await s.refresh(profile)
+            return _row(profile)
+
+    async def list(
+        self,
+        org_id: UUID,
+        *,
+        user_id: UUID | None,
+        service_account_id: UUID | None,
+    ) -> list[BrowserProfileRow]:
+        clause = self._principal_clause(user_id, service_account_id)
+        async with self._session_factory() as s:
+            rows = (
+                await s.execute(
+                    select(BrowserProfile)
+                    .where(BrowserProfile.org_id == org_id, clause)
+                    .order_by(BrowserProfile.created_at.asc())
+                )
+            ).scalars().all()
+        return [_row(p) for p in rows]
+
+    async def _get(
+        self, s, profile_id, org_id, user_id, service_account_id
+    ) -> BrowserProfile | None:
+        clause = self._principal_clause(user_id, service_account_id)
+        return (
+            await s.execute(
+                select(BrowserProfile).where(
+                    BrowserProfile.id == profile_id,
+                    BrowserProfile.org_id == org_id,
+                    clause,
+                )
+            )
+        ).scalar_one_or_none()
+
+    async def rename(
+        self, profile_id, org_id, *, user_id, service_account_id, name
+    ) -> bool:
+        clause = self._principal_clause(user_id, service_account_id)
+        async with self._session_factory() as s:
+            async with s.begin():
+                result = await s.execute(
+                    update(BrowserProfile)
+                    .where(
+                        BrowserProfile.id == profile_id,
+                        BrowserProfile.org_id == org_id,
+                        clause,
+                    )
+                    .values(name=name)
+                )
+        return result.rowcount > 0
+
+    async def delete(
+        self, profile_id, org_id, *, user_id, service_account_id
+    ) -> bool:
+        clause = self._principal_clause(user_id, service_account_id)
+        async with self._session_factory() as s:
+            async with s.begin():
+                result = await s.execute(
+                    sa_delete(BrowserProfile).where(
+                        BrowserProfile.id == profile_id,
+                        BrowserProfile.org_id == org_id,
+                        clause,
+                    )
+                )
+        return result.rowcount > 0
+
+    async def save_capture(
+        self,
+        profile_id,
+        org_id,
+        *,
+        user_id,
+        service_account_id,
+        storage_state: dict,
+    ) -> BrowserProfileRow:
+        blob = self._fernet.encrypt(json.dumps(storage_state).encode("utf-8"))
+        domains = _cookie_domains(storage_state)
+        async with self._session_factory() as s:
+            async with s.begin():
+                profile = await self._get(
+                    s, profile_id, org_id, user_id, service_account_id
+                )
+                if profile is None:
+                    raise KeyError("profile not found")
+                profile.storage_state_enc = blob
+                profile.cookie_domains = domains
+            await s.refresh(profile)
+            return _row(profile)
+
+    async def storage_state_for(
+        self, profile_id, org_id, *, user_id, service_account_id
+    ) -> dict | None:
+        async with self._session_factory() as s:
+            profile = await self._get(
+                s, profile_id, org_id, user_id, service_account_id
+            )
+            if profile is None or profile.storage_state_enc is None:
+                return None
+            raw = profile.storage_state_enc
+        try:
+            return json.loads(self._fernet.decrypt(raw).decode("utf-8"))
+        except InvalidToken:
+            raise ValueError("failed to decrypt browser profile state")
+
+    async def touch_last_used(
+        self, profile_id, org_id, *, user_id, service_account_id
+    ) -> None:
+        clause = self._principal_clause(user_id, service_account_id)
+        async with self._session_factory() as s:
+            async with s.begin():
+                await s.execute(
+                    update(BrowserProfile)
+                    .where(
+                        BrowserProfile.id == profile_id,
+                        BrowserProfile.org_id == org_id,
+                        clause,
+                    )
+                    .values(last_used_at=datetime.now(timezone.utc))
+                )

--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -594,6 +594,71 @@ class ScheduledSession(Base):
 
 
 # ---------------------------------------------------------------------------
+# Browser Profiles
+# ---------------------------------------------------------------------------
+
+
+class BrowserProfile(Base):
+    """A reusable, encrypted browser login state owned by one principal.
+
+    Like ``ScheduledSession``, a profile is owned by exactly one principal —
+    a human ``user_id`` or a ``service_account_id`` (the ops-chat SA that
+    work-chat requests authenticate as). The CHECK enforces the XOR.
+    """
+
+    __tablename__ = "browser_profiles"
+    __table_args__ = (
+        CheckConstraint(
+            "(user_id IS NOT NULL)::int + (service_account_id IS NOT NULL)::int = 1",
+            name="ck_browser_profiles_one_principal",
+        ),
+        Index(
+            "uq_browser_profiles_user_name",
+            "org_id",
+            "user_id",
+            "name",
+            unique=True,
+            postgresql_where=text("user_id IS NOT NULL"),
+        ),
+        Index(
+            "uq_browser_profiles_sa_name",
+            "org_id",
+            "service_account_id",
+            "name",
+            unique=True,
+            postgresql_where=text("service_account_id IS NOT NULL"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False
+    )
+    user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+    service_account_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("service_accounts.id"), nullable=True
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    source: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'manual_vnc'")
+    )
+    storage_state_enc: Mapped[Optional[bytes]] = mapped_column(
+        LargeBinary, nullable=True
+    )
+    cookie_domains: Mapped[list[Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        nullable=False, server_default=func.now()
+    )
+    last_used_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
+
+
+# ---------------------------------------------------------------------------
 # Service Accounts
 # ---------------------------------------------------------------------------
 

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -768,6 +768,41 @@ class AgentHarness(
     # Entry point
     # ------------------------------------------------------------------
 
+    async def _run_browser_setup(self, session: "Session") -> None:
+        """Provision (or release) the interactive browser for a setup session.
+
+        The browser is provisioned here — in the worker, the only process that
+        owns a ``BrowserPool`` and the fleet credentials — rather than from the
+        API. No agent loop runs: the human logs in through the live view and the
+        ``/browser-profiles/{id}/capture`` route exports the result. Capture (or
+        cancel) flips the session to a terminal status and re-enqueues it, which
+        brings us back here to destroy the browser instead of provisioning it,
+        so it stops billing well before its pod deadline.
+        """
+        if self._browser_pool is None:
+            return
+        browser_cfg = (session.config or {}).get("browser", {})
+        owner = browser_cfg.get("setup_owner_user_id")
+        if not owner:
+            return
+        sid = str(session.id)
+        if session.status in ("completed", "failed"):
+            await self._browser_pool.destroy_for_session(sid)
+            return
+
+        from surogates.browser.base import BrowserSpec
+
+        ttl = int(browser_cfg.get("setup_ttl_seconds") or 15 * 60)
+        # No profile injection: the user logs in by hand from a fresh context.
+        await self._browser_pool.ensure(
+            session_id=sid,
+            org_id=str(session.org_id),
+            user_id=str(owner),
+            spec=BrowserSpec(active_deadline_seconds=ttl),
+        )
+        if self._browser_control is not None:
+            await self._browser_control.acquire(sid, str(owner))
+
     async def wake(self, session_id: UUID) -> str | None:
         """Entry point.  Acquire lease, replay events, run loop, release lease."""
         from surogates.trace import new_span
@@ -815,6 +850,13 @@ class AgentHarness(
                 "wake step=fetch_session session=%s", session_id,
             )
             session = await self._store.get_session(session_id)
+
+            # A browser-setup session is interactive-only: provision a fresh
+            # browser + grant the user control on the first wake, and release it
+            # once capture/cancel flips the status to terminal. No LLM loop runs.
+            if session.channel == "browser_setup":
+                await self._run_browser_setup(session)
+                return None
 
             # Bail out if the session was already paused/completed/failed
             # before this wake cycle -- prevents re-running a session

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -786,22 +786,35 @@ class AgentHarness(
         if not owner:
             return
         sid = str(session.id)
-        if session.status in ("completed", "failed"):
-            await self._browser_pool.destroy_for_session(sid)
-            return
 
-        from surogates.browser.base import BrowserSpec
-
-        ttl = int(browser_cfg.get("setup_ttl_seconds") or 15 * 60)
-        # No profile injection: the user logs in by hand from a fresh context.
-        await self._browser_pool.ensure(
-            session_id=sid,
-            org_id=str(session.org_id),
-            user_id=str(owner),
-            spec=BrowserSpec(active_deadline_seconds=ttl),
+        # Take the session lease so two workers can't double-provision or race
+        # provision-vs-teardown for the same setup session. A no-op (skip) when
+        # another worker already holds it.
+        lease = await self._store.try_acquire_lease(
+            session.id, self._worker_id, ttl_seconds=_LEASE_TTL_SECONDS
         )
-        if self._browser_control is not None:
-            await self._browser_control.acquire(sid, str(owner))
+        if lease is None:
+            return
+        try:
+            if session.status in ("completed", "failed"):
+                await self._browser_pool.destroy_for_session(sid)
+                return
+
+            from surogates.browser.base import BrowserSpec
+
+            ttl = int(browser_cfg.get("setup_ttl_seconds") or 15 * 60)
+            # No profile injection: the user logs in by hand from a fresh
+            # context.
+            await self._browser_pool.ensure(
+                session_id=sid,
+                org_id=str(session.org_id),
+                user_id=str(owner),
+                spec=BrowserSpec(active_deadline_seconds=ttl),
+            )
+            if self._browser_control is not None:
+                await self._browser_control.acquire(sid, str(owner))
+        finally:
+            await self._store.release_lease(session.id, lease.lease_token)
 
     async def wake(self, session_id: UUID) -> str | None:
         """Entry point.  Acquire lease, replay events, run loop, release lease."""

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -26,6 +26,7 @@ from surogates.harness.prompt_library import default_library as default_prompt_l
 from surogates.health import infrastructure_readiness, start_health_server
 from surogates.browser.control import BrowserControlStore
 from surogates.browser.pool import BrowserPool
+from surogates.browser.profiles import BrowserProfileStore
 from surogates.browser.process import ProcessBrowserBackend
 from surogates.browser.registry import BrowserRegistry
 from surogates.memory.manager import MemoryManager
@@ -716,6 +717,14 @@ async def run_worker(settings: Settings) -> None:
         registry=browser_registry,
         event_emitter=_emit_browser_event,
         credit_guard=assert_browser_minutes_available,
+        browser_profile_store=(
+            BrowserProfileStore(
+                session_factory,
+                encryption_key=settings.encryption_key.encode("utf-8"),
+            )
+            if settings.encryption_key
+            else None
+        ),
     )
     logger.info("Agent browser ready (backend=%s)", settings.browser.backend)
 

--- a/surogates/tools/builtin/browser.py
+++ b/surogates/tools/builtin/browser.py
@@ -125,19 +125,30 @@ async def _resolve_session_browser(
                 else getattr(tenant, "user_id", None)
             )
             if (user_id is not None) ^ (service_account_id is not None):
-                state = await store.storage_state_for(
-                    UUID(str(profile_id)),
-                    org_id,
-                    user_id=user_id,
-                    service_account_id=service_account_id,
-                )
-                if state is not None:
-                    browser_spec.storage_state = state
-                    await store.touch_last_used(
+                try:
+                    state = await store.storage_state_for(
                         UUID(str(profile_id)),
                         org_id,
                         user_id=user_id,
                         service_account_id=service_account_id,
+                    )
+                    if state is not None:
+                        browser_spec.storage_state = state
+                        await store.touch_last_used(
+                            UUID(str(profile_id)),
+                            org_id,
+                            user_id=user_id,
+                            service_account_id=service_account_id,
+                        )
+                except Exception:
+                    # Fail open to a fresh browser rather than crashing the
+                    # tool — e.g. the encryption key was rotated and the blob
+                    # can no longer be decrypted.
+                    logger.warning(
+                        "Could not load browser profile %s; "
+                        "provisioning a fresh browser",
+                        profile_id,
+                        exc_info=True,
                     )
 
         result = await browser_pool.ensure(

--- a/surogates/tools/builtin/browser.py
+++ b/surogates/tools/builtin/browser.py
@@ -77,6 +77,7 @@ async def _resolve_session_browser(
     spec: BrowserSpec | None = None,
     workspace_path: str | None = None,
     session_config: dict[str, Any] | None = None,
+    browser_profile_store: Any = None,
 ) -> tuple[str, BrowserEndpoint, dict[str, dict[str, Any]]] | str:
     if browser_pool is None or session_id is None:
         return browser_unavailable_result("browser pool not configured")
@@ -100,6 +101,45 @@ async def _resolve_session_browser(
                 else None
             ),
         )
+
+        # Attach a saved browser profile's login state, if one is bound to the
+        # session. The pool injects it into the fresh context at provision. The
+        # store rides on the pool (set at worker construction); an explicit
+        # ``browser_profile_store`` overrides it for tests.
+        store = browser_profile_store or getattr(
+            browser_pool, "browser_profile_store", None
+        )
+        profile_id = (session_config or {}).get("browser", {}).get("profile_id")
+        if profile_id and store is not None:
+            org_id = getattr(tenant, "org_id", None)
+            service_account_id = getattr(tenant, "service_account_id", None)
+            if service_account_id is None:
+                sa_raw = (session_config or {}).get("service_account_id")
+                if sa_raw:
+                    service_account_id = UUID(str(sa_raw))
+            # SA-owned profiles (the ops-chat path) take precedence; the store
+            # requires exactly one principal, so null the user when an SA is set.
+            user_id = (
+                None
+                if service_account_id is not None
+                else getattr(tenant, "user_id", None)
+            )
+            if (user_id is not None) ^ (service_account_id is not None):
+                state = await store.storage_state_for(
+                    UUID(str(profile_id)),
+                    org_id,
+                    user_id=user_id,
+                    service_account_id=service_account_id,
+                )
+                if state is not None:
+                    browser_spec.storage_state = state
+                    await store.touch_last_used(
+                        UUID(str(profile_id)),
+                        org_id,
+                        user_id=user_id,
+                        service_account_id=service_account_id,
+                    )
+
         result = await browser_pool.ensure(
             session_id=sid,
             org_id=str(getattr(tenant, "org_id", "")) if tenant is not None else "",

--- a/tests/integration/test_browser_profiles_store.py
+++ b/tests/integration/test_browser_profiles_store.py
@@ -1,11 +1,19 @@
 import pytest
+from cryptography.fernet import Fernet
 from sqlalchemy import select
 
+from surogates.browser.profiles import BrowserProfileStore
 from surogates.db.models import BrowserProfile
 
 from .conftest import create_org, issue_service_account_token
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+_KEY = Fernet.generate_key()
+
+
+def _store(session_factory):
+    return BrowserProfileStore(session_factory, encryption_key=_KEY)
 
 
 async def test_browser_profile_persists_for_service_account_principal(session_factory):
@@ -36,3 +44,66 @@ async def test_browser_profile_persists_for_service_account_principal(session_fa
     assert row.source == "manual_vnc"
     assert row.cookie_domains == []
     assert row.storage_state_enc is None
+
+
+async def test_create_list_scoped_to_principal(session_factory):
+    store = _store(session_factory)
+    org = await create_org(session_factory)
+    sa_a = (await issue_service_account_token(session_factory, org, name="a")).id
+    sa_b = (await issue_service_account_token(session_factory, org, name="b")).id
+
+    a = await store.create(org, user_id=None, service_account_id=sa_a, name="A")
+    await store.create(org, user_id=None, service_account_id=sa_b, name="B")
+
+    rows = await store.list(org, user_id=None, service_account_id=sa_a)
+    assert [r.name for r in rows] == ["A"]
+    assert rows[0].id == a.id
+    assert rows[0].has_state is False
+
+
+async def test_capture_roundtrip_and_cookie_domains(session_factory):
+    store = _store(session_factory)
+    org = await create_org(session_factory)
+    sa = (await issue_service_account_token(session_factory, org)).id
+
+    p = await store.create(org, user_id=None, service_account_id=sa, name="P")
+    state = {
+        "cookies": [
+            {"name": "SID", "domain": ".google.com", "value": "x"},
+            {"name": "h", "domain": "github.com", "value": "y"},
+        ],
+        "origins": [],
+    }
+    row = await store.save_capture(
+        p.id, org, user_id=None, service_account_id=sa, storage_state=state
+    )
+    assert sorted(row.cookie_domains) == ["github.com", "google.com"]
+    assert row.has_state is True
+
+    got = await store.storage_state_for(
+        p.id, org, user_id=None, service_account_id=sa
+    )
+    assert got == state
+
+
+async def test_storage_state_for_denies_foreign_principal(session_factory):
+    store = _store(session_factory)
+    org = await create_org(session_factory)
+    sa = (await issue_service_account_token(session_factory, org, name="owner")).id
+    other = (await issue_service_account_token(session_factory, org, name="other")).id
+
+    p = await store.create(org, user_id=None, service_account_id=sa, name="P")
+    await store.save_capture(
+        p.id,
+        org,
+        user_id=None,
+        service_account_id=sa,
+        storage_state={"cookies": [], "origins": []},
+    )
+
+    assert (
+        await store.storage_state_for(
+            p.id, org, user_id=None, service_account_id=other
+        )
+        is None
+    )

--- a/tests/integration/test_browser_profiles_store.py
+++ b/tests/integration/test_browser_profiles_store.py
@@ -1,0 +1,38 @@
+import pytest
+from sqlalchemy import select
+
+from surogates.db.models import BrowserProfile
+
+from .conftest import create_org, issue_service_account_token
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def test_browser_profile_persists_for_service_account_principal(session_factory):
+    org_id = await create_org(session_factory)
+    sa = await issue_service_account_token(session_factory, org_id)
+
+    async with session_factory() as s:
+        async with s.begin():
+            s.add(
+                BrowserProfile(
+                    org_id=org_id,
+                    service_account_id=sa.id,
+                    name="Personal",
+                )
+            )
+
+    # Read back in a fresh session so server defaults are loaded from the DB.
+    async with session_factory() as s:
+        row = (
+            await s.execute(
+                select(BrowserProfile).where(BrowserProfile.org_id == org_id)
+            )
+        ).scalar_one()
+
+    assert row.name == "Personal"
+    assert row.user_id is None
+    assert row.service_account_id == sa.id
+    assert row.source == "manual_vnc"
+    assert row.cookie_domains == []
+    assert row.storage_state_enc is None

--- a/tests/test_browser_client_storage_state.py
+++ b/tests/test_browser_client_storage_state.py
@@ -1,0 +1,42 @@
+import json
+
+from surogates.browser.client import KernelBrowserClient
+
+
+async def test_storage_state_returns_execute_result(monkeypatch):
+    client = KernelBrowserClient("http://browser:10001")
+    captured = {}
+
+    async def fake_exec(code, *, timeout_sec=60):
+        captured["code"] = code
+        return {"cookies": [{"name": "SID"}], "origins": []}
+
+    monkeypatch.setattr(client, "_playwright_execute", fake_exec)
+    state = await client.storage_state()
+    assert state["cookies"][0]["name"] == "SID"
+    assert "storageState()" in captured["code"]
+    await client.close()
+
+
+async def test_apply_storage_state_adds_cookies(monkeypatch):
+    client = KernelBrowserClient("http://browser:10001")
+    captured = {}
+
+    async def fake_exec(code, *, timeout_sec=60):
+        captured["code"] = code
+        return None
+
+    monkeypatch.setattr(client, "_playwright_execute", fake_exec)
+    state = {
+        "cookies": [{"name": "SID", "domain": ".google.com", "value": "x"}],
+        "origins": [
+            {
+                "origin": "https://google.com",
+                "localStorage": [{"name": "k", "value": "v"}],
+            }
+        ],
+    }
+    await client.apply_storage_state(state)
+    assert "addCookies" in captured["code"]
+    assert json.dumps(state["cookies"]) in captured["code"]
+    await client.close()

--- a/tests/test_browser_pool_inject.py
+++ b/tests/test_browser_pool_inject.py
@@ -1,0 +1,56 @@
+from surogates.browser.base import BrowserEndpoint, BrowserSpec, BrowserStatus
+from surogates.browser.pool import BrowserPool
+
+
+def _make_recording_emitter(order):
+    async def _emit(session_id, event_type, data):
+        order.append("event")
+
+    return _emit
+
+
+class _FakeBackend:
+    async def provision(self, spec, *, session_id, org_id, user_id):
+        return "bid-1", BrowserEndpoint(
+            rest_url="http://b:10001",
+            cdp_url="ws://b:9222",
+            live_view_url="ws://b:8080",
+        )
+
+    async def status(self, browser_id):
+        return BrowserStatus.RUNNING
+
+
+async def test_inject_applies_state_before_registry_publish(monkeypatch):
+    order = []
+
+    class _Registry:
+        async def set(self, entry):
+            order.append("registry")
+
+    applied = {}
+
+    class _FakeClient:
+        def __init__(self, rest_url, **kw):
+            applied["rest_url"] = rest_url
+
+        async def apply_storage_state(self, state):
+            order.append("apply")
+            applied["state"] = state
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("surogates.browser.pool.KernelBrowserClient", _FakeClient)
+
+    pool = BrowserPool(
+        backend=_FakeBackend(),
+        registry=_Registry(),
+        event_emitter=_make_recording_emitter(order),
+    )
+    spec = BrowserSpec(storage_state={"cookies": [{"name": "SID"}], "origins": []})
+    await pool.ensure(session_id="s1", org_id="o1", user_id="u1", spec=spec)
+
+    assert order.index("apply") < order.index("registry")
+    assert applied["state"]["cookies"][0]["name"] == "SID"
+    assert applied["rest_url"] == "http://b:10001"

--- a/tests/test_browser_profiles_routes.py
+++ b/tests/test_browser_profiles_routes.py
@@ -73,28 +73,28 @@ def _app(store, *, user_id=None, sa_id=None):
 def test_create_then_list_returns_metadata_only():
     store = _FakeStore()
     client = TestClient(_app(store))
-    created = client.post("/api/browser-profiles", json={"name": "Personal"})
+    created = client.post("/browser-profiles", json={"name": "Personal"})
     assert created.status_code == 201
     body = created.json()
     assert body["name"] == "Personal"
     assert body["has_state"] is False
     assert "storage_state_enc" not in body
-    listed = client.get("/api/browser-profiles").json()
+    listed = client.get("/browser-profiles").json()
     assert [p["name"] for p in listed] == ["Personal"]
 
 
 def test_rename_and_delete():
     store = _FakeStore()
     client = TestClient(_app(store))
-    pid = client.post("/api/browser-profiles", json={"name": "P"}).json()["id"]
+    pid = client.post("/browser-profiles", json={"name": "P"}).json()["id"]
     renamed = client.patch(
-        f"/api/browser-profiles/{pid}", json={"name": "Renamed"}
+        f"/browser-profiles/{pid}", json={"name": "Renamed"}
     )
     assert renamed.status_code == 200
-    assert client.get("/api/browser-profiles").json()[0]["name"] == "Renamed"
-    deleted = client.delete(f"/api/browser-profiles/{pid}")
+    assert client.get("/browser-profiles").json()[0]["name"] == "Renamed"
+    deleted = client.delete(f"/browser-profiles/{pid}")
     assert deleted.status_code == 204
-    assert client.get("/api/browser-profiles").json() == []
+    assert client.get("/browser-profiles").json() == []
 
 
 class _SettingsStub:
@@ -153,7 +153,7 @@ def test_setup_session_creates_browser_setup_without_wake():
 
     client = TestClient(app)
     resp = client.post(
-        f"/api/browser-profiles/{row.id}/setup-session",
+        f"/browser-profiles/{row.id}/setup-session",
         json={"owner_user_id": "ops-user", "agent_id": "agent-1"},
     )
     assert resp.status_code == 200
@@ -196,7 +196,7 @@ def test_capture_rejects_non_setup_session():
 
     client = TestClient(app)
     resp = client.post(
-        f"/api/browser-profiles/{row.id}/capture",
+        f"/browser-profiles/{row.id}/capture",
         params={"session_id": str(uuid.uuid4())},
         json={"owner_user_id": "ops-user"},
     )
@@ -251,7 +251,7 @@ def test_capture_saves_storage_state(monkeypatch):
 
     client = TestClient(app)
     resp = client.post(
-        f"/api/browser-profiles/{row.id}/capture",
+        f"/browser-profiles/{row.id}/capture",
         params={"session_id": str(sid)},
         json={"owner_user_id": "ops-user"},
     )

--- a/tests/test_browser_profiles_routes.py
+++ b/tests/test_browser_profiles_routes.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -94,3 +95,70 @@ def test_rename_and_delete():
     deleted = client.delete(f"/api/browser-profiles/{pid}")
     assert deleted.status_code == 204
     assert client.get("/api/browser-profiles").json() == []
+
+
+class _SettingsStub:
+    storage = type("S", (), {"bucket": "test-bucket", "key_prefix": ""})()
+    llm = type("L", (), {"model": "gpt-4o"})()
+
+
+class _StorageStub:
+    def __init__(self, sink):
+        self._sink = sink
+
+    async def create_bucket(self, bucket):
+        self._sink["bucket"] = bucket
+
+    def resolve_workspace_path(self, bucket, sid):
+        return f"/tmp/{bucket}/{sid}"
+
+
+def test_setup_session_creates_browser_setup_without_wake():
+    store = _FakeStore()
+    app = _app(store)
+    created = {}
+    waked = {"called": False}
+
+    row = asyncio.run(
+        store.create(uuid.uuid4(), user_id=None, service_account_id=uuid.uuid4(), name="P")
+    )
+
+    class _SessionStore:
+        async def create_session(self, **kw):
+            created.update(kw)
+
+            class _S:
+                id = kw["session_id"]
+                config = kw["config"]
+
+            return _S()
+
+    async def _ensure(**kw):
+        return None
+
+    class _Control:
+        async def acquire(self, sid, uid):
+            from surogates.browser.control import AcquireOutcome, ControlEntry
+
+            return AcquireOutcome.GRANTED, ControlEntry(
+                uid, datetime.now(timezone.utc)
+            )
+
+    app.state.session_store = _SessionStore()
+    app.state.browser_pool = type("P", (), {"ensure": staticmethod(_ensure)})()
+    app.state.browser_control = _Control()
+    app.state.session_wake = lambda sid: waked.update(called=True)
+    app.state.storage = _StorageStub(created)
+    app.state.settings = _SettingsStub()
+
+    client = TestClient(app)
+    resp = client.post(
+        f"/api/browser-profiles/{row.id}/setup-session",
+        json={"owner_user_id": "ops-user", "agent_id": "agent-1"},
+    )
+    assert resp.status_code == 200
+    assert created["channel"] == "browser_setup"
+    assert created["config"]["browser"]["profile_id"] == str(row.id)
+    assert waked["called"] is False
+    assert "session_id" in resp.json()
+    assert "expires_at" in resp.json()

--- a/tests/test_browser_profiles_routes.py
+++ b/tests/test_browser_profiles_routes.py
@@ -19,6 +19,10 @@ class _FakeStore:
         return list(self.rows)
 
     async def create(self, org_id, *, user_id, service_account_id, name):
+        if any(r.name == name for r in self.rows):
+            from sqlalchemy.exc import IntegrityError
+
+            raise IntegrityError("INSERT", {}, Exception("unique violation"))
         row = BrowserProfileRow(
             uuid.uuid4(), name, "manual_vnc", [],
             datetime.now(timezone.utc), None, False,
@@ -83,6 +87,14 @@ def test_create_then_list_returns_metadata_only():
     assert [p["name"] for p in listed] == ["Personal"]
 
 
+def test_create_duplicate_name_returns_409():
+    store = _FakeStore()
+    client = TestClient(_app(store))
+    assert client.post("/browser-profiles", json={"name": "Work"}).status_code == 201
+    dup = client.post("/browser-profiles", json={"name": "Work"})
+    assert dup.status_code == 409
+
+
 def test_rename_and_delete():
     store = _FakeStore()
     client = TestClient(_app(store))
@@ -113,11 +125,14 @@ class _StorageStub:
         return f"/tmp/{bucket}/{sid}"
 
 
-def test_setup_session_creates_browser_setup_without_wake():
+def test_setup_session_creates_browser_setup_and_wakes():
+    # Provisioning is worker-driven: the API creates the browser_setup session
+    # (stamping the owner into config) and wakes it — the worker's loop does the
+    # actual provision + control grant.
     store = _FakeStore()
     app = _app(store)
     created = {}
-    waked = {"called": False}
+    waked = {"sid": None}
 
     row = asyncio.run(
         store.create(uuid.uuid4(), user_id=None, service_account_id=uuid.uuid4(), name="P")
@@ -133,21 +148,11 @@ def test_setup_session_creates_browser_setup_without_wake():
 
             return _S()
 
-    async def _ensure(**kw):
-        return None
-
-    class _Control:
-        async def acquire(self, sid, uid):
-            from surogates.browser.control import AcquireOutcome, ControlEntry
-
-            return AcquireOutcome.GRANTED, ControlEntry(
-                uid, datetime.now(timezone.utc)
-            )
+    async def _wake(sid):
+        waked["sid"] = sid
 
     app.state.session_store = _SessionStore()
-    app.state.browser_pool = type("P", (), {"ensure": staticmethod(_ensure)})()
-    app.state.browser_control = _Control()
-    app.state.session_wake = lambda sid: waked.update(called=True)
+    app.state.session_wake = _wake
     app.state.storage = _StorageStub(created)
     app.state.settings = _SettingsStub()
 
@@ -159,7 +164,8 @@ def test_setup_session_creates_browser_setup_without_wake():
     assert resp.status_code == 200
     assert created["channel"] == "browser_setup"
     assert created["config"]["browser"]["profile_id"] == str(row.id)
-    assert waked["called"] is False
+    assert created["config"]["browser"]["setup_owner_user_id"] == "ops-user"
+    assert waked["sid"] == str(created["session_id"])
     assert "session_id" in resp.json()
     assert "expires_at" in resp.json()
 
@@ -208,6 +214,7 @@ def test_capture_saves_storage_state(monkeypatch):
     app = _app(store)
     row = _seed_profile(store)
     sid = uuid.uuid4()
+    teardown = {"status": None, "waked": None}
 
     class _SessionStore:
         async def get_session(self, _sid):
@@ -216,6 +223,9 @@ def test_capture_saves_storage_state(monkeypatch):
                 config = {"browser": {"profile_id": str(row.id)}}
 
             return _S()
+
+        async def update_session_status(self, _sid, status):
+            teardown["status"] = status
 
     class _Control:
         async def held_by(self, _sid):
@@ -244,10 +254,14 @@ def test_capture_saves_storage_state(monkeypatch):
         async def close(self):
             pass
 
+    async def _wake(_sid):
+        teardown["waked"] = _sid
+
     monkeypatch.setattr(bp, "KernelBrowserClient", _Client)
     app.state.session_store = _SessionStore()
     app.state.browser_control = _Control()
     app.state.browser_resolver = _Resolver()
+    app.state.session_wake = _wake
 
     client = TestClient(app)
     resp = client.post(
@@ -259,3 +273,7 @@ def test_capture_saves_storage_state(monkeypatch):
     assert resp.json()["has_state"] is True
     # The encrypted blob is never exposed in the response.
     assert "storage_state_enc" not in resp.json()
+    # Teardown: the session is flipped terminal and re-woken so the worker
+    # (which owns the pool) releases the browser.
+    assert teardown["status"] == "completed"
+    assert teardown["waked"] == str(sid)

--- a/tests/test_browser_profiles_routes.py
+++ b/tests/test_browser_profiles_routes.py
@@ -170,6 +170,28 @@ def test_setup_session_creates_browser_setup_and_wakes():
     assert "expires_at" in resp.json()
 
 
+def test_setup_session_402_when_out_of_minutes(monkeypatch):
+    from surogates.browser.base import BrowserCreditsExhaustedError
+
+    store = _FakeStore()
+    app = _app(store)
+    row = asyncio.run(
+        store.create(uuid.uuid4(), user_id=None, service_account_id=uuid.uuid4(), name="P")
+    )
+
+    async def _exhausted(_org_id):
+        raise BrowserCreditsExhaustedError("This project is out of browsing minutes.")
+
+    monkeypatch.setattr(bp, "assert_browser_minutes_available", _exhausted)
+
+    client = TestClient(app)
+    resp = client.post(
+        f"/browser-profiles/{row.id}/setup-session",
+        json={"owner_user_id": "ops-user"},
+    )
+    assert resp.status_code == 402
+
+
 def _seed_profile(store):
     return asyncio.run(
         store.create(uuid.uuid4(), user_id=None, service_account_id=uuid.uuid4(), name="P")

--- a/tests/test_browser_profiles_routes.py
+++ b/tests/test_browser_profiles_routes.py
@@ -1,0 +1,96 @@
+import uuid
+from dataclasses import replace
+from datetime import datetime, timezone
+
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+import surogates.api.routes.browser_profiles as bp
+from surogates.browser.profiles import BrowserProfileRow
+from surogates.tenant.context import TenantContext
+
+
+class _FakeStore:
+    def __init__(self):
+        self.rows = []
+
+    async def list(self, org_id, *, user_id, service_account_id):
+        return list(self.rows)
+
+    async def create(self, org_id, *, user_id, service_account_id, name):
+        row = BrowserProfileRow(
+            uuid.uuid4(), name, "manual_vnc", [],
+            datetime.now(timezone.utc), None, False,
+        )
+        self.rows.append(row)
+        return row
+
+    async def rename(self, profile_id, org_id, *, user_id, service_account_id, name):
+        for i, row in enumerate(self.rows):
+            if row.id == profile_id:
+                self.rows[i] = replace(row, name=name)
+                return True
+        return False
+
+    async def delete(self, profile_id, org_id, *, user_id, service_account_id):
+        before = len(self.rows)
+        self.rows = [r for r in self.rows if r.id != profile_id]
+        return len(self.rows) != before
+
+    async def save_capture(
+        self, profile_id, org_id, *, user_id, service_account_id, storage_state
+    ):
+        for i, row in enumerate(self.rows):
+            if row.id == profile_id:
+                updated = replace(row, has_state=True, cookie_domains=["google.com"])
+                self.rows[i] = updated
+                return updated
+        raise KeyError("profile not found")
+
+
+def _app(store, *, user_id=None, sa_id=None):
+    sa_id = sa_id or uuid.uuid4()
+    app = FastAPI()
+    app.include_router(bp.router)
+    app.state.browser_profile_store = store
+
+    async def _tenant():
+        return TenantContext(
+            org_id=uuid.uuid4(),
+            user_id=user_id,
+            org_config={},
+            user_preferences={},
+            permissions=frozenset(),
+            asset_root="/tmp",
+            service_account_id=sa_id,
+        )
+
+    app.dependency_overrides[bp.get_current_tenant] = _tenant
+    return app
+
+
+def test_create_then_list_returns_metadata_only():
+    store = _FakeStore()
+    client = TestClient(_app(store))
+    created = client.post("/api/browser-profiles", json={"name": "Personal"})
+    assert created.status_code == 201
+    body = created.json()
+    assert body["name"] == "Personal"
+    assert body["has_state"] is False
+    assert "storage_state_enc" not in body
+    listed = client.get("/api/browser-profiles").json()
+    assert [p["name"] for p in listed] == ["Personal"]
+
+
+def test_rename_and_delete():
+    store = _FakeStore()
+    client = TestClient(_app(store))
+    pid = client.post("/api/browser-profiles", json={"name": "P"}).json()["id"]
+    renamed = client.patch(
+        f"/api/browser-profiles/{pid}", json={"name": "Renamed"}
+    )
+    assert renamed.status_code == 200
+    assert client.get("/api/browser-profiles").json()[0]["name"] == "Renamed"
+    deleted = client.delete(f"/api/browser-profiles/{pid}")
+    assert deleted.status_code == 204
+    assert client.get("/api/browser-profiles").json() == []

--- a/tests/test_browser_profiles_routes.py
+++ b/tests/test_browser_profiles_routes.py
@@ -162,3 +162,100 @@ def test_setup_session_creates_browser_setup_without_wake():
     assert waked["called"] is False
     assert "session_id" in resp.json()
     assert "expires_at" in resp.json()
+
+
+def _seed_profile(store):
+    return asyncio.run(
+        store.create(uuid.uuid4(), user_id=None, service_account_id=uuid.uuid4(), name="P")
+    )
+
+
+def test_capture_rejects_non_setup_session():
+    store = _FakeStore()
+    app = _app(store)
+    row = _seed_profile(store)
+
+    async def _async(v):
+        return v
+
+    class _SessionStore:
+        async def get_session(self, _sid):
+            class _S:
+                channel = "web"  # not browser_setup
+                config = {"browser": {"profile_id": str(row.id)}}
+
+            return _S()
+
+    app.state.session_store = _SessionStore()
+    app.state.browser_control = type(
+        "C", (), {"held_by": staticmethod(lambda sid: _async("ops-user"))}
+    )()
+    app.state.browser_resolver = type(
+        "R", (), {"resolve": staticmethod(lambda sid, expected_org_id=None: _async(object()))}
+    )()
+
+    client = TestClient(app)
+    resp = client.post(
+        f"/api/browser-profiles/{row.id}/capture",
+        params={"session_id": str(uuid.uuid4())},
+        json={"owner_user_id": "ops-user"},
+    )
+    assert resp.status_code == 409
+
+
+def test_capture_saves_storage_state(monkeypatch):
+    store = _FakeStore()
+    app = _app(store)
+    row = _seed_profile(store)
+    sid = uuid.uuid4()
+
+    class _SessionStore:
+        async def get_session(self, _sid):
+            class _S:
+                channel = "browser_setup"
+                config = {"browser": {"profile_id": str(row.id)}}
+
+            return _S()
+
+    class _Control:
+        async def held_by(self, _sid):
+            return "ops-user"
+
+    class _Resolver:
+        async def resolve(self, _sid, expected_org_id=None):
+            from surogates.browser.base import BrowserEndpoint
+            from surogates.browser.resolver import ResolvedBrowser
+
+            return ResolvedBrowser(
+                session_id=str(sid),
+                endpoint=BrowserEndpoint("http://browser", "ws://cdp", "ws://live"),
+            )
+
+    class _Client:
+        def __init__(self, rest_url):
+            assert rest_url == "http://browser"
+
+        async def storage_state(self):
+            return {
+                "cookies": [{"name": "SID", "domain": ".google.com"}],
+                "origins": [],
+            }
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(bp, "KernelBrowserClient", _Client)
+    app.state.session_store = _SessionStore()
+    app.state.browser_control = _Control()
+    app.state.browser_resolver = _Resolver()
+
+    client = TestClient(app)
+    resp = client.post(
+        f"/api/browser-profiles/{row.id}/capture",
+        params={"session_id": str(sid)},
+        json={"owner_user_id": "ops-user"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["has_state"] is True
+    # The encrypted blob is never exposed in the response.
+    assert "storage_state_enc" not in resp.json()

--- a/tests/test_browser_setup_loop.py
+++ b/tests/test_browser_setup_loop.py
@@ -1,0 +1,61 @@
+import types
+
+from surogates.harness.loop import AgentHarness
+
+
+class _Pool:
+    def __init__(self):
+        self.calls = {}
+
+    async def ensure(self, **kw):
+        self.calls["ensure"] = kw
+
+    async def destroy_for_session(self, sid):
+        self.calls["destroy"] = sid
+
+
+class _Control:
+    def __init__(self):
+        self.acquired = None
+
+    async def acquire(self, sid, uid):
+        self.acquired = (sid, uid)
+
+
+def _session(status, **browser):
+    return types.SimpleNamespace(
+        id="s1",
+        org_id="o1",
+        status=status,
+        config={"browser": {"setup_owner_user_id": "u1", **browser}},
+    )
+
+
+async def test_browser_setup_provisions_and_grants_control():
+    pool, control = _Pool(), _Control()
+    me = types.SimpleNamespace(_browser_pool=pool, _browser_control=control)
+    await AgentHarness._run_browser_setup(me, _session("active", setup_ttl_seconds=900))
+    assert pool.calls["ensure"]["session_id"] == "s1"
+    assert pool.calls["ensure"]["user_id"] == "u1"
+    assert pool.calls["ensure"]["spec"].active_deadline_seconds == 900
+    assert control.acquired == ("s1", "u1")
+    assert "destroy" not in pool.calls
+
+
+async def test_browser_setup_destroys_on_terminal_status():
+    pool, control = _Pool(), _Control()
+    me = types.SimpleNamespace(_browser_pool=pool, _browser_control=control)
+    await AgentHarness._run_browser_setup(me, _session("completed"))
+    assert pool.calls["destroy"] == "s1"
+    assert "ensure" not in pool.calls
+    assert control.acquired is None
+
+
+async def test_browser_setup_noop_without_owner():
+    pool = _Pool()
+    me = types.SimpleNamespace(_browser_pool=pool, _browser_control=None)
+    session = types.SimpleNamespace(
+        id="s1", org_id="o1", status="active", config={"browser": {}}
+    )
+    await AgentHarness._run_browser_setup(me, session)
+    assert pool.calls == {}

--- a/tests/test_browser_setup_loop.py
+++ b/tests/test_browser_setup_loop.py
@@ -22,6 +22,31 @@ class _Control:
         self.acquired = (sid, uid)
 
 
+class _Lease:
+    lease_token = "tok"
+
+
+class _Store:
+    def __init__(self, acquire=True):
+        self._acquire = acquire
+        self.released = None
+
+    async def try_acquire_lease(self, sid, worker_id, ttl_seconds=None):
+        return _Lease() if self._acquire else None
+
+    async def release_lease(self, sid, token):
+        self.released = token
+
+
+def _me(pool, control, store=None):
+    return types.SimpleNamespace(
+        _browser_pool=pool,
+        _browser_control=control,
+        _store=store or _Store(),
+        _worker_id="w1",
+    )
+
+
 def _session(status, **browser):
     return types.SimpleNamespace(
         id="s1",
@@ -32,30 +57,40 @@ def _session(status, **browser):
 
 
 async def test_browser_setup_provisions_and_grants_control():
-    pool, control = _Pool(), _Control()
-    me = types.SimpleNamespace(_browser_pool=pool, _browser_control=control)
-    await AgentHarness._run_browser_setup(me, _session("active", setup_ttl_seconds=900))
+    pool, control, store = _Pool(), _Control(), _Store()
+    await AgentHarness._run_browser_setup(
+        _me(pool, control, store), _session("active", setup_ttl_seconds=900)
+    )
     assert pool.calls["ensure"]["session_id"] == "s1"
     assert pool.calls["ensure"]["user_id"] == "u1"
     assert pool.calls["ensure"]["spec"].active_deadline_seconds == 900
     assert control.acquired == ("s1", "u1")
     assert "destroy" not in pool.calls
+    assert store.released == "tok"  # lease released in finally
 
 
 async def test_browser_setup_destroys_on_terminal_status():
-    pool, control = _Pool(), _Control()
-    me = types.SimpleNamespace(_browser_pool=pool, _browser_control=control)
-    await AgentHarness._run_browser_setup(me, _session("completed"))
+    pool, control, store = _Pool(), _Control(), _Store()
+    await AgentHarness._run_browser_setup(_me(pool, control, store), _session("completed"))
     assert pool.calls["destroy"] == "s1"
     assert "ensure" not in pool.calls
+    assert control.acquired is None
+    assert store.released == "tok"
+
+
+async def test_browser_setup_skips_when_lease_held_elsewhere():
+    pool, control = _Pool(), _Control()
+    await AgentHarness._run_browser_setup(
+        _me(pool, control, _Store(acquire=False)), _session("active")
+    )
+    assert pool.calls == {}  # another worker holds the lease
     assert control.acquired is None
 
 
 async def test_browser_setup_noop_without_owner():
     pool = _Pool()
-    me = types.SimpleNamespace(_browser_pool=pool, _browser_control=None)
     session = types.SimpleNamespace(
         id="s1", org_id="o1", status="active", config={"browser": {}}
     )
-    await AgentHarness._run_browser_setup(me, session)
+    await AgentHarness._run_browser_setup(_me(pool, None), session)
     assert pool.calls == {}

--- a/tests/test_browser_tools_profile_inject.py
+++ b/tests/test_browser_tools_profile_inject.py
@@ -1,0 +1,78 @@
+import uuid
+
+from surogates.browser.base import BrowserEndpoint
+from surogates.tools.builtin.browser import _resolve_session_browser
+
+
+class _Tenant:
+    def __init__(self, org_id, user_id=None, service_account_id=None):
+        self.org_id = org_id
+        self.user_id = user_id
+        self.service_account_id = service_account_id
+
+
+class _Pool:
+    def __init__(self):
+        self.spec = None
+
+    async def ensure(self, *, session_id, org_id, user_id, spec):
+        self.spec = spec
+        from surogates.browser.pool import EnsureResult
+
+        return EnsureResult(
+            "bid", BrowserEndpoint("http://b", "ws://c", "ws://l"), True, {}
+        )
+
+
+class _Store:
+    def __init__(self, state):
+        self._state = state
+        self.touched = False
+
+    async def storage_state_for(
+        self, profile_id, org_id, *, user_id, service_account_id
+    ):
+        return self._state
+
+    async def touch_last_used(self, *a, **k):
+        self.touched = True
+
+
+async def test_profile_state_is_set_on_spec():
+    org, sa, pid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    pool = _Pool()
+    store = _Store({"cookies": [{"name": "SID"}], "origins": []})
+    result = await _resolve_session_browser(
+        tenant=_Tenant(org, service_account_id=sa),
+        session_id="s1",
+        browser_pool=pool,
+        browser_control=None,
+        browser_profile_store=store,
+        session_config={
+            "browser": {"profile_id": str(pid)},
+            "service_account_id": str(sa),
+        },
+    )
+    assert not isinstance(result, str)
+    assert pool.spec.storage_state == {"cookies": [{"name": "SID"}], "origins": []}
+    assert store.touched is True
+
+
+async def test_profile_state_read_from_pool_when_no_explicit_store():
+    # Production path: handlers don't thread the store; it rides on the pool.
+    org, sa, pid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    pool = _Pool()
+    pool.browser_profile_store = _Store({"cookies": [{"name": "T"}], "origins": []})
+    result = await _resolve_session_browser(
+        tenant=_Tenant(org, service_account_id=sa),
+        session_id="s1",
+        browser_pool=pool,
+        browser_control=None,
+        session_config={
+            "browser": {"profile_id": str(pid)},
+            "service_account_id": str(sa),
+        },
+    )
+    assert not isinstance(result, str)
+    assert pool.spec.storage_state == {"cookies": [{"name": "T"}], "origins": []}
+    assert pool.browser_profile_store.touched is True

--- a/web/src/api/browser-profiles.ts
+++ b/web/src/api/browser-profiles.ts
@@ -1,0 +1,100 @@
+// Client for the per-user browser-profile routes. The web app authenticates
+// as a real harness user (JWT), so the harness scopes profiles by user id —
+// no agent transport is needed. Calls go to ``/api/v1/...``; the dev proxy
+// strips ``/api`` so they reach the harness as ``/v1/browser-profiles``.
+import { authFetch } from "@/api/auth";
+
+export interface BrowserProfile {
+  id: string;
+  name: string;
+  source: string;
+  cookieDomains: string[];
+  hasState: boolean;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
+interface RawProfile {
+  id: string;
+  name: string;
+  source: string;
+  cookie_domains: string[];
+  has_state: boolean;
+  created_at: string;
+  last_used_at: string | null;
+}
+
+const toProfile = (p: RawProfile): BrowserProfile => ({
+  id: p.id,
+  name: p.name,
+  source: p.source,
+  cookieDomains: p.cookie_domains,
+  hasState: p.has_state,
+  createdAt: p.created_at,
+  lastUsedAt: p.last_used_at,
+});
+
+async function json<T>(url: string, msg: string, init?: RequestInit): Promise<T> {
+  const r = await authFetch(url, init);
+  if (!r.ok) throw new Error(msg);
+  return (await r.json()) as T;
+}
+
+const JSON_POST: RequestInit = {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: "{}",
+};
+
+export async function listBrowserProfiles(): Promise<BrowserProfile[]> {
+  const raw = await json<RawProfile[]>(
+    "/api/v1/browser-profiles",
+    "Failed to load profiles",
+  );
+  return raw.map(toProfile);
+}
+
+export async function createBrowserProfile(name: string): Promise<BrowserProfile> {
+  return toProfile(
+    await json<RawProfile>(
+      "/api/v1/browser-profiles",
+      "Failed to create profile",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      },
+    ),
+  );
+}
+
+export async function deleteBrowserProfile(id: string): Promise<void> {
+  const r = await authFetch(`/api/v1/browser-profiles/${id}`, {
+    method: "DELETE",
+  });
+  if (!r.ok && r.status !== 204) throw new Error("Failed to delete profile");
+}
+
+export async function createSetupSession(
+  id: string,
+): Promise<{ sessionId: string; expiresAt: string }> {
+  const raw = await json<{ session_id: string; expires_at: string }>(
+    `/api/v1/browser-profiles/${id}/setup-session`,
+    "Failed to start setup",
+    JSON_POST,
+  );
+  return { sessionId: raw.session_id, expiresAt: raw.expires_at };
+}
+
+export async function captureProfile(
+  id: string,
+  sessionId: string,
+): Promise<BrowserProfile> {
+  return toProfile(
+    await json<RawProfile>(
+      `/api/v1/browser-profiles/${id}/capture?session_id=${encodeURIComponent(sessionId)}`,
+      "Failed to save authentication",
+      JSON_POST,
+    ),
+  );
+}

--- a/web/src/api/sessions.ts
+++ b/web/src/api/sessions.ts
@@ -54,10 +54,17 @@ export async function getSession(sessionId: string): Promise<Session> {
 export async function createSession(
   body: SessionCreateRequest,
 ): Promise<Session> {
+  const { browserProfileId, ...rest } = body;
+  // The harness reads ``config.browser.profile_id`` to inject the saved login
+  // state when it provisions the session's browser.
+  const payload: Record<string, unknown> = { ...rest };
+  if (browserProfileId) {
+    payload.config = { browser: { profile_id: browserProfileId } };
+  }
   const response = await authFetch("/api/v1/sessions", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
+    body: JSON.stringify(payload),
   });
   if (!response.ok) throw new Error("Failed to create session");
   return (await response.json()) as Session;

--- a/web/src/features/chat/chat-page.tsx
+++ b/web/src/features/chat/chat-page.tsx
@@ -131,12 +131,15 @@ export function ChatPage() {
     [fetchSessions, navigate, setActiveSession],
   );
 
+  const [browserProfileId, setBrowserProfileId] = useState<string | null>(null);
+
   const chatAdapter = useMemo<AgentChatAdapter>(
     () => ({
       ...surogatesWebChatAdapter,
       async createSession(input) {
         const rawSession = await sessionsApi.createSession({
           system: input.system,
+          browserProfileId: browserProfileId ?? undefined,
         });
         upsertSession(rawSession);
         handleSessionChange(rawSession.id);
@@ -154,7 +157,7 @@ export function ChatPage() {
         return toAgentChatSession(rawSession);
       },
     }),
-    [handleSessionChange, upsertSession],
+    [handleSessionChange, upsertSession, browserProfileId],
   );
 
   const handleDisclosureConfirmed = useCallback(() => {
@@ -207,6 +210,8 @@ export function ChatPage() {
               disabled={sessionDeclined}
               onMessagesChange={setChatMessages}
               onOpenIntegrations={() => void navigate({ to: "/integrations" })}
+              browserProfileId={browserProfileId}
+              onSelectBrowserProfile={setBrowserProfileId}
               // Hide built-in slash commands the agent has disabled. Unknown
               // (capabilities not yet loaded) fails open via the helper.
               compressEnabled={slashCommandEnabled(slashCommands, "compress")}

--- a/web/src/features/chat/surogates-web-chat-adapter.ts
+++ b/web/src/features/chat/surogates-web-chat-adapter.ts
@@ -330,6 +330,27 @@ export const surogatesWebChatAdapter: AgentChatAdapter = {
     return url.pathname + url.search;
   },
 
+  async listBrowserProfiles() {
+    const response = await authFetch("/api/v1/browser-profiles");
+    if (!response.ok) throw new Error("Failed to list browser profiles");
+    const data = (await response.json()) as Array<{
+      id: string;
+      name: string;
+      cookie_domains: string[];
+      has_state: boolean;
+      created_at: string;
+      last_used_at: string | null;
+    }>;
+    return data.map((p) => ({
+      id: p.id,
+      name: p.name,
+      cookieDomains: p.cookie_domains,
+      hasState: p.has_state,
+      createdAt: p.created_at,
+      lastUsedAt: p.last_used_at,
+    }));
+  },
+
   // ---- Composio connections (end-user OAuth) --------------------------
   async listComposioConnections() {
     return composioApi.listComposioConnections();

--- a/web/src/features/chat/surogates-web-chat-adapter.ts
+++ b/web/src/features/chat/surogates-web-chat-adapter.ts
@@ -326,7 +326,6 @@ export const surogatesWebChatAdapter: AgentChatAdapter = {
     );
     const token = getAuthToken();
     if (token) url.searchParams.set("token", token);
-    url.searchParams.set("pwd", "admin");
     return url.pathname + url.search;
   },
 

--- a/web/src/features/settings/browser-profile-create-dialog.tsx
+++ b/web/src/features/settings/browser-profile-create-dialog.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Create with the typed name (empty string → the manager picks a default). */
+  onCreate: (name: string) => Promise<void>;
+}
+
+export function BrowserProfileCreateDialog({
+  open,
+  onOpenChange,
+  onCreate,
+}: Props) {
+  const [name, setName] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  async function submit() {
+    setBusy(true);
+    try {
+      await onCreate(name.trim());
+      setName("");
+      onOpenChange(false);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Set up your browser profile</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Profile Name (optional)</label>
+          <Input
+            autoFocus
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g., Personal Account, Work Profile"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void submit();
+            }}
+          />
+          <p className="text-xs text-muted-foreground">
+            Give your profile a name to easily identify it later.
+          </p>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={busy}
+          >
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={busy}>
+            {busy ? "Creating…" : "Create Profile"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/features/settings/browser-profile-setup-dialog.tsx
+++ b/web/src/features/settings/browser-profile-setup-dialog.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import { BrowserLiveView } from "@invergent/agent-chat-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { captureProfile, createSetupSession } from "@/api/browser-profiles";
+import { surogatesWebChatAdapter } from "@/features/chat/surogates-web-chat-adapter";
+
+interface Props {
+  profileId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+}
+
+export function BrowserProfileSetupDialog({
+  profileId,
+  open,
+  onOpenChange,
+  onSaved,
+}: Props) {
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [expiresAt, setExpiresAt] = useState<number | null>(null);
+  const [remaining, setRemaining] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (!open || startedRef.current) return;
+    startedRef.current = true;
+    createSetupSession(profileId)
+      .then((res) => {
+        setSessionId(res.sessionId);
+        setExpiresAt(new Date(res.expiresAt).getTime());
+      })
+      .catch(() => {
+        toast.error("Couldn't start the setup browser.");
+        onOpenChange(false);
+      });
+    return () => {
+      startedRef.current = false;
+    };
+  }, [open, profileId, onOpenChange]);
+
+  useEffect(() => {
+    if (!expiresAt) return;
+    const tick = () =>
+      setRemaining(Math.max(0, Math.round((expiresAt - Date.now()) / 1000)));
+    tick();
+    const h = window.setInterval(tick, 1000);
+    return () => window.clearInterval(h);
+  }, [expiresAt]);
+
+  useEffect(() => {
+    if (expiresAt && remaining === 0) {
+      toast.info("Setup session expired.");
+      onOpenChange(false);
+    }
+  }, [remaining, expiresAt, onOpenChange]);
+
+  const liveViewUrl = useMemo(
+    () => (sessionId ? surogatesWebChatAdapter.browserLiveViewUrl(sessionId) : ""),
+    [sessionId],
+  );
+
+  async function handleSave() {
+    if (!sessionId) return;
+    setSaving(true);
+    try {
+      await captureProfile(profileId, sessionId);
+      toast.success("Authentication saved.");
+      onSaved();
+    } catch {
+      toast.error("Couldn't save authentication.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const mmss = `${Math.floor(remaining / 60)}:${String(remaining % 60).padStart(2, "0")}`;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-dvh w-screen max-w-none flex-col gap-0 rounded-none border-0 bg-background p-0">
+        <DialogHeader className="h-12 shrink-0 flex-row items-center justify-between border-b border-line px-4">
+          <DialogTitle className="text-sm">
+            Set up browser authentication
+          </DialogTitle>
+          <div className="flex items-center gap-3">
+            {expiresAt && (
+              <span className="text-xs tabular-nums text-muted-foreground">
+                {mmss}
+              </span>
+            )}
+            <Button size="sm" onClick={handleSave} disabled={!sessionId || saving}>
+              {saving ? "Saving…" : "Save authentication and close"}
+            </Button>
+          </div>
+        </DialogHeader>
+        <div className="min-h-0 flex-1 bg-black">
+          {liveViewUrl ? (
+            <BrowserLiveView
+              src={liveViewUrl}
+              testId="browser-profile-setup-rfb"
+              onDisconnect={() => onOpenChange(false)}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              Starting browser…
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/features/settings/browser-profile-setup-dialog.tsx
+++ b/web/src/features/settings/browser-profile-setup-dialog.tsx
@@ -29,8 +29,10 @@ export function BrowserProfileSetupDialog({
   const [expiresAt, setExpiresAt] = useState<number | null>(null);
   const [remaining, setRemaining] = useState(0);
   const [saving, setSaving] = useState(false);
+  const [phase, setPhase] = useState<"starting" | "ready">("starting");
   const startedRef = useRef(false);
 
+  // Start the setup session exactly once per open.
   useEffect(() => {
     if (!open || startedRef.current) return;
     startedRef.current = true;
@@ -48,6 +50,53 @@ export function BrowserProfileSetupDialog({
     };
   }, [open, profileId, onOpenChange]);
 
+  // Provisioning is worker-driven (async), so poll until the browser is up
+  // before mounting the live view — otherwise it would connect to an
+  // unprovisioned session, disconnect, and tear the dialog down.
+  useEffect(() => {
+    if (!sessionId || phase === "ready") return;
+    let cancelled = false;
+    let timer: number | undefined;
+    const poll = async () => {
+      if (cancelled) return;
+      try {
+        const state = await surogatesWebChatAdapter.getBrowserState(sessionId);
+        if (
+          !cancelled &&
+          state &&
+          (state.status === "live" || state.status === "user-control")
+        ) {
+          setPhase("ready");
+          return;
+        }
+      } catch {
+        /* keep polling */
+      }
+      if (!cancelled) timer = window.setTimeout(poll, 1500);
+    };
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer) window.clearTimeout(timer);
+    };
+  }, [sessionId, phase]);
+
+  // Keep the 60s control lease alive (this dialog renders BrowserLiveView
+  // directly, without BrowserPane's heartbeat) so input doesn't go read-only
+  // mid-login. Re-acquire immediately on ready, then every 25s.
+  useEffect(() => {
+    if (!sessionId || phase !== "ready") return;
+    const beat = () => {
+      void surogatesWebChatAdapter
+        .acquireBrowserControl(sessionId)
+        .catch(() => {});
+    };
+    beat();
+    const h = window.setInterval(beat, 25_000);
+    return () => window.clearInterval(h);
+  }, [sessionId, phase]);
+
+  // Countdown to the server-side TTL.
   useEffect(() => {
     if (!expiresAt) return;
     const tick = () =>
@@ -65,7 +114,8 @@ export function BrowserProfileSetupDialog({
   }, [remaining, expiresAt, onOpenChange]);
 
   const liveViewUrl = useMemo(
-    () => (sessionId ? surogatesWebChatAdapter.browserLiveViewUrl(sessionId) : ""),
+    () =>
+      sessionId ? surogatesWebChatAdapter.browserLiveViewUrl(sessionId) : "",
     [sessionId],
   );
 
@@ -98,17 +148,21 @@ export function BrowserProfileSetupDialog({
                 {mmss}
               </span>
             )}
-            <Button size="sm" onClick={handleSave} disabled={!sessionId || saving}>
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={phase !== "ready" || saving}
+            >
               {saving ? "Saving…" : "Save authentication and close"}
             </Button>
           </div>
         </DialogHeader>
         <div className="min-h-0 flex-1 bg-black">
-          {liveViewUrl ? (
+          {phase === "ready" && liveViewUrl ? (
             <BrowserLiveView
               src={liveViewUrl}
               testId="browser-profile-setup-rfb"
-              onDisconnect={() => onOpenChange(false)}
+              onDisconnect={() => setPhase("starting")}
             />
           ) : (
             <div className="flex h-full items-center justify-center text-sm text-muted-foreground">

--- a/web/src/features/settings/browser-profiles-tab.tsx
+++ b/web/src/features/settings/browser-profiles-tab.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useState } from "react";
+import { Globe, Play, Plus, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import {
+  type BrowserProfile,
+  createBrowserProfile,
+  deleteBrowserProfile,
+  listBrowserProfiles,
+} from "@/api/browser-profiles";
+
+import { BrowserProfileSetupDialog } from "./browser-profile-setup-dialog";
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? "—" : d.toLocaleDateString();
+}
+
+export function BrowserProfilesTab() {
+  const [profiles, setProfiles] = useState<BrowserProfile[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [removeId, setRemoveId] = useState<string | null>(null);
+  const [setupId, setSetupId] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    listBrowserProfiles()
+      .then(setProfiles)
+      .catch(() => toast.error("Couldn't load browser profiles."))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  async function handleCreate() {
+    setCreating(true);
+    try {
+      await createBrowserProfile("Personal Profile");
+      refresh();
+    } catch {
+      toast.error("Couldn't create profile.");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!removeId) return;
+    try {
+      await deleteBrowserProfile(removeId);
+      setRemoveId(null);
+      refresh();
+    } catch {
+      toast.error("Couldn't delete profile.");
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <div>
+          <h2 className="text-base font-semibold text-foreground">
+            Browser Profiles
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Preserve browser state and login sessions across tasks.
+          </p>
+        </div>
+        <Button size="sm" onClick={handleCreate} disabled={creating}>
+          <Plus className="size-4" /> Create Profile
+        </Button>
+      </div>
+
+      {loading && profiles.length === 0 ? (
+        <div className="text-sm text-muted-foreground">Loading…</div>
+      ) : profiles.length === 0 ? (
+        <div className="text-sm text-muted-foreground">No profiles yet.</div>
+      ) : (
+        <div className="space-y-3 mt-4">
+          {profiles.map((p) => (
+            <div
+              key={p.id}
+              className="bg-card border border-line rounded-xl px-5 py-4"
+            >
+              <div className="flex items-center justify-between">
+                <div className="text-sm font-semibold text-foreground">
+                  {p.name}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setSetupId(p.id)}
+                  >
+                    <Play className="size-3.5" /> Set up authentication
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setRemoveId(p.id)}
+                    aria-label="Delete profile"
+                  >
+                    <Trash2 className="size-3.5 text-destructive" />
+                  </Button>
+                </div>
+              </div>
+              <div className="text-xs text-muted-foreground mt-2">
+                Created {formatDate(p.createdAt)}
+                {p.lastUsedAt && ` · Last used ${formatDate(p.lastUsedAt)}`}
+              </div>
+              {p.cookieDomains.length > 0 && (
+                <div className="flex items-center gap-1.5 mt-2 text-xs text-muted-foreground">
+                  <Globe className="size-3.5" />
+                  Cookie Domains ({p.cookieDomains.length}):{" "}
+                  {p.cookieDomains.join(", ")}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={!!removeId}
+        title="Delete this profile?"
+        description="Its saved authentication will be permanently removed."
+        confirmLabel="Delete"
+        onConfirm={handleDelete}
+        onCancel={() => setRemoveId(null)}
+      />
+
+      {setupId && (
+        <BrowserProfileSetupDialog
+          profileId={setupId}
+          open={!!setupId}
+          onOpenChange={(o) => {
+            if (!o) setSetupId(null);
+          }}
+          onSaved={() => {
+            setSetupId(null);
+            refresh();
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/features/settings/browser-profiles-tab.tsx
+++ b/web/src/features/settings/browser-profiles-tab.tsx
@@ -11,6 +11,7 @@ import {
   listBrowserProfiles,
 } from "@/api/browser-profiles";
 
+import { BrowserProfileCreateDialog } from "./browser-profile-create-dialog";
 import { BrowserProfileSetupDialog } from "./browser-profile-setup-dialog";
 
 function formatDate(iso: string): string {
@@ -21,7 +22,7 @@ function formatDate(iso: string): string {
 export function BrowserProfilesTab() {
   const [profiles, setProfiles] = useState<BrowserProfile[]>([]);
   const [loading, setLoading] = useState(false);
-  const [creating, setCreating] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
   const [removeId, setRemoveId] = useState<string | null>(null);
   const [setupId, setSetupId] = useState<string | null>(null);
 
@@ -37,15 +38,12 @@ export function BrowserProfilesTab() {
     refresh();
   }, [refresh]);
 
-  async function handleCreate() {
-    setCreating(true);
+  async function handleCreate(name: string) {
     try {
-      await createBrowserProfile(`Profile ${profiles.length + 1}`);
+      await createBrowserProfile(name || `Profile ${profiles.length + 1}`);
       refresh();
     } catch {
       toast.error("Couldn't create profile — that name may already exist.");
-    } finally {
-      setCreating(false);
     }
   }
 
@@ -71,7 +69,7 @@ export function BrowserProfilesTab() {
             Preserve browser state and login sessions across tasks.
           </p>
         </div>
-        <Button size="sm" onClick={handleCreate} disabled={creating}>
+        <Button size="sm" onClick={() => setCreateOpen(true)}>
           <Plus className="size-4" /> Create Profile
         </Button>
       </div>
@@ -124,6 +122,12 @@ export function BrowserProfilesTab() {
           ))}
         </div>
       )}
+
+      <BrowserProfileCreateDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreate={handleCreate}
+      />
 
       <ConfirmDialog
         open={!!removeId}

--- a/web/src/features/settings/browser-profiles-tab.tsx
+++ b/web/src/features/settings/browser-profiles-tab.tsx
@@ -40,10 +40,10 @@ export function BrowserProfilesTab() {
   async function handleCreate() {
     setCreating(true);
     try {
-      await createBrowserProfile("Personal Profile");
+      await createBrowserProfile(`Profile ${profiles.length + 1}`);
       refresh();
     } catch {
-      toast.error("Couldn't create profile.");
+      toast.error("Couldn't create profile — that name may already exist.");
     } finally {
       setCreating(false);
     }

--- a/web/src/features/settings/settings-page.tsx
+++ b/web/src/features/settings/settings-page.tsx
@@ -12,6 +12,7 @@ import {
 import { toast } from "sonner";
 import { CodingAgentsPanel } from "@invergent/agent-chat-react";
 import { surogatesWebChatAdapter } from "@/features/chat";
+import { BrowserProfilesTab } from "./browser-profiles-tab";
 import { useAppStore } from "@/stores/app-store";
 import {
   updateCurrentUser,
@@ -152,6 +153,9 @@ export function SettingsPage() {
                 Connected Channels
               </TabsTrigger>
               <TabsTrigger value="coding-agents">Coding Agents</TabsTrigger>
+              <TabsTrigger value="browser-profiles">
+                Browser Profiles
+              </TabsTrigger>
             </TabsList>
 
             {/* ── Profile ── */}
@@ -307,6 +311,10 @@ export function SettingsPage() {
             {/* ── Coding Agents ── */}
             <TabsContent value="coding-agents">
               <CodingAgentsPanel adapter={surogatesWebChatAdapter} />
+            </TabsContent>
+
+            <TabsContent value="browser-profiles">
+              <BrowserProfilesTab />
             </TabsContent>
           </Tabs>
         </div>

--- a/web/src/types/session.ts
+++ b/web/src/types/session.ts
@@ -23,6 +23,8 @@ export interface Session {
 
 export interface SessionCreateRequest {
   system?: string;
+  /** Saved browser profile to attach; sent as ``config.browser.profile_id``. */
+  browserProfileId?: string;
 }
 
 export interface SessionEvent {


### PR DESCRIPTION
Backend foundation for **browser profiles** — saved, encrypted browser login state reused across agent tasks. Harness layer only (ops proxy + SDK selector + Studio manager follow). Implements Tasks 1–8 of [the plan](docs/superpowers/plans/2026-06-19-browser-profiles.md).

## What's here
- **`BrowserProfile` model** (`db/models.py`) — principal-owned (`user_id` XOR `service_account_id`), `source` seam, encrypted `storage_state_enc`, `cookie_domains` metadata. Ships via `Base.metadata.create_all` (no Alembic for the surogates DB).
- **`BrowserProfileStore`** (`browser/profiles.py`) — Fernet-encrypted CRUD scoped strictly to `(org_id, principal)`; capture/inject + `cookie_domains` derivation; cross-principal reads denied.
- **`KernelBrowserClient.storage_state()` / `apply_storage_state()`** — export/inject Playwright storage_state.
- **Inject at provision** (`BrowserPool.ensure`) — applies the profile's cookies into the fresh context **before** registry publish / `browser.provisioned` / first navigation; sits after the #84 credit guard.
- **Tool-layer resolution** — the store rides on the pool (`pool.browser_profile_store`, built in the worker), so handlers reach it via the `browser_pool` they already hold (no executor-chain threading). SA-owned profiles take precedence.
- **`/v1/api/browser-profiles` routes** — CRUD, `setup-session` (creates a `browser_setup` session, provisions a browser, grants control, ~15-min TTL, **no harness wake**), and `capture` (the only CDP call allowed under a control lease — guarded on `browser_setup` channel + bound profile + lease holder).

## Tests
14 new tests (store scoping/encryption, client code-shape, inject-before-registry ordering, tool pool-fallback, route CRUD/setup/capture guards). Full harness browser suite green: **257 passed**.

> Pre-existing unrelated failure: `test_browser_image_autostarts_neko_live_view` asserts the Dockerfile autostarts `neko.conf`, but neko was disabled in the merged VNC live-view work — stale test, not touched here.

> Deploy: ships in the runtime image; run `surogate-ops migrate upgrade` once after rollout to create `browser_profiles`.