### PR TITLE
fix(browser-profiles): setup dialog closes itself with a false 'expired'

### DIFF
--- a/surogates/orchestrator/dispatcher.py
+++ b/surogates/orchestrator/dispatcher.py
@@ -846,6 +846,13 @@ class Orchestrator:
             logger.exception("Orphan sweep failed; continuing")
             return 0
         for session in orphans:
+            # browser_setup sessions are interactive and have no agent loop to
+            # recover; their lifecycle is the pod TTL + the capture/cancel
+            # teardown. They sit ``active`` and leaseless by design, so the
+            # sweeper would otherwise re-wake them every cycle and re-provision
+            # the browser out from under the live view.
+            if getattr(session, "channel", None) == "browser_setup":
+                continue
             try:
                 await self.session_store.emit_event(
                     session.id,

--- a/tests/test_orphan_sweep_gate_release.py
+++ b/tests/test_orphan_sweep_gate_release.py
@@ -183,6 +183,45 @@ async def test_sweep_does_not_drive_gate_below_zero(
 
 
 @pytest.mark.asyncio
+async def test_sweep_skips_browser_setup_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """browser_setup sessions sit ``active`` and leaseless by design (an
+    interactive login, no agent loop). The sweeper must skip them — recovering
+    one would re-wake it and re-provision the browser out from under the live
+    view."""
+    enqueue = AsyncMock()
+    monkeypatch.setattr(
+        "surogates.orchestrator.dispatcher.enqueue_session", enqueue
+    )
+
+    org_id = uuid4()
+    normal = SimpleNamespace(
+        id=uuid4(), org_id=org_id, agent_id="agent-X", channel="web"
+    )
+    setup = SimpleNamespace(
+        id=uuid4(), org_id=org_id, agent_id="agent-X", channel="browser_setup"
+    )
+    session_store = AsyncMock()
+    session_store.find_orphaned_sessions = AsyncMock(return_value=[setup, normal])
+    session_store.emit_event = AsyncMock()
+    session_store.release_stale_lease = AsyncMock(return_value=True)
+
+    orchestrator = _make_orchestrator(
+        session_store=session_store, redis=_FakeQueueRedis(), gate=None
+    )
+    recovered = await orchestrator._sweep_orphans_once(
+        stale_seconds=60, reason="orchestrator_sweeper",
+    )
+
+    assert recovered == 1  # only the normal session
+    assert enqueue.await_count == 1
+    emitted = {call.args[0] for call in session_store.emit_event.await_args_list}
+    assert normal.id in emitted
+    assert setup.id not in emitted
+
+
+@pytest.mark.asyncio
 async def test_sweep_without_gate_still_recovers(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/web/src/features/settings/browser-profile-setup-dialog.tsx
+++ b/web/src/features/settings/browser-profile-setup-dialog.tsx
@@ -143,7 +143,7 @@ export function BrowserProfileSetupDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex h-dvh w-screen max-w-none flex-col gap-0 rounded-none border-0 bg-background p-0">
+      <DialogContent className="flex h-dvh w-screen max-w-none sm:max-w-none flex-col gap-0 rounded-none border-0 bg-background p-0">
         <DialogHeader className="h-12 shrink-0 flex-row items-center justify-between border-b border-line px-4">
           <DialogTitle className="text-sm">
             Set up browser authentication

--- a/web/src/features/settings/browser-profile-setup-dialog.tsx
+++ b/web/src/features/settings/browser-profile-setup-dialog.tsx
@@ -31,6 +31,10 @@ export function BrowserProfileSetupDialog({
   const [saving, setSaving] = useState(false);
   const [phase, setPhase] = useState<"starting" | "ready">("starting");
   const startedRef = useRef(false);
+  // ``onOpenChange`` is a fresh arrow each render; ref it so effects don't
+  // re-run (and re-create the session) on the parent's re-renders.
+  const onOpenChangeRef = useRef(onOpenChange);
+  onOpenChangeRef.current = onOpenChange;
 
   // Start the setup session exactly once per open.
   useEffect(() => {
@@ -43,12 +47,12 @@ export function BrowserProfileSetupDialog({
       })
       .catch(() => {
         toast.error("Couldn't start the setup browser.");
-        onOpenChange(false);
+        onOpenChangeRef.current(false);
       });
     return () => {
       startedRef.current = false;
     };
-  }, [open, profileId, onOpenChange]);
+  }, [open, profileId]);
 
   // Provisioning is worker-driven (async), so poll until the browser is up
   // before mounting the live view — otherwise it would connect to an
@@ -96,22 +100,24 @@ export function BrowserProfileSetupDialog({
     return () => window.clearInterval(h);
   }, [sessionId, phase]);
 
-  // Countdown to the server-side TTL.
+  // Countdown to the server-side TTL, closing only when it actually elapses.
+  // The expiry decision uses the freshly-computed ``r`` — not the ``remaining``
+  // state — so it can't fire on the first render (where ``remaining`` is still
+  // its initial 0 the instant ``expiresAt`` is set).
   useEffect(() => {
     if (!expiresAt) return;
-    const tick = () =>
-      setRemaining(Math.max(0, Math.round((expiresAt - Date.now()) / 1000)));
+    const tick = () => {
+      const r = Math.max(0, Math.round((expiresAt - Date.now()) / 1000));
+      setRemaining(r);
+      if (r <= 0) {
+        toast.info("Setup session expired.");
+        onOpenChangeRef.current(false);
+      }
+    };
     tick();
     const h = window.setInterval(tick, 1000);
     return () => window.clearInterval(h);
   }, [expiresAt]);
-
-  useEffect(() => {
-    if (expiresAt && remaining === 0) {
-      toast.info("Setup session expired.");
-      onOpenChange(false);
-    }
-  }, [remaining, expiresAt, onOpenChange]);
 
   const liveViewUrl = useMemo(
     () =>

--- a/web/src/features/settings/browser-profile-setup-dialog.tsx
+++ b/web/src/features/settings/browser-profile-setup-dialog.tsx
@@ -36,9 +36,16 @@ export function BrowserProfileSetupDialog({
   const onOpenChangeRef = useRef(onOpenChange);
   onOpenChangeRef.current = onOpenChange;
 
-  // Start the setup session exactly once per open.
+  // Start the setup session exactly once per open. The guard is reset on close
+  // (not in effect cleanup) so a later reopen starts fresh — resetting in
+  // cleanup would let React StrictMode's mount→unmount→mount create two setup
+  // sessions, i.e. two billed browsers.
   useEffect(() => {
-    if (!open || startedRef.current) return;
+    if (!open) {
+      startedRef.current = false;
+      return;
+    }
+    if (startedRef.current) return;
     startedRef.current = true;
     createSetupSession(profileId)
       .then((res) => {
@@ -49,14 +56,13 @@ export function BrowserProfileSetupDialog({
         toast.error("Couldn't start the setup browser.");
         onOpenChangeRef.current(false);
       });
-    return () => {
-      startedRef.current = false;
-    };
   }, [open, profileId]);
 
-  // Provisioning is worker-driven (async), so poll until the browser is up
-  // before mounting the live view — otherwise it would connect to an
-  // unprovisioned session, disconnect, and tear the dialog down.
+  // Provisioning is worker-driven (async), so poll until the browser is up,
+  // then take the control lease *before* flipping to "ready" — only then do we
+  // mount the live view. The harness 403s the live-view WebSocket unless the
+  // caller already holds control, so mounting it first would drop the RFB
+  // connection on every render and loop forever on "Connecting…".
   useEffect(() => {
     if (!sessionId || phase === "ready") return;
     let cancelled = false;
@@ -70,8 +76,11 @@ export function BrowserProfileSetupDialog({
           state &&
           (state.status === "live" || state.status === "user-control")
         ) {
-          setPhase("ready");
-          return;
+          await surogatesWebChatAdapter.acquireBrowserControl(sessionId);
+          if (!cancelled) {
+            setPhase("ready");
+            return;
+          }
         }
       } catch {
         /* keep polling */
@@ -85,9 +94,9 @@ export function BrowserProfileSetupDialog({
     };
   }, [sessionId, phase]);
 
-  // Keep the 60s control lease alive (this dialog renders BrowserLiveView
-  // directly, without BrowserPane's heartbeat) so input doesn't go read-only
-  // mid-login. Re-acquire immediately on ready, then every 25s.
+  // The readiness gate already took the control lease; renew it here every 25s
+  // (the lease is 60s) so input doesn't go read-only mid-login — this dialog
+  // renders BrowserLiveView directly, without BrowserPane's control bar.
   useEffect(() => {
     if (!sessionId || phase !== "ready") return;
     const beat = () => {


### PR DESCRIPTION
**Symptom:** open the profile manager → Create a profile → "Set up authentication" → the dialog flashes open and immediately closes with toast "Setup session expired."

**Root cause:** a first-render effect race. `expiresAt` (future) and the initial `remaining` (0) are committed on different renders. When `createSetupSession` resolves and sets `expiresAt`, the separate expiry effect (`if expiresAt && remaining === 0`) re-runs on that render — but `remaining` is still its initial `0` (the countdown effect's `setRemaining(~900)` is queued for the next render) — so it fires the expiry and closes at once.

**Fix:** fold the expiry into the countdown tick and decide on the freshly-computed `r` (= `expiresAt − now`), never on the stale `remaining` state — so it can only close once the TTL truly elapses. Also ref-stabilized `onOpenChange` (a fresh arrow each render) so the effects don't re-run / re-create the session on the parent's re-renders.

Web setup dialog; the identical Studio fix is in surogate-ops. `tsc -b` clean.