### PR TITLE
fix(browser): write last_used_at with the server clock

### DIFF
--- a/surogates/browser/profiles.py
+++ b/surogates/browser/profiles.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from cryptography.fernet import Fernet, InvalidToken
 from sqlalchemy import delete as sa_delete
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from surogates.db.models import BrowserProfile
@@ -209,5 +209,11 @@ class BrowserProfileStore:
                         BrowserProfile.org_id == org_id,
                         clause,
                     )
-                    .values(last_used_at=datetime.now(timezone.utc))
+                    # ``last_used_at`` is a naive ``timestamp without time
+                    # zone`` column (like ``created_at``); a tz-aware
+                    # ``datetime.now(timezone.utc)`` can't be encoded into it
+                    # (asyncpg raises "can't subtract offset-naive and
+                    # offset-aware datetimes"). Use the server clock, matching
+                    # ``created_at``'s ``server_default=func.now()``.
+                    .values(last_used_at=func.now())
                 )


### PR DESCRIPTION
`touch_last_used` wrote a tz-aware `datetime.now(timezone.utc)` into the naive `timestamp without time zone` `last_used_at` column → asyncpg `TypeError: can't subtract offset-naive and offset-aware datetimes`. The profile-load `except` swallowed it as *"could not load … provisioning a fresh browser"*, leaving `last_used_at` NULL and the logs misleading. Fixed with `func.now()` (matches `created_at`).

Note: this did **not** cause the reported Gmail-logged-out symptom — the cookies are loaded onto the browser spec *before* this crash and inject regardless. Verified on the live browser for session `df9b5141`: all 55 cookies (incl. `SID`/`__Secure-1PSID`) are present, but Google redirects `mail.google.com` to the logged-out page — i.e. Google rejects transferred session cookies (device-bound).