### PR TITLE
fix(browser): reattach a session's browser across workers instead of re-provisioning

### DIFF
--- a/surogates/browser/pool.py
+++ b/surogates/browser/pool.py
@@ -76,6 +76,26 @@ class BrowserPool:
         lock = await self._session_lock(session_id)
         async with lock:
             slot = self._mapping.get(session_id)
+            if slot is None:
+                # Shared-runtime sessions can move between workers, so this
+                # worker's local map may miss a browser another worker
+                # provisioned. Reattach from the shared registry before
+                # provisioning a fresh (blank) one — otherwise the session
+                # loses its page (lands on the browser's default start page)
+                # and the live pod leaks. The status check below validates the
+                # reattached slot and reprovisions if the pod is really gone.
+                entry = await self._registry.get(session_id)
+                if entry is not None and entry.browser_id:
+                    slot = _Slot(
+                        browser_id=entry.browser_id,
+                        endpoint=BrowserEndpoint(
+                            rest_url=entry.rest_url,
+                            cdp_url=entry.cdp_url,
+                            live_view_url=entry.live_view_url,
+                        ),
+                        snapshot_cache={},
+                    )
+                    self._mapping[session_id] = slot
             if slot is not None:
                 status = await self._backend.status(slot.browser_id)
                 if status == BrowserStatus.RUNNING:
@@ -138,6 +158,7 @@ class BrowserPool:
                     cdp_url=endpoint.cdp_url,
                     live_view_url=endpoint.live_view_url,
                     provisioned_at=datetime.now(timezone.utc),
+                    browser_id=browser_id,
                 )
             )
             await self._emit_event(

--- a/surogates/browser/registry.py
+++ b/surogates/browser/registry.py
@@ -25,6 +25,10 @@ class BrowserEntry:
     cdp_url: str
     live_view_url: str
     provisioned_at: datetime
+    # Backend handle for the live browser (fleet pod / container id). Needed to
+    # reattach to — or tear down — an existing browser from a worker that did
+    # not provision it; defaulted for backwards-compat with older entries.
+    browser_id: str = ""
 
     def to_json(self) -> str:
         payload = asdict(self)
@@ -44,6 +48,7 @@ class BrowserEntry:
             cdp_url=payload["cdp_url"],
             live_view_url=payload["live_view_url"],
             provisioned_at=datetime.fromisoformat(payload["provisioned_at"]),
+            browser_id=payload.get("browser_id", ""),
         )
 
 

--- a/tests/test_browser_pool.py
+++ b/tests/test_browser_pool.py
@@ -95,6 +95,45 @@ class TestEnsure:
         assert result.newly_provisioned is False
         assert backend.provisions == 1
 
+    async def test_reattaches_from_registry_when_local_map_misses(self) -> None:
+        # Shared-runtime sessions move between workers. A worker whose local
+        # map misses the browser must reattach from the shared registry, not
+        # provision a fresh (blank) pod — otherwise the session lands on the
+        # browser's default start page and the live pod leaks.
+        registry = FakeRegistry()  # shared across both "workers"
+        backend_a = FakeBackend()
+        pool_a = BrowserPool(backend=backend_a, registry=registry)  # type: ignore[arg-type]
+        first = await pool_a.ensure("sess-1", "o", "u", BrowserSpec())
+        assert first.browser_id == "b1"
+        assert registry.entries["sess-1"].browser_id == "b1"
+
+        # Different worker: fresh pool (empty map), its own backend, same registry.
+        backend_b = FakeBackend()
+        pool_b = BrowserPool(backend=backend_b, registry=registry)  # type: ignore[arg-type]
+        result = await pool_b.ensure("sess-1", "o", "u", BrowserSpec())
+
+        assert result.newly_provisioned is False  # reattached, not reprovisioned
+        assert result.browser_id == "b1"
+        assert result.endpoint.rest_url == first.endpoint.rest_url
+        assert backend_b.provisions == 0  # no fresh pod -> no default-page reset
+
+    async def test_reattach_reprovisions_when_registry_browser_dead(self) -> None:
+        # If the registry-tracked browser is actually gone, fall through to a
+        # clean destroy + reprovision rather than reusing a dead pod.
+        registry = FakeRegistry()
+        backend_a = FakeBackend()
+        pool_a = BrowserPool(backend=backend_a, registry=registry)  # type: ignore[arg-type]
+        await pool_a.ensure("sess-1", "o", "u", BrowserSpec())
+
+        backend_b = FakeBackend()
+        backend_b.status_overrides["b1"] = BrowserStatus.FAILED
+        pool_b = BrowserPool(backend=backend_b, registry=registry)  # type: ignore[arg-type]
+        result = await pool_b.ensure("sess-1", "o", "u", BrowserSpec())
+
+        assert result.newly_provisioned is True
+        assert backend_b.provisions == 1
+        assert backend_b.destroys == ["b1"]
+
     async def test_stale_status_reprovisions(self) -> None:
         backend = FakeBackend()
         pool = BrowserPool(backend=backend, registry=FakeRegistry())  # type: ignore[arg-type]

--- a/tests/test_browser_pool_inject.py
+++ b/tests/test_browser_pool_inject.py
@@ -28,6 +28,9 @@ async def test_inject_applies_state_before_registry_publish(monkeypatch):
         async def set(self, entry):
             order.append("registry")
 
+        async def get(self, session_id):
+            return None
+
     applied = {}
 
     class _FakeClient:


### PR DESCRIPTION
## Problem
A session's browser would suddenly reset to **DuckDuckGo** mid-task (observed in session `5fb74b61`: `browser_id` flipped `06b8af20d355`→`06c3bdcd4433`, and a fresh fleet pod boots on its default start page `start.duckduckgo.com`). The x.com page was lost and the original pod leaked.

## Cause
`BrowserPool.ensure` only checked the **worker-local in-memory `_mapping`**. Shared-runtime sessions move between workers (the logs show cross-worker `lease is held; requeueing wake`), and a worker whose map misses the browser fell straight through to `provision()` a fresh, blank pod — never consulting the **shared Redis registry**, which still held the live browser.

## Fix
`ensure` reattaches from the registry when the local map misses: rebuild the `_Slot` from the registry entry and let the existing status check reuse it (RUNNING) or cleanly destroy + reprovision (genuinely gone). Adds `browser_id` to `BrowserEntry` (needed so a non-owning worker can `status`/`destroy` it; defaulted for backwards-compat).

## Tests
+2 (cross-worker reattach reuses the same browser with no new provision; stale registry entry → clean reprovision). `269 passed` in the full browser suite; the lone `test_browser_image` failure is pre-existing on `master`.

Runtime/harness change — reaches PROD via a surogates release.