### PR TITLE
Show delegation children in the chat sidebar for non-active sessions

### DIFF
--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -1179,8 +1179,14 @@ async def list_sessions(
     agent_runtime: AgentRuntimeContext = Depends(agent_runtime_context_dep),
     limit: int = 50,
     offset: int = 0,
+    include_descendants: bool = False,
 ) -> ListSessionsResponse:
-    """List the authenticated user's sessions for this agent, newest first."""
+    """List the authenticated user's sessions for this agent, newest first.
+
+    With ``include_descendants`` the delegation subtree of each returned root
+    rides along (the chat sidebar uses this to show collapsed children);
+    pagination still applies to roots only.
+    """
     store = _get_session_store(request)
     settings = request.app.state.settings
 
@@ -1197,12 +1203,12 @@ async def list_sessions(
         agent_id=agent_runtime.agent_id,
         limit=limit,
         offset=offset,
+        include_descendants=include_descendants,
     )
 
-    # For total count we fetch one extra page to determine if there are more.
-    # A production system would use COUNT(*) but this avoids a second query
-    # for the common case.
-    total = offset + len(sessions)
+    # Pagination is over roots; any descendants ride along with their root, so
+    # the "is there another page" heuristic counts roots only.
+    total = offset + sum(1 for s in sessions if s.parent_id is None)
 
     return ListSessionsResponse(sessions=sessions, total=total)
 

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -64,6 +64,12 @@ _INBOX_EVENTS = frozenset({
     EventType.INBOX_PROGRESS_CHECKIN,
 })
 
+# Safety cap on descendants appended to a session-list page (see
+# list_sessions(include_descendants=True)).  Far above any real sidebar tree;
+# guards against a pathological delegation forest (e.g. an automated loop)
+# returning thousands of rows on every poll.
+_MAX_LISTED_DESCENDANTS = 1000
+
 
 class SessionStore:
     """Async, PostgreSQL-backed store for sessions, events, leases, and cursors.
@@ -557,13 +563,18 @@ class SessionStore:
                 )
                 desc_result = await db.execute(
                     select(SessionRow)
+                    .join(subtree, SessionRow.id == subtree.c.id)
                     .where(
-                        SessionRow.id.in_(select(subtree.c.id)),
                         SessionRow.parent_id.is_not(None),
                         SessionRow.org_id == org_id,
                         SessionRow.status != "archived",
                     )
-                    .order_by(SessionRow.created_at.desc())
+                    # Oldest-first so a parent always precedes its (later-created)
+                    # children; with the cap below, truncation then drops the
+                    # deepest leaves first and can't strand a child whose parent
+                    # was cut.
+                    .order_by(SessionRow.created_at.asc())
+                    .limit(_MAX_LISTED_DESCENDANTS)
                 )
                 sessions.extend(desc_result.scalars().all())
         return [Session.model_validate(r) for r in sessions]

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -15,8 +15,9 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, bindparam, not_, select, text, update, delete, func, or_, tuple_
+from sqlalchemy import and_, not_, select, text, update, delete, func, or_, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import aliased
 
 from surogates.db.models import (
     Event as EventRow,
@@ -534,40 +535,31 @@ class SessionStore:
             roots = result.scalars().all()
             sessions = list(roots)
             if include_descendants and roots:
-                root_ids = [r.id for r in roots]
                 # Walk the delegation forest down from this page of roots and
-                # collect descendant ids (any depth).  A child inherits its
-                # root's org/agent (see create_child_session), so staying within
-                # the returned roots is what scopes the walk.
-                descendant_ids = (
-                    (
-                        await db.execute(
-                            text(
-                                "WITH RECURSIVE subtree AS ("
-                                "  SELECT id, parent_id FROM sessions "
-                                "  WHERE id IN :root_ids "
-                                "  UNION ALL "
-                                "  SELECT s.id, s.parent_id FROM sessions s "
-                                "  JOIN subtree st ON s.parent_id = st.id"
-                                ") "
-                                "SELECT id FROM subtree WHERE parent_id IS NOT NULL"
-                            ).bindparams(bindparam("root_ids", expanding=True)),
-                            {"root_ids": root_ids},
-                        )
-                    )
-                    .scalars()
-                    .all()
+                # append every descendant (any depth).  A child inherits its
+                # root's org/agent (see create_child_session), so seeding the
+                # walk with the roots is what scopes it; the org filter on the
+                # final fetch is belt-and-suspenders.
+                subtree = (
+                    select(SessionRow.id)
+                    .where(SessionRow.id.in_([r.id for r in roots]))
+                    .cte("subtree", recursive=True)
                 )
-                if descendant_ids:
-                    desc_result = await db.execute(
-                        select(SessionRow)
-                        .where(
-                            SessionRow.id.in_(descendant_ids),
-                            SessionRow.status != "archived",
-                        )
-                        .order_by(SessionRow.created_at.desc())
+                child = aliased(SessionRow)
+                subtree = subtree.union_all(
+                    select(child.id).join(subtree, child.parent_id == subtree.c.id)
+                )
+                desc_result = await db.execute(
+                    select(SessionRow)
+                    .where(
+                        SessionRow.id.in_(select(subtree.c.id)),
+                        SessionRow.parent_id.is_not(None),
+                        SessionRow.org_id == org_id,
+                        SessionRow.status != "archived",
                     )
-                    sessions.extend(desc_result.scalars().all())
+                    .order_by(SessionRow.created_at.desc())
+                )
+                sessions.extend(desc_result.scalars().all())
         return [Session.model_validate(r) for r in sessions]
 
     # ------------------------------------------------------------------

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -15,7 +15,7 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, not_, select, text, update, delete, func, or_, tuple_
+from sqlalchemy import and_, bindparam, not_, select, text, update, delete, func, or_, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from surogates.db.models import (
@@ -495,14 +495,20 @@ class SessionStore:
         service_account_id: UUID | None = None,
         limit: int = 50,
         offset: int = 0,
+        include_descendants: bool = False,
     ) -> list[Session]:
         """Return top-level sessions for a principal within an org, newest first.
 
