### PR TITLE
fix(browser-profiles): show the profile selector before a session starts

### DIFF
--- a/sdk/agent-chat-react/src/agent-chat.tsx
+++ b/sdk/agent-chat-react/src/agent-chat.tsx
@@ -32,11 +32,15 @@ export interface AgentChatProps {
   onComposerError?: (err: ChatComposerError) => void;
   /**
    * Browser-profile selection (host-managed). When ``onSelectBrowserProfile``
-   * is provided and the browser is available, the composer shows a profile
-   * picker; the host threads the chosen id into session creation.
+   * is provided and ``browserProfilesEnabled`` is set, the composer shows a
+   * profile picker; the host threads the chosen id into session creation.
+   * The picker is shown before a session exists (a profile can only be bound
+   * at creation) and is locked once a session is active.
    */
   browserProfileId?: string | null;
   onSelectBrowserProfile?: (id: string | null) => void;
+  /** Whether this agent supports a live browser (gates the profile picker). */
+  browserProfilesEnabled?: boolean;
   /**
    * Per-agent capability flag.  When true, the composer surfaces the
    * ``/deep-research`` slash command in its builtin menu.  Off by
@@ -99,6 +103,7 @@ export function AgentChat({
   onComposerError,
   browserProfileId,
   onSelectBrowserProfile,
+  browserProfilesEnabled = false,
   deepResearchEnabled = false,
   researchEnabled = false,
   codeAgentsEnabled = false,
@@ -295,6 +300,8 @@ export function AgentChat({
               onComposerError={onComposerError}
               browserProfileId={browserProfileId}
               onSelectBrowserProfile={onSelectBrowserProfile}
+              browserProfilesEnabled={browserProfilesEnabled}
+              browserProfileLocked={!!sessionId}
               showBrowser={showBrowser}
               onToggleBrowser={handleToggleBrowser}
               showWorkspace={showWorkspace}

--- a/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
@@ -137,8 +137,21 @@ interface ChatComposerProps {
   canShowBrowser?: boolean;
   /** Currently-selected browser profile id (drives the active style). */
   browserProfileId?: string | null;
-  /** When provided (with ``canShowBrowser``), renders the profile selector. */
+  /** When provided (with ``browserProfilesEnabled``), renders the profile selector. */
   onSelectBrowserProfile?: (id: string | null) => void;
+  /**
+   * When true, the browser-profile selector is shown. Unlike ``canShowBrowser``
+   * (which is only true once a browser pane is live) this is a static agent
+   * capability, so the selector is available *before* a session starts — the
+   * only point at which a profile can actually be bound to the session.
+   */
+  browserProfilesEnabled?: boolean;
+  /**
+   * When true, the profile choice is locked: a session is already active, so
+   * the selector renders disabled with an explanatory tooltip. A profile is
+   * bound at session creation and cannot be changed mid-session.
+   */
+  browserProfileLocked?: boolean;
   /** When false (default), the workspace toggle button is omitted entirely. */
   canShowWorkspace?: boolean;
 
@@ -363,6 +376,8 @@ function ChatComposerInner({
   canShowBrowser = false,
   browserProfileId,
   onSelectBrowserProfile,
+  browserProfilesEnabled = false,
+  browserProfileLocked = false,
   canShowWorkspace = false,
   deepResearchEnabled = false,
   researchEnabled = false,
@@ -823,9 +838,26 @@ function ChatComposerInner({
                   <GlobeIcon className="size-4" />
                 </PromptInputButton>
               )}
-              {canShowBrowser &&
+              {browserProfilesEnabled &&
                 onSelectBrowserProfile &&
-                adapter.listBrowserProfiles && (
+                adapter.listBrowserProfiles &&
+                (browserProfileLocked ? (
+                  // A profile is bound at session creation; once a session is
+                  // active the choice can't change. Render disabled (via
+                  // aria-disabled, not the `disabled` attribute, so the
+                  // tooltip still shows on hover) with an explanation.
+                  <PromptInputButton
+                    aria-label="Select browser profile"
+                    aria-disabled
+                    aria-pressed={!!browserProfileId}
+                    tooltip="A browser profile must be chosen before starting the session"
+                    className={`cursor-not-allowed opacity-50 ${
+                      browserProfileId ? "bg-accent text-foreground" : ""
+                    }`}
+                  >
+                    <IdCardIcon className="size-4" />
+                  </PromptInputButton>
+                ) : (
                   <Popover
                     open={profileMenuOpen}
                     onOpenChange={setProfileMenuOpen}
@@ -880,7 +912,7 @@ function ChatComposerInner({
                       </Command>
                     </PopoverContent>
                   </Popover>
-                )}
+                ))}
               {canShowWorkspace && onToggleWorkspace && (
                 <PromptInputButton
                   aria-label={

--- a/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
@@ -125,6 +125,8 @@ interface ChatThreadProps {
   canShowBrowser?: boolean;
   browserProfileId?: string | null;
   onSelectBrowserProfile?: (id: string | null) => void;
+  browserProfilesEnabled?: boolean;
+  browserProfileLocked?: boolean;
   canShowWorkspace?: boolean;
   // Simple/Expert view-mode toggle — also threaded into AssistantGroup
   // in B9 to gate the actual render path. When omitted, the composer
@@ -2123,6 +2125,8 @@ export function ChatThread({
   canShowBrowser = false,
   browserProfileId,
   onSelectBrowserProfile,
+  browserProfilesEnabled = false,
+  browserProfileLocked = false,
   canShowWorkspace = false,
   viewMode = "simple",
   onViewModeChange,
@@ -2234,6 +2238,8 @@ export function ChatThread({
         canShowBrowser={canShowBrowser}
         browserProfileId={browserProfileId}
         onSelectBrowserProfile={onSelectBrowserProfile}
+        browserProfilesEnabled={browserProfilesEnabled}
+        browserProfileLocked={browserProfileLocked}
         canShowWorkspace={canShowWorkspace}
         viewMode={viewMode}
         onViewModeChange={onViewModeChange}

--- a/sdk/agent-chat-react/tests/browser-profile-selector.test.tsx
+++ b/sdk/agent-chat-react/tests/browser-profile-selector.test.tsx
@@ -7,6 +7,7 @@ import {
   NO_BROWSER_ADAPTER,
 } from "../src/adapter-context";
 import { ChatComposer } from "../src/components/chat/chat-composer";
+import { TooltipProvider } from "../src/components/ui/tooltip";
 import type { AgentChatAdapter } from "../src/types";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -24,6 +25,7 @@ afterEach(() => {
 
 async function renderComposer(
   onSelectBrowserProfile: (id: string | null) => void,
+  { locked = false }: { locked?: boolean } = {},
 ) {
   container = document.createElement("div");
   document.body.appendChild(container);
@@ -53,15 +55,18 @@ async function renderComposer(
   } as unknown as AgentChatAdapter;
   await act(async () => {
     root?.render(
-      <AgentChatAdapterProvider value={{ adapter, sessionId: "s-1" }}>
-        <ChatComposer
-          onSend={vi.fn()}
-          onStop={vi.fn()}
-          isRunning={false}
-          canShowBrowser
-          onSelectBrowserProfile={onSelectBrowserProfile}
-        />
-      </AgentChatAdapterProvider>,
+      <TooltipProvider>
+        <AgentChatAdapterProvider value={{ adapter, sessionId: "s-1" }}>
+          <ChatComposer
+            onSend={vi.fn()}
+            onStop={vi.fn()}
+            isRunning={false}
+            browserProfilesEnabled
+            browserProfileLocked={locked}
+            onSelectBrowserProfile={onSelectBrowserProfile}
+          />
+        </AgentChatAdapterProvider>
+      </TooltipProvider>,
     );
   });
   return container;
@@ -86,5 +91,32 @@ describe("browser profile selector", () => {
     ) as HTMLElement;
     await act(async () => work.click());
     expect(onSelect).toHaveBeenCalledWith("p2");
+  });
+
+  it("is shown without a live browser (so a profile can be picked first)", async () => {
+    // The selector gates on browserProfilesEnabled — NOT canShowBrowser — so it
+    // is available before a session/browser exists, the only point at which a
+    // profile binds to the session.
+    const node = await renderComposer(vi.fn());
+    expect(
+      node.querySelector('[aria-label="Select browser profile"]'),
+    ).not.toBeNull();
+  });
+
+  it("locks the selector for an active session", async () => {
+    const onSelect = vi.fn();
+    const node = await renderComposer(onSelect, { locked: true });
+    const trigger = node.querySelector(
+      '[aria-label="Select browser profile"]',
+    ) as HTMLElement;
+    expect(trigger).not.toBeNull();
+    expect(trigger.getAttribute("aria-disabled")).toBe("true");
+    // Clicking the locked trigger opens no popover and selects nothing.
+    await act(async () => trigger.click());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(document.body.textContent).not.toContain("Personal");
   });
 });

--- a/web/src/features/chat/chat-page.tsx
+++ b/web/src/features/chat/chat-page.tsx
@@ -212,6 +212,11 @@ export function ChatPage() {
               onOpenIntegrations={() => void navigate({ to: "/integrations" })}
               browserProfileId={browserProfileId}
               onSelectBrowserProfile={setBrowserProfileId}
+              // The web app has no per-agent browser-capability flag, so the
+              // picker is always offered; selecting a profile for a non-browser
+              // agent is a harmless no-op. Shown before the session starts and
+              // locked once it is active (the SDK handles the lock).
+              browserProfilesEnabled
               // Hide built-in slash commands the agent has disabled. Unknown
               // (capabilities not yet loaded) fails open via the helper.
               compressEnabled={slashCommandEnabled(slashCommands, "compress")}


### PR DESCRIPTION
## Problem
The browser-profile selector was gated on `canShowBrowser`, which is only true once a browser pane is live (mid-session). So it was invisible in a *new* chat — the one point at which a profile binds (it is read at `createSession`). Users couldn't pick a profile before starting, so the cookies never applied.

## Change
- Gate the selector on a new `browserProfilesEnabled` capability (static agent flag) so it shows before any session exists.
- Lock it once a session is active (`browserProfileLocked = !!sessionId`): the trigger renders disabled with a tooltip — *"A browser profile must be chosen before starting the session."* Uses `aria-disabled` so the tooltip stays hoverable.
- Threaded through `ChatThread` and `AgentChat`. Web chat opts in unconditionally (no per-agent browser flag there).
- Updated the selector test + added new-session-visible and locked-state coverage.

## Release note
The SDK must be republished (version bump) for the Studio (cross-repo, npm-pinned) to pick this up in a release build. The web app uses the local `file:` dep so it's self-consistent.