### PR TITLE
fix(browser): type and press keys via the CDP keyboard, not /computer/*

### DIFF
--- a/surogates/browser/client.py
+++ b/surogates/browser/client.py
@@ -31,6 +31,24 @@ class KernelBrowserClient:
             "spinbutton",
         }
     )
+    # Casual / xdotool key names a model is likely to emit, mapped to the
+    # Playwright vocabulary used by keyboard.press(). Applied per key before
+    # the keys are joined into a chord. Unlisted keys (letters, "Enter",
+    # "Shift", "ArrowUp", "F5", …) already match Playwright and pass through.
+    _KEY_ALIASES: dict[str, str] = {
+        "ctrl": "Control",
+        "control": "Control",
+        "cmd": "Meta",
+        "command": "Meta",
+        "super": "Meta",
+        "win": "Meta",
+        "opt": "Alt",
+        "option": "Alt",
+        "esc": "Escape",
+        "del": "Delete",
+        "return": "Enter",
+        "space": " ",
+    }
     _CONSENT_ACTION_RE = re.compile(
         r"^("
         r"accept(?:\s+(?:all|toate|cookies|all\s+cookies))?|"
@@ -324,13 +342,23 @@ return {
         )
 
     async def type_text(self, text: str, *, delay_ms: int = 0) -> None:
-        """Type text into the currently focused element."""
+        """Type text into the currently focused element.
 
-        body: dict[str, Any] = {"text": text, "smooth": False}
-        if delay_ms:
-            body["delay"] = delay_ms
-        response = await self._http.post("/computer/type", json=body)
-        response.raise_for_status()
+        Goes through Playwright's ``keyboard.type`` rather than the kernel
+        ``/computer/type`` endpoint: that endpoint sends OS-level (xdotool)
+        keystrokes that never reach contenteditable rich-text editors — e.g.
+        x.com's Draft.js composer silently drops them while the endpoint still
+        returns 200, so every ``typed: true`` was a lie. CDP key events are
+        delivered to the focused element and trigger its input handling, so
+        the text actually lands.
+        """
+
+        opts = {"delay": delay_ms} if delay_ms else {}
+        code = (
+            f"await page.keyboard.type({json.dumps(text)}, {json.dumps(opts)});\n"
+            "return true;"
+        )
+        await self._playwright_execute(code)
 
     async def type_into_ref(self, ref: str, text: str, **kwargs: Any) -> None:
         """Re-locate a ref, click it to focus, then type text."""
@@ -339,13 +367,24 @@ return {
         await self.type_text(text, **kwargs)
 
     async def press_key(self, *keys: str, duration_ms: int = 0) -> None:
-        """Press one key or key chord."""
+        """Press one key or key chord (e.g. ``Enter`` or ``Control+a``).
 
-        body: dict[str, Any] = {"keys": list(keys)}
-        if duration_ms:
-            body["duration"] = duration_ms
-        response = await self._http.post("/computer/press_key", json=body)
-        response.raise_for_status()
+        Like :meth:`type_text`, uses Playwright's ``keyboard.press`` instead of
+        the kernel ``/computer/press_key`` endpoint so the key reaches the
+        focused DOM element rather than the OS-level X display. Multiple keys
+        are normalized to the Playwright vocabulary and joined into one chord
+        (``"Ctrl", "a"`` -> ``"Control+a"``).
+        """
+
+        if not keys:
+            raise ValueError("press_key requires at least one key")
+        chord = "+".join(self._KEY_ALIASES.get(k.lower(), k) for k in keys)
+        opts = {"delay": duration_ms} if duration_ms else {}
+        code = (
+            f"await page.keyboard.press({json.dumps(chord)}, {json.dumps(opts)});\n"
+            "return true;"
+        )
+        await self._playwright_execute(code)
 
     async def scroll_at(
         self, x: int, y: int, *, delta_x: int = 0, delta_y: int = 0

--- a/surogates/tools/builtin/browser.py
+++ b/surogates/tools/builtin/browser.py
@@ -925,7 +925,11 @@ def register(registry: ToolRegistry) -> None:
         name="browser_press_key",
         schema=ToolSchema(
             name="browser_press_key",
-            description="Press one or more keyboard keys or chords.",
+            description=(
+                "Press a single key or chord such as Enter, Escape, Tab, or "
+                "Control+a — multiple keys form one chord, not a sequence. To "
+                "enter text, use browser_type."
+            ),
             parameters=PRESS_KEY_SCHEMA,
         ),
         handler=_browser_press_key_handler,

--- a/tests/test_browser_client.py
+++ b/tests/test_browser_client.py
@@ -666,11 +666,37 @@ class TestClickType:
             "role": "textbox",
             "name": "Email",
         }
-        handlers.append(("POST", "/computer/type", 200, {"ok": True}))
+        handlers.append(
+            ("POST", "/playwright/execute", 200, {"success": True, "result": True})
+        )
         await client.type_text("hello")
         # Typing must not invalidate refs; a click→type on the same ref has to
         # keep working without a fresh browser_get_state.
         assert "@e1" in client._snapshot_cache
+
+    async def test_type_text_uses_cdp_keyboard(self, client_with_transport) -> None:
+        client, _handlers = client_with_transport
+        captured: list[dict[str, Any]] = []
+
+        class CapturingTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(
+                self, request: httpx.Request
+            ) -> httpx.Response:
+                captured.append(
+                    {"path": request.url.path, "body": json.loads(request.content)}
+                )
+                return httpx.Response(200, json={"success": True, "result": True})
+
+        client._http = httpx.AsyncClient(
+            base_url=client.rest_url, transport=CapturingTransport()
+        )
+        await client.type_text("hi there")
+        # The kernel /computer/type endpoint is bypassed entirely: OS-level
+        # keystrokes never reach contenteditable editors, so typing must go
+        # through Playwright's CDP keyboard.
+        assert captured[0]["path"] == "/playwright/execute"
+        assert "keyboard.type" in captured[0]["body"]["code"]
+        assert "hi there" in captured[0]["body"]["code"]
 
     async def test_type_into_ref_clicks_via_cdp_then_types(
         self, client_with_transport
@@ -702,11 +728,12 @@ class TestClickType:
             base_url=client.rest_url, transport=TracingTransport()
         )
         await client.type_into_ref("@e2", "test@example.com")
-        # First a CDP click to focus the field, then the type call.
+        # First a CDP click to focus the field, then a CDP keyboard type.
         assert seen[0]["path"] == "/playwright/execute"
         assert "newCDPSession" in seen[0]["body"]["code"]
-        assert seen[1]["path"] == "/computer/type"
-        assert seen[1]["body"]["text"] == "test@example.com"
+        assert seen[1]["path"] == "/playwright/execute"
+        assert "keyboard.type" in seen[1]["body"]["code"]
+        assert "test@example.com" in seen[1]["body"]["code"]
         # The ref must survive so a follow-up action can reuse it.
         assert "@e2" in client._snapshot_cache
 
@@ -715,7 +742,9 @@ class TestSmallActions:
     async def test_press_key_keeps_cache(self, client_with_transport) -> None:
         client, handlers = client_with_transport
         client._snapshot_cache["@e1"] = {"x": 1, "y": 1, "role": "button", "name": "Go"}
-        handlers.append(("POST", "/computer/press_key", 200, {"ok": True}))
+        handlers.append(
+            ("POST", "/playwright/execute", 200, {"success": True, "result": True})
+        )
         await client.press_key("Enter")
         # Pressing a key must not invalidate refs.
         assert "@e1" in client._snapshot_cache
@@ -729,13 +758,17 @@ class TestSmallActions:
                 self, request: httpx.Request
             ) -> httpx.Response:
                 captured.append(json.loads(request.content))
-                return httpx.Response(200, json={"ok": True})
+                return httpx.Response(200, json={"success": True, "result": True})
 
         client._http = httpx.AsyncClient(
             base_url=client.rest_url, transport=CapturingTransport()
         )
-        await client.press_key("Ctrl+l")
-        assert captured[0]["keys"] == ["Ctrl+l"]
+        # Casual modifier names normalize to Playwright's vocabulary and the
+        # keys join into a single chord pressed via the CDP keyboard.
+        await client.press_key("Ctrl", "a")
+        code = captured[0]["code"]
+        assert "keyboard.press" in code
+        assert "Control+a" in code
 
     async def test_scroll_at(self, client_with_transport) -> None:
         client, handlers = client_with_transport


### PR DESCRIPTION
## Problem

PROD session `5fb74b61` got stuck trying to write into x.com's compose box: `browser_type @e134 "hello"` returned `typed: true`, `browser_press_key` returned `pressed`, but nothing landed. The agent flailed between `browser_type`, `browser_press_key`, and coordinate clicks, none of which entered text.

## Root cause (reproduced on the live PROD browser)

`type_text` and `press_key` route through the kernel `/computer/type` and `/computer/press_key` endpoints, which inject **OS-level (xdotool) keystrokes**. Those never reach a `contenteditable` rich-text editor — x.com's composer is Draft.js. The endpoints return 200, so the tool reports success while the keys go nowhere.

Decisive A/B on the actual stuck browser, into the live `tweetTextarea_0`:

| Method | Result |
|---|---|
| `page.keyboard.type` (CDP `Input.dispatchKeyEvent`) | ✅ text landed |
| `/computer/type` (current path) | ❌ composer stayed on its placeholder |

`page.mouse.click(center)` + `page.keyboard.type("VERIFY123")` → `'VERIFY123'`; `page.keyboard.press("Backspace")` → `'VERIFY12'`.

## Fix

Move both `type_text` and `press_key` onto Playwright's CDP keyboard via `/playwright/execute` — the same move `scroll_at` already made off the unreliable `/computer/scroll` endpoint. `press_key` normalizes casual modifier names (`Ctrl`→`Control`, `Cmd`→`Meta`, `Esc`→`Escape`, …) and joins keys into a single chord. The `browser_press_key` description now steers the model to `browser_type` for text.

## Tests

`tests/test_browser_client.py` updated to assert the CDP-keyboard path (no more `/computer/type|press_key`), plus a new `test_type_text_uses_cdp_keyboard`. `266 passed` across the browser suite (only the pre-existing, unrelated `test_browser_image` Dockerfile-string assertion fails on master too).