-        Delegation children (``parent_id IS NOT NULL``) are excluded --
-        they belong under their parent in the session tree, not as
-        siblings in the main sidebar list.  The tree endpoint
-        (:func:`get_session_tree`) surfaces them when the parent is
-        opened.
+        Delegation children (``parent_id IS NOT NULL``) are excluded from the
+        page itself -- they belong under their parent in the session tree, not
+        as siblings in the main sidebar list.  The tree endpoint
+        (:func:`get_session_tree`) surfaces them when the parent is opened.
+
+        When *include_descendants* is set, each returned root's delegation
+        subtree (any depth) is appended to the result so a caller that renders
+        the tree (the chat sidebar) can show a collapsed-children indicator
+        without a separate per-session tree fetch.  Pagination still applies to
+        roots only; descendants ride along with their root.
         """
         if (user_id is None) == (service_account_id is None):
             raise ValueError("list_sessions requires exactly one principal id")
@@ -525,8 +531,44 @@ class SessionStore:
                 .limit(limit)
                 .offset(offset)
             )
-            rows = result.scalars().all()
-        return [Session.model_validate(r) for r in rows]
+            roots = result.scalars().all()
+            sessions = list(roots)
+            if include_descendants and roots:
+                root_ids = [r.id for r in roots]
+                # Walk the delegation forest down from this page of roots and
+                # collect descendant ids (any depth).  A child inherits its
+                # root's org/agent (see create_child_session), so staying within
+                # the returned roots is what scopes the walk.
+                descendant_ids = (
+                    (
+                        await db.execute(
+                            text(
+                                "WITH RECURSIVE subtree AS ("
+                                "  SELECT id, parent_id FROM sessions "
+                                "  WHERE id IN :root_ids "
+                                "  UNION ALL "
+                                "  SELECT s.id, s.parent_id FROM sessions s "
+                                "  JOIN subtree st ON s.parent_id = st.id"
+                                ") "
+                                "SELECT id FROM subtree WHERE parent_id IS NOT NULL"
+                            ).bindparams(bindparam("root_ids", expanding=True)),
+                            {"root_ids": root_ids},
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                if descendant_ids:
+                    desc_result = await db.execute(
+                        select(SessionRow)
+                        .where(
+                            SessionRow.id.in_(descendant_ids),
+                            SessionRow.status != "archived",
+                        )
+                        .order_by(SessionRow.created_at.desc())
+                    )
+                    sessions.extend(desc_result.scalars().all())
+        return [Session.model_validate(r) for r in sessions]
 
     # ------------------------------------------------------------------
     # Event log

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -547,7 +547,13 @@ class SessionStore:
                 )
                 child = aliased(SessionRow)
                 subtree = subtree.union_all(
-                    select(child.id).join(subtree, child.parent_id == subtree.c.id)
+                    select(child.id)
+                    .join(subtree, child.parent_id == subtree.c.id)
+                    # Stop the walk at archived nodes: pruning their whole
+                    # subtree keeps an active grandchild of an archived child
+                    # from arriving with a parent that isn't in the list (the
+                    # SDK's buildTree would render such an orphan as a root).
+                    .where(child.status != "archived")
                 )
                 desc_result = await db.execute(
                     select(SessionRow)

--- a/tests/integration/test_session_store.py
+++ b/tests/integration/test_session_store.py
@@ -611,6 +611,44 @@ async def test_list_sessions_excludes_delegation_children(
     assert child.id not in listed_ids
 
 
+async def test_list_sessions_includes_descendants_when_requested(
+    session_store, session_factory,
+):
+    """include_descendants appends each root's delegation subtree (any depth)
+    so the sidebar can render collapsed children; default stays roots-only."""
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+
+    top = await session_store.create_session(
+        user_id=user_id, org_id=org_id, agent_id="test-agent",
+    )
+    child = await session_store.create_session(
+        user_id=user_id, org_id=org_id, agent_id="test-agent",
+        parent_id=top.id, channel="delegation",
+    )
+    grandchild = await session_store.create_session(
+        user_id=user_id, org_id=org_id, agent_id="test-agent",
+        parent_id=child.id, channel="delegation",
+    )
+
+    listed = await session_store.list_sessions(
+        org_id=org_id, user_id=user_id, agent_id="test-agent",
+        include_descendants=True,
+    )
+    listed_ids = {s.id for s in listed}
+    assert {top.id, child.id, grandchild.id} <= listed_ids
+
+    default_ids = {
+        s.id
+        for s in await session_store.list_sessions(
+            org_id=org_id, user_id=user_id, agent_id="test-agent",
+        )
+    }
+    assert top.id in default_ids
+    assert child.id not in default_ids
+    assert grandchild.id not in default_ids
+
+
 async def test_release_stale_lease_only_touches_expired(
     session_store, session_factory,
 ):

--- a/tests/integration/test_session_store.py
+++ b/tests/integration/test_session_store.py
@@ -649,6 +649,40 @@ async def test_list_sessions_includes_descendants_when_requested(
     assert grandchild.id not in default_ids
 
 
+async def test_list_sessions_descendants_prune_archived_subtree(
+    session_store, session_factory,
+):
+    """The descendant walk stops at archived nodes so an active grandchild of
+    an archived child is not returned as an orphan (its parent would be absent
+    from the list, which the sidebar would render as a spurious root)."""
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+
+    top = await session_store.create_session(
+        user_id=user_id, org_id=org_id, agent_id="test-agent",
+    )
+    child = await session_store.create_session(
+        user_id=user_id, org_id=org_id, agent_id="test-agent",
+        parent_id=top.id, channel="delegation",
+    )
+    grandchild = await session_store.create_session(
+        user_id=user_id, org_id=org_id, agent_id="test-agent",
+        parent_id=child.id, channel="delegation",
+    )
+    await session_store.update_session_status(child.id, "archived")
+
+    listed_ids = {
+        s.id
+        for s in await session_store.list_sessions(
+            org_id=org_id, user_id=user_id, agent_id="test-agent",
+            include_descendants=True,
+        )
+    }
+    assert top.id in listed_ids
+    assert child.id not in listed_ids  # archived
+    assert grandchild.id not in listed_ids  # pruned with its archived parent
+
+
 async def test_release_stale_lease_only_touches_expired(
     session_store, session_factory,
 ):

--- a/web/src/api/sessions.ts
+++ b/web/src/api/sessions.ts
@@ -30,10 +30,12 @@ export interface BrowserControlResponse {
 export async function listSessions(params?: {
   limit?: number;
   offset?: number;
+  includeDescendants?: boolean;
 }): Promise<SessionListResponse> {
   const search = new URLSearchParams();
   if (params?.limit != null) search.append("limit", String(params.limit));
   if (params?.offset != null) search.append("offset", String(params.offset));
+  if (params?.includeDescendants) search.append("include_descendants", "true");
 
   const response = await authFetch(`/api/v1/sessions?${search}`);
   if (!response.ok) {

--- a/web/src/features/chat/surogates-web-chat-adapter.ts
+++ b/web/src/features/chat/surogates-web-chat-adapter.ts
@@ -40,6 +40,9 @@ export const surogatesWebChatAdapter: AgentChatAdapter = {
     const response = await sessionsApi.listSessions({
       limit: input.limit,
       offset: input.offset,
+      // The sidebar renders the delegation tree, so it needs each root's
+      // children to show the collapse arrow even when the root isn't active.
+      includeDescendants: true,
     });
     return {
       sessions: response.sessions.map(toAgentChatSession),


### PR DESCRIPTION
## Problem
In the agent chat sidebar, a session that delegated children (sub-agent tasks) only showed its expand/collapse arrow while that session was the active one. Children were fetched only via the active session's tree request, so clicking away to another session removed the arrow entirely — there was no indication the session had children.

(Ops Studio doesn't have this problem because its session-list query returns all sessions including children; the agent web app's list returns roots only.)

## Change
Add an opt-in `include_descendants` flag to the session-list path (default off, so existing callers are unchanged):

- **`store.list_sessions` / `GET /sessions`**: when set, each returned root's delegation subtree (any depth) is appended via a single recursive CTE. Pagination still applies to roots only (`total` counts roots). The walk prunes archived subtrees, so an active grandchild of an archived child can't arrive without its parent.
- **Web chat adapter** (which feeds the sidebar `SessionTreePanel`) opts in. The SDK's existing `buildTree` nests rows by `parentId`, so every parent now shows the collapsed arrow whether or not it's active, and the children can be expanded in place.
- The **flat mobile session list** and the sessions store stay roots-only (they don't pass the flag), so children are not shown as flat siblings there.

## Notes
- Single repo; no SDK or ops change (the SDK already nests by `parentId`).
- Tests: store coverage for the opt-in (`root → child → grandchild`), the roots-only default, and archived-subtree pruning.
