### PR TITLE
fix(browser): don't redeclare `context` in storage-state injection

### DIFF
--- a/surogates/browser/client.py
+++ b/surogates/browser/client.py
@@ -198,8 +198,12 @@ return {
         cookies_json = json.dumps(state.get("cookies", []) or [])
         origins_json = json.dumps(state.get("origins", []) or [])
         code = (
-            "const context = page.context();\n"
-            f"await context.addCookies({cookies_json});\n"
+            # The kernel-images execute wrapper already binds ``context`` in
+            # scope; redeclaring it is a SyntaxError ("Identifier 'context' has
+            # already been declared") that aborts the whole injection. Use a
+            # local name instead.
+            "const ctx = page.context();\n"
+            f"await ctx.addCookies({cookies_json});\n"
             f"for (const o of {origins_json}) {{\n"
             "  try {\n"
             "    await page.goto(o.origin, {waitUntil: 'domcontentloaded'});\n"

--- a/tests/test_browser_client_storage_state.py
+++ b/tests/test_browser_client_storage_state.py
@@ -39,4 +39,8 @@ async def test_apply_storage_state_adds_cookies(monkeypatch):
     await client.apply_storage_state(state)
     assert "addCookies" in captured["code"]
     assert json.dumps(state["cookies"]) in captured["code"]
+    # The kernel-images execute wrapper already binds ``context``; redeclaring
+    # it is a SyntaxError that aborts the injection (profile cookies never land
+    # and browser provisioning fails). Guard against reintroducing the shadow.
+    assert "const context" not in captured["code"]
     await client.close()


### PR DESCRIPTION
## Problem
Profile-backed browser sessions could never provision a browser. Every `browser_navigate` call failed with:

```
Tool execution failed: Identifier 'context' has already been declared
```

`apply_storage_state` injected JS that opened with `const context = page.context();`, but the kernel-images `/playwright/execute` wrapper **already binds `context`** in that scope. The redeclaration is a parse-time `SyntaxError`, so the entire injection (cookies + localStorage) never runs, `ensure()` fails, and the browser is never provisioned. Sessions *without* a profile are unaffected (no injection).

Observed in PROD session `3c27c3c9-f290-4a9c-baa0-ccabe50b7c0a` (profile correctly attached, browser never came up).

## Fix
Use a local `ctx` name instead of shadowing the wrapper's `context`. Added a regression test asserting the generated code never reintroduces `const context`.

## Deploy
Runtime/harness change — reaches PROD via a surogates release + the wheel-pin bump in surogate-ops.