### PR TITLE
fix(browser): make element refs relocatable and self-healing

### DIFF
--- a/surogates/browser/client.py
+++ b/surogates/browser/client.py
@@ -101,6 +101,7 @@ for (const el of Array.from(root.querySelectorAll('*'))) {
   if (style.visibility === 'hidden' || style.display === 'none') continue;
   const bbox = el.getBoundingClientRect();
   if (!bbox || bbox.width <= 0 || bbox.height <= 0) continue;
+  el.setAttribute('data-sg-i', String(out.length));
   out.push({
     role: roleOf(el),
     name: nameOf(el),
@@ -110,6 +111,7 @@ for (const el of Array.from(root.querySelectorAll('*'))) {
     height: Math.round(bbox.height),
     depth: depthOf(el),
     children_count: el.children ? el.children.length : 0,
+    idx: out.length,
   });
 }
 return {
@@ -117,6 +119,11 @@ return {
   nodes: out,
 };
 }, __surogatesSelector);
+const __cdp = await page.context().newCDPSession(page);
+const __doc = await __cdp.send('DOM.getDocument', {depth: -1, pierce: true});
+const __map = {};
+(function walk(n){ if(!n) return; const a=n.attributes||[]; for(let i=0;i<a.length;i+=2){ if(a[i]==='data-sg-i'){ __map[a[i+1]] = n.backendNodeId; } } for(const c of (n.children||[])) walk(c); if(n.contentDocument) walk(n.contentDocument); })(__doc.root);
+for (const node of __surogatesSnapshot.nodes) { node.backend_node_id = (node.idx!=null && __map[String(node.idx)]!=null) ? __map[String(node.idx)] : null; }
 return {
   url: page.url(),
   title: await page.title(),
@@ -299,13 +306,22 @@ return {
         else:
             raise ValueError(f"unsupported click_type: {click_type}")
         await self._playwright_execute(code)
-        self._invalidate_snapshot_cache()
 
     async def click_ref(self, ref: str, **kwargs: Any) -> None:
-        """Click the cached center point for a `browser_get_state` ref."""
+        """Re-locate a `browser_get_state` ref and click its live center.
+
+        Refs are two-tier: a CDP backend node id is tried first, then a
+        role/name/nth lookup in the accessibility tree heals the ref when the
+        DOM has re-rendered. The element's center is recomputed at action time,
+        so the click lands correctly on dynamic pages.
+        """
 
         entry = self._resolve_ref(ref)
-        await self.click_at(int(entry["x"]), int(entry["y"]), **kwargs)
+        await self._act_click_on_entry(
+            entry,
+            button=kwargs.get("button", "left"),
+            num_clicks=kwargs.get("num_clicks", 1),
+        )
 
     async def type_text(self, text: str, *, delay_ms: int = 0) -> None:
         """Type text into the currently focused element."""
@@ -315,13 +331,11 @@ return {
             body["delay"] = delay_ms
         response = await self._http.post("/computer/type", json=body)
         response.raise_for_status()
-        self._invalidate_snapshot_cache()
 
     async def type_into_ref(self, ref: str, text: str, **kwargs: Any) -> None:
-        """Click a cached ref to focus it, then type text."""
+        """Re-locate a ref, click it to focus, then type text."""
 
-        entry = self._resolve_ref(ref)
-        await self.click_at(int(entry["x"]), int(entry["y"]))
+        await self._act_click_on_entry(self._resolve_ref(ref))
         await self.type_text(text, **kwargs)
 
     async def press_key(self, *keys: str, duration_ms: int = 0) -> None:
@@ -332,7 +346,6 @@ return {
             body["duration"] = duration_ms
         response = await self._http.post("/computer/press_key", json=body)
         response.raise_for_status()
-        self._invalidate_snapshot_cache()
 
     async def scroll_at(
         self, x: int, y: int, *, delta_x: int = 0, delta_y: int = 0
@@ -360,7 +373,9 @@ return await page.evaluate(() => ({{
 }}));
 """
         result = await self._playwright_execute(code)
-        self._invalidate_snapshot_cache()
+        # Scrolling only moves the viewport; the elements (and their backend
+        # node ids) persist, and a ref's click center is recomputed at action
+        # time — so refs survive a scroll and need no re-snapshot.
         return result if isinstance(result, dict) else {}
 
     async def drag(self, path: list[tuple[int, int]], *, button: str = "left") -> None:
@@ -463,12 +478,122 @@ return await page.evaluate(() => ({{
             )
         return entry
 
+    async def _act_click_on_entry(
+        self,
+        entry: dict[str, Any],
+        *,
+        button: str = "left",
+        num_clicks: int = 1,
+    ) -> None:
+        """Resolve a cache entry two-tier and click its live center."""
+
+        code = self._build_ref_click_js(entry, button, num_clicks)
+        await self._playwright_execute(code)
+
+    def _build_ref_click_js(
+        self,
+        entry: dict[str, Any],
+        button: str,
+        num_clicks: int,
+    ) -> str:
+        """Build the JS that re-locates a cached ref and clicks it.
+
+        Tier one is a CDP ``DOM.resolveNode`` on the snapshot's backend node id;
+        tier two heals the ref by matching role + normalized name + nth in the
+        accessibility tree. The clicked center is computed at action time, after
+        ``scrollIntoView``, with a covering-element guard.
+        """
+
+        backend_node_id = entry.get("backend_node_id")
+        bid_lit = json.dumps(backend_node_id)
+        role_lit = json.dumps(str(entry.get("role", "")))
+        name_lit = json.dumps(str(entry.get("name", "")))
+        nth_lit = json.dumps(int(entry.get("nth", 0)))
+        ref_lit = json.dumps(str(entry.get("ref", "")))
+        button_lit = json.dumps(button)
+        click_opts = (
+            f"{{button: {button_lit}, clickCount: {int(num_clicks)}}}"
+            if num_clicks != 1
+            else f"{{button: {button_lit}}}"
+        )
+        return f"""
+const cdp = await page.context().newCDPSession(page);
+let objectId = null;
+const __bid = {bid_lit};
+if (__bid !== null) {{
+  try {{
+    const r = await cdp.send('DOM.resolveNode', {{backendNodeId: __bid}});
+    objectId = (r && r.object && r.object.objectId) ? r.object.objectId : null;
+  }} catch (e) {{ objectId = null; }}
+}}
+if (!objectId) {{
+  const ax = await cdp.send('Accessibility.getFullAXTree');
+  const target = {role_lit};
+  const wantName = {name_lit};
+  const matches = [];
+  for (const n of (ax.nodes || [])) {{
+    if (n.ignored) continue;
+    if (!n.role || n.role.value !== target) continue;
+    const nm = (n.name && n.name.value != null) ? String(n.name.value) : '';
+    const norm = nm.replace(/\\s+/g, ' ').trim().slice(0, 240);
+    if (norm !== wantName) continue;
+    if (n.backendDOMNodeId == null) continue;
+    matches.push(n.backendDOMNodeId);
+  }}
+  const pick = matches[{nth_lit}] != null ? matches[{nth_lit}] : matches[0];
+  if (pick != null) {{
+    try {{
+      const r = await cdp.send('DOM.resolveNode', {{backendNodeId: pick}});
+      objectId = (r && r.object && r.object.objectId) ? r.object.objectId : null;
+    }} catch (e) {{ objectId = null; }}
+  }}
+}}
+if (!objectId) {{
+  throw new Error("Unknown ref " + {ref_lit} + "; the element is gone — call browser_get_state to refresh refs");
+}}
+const probe = await cdp.send('Runtime.callFunctionOn', {{
+  objectId: objectId,
+  returnByValue: true,
+  functionDeclaration: function () {{
+    this.scrollIntoView({{block: 'center', inline: 'center'}});
+    const r = this.getBoundingClientRect();
+    if (r.width <= 0 || r.height <= 0) return {{ok: false}};
+    const cx = Math.round(r.left + r.width / 2);
+    const cy = Math.round(r.top + r.height / 2);
+    let cover = null;
+    const hit = document.elementFromPoint(cx, cy);
+    if (hit && hit !== this && !this.contains(hit) && !hit.contains(this)) {{
+      const cls = (hit.className && typeof hit.className === 'string')
+        ? hit.className.split(/\\s+/)[0] : '';
+      cover = hit.tagName.toLowerCase()
+        + (hit.id ? '#' + hit.id : '')
+        + (cls ? '.' + cls : '');
+    }}
+    return {{ok: true, cx: cx, cy: cy, cover: cover}};
+  }}.toString(),
+}});
+const res = (probe && probe.result && probe.result.value) ? probe.result.value : {{ok: false}};
+if (!res.ok) {{
+  throw new Error("ref element not visible; call browser_get_state to refresh refs");
+}}
+if (res.cover) {{
+  throw new Error("ref click blocked: covered by <" + res.cover + ">. Dismiss that element, then browser_get_state and retry.");
+}}
+await page.mouse.click(res.cx, res.cy, {click_opts});
+await page.waitForTimeout(150);
+return true;
+"""
+
     def _build_tree_and_cache(
         self,
         nodes: list[dict[str, Any]],
     ) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
         tree: list[dict[str, Any]] = []
         cache: dict[str, dict[str, Any]] = {}
+        # 0-based occurrence counter per (role, name) so a cache entry can be
+        # re-located in the accessibility tree even when its backend node id is
+        # gone — the nth match disambiguates duplicate (role, name) pairs.
+        nth_counts: dict[tuple[str, str], int] = {}
 
         for index, node in enumerate(nodes, start=1):
             ref = f"@e{index}"
@@ -480,6 +605,9 @@ return await page.evaluate(() => ({{
             center_y = y + height // 2
             role = str(node.get("role", ""))
             name = str(node.get("name", ""))
+            backend_node_id = node.get("backend_node_id")
+            nth = nth_counts.get((role, name), 0)
+            nth_counts[(role, name)] = nth + 1
 
             entry: dict[str, Any] = {
                 "ref": ref,
@@ -500,6 +628,8 @@ return await page.evaluate(() => ({{
                 "y": center_y,
                 "role": role,
                 "name": name,
+                "backend_node_id": backend_node_id,
+                "nth": nth,
             }
             if intent is not None:
                 cache_entry["intent"] = intent

--- a/tests/test_browser_client.py
+++ b/tests/test_browser_client.py
@@ -233,6 +233,7 @@ class TestGetState:
                                 "y": 20,
                                 "width": 50,
                                 "height": 30,
+                                "backend_node_id": 42,
                             }
                         ],
                     },
@@ -245,6 +246,66 @@ class TestGetState:
         assert cached["y"] == 20 + 30 // 2
         assert cached["role"] == "button"
         assert cached["name"] == "Go"
+        assert cached["backend_node_id"] == 42
+        assert cached["nth"] == 0
+
+    async def test_get_state_assigns_backend_node_id_and_nth(
+        self, client_with_transport
+    ) -> None:
+        client, handlers = client_with_transport
+        handlers.append(
+            (
+                "POST",
+                "/playwright/execute",
+                200,
+                {
+                    "success": True,
+                    "result": {
+                        "url": "u",
+                        "title": "t",
+                        "viewport": {"width": 100, "height": 100},
+                        "nodes": [
+                            {
+                                "role": "button",
+                                "name": "Add",
+                                "x": 0,
+                                "y": 0,
+                                "width": 10,
+                                "height": 10,
+                                "backend_node_id": 7,
+                            },
+                            {
+                                "role": "button",
+                                "name": "Add",
+                                "x": 20,
+                                "y": 0,
+                                "width": 10,
+                                "height": 10,
+                                "backend_node_id": 9,
+                            },
+                            {
+                                "role": "link",
+                                "name": "Add",
+                                "x": 40,
+                                "y": 0,
+                                "width": 10,
+                                "height": 10,
+                            },
+                        ],
+                    },
+                },
+            )
+        )
+        await client.get_state()
+        # nth disambiguates duplicate (role, name) pairs; a different role
+        # restarts the counter.
+        assert client._snapshot_cache["@e1"]["nth"] == 0
+        assert client._snapshot_cache["@e1"]["backend_node_id"] == 7
+        assert client._snapshot_cache["@e2"]["nth"] == 1
+        assert client._snapshot_cache["@e2"]["backend_node_id"] == 9
+        assert client._snapshot_cache["@e3"]["nth"] == 0
+        # A missing backend_node_id is preserved as None for the fallback path.
+        assert client._snapshot_cache["@e3"]["backend_node_id"] is None
 
     async def test_get_state_overwrites_old_cache(self, client_with_transport) -> None:
         client, handlers = client_with_transport
@@ -438,17 +499,24 @@ class TestClickType:
             ("POST", "/playwright/execute", 200, {"success": True, "result": True})
         )
         await client.click_at(120, 240)
-        assert client._snapshot_cache == {}
+        # Explicit-coordinate clicks no longer invalidate cached refs; only
+        # navigation does.
+        assert client._snapshot_cache == {"@e1": {"x": 1, "y": 1, "role": "button", "name": "Go"}}
 
-    async def test_click_ref_uses_playwright_viewport_coordinates(
+    async def test_click_ref_resolves_via_cdp_at_action_time(
         self, client_with_transport
     ) -> None:
         client, _handlers = client_with_transport
+        # The cached center (50/60) is stale on a dynamic page; the live center
+        # is recomputed via CDP, so the JS must resolve by backend node id and
+        # never click the frozen coordinates.
         client._snapshot_cache["@e3"] = {
             "x": 50,
             "y": 60,
             "role": "button",
             "name": "Go",
+            "backend_node_id": 314,
+            "nth": 0,
         }
         captured: list[dict[str, Any]] = []
 
@@ -468,24 +536,27 @@ class TestClickType:
         await client.click_ref("@e3")
         assert captured[0]["path"] == "/playwright/execute"
         code = captured[0]["body"]["code"]
-        assert "page.mouse.click" in code
-        assert "50" in code
-        assert "60" in code
+        assert "newCDPSession" in code
+        assert "DOM.resolveNode" in code
+        assert "backendNodeId: __bid" in code
+        assert "314" in code
+        assert "Accessibility.getFullAXTree" in code
+        assert "elementFromPoint" in code
+        assert "page.mouse.click(res.cx, res.cy" in code
+        # The ref path must not invalidate the cache so a follow-up type works.
+        assert "@e3" in client._snapshot_cache
 
-    async def test_click_ref_unknown_raises(self, client_with_transport) -> None:
-        client, _ = client_with_transport
-        with pytest.raises(KeyError, match="@e99"):
-            await client.click_ref("@e99")
-
-    async def test_click_waits_for_network_after_request(
+    async def test_click_ref_passes_button_and_num_clicks(
         self, client_with_transport
     ) -> None:
-        client, _ = client_with_transport
+        client, _handlers = client_with_transport
         client._snapshot_cache["@e1"] = {
-            "x": 10,
-            "y": 20,
+            "x": 1,
+            "y": 1,
             "role": "button",
             "name": "Go",
+            "backend_node_id": 5,
+            "nth": 0,
         }
         captured: list[dict[str, Any]] = []
 
@@ -499,7 +570,67 @@ class TestClickType:
         client._http = httpx.AsyncClient(
             base_url=client.rest_url, transport=CapturingTransport()
         )
-        await client.click_ref("@e1")
+        await client.click_ref("@e1", button="right", num_clicks=2)
+        code = captured[0]["body"]["code"]
+        assert '"right"' in code
+        assert "clickCount: 2" in code
+
+    async def test_ref_fallback_uses_role_name_nth(
+        self, client_with_transport
+    ) -> None:
+        client, _handlers = client_with_transport
+        # A null backend node id forces the role/name/nth healing path.
+        client._snapshot_cache["@e2"] = {
+            "x": 5,
+            "y": 5,
+            "role": "link",
+            "name": "Profile",
+            "backend_node_id": None,
+            "nth": 3,
+        }
+        captured: list[dict[str, Any]] = []
+
+        class CapturingTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(
+                self, request: httpx.Request
+            ) -> httpx.Response:
+                captured.append({"body": json.loads(request.content)})
+                return httpx.Response(200, json={"success": True, "result": True})
+
+        client._http = httpx.AsyncClient(
+            base_url=client.rest_url, transport=CapturingTransport()
+        )
+        await client.click_ref("@e2")
+        code = captured[0]["body"]["code"]
+        # backend node id is null -> the fast-path resolveNode is gated off.
+        assert "const __bid = null;" in code
+        assert "Accessibility.getFullAXTree" in code
+        assert '"link"' in code
+        assert '"Profile"' in code
+        assert "matches[3]" in code
+
+    async def test_click_ref_unknown_raises(self, client_with_transport) -> None:
+        client, _ = client_with_transport
+        with pytest.raises(KeyError, match="@e99"):
+            await client.click_ref("@e99")
+
+    async def test_click_waits_for_network_after_request(
+        self, client_with_transport
+    ) -> None:
+        client, _ = client_with_transport
+        captured: list[dict[str, Any]] = []
+
+        class CapturingTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(
+                self, request: httpx.Request
+            ) -> httpx.Response:
+                captured.append({"body": json.loads(request.content)})
+                return httpx.Response(200, json={"success": True, "result": True})
+
+        client._http = httpx.AsyncClient(
+            base_url=client.rest_url, transport=CapturingTransport()
+        )
+        await client.click_at(10, 20)
         code = captured[0]["body"]["code"]
         assert "page.on('request'" in code
         assert "page.mouse.click" in code
@@ -527,7 +658,7 @@ class TestClickType:
         assert "page.mouse.down" in code
         assert "waitForLoadState" not in code
 
-    async def test_type_text_invalidates_cache(self, client_with_transport) -> None:
+    async def test_type_text_keeps_cache(self, client_with_transport) -> None:
         client, handlers = client_with_transport
         client._snapshot_cache["@e1"] = {
             "x": 1,
@@ -537,31 +668,57 @@ class TestClickType:
         }
         handlers.append(("POST", "/computer/type", 200, {"ok": True}))
         await client.type_text("hello")
-        assert client._snapshot_cache == {}
+        # Typing must not invalidate refs; a click→type on the same ref has to
+        # keep working without a fresh browser_get_state.
+        assert "@e1" in client._snapshot_cache
 
-    async def test_type_into_ref_clicks_first(self, client_with_transport) -> None:
-        client, handlers = client_with_transport
+    async def test_type_into_ref_clicks_via_cdp_then_types(
+        self, client_with_transport
+    ) -> None:
+        client, _handlers = client_with_transport
         client._snapshot_cache["@e2"] = {
             "x": 30,
             "y": 40,
             "role": "textbox",
             "name": "Email",
+            "backend_node_id": 88,
+            "nth": 0,
         }
-        handlers.append(
-            ("POST", "/playwright/execute", 200, {"success": True, "result": True})
+        seen: list[dict[str, Any]] = []
+
+        class TracingTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(
+                self, request: httpx.Request
+            ) -> httpx.Response:
+                body = (
+                    json.loads(request.content) if request.content else {}
+                )
+                seen.append({"path": request.url.path, "body": body})
+                if request.url.path == "/playwright/execute":
+                    return httpx.Response(200, json={"success": True, "result": True})
+                return httpx.Response(200, json={"ok": True})
+
+        client._http = httpx.AsyncClient(
+            base_url=client.rest_url, transport=TracingTransport()
         )
-        handlers.append(("POST", "/computer/type", 200, {"ok": True}))
         await client.type_into_ref("@e2", "test@example.com")
-        assert client._snapshot_cache == {}
+        # First a CDP click to focus the field, then the type call.
+        assert seen[0]["path"] == "/playwright/execute"
+        assert "newCDPSession" in seen[0]["body"]["code"]
+        assert seen[1]["path"] == "/computer/type"
+        assert seen[1]["body"]["text"] == "test@example.com"
+        # The ref must survive so a follow-up action can reuse it.
+        assert "@e2" in client._snapshot_cache
 
 
 class TestSmallActions:
-    async def test_press_key_single(self, client_with_transport) -> None:
+    async def test_press_key_keeps_cache(self, client_with_transport) -> None:
         client, handlers = client_with_transport
         client._snapshot_cache["@e1"] = {"x": 1, "y": 1, "role": "button", "name": "Go"}
         handlers.append(("POST", "/computer/press_key", 200, {"ok": True}))
         await client.press_key("Enter")
-        assert client._snapshot_cache == {}
+        # Pressing a key must not invalidate refs.
+        assert "@e1" in client._snapshot_cache
 
     async def test_press_key_chord(self, client_with_transport) -> None:
         client, _handlers = client_with_transport
@@ -601,7 +758,10 @@ class TestSmallActions:
         )
         position = await client.scroll_at(640, 400, delta_y=300)
         assert position["scroll_y"] == 300
-        assert client._snapshot_cache == {}
+        # Scrolling preserves refs: elements (and their backend node ids)
+        # persist and a ref's click center is recomputed at action time, so a
+        # scroll no longer forces a re-snapshot. Only navigation invalidates.
+        assert "@e1" in client._snapshot_cache
 
     async def test_drag(self, client_with_transport) -> None:
         client, handlers = client_with_transport


### PR DESCRIPTION
## Problem
`@eN` refs from `browser_get_state` were **frozen center coordinates**, and `click`/`type`/`press` each wiped the ref cache. On dynamic sites (x.com) this meant `browser_click @e308` → `browser_type @e308` returned `unknown_ref`, and stale coordinates clicked the wrong element. (Observed in session `fd7f48e1`.)

## Fix (two-tier refs, à la vercel-labs/agent-browser)
A ref now carries a **precise CDP `backendNodeId` + a semantic identity (`role`/`name`/`nth`)** and re-resolves at action time:
1. Fast path: `DOM.resolveNode(backendNodeId)` → the exact element.
2. Self-heal: if it's stale (re-rendered), re-find by `role`+`name`+`nth` in a fresh accessibility tree.
3. Click at the element's **live center** (recomputed after `scrollIntoView`), with a **covering-element guard** (reports e.g. `covered by <div#consent-banner>` so the agent dismisses overlays and re-snapshots) — never a silent mis-click.

Per-action cache invalidation removed for `click`/`type`/`press`/`scroll` (refs survive these); kept for `navigate`/`apply_storage_state`. Snapshot is augmented (DOM walk + one CDP `DOM.getDocument` to attach `backendNodeId`); tool API and `get_state` shape unchanged.

## Verified
- Live on a PROD browser-fleet pod against **example.com and x.com**: snapshot→cache carries non-null `backendNodeId` (188/188 interactive nodes on x.com); the backendNodeId path **and** the role/name/nth heal path both resolve + click the right element.
- `267 passed` (full browser suite). The lone `test_browser_image` failure is pre-existing on `master` (asserts a Dockerfile string, untouched).

Runtime/harness change — reaches PROD via a surogates release.