### PR TITLE
fix(browser): drag and screenshot via Playwright, not /computer/*

### DIFF
--- a/surogates/api/routes/browser.py
+++ b/surogates/api/routes/browser.py
@@ -347,7 +347,7 @@ async def get_browser_preview(
 
     try:
         async with _browser_preview_client(resolved.endpoint.rest_url) as client:
-            screenshot = await client.screenshot(viewport_only=True)
+            screenshot = await client.screenshot()
     except Exception as exc:
         raise HTTPException(
             status_code=502,

--- a/surogates/browser/client.py
+++ b/surogates/browser/client.py
@@ -418,19 +418,27 @@ return await page.evaluate(() => ({{
         return result if isinstance(result, dict) else {}
 
     async def drag(self, path: list[tuple[int, int]], *, button: str = "left") -> None:
-        """Drag the mouse along a path of viewport coordinates."""
+        """Drag the mouse along a path of viewport coordinates.
+
+        Goes through Playwright's mouse rather than the kernel
+        ``/computer/drag_mouse`` endpoint: that endpoint's xdotool coordinates
+        don't map onto the page's CSS-pixel viewport — a drag aimed at y=400
+        lands near y=224 — so it grabs the wrong element. Playwright's mouse is
+        pixel-accurate against the viewport, matching ``click_at``/``scroll_at``.
+        """
 
         if len(path) < 2:
             raise ValueError("drag path must contain at least two points")
-        body: dict[str, Any] = {
-            "path": [list(point) for point in path],
-            "smooth": False,
-        }
-        if button != "left":
-            body["button"] = button
-        response = await self._http.post("/computer/drag_mouse", json=body)
-        response.raise_for_status()
-        self._invalidate_snapshot_cache()
+        button_lit = json.dumps(button)
+        steps = [f"await page.mouse.move({int(path[0][0])}, {int(path[0][1])});"]
+        steps.append(f"await page.mouse.down({{button: {button_lit}}});")
+        for x, y in path[1:]:
+            steps.append(f"await page.mouse.move({int(x)}, {int(y)});")
+        steps.append(f"await page.mouse.up({{button: {button_lit}}});")
+        steps.append("return true;")
+        # Two-tier refs re-resolve at action time, so a drag — like click and
+        # scroll — does not invalidate the snapshot cache.
+        await self._playwright_execute("\n".join(steps))
 
     async def wait(self, ms: int) -> None:
         """Sleep without changing browser state or cached refs."""
@@ -443,9 +451,15 @@ return await page.evaluate(() => ({{
         region: dict[str, int] | None = None,
         annotate: bool = False,
         save_path: str | None = None,
-        viewport_only: bool = False,
     ) -> dict[str, Any]:
-        """Capture a PNG screenshot, optionally with numbered ref overlays."""
+        """Capture a PNG screenshot, optionally with numbered ref overlays.
+
+        Always captures through Playwright's ``page.screenshot`` rather than
+        the kernel ``/computer/screenshot`` endpoint: that endpoint grabs the
+        whole X framebuffer (e.g. 3840x2160) instead of the page viewport
+        (e.g. 1905x1984), so the bytes are the wrong size and any ref-overlay
+        annotations — positioned in CSS pixels — would not line up.
+        """
 
         annotations: list[dict[str, Any]] | None = None
         if annotate:
@@ -455,32 +469,24 @@ return await page.evaluate(() => ({{
             await self._inject_overlay(annotations)
 
         try:
-            if save_path is not None or viewport_only:
-                options: dict[str, Any] = {}
-                if save_path is not None:
-                    options["path"] = save_path
-                if region is not None:
-                    options["clip"] = {
-                        "x": region["x"],
-                        "y": region["y"],
-                        "width": region["width"],
-                        "height": region["height"],
-                    }
-                encoded = await self._playwright_execute(
-                    "const options = "
-                    + json.dumps(options)
-                    + ";\n"
-                    + "const data = await page.screenshot(options);\n"
-                    + "return data.toString('base64');"
-                )
-                result: dict[str, Any] = {"png_bytes": base64.b64decode(encoded)}
-            else:
-                response = await self._http.post(
-                    "/computer/screenshot",
-                    json={} if region is None else {"region": region},
-                )
-                response.raise_for_status()
-                result = {"png_bytes": response.content}
+            options: dict[str, Any] = {}
+            if save_path is not None:
+                options["path"] = save_path
+            if region is not None:
+                options["clip"] = {
+                    "x": region["x"],
+                    "y": region["y"],
+                    "width": region["width"],
+                    "height": region["height"],
+                }
+            encoded = await self._playwright_execute(
+                "const options = "
+                + json.dumps(options)
+                + ";\n"
+                + "const data = await page.screenshot(options);\n"
+                + "return data.toString('base64');"
+            )
+            result: dict[str, Any] = {"png_bytes": base64.b64decode(encoded)}
             if annotations is not None:
                 result["annotations"] = annotations
             return result

--- a/tests/test_browser_client.py
+++ b/tests/test_browser_client.py
@@ -797,11 +797,34 @@ class TestSmallActions:
         assert "@e1" in client._snapshot_cache
 
     async def test_drag(self, client_with_transport) -> None:
-        client, handlers = client_with_transport
+        client, _handlers = client_with_transport
         client._snapshot_cache["@e1"] = {"x": 1, "y": 1, "role": "button", "name": "Go"}
-        handlers.append(("POST", "/computer/drag_mouse", 200, {"ok": True}))
+        captured: list[dict[str, Any]] = []
+
+        class CapturingTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(
+                self, request: httpx.Request
+            ) -> httpx.Response:
+                captured.append(
+                    {"path": request.url.path, "body": json.loads(request.content)}
+                )
+                return httpx.Response(200, json={"success": True, "result": True})
+
+        client._http = httpx.AsyncClient(
+            base_url=client.rest_url, transport=CapturingTransport()
+        )
         await client.drag([(10, 10), (200, 200)])
-        assert client._snapshot_cache == {}
+        # Drag goes through Playwright's mouse (down → move → up), not the kernel
+        # /computer/drag_mouse endpoint whose xdotool coords miss the target.
+        assert captured[0]["path"] == "/playwright/execute"
+        code = captured[0]["body"]["code"]
+        assert "mouse.down" in code
+        assert "mouse.move(10, 10)" in code
+        assert "mouse.move(200, 200)" in code
+        assert "mouse.up" in code
+        # Two-tier refs re-resolve at action time, so a drag no longer forces a
+        # re-snapshot — the ref survives like it does for click/scroll.
+        assert "@e1" in client._snapshot_cache
 
     async def test_wait_sleeps(self, client_with_transport) -> None:
         client, _ = client_with_transport
@@ -816,7 +839,15 @@ class TestScreenshot:
     async def test_screenshot_returns_png_bytes(self, client_with_transport) -> None:
         client, handlers = client_with_transport
         handlers.append(
-            ("POST", "/computer/screenshot", 200, PNG_MAGIC + b"fakepngbody")
+            (
+                "POST",
+                "/playwright/execute",
+                200,
+                {
+                    "success": True,
+                    "result": base64.b64encode(PNG_MAGIC + b"fakepngbody").decode(),
+                },
+            )
         )
         result = await client.screenshot()
         assert result["png_bytes"].startswith(PNG_MAGIC)
@@ -848,7 +879,7 @@ class TestScreenshot:
             transport=httpx.MockTransport(handler),
         )
 
-        result = await client.screenshot(viewport_only=True)
+        result = await client.screenshot()
 
         assert result["png_bytes"] == PNG_MAGIC + b"viewport"
         assert seen_paths == ["/playwright/execute"]
@@ -906,9 +937,16 @@ class TestScreenshot:
                 self, request: httpx.Request
             ) -> httpx.Response:
                 seen_paths.append(request.url.path)
-                if request.url.path == "/computer/screenshot":
-                    return httpx.Response(200, content=PNG_MAGIC + b"img")
                 if request.url.path == "/playwright/execute":
+                    payload = json.loads(request.content.decode())
+                    if "page.screenshot" in payload["code"]:
+                        return httpx.Response(
+                            200,
+                            json={
+                                "success": True,
+                                "result": base64.b64encode(PNG_MAGIC + b"img").decode(),
+                            },
+                        )
                     return httpx.Response(200, json={"success": True, "result": True})
                 return httpx.Response(404)
 
@@ -917,8 +955,11 @@ class TestScreenshot:
         )
         result = await client.screenshot(annotate=True)
 
-        assert seen_paths.count("/playwright/execute") == 2
-        assert seen_paths.count("/computer/screenshot") == 1
+        # Overlay inject, page.screenshot capture, overlay remove — all via CDP;
+        # the /computer/screenshot framebuffer grab is gone.
+        assert seen_paths.count("/playwright/execute") == 3
+        assert seen_paths.count("/computer/screenshot") == 0
+        assert result["png_bytes"] == PNG_MAGIC + b"img"
         assert result["annotations"] == [
             {"ref": "@e1", "label": 1, "role": "button", "name": "Go"},
             {"ref": "@e2", "label": 2, "role": "link", "name": "Help"},

--- a/tests/test_browser_route.py
+++ b/tests/test_browser_route.py
@@ -511,7 +511,7 @@ class TestPreviewEndpoint:
         assert response.headers["cache-control"] == "no-store"
         assert response.content == b"\x89PNG\r\n\x1a\npreview"
         assert seen == ["http://browser-x.svc:10001"]
-        assert screenshot_kwargs == [{"viewport_only": True}]
+        assert screenshot_kwargs == [{}]
 
     async def test_preview_unknown_session_returns_404(self, app_factory) -> None:
         build, _resolver, _control = app_factory


### PR DESCRIPTION
## Context

Follow-up to #95 (type/press_key). Same audit, same root-cause family: action tools routed through the kernel `/computer/*` endpoints operate on the **OS X display**, not the page, so they mis-target. After #95, two tools still did this. Both verified broken on a live PROD warm-pool browser.

## `browser_drag` — wrong coordinates

`/computer/drag_mouse` uses xdotool coords that don't map onto the CSS-pixel viewport. Probe overlay on a live page, requested `(300,400)→(600,400)`:

| Path | Events fired |
|---|---|
| `/computer/drag_mouse` | `mousedown@290,224 … mouseup@590,224` — **off by ~176px in Y** |
| `page.mouse` down/move/up | `mousedown@300,400 … mouseup@600,400` — exact ✓ |

A drag grabs whatever sits ~176px above the intended element.

## `browser_screenshot` — 4K framebuffer instead of the page

`/computer/screenshot` (the default path when a session has no local workspace path) captures the whole X framebuffer:

| Path | Dimensions (viewport is 1905×1984, DPR 1) |
|---|---|
| `/computer/screenshot` | **3840×2160** (the 4K desktop) |
| `page.screenshot` | 1905×1984 (the viewport) ✓ |

Annotation overlays (CSS pixels) and any coordinates derived from such a screenshot land in the wrong space.

## Fix

Both move to Playwright over `/playwright/execute`, matching `click_at`/`scroll_at`/`type_text`:
- `drag` → `page.mouse.down/move/up` (pixel-accurate; no longer invalidates the snapshot cache, consistent with the two-tier refs).
- `screenshot` → always `page.screenshot`; the now-dead `viewport_only` flag (previously the workaround to force this path) is removed along with its one route call site.

**No `/computer/*` calls remain in the browser client** — every browser action now goes through CDP.

## Tests

`tests/test_browser_client.py` / `test_browser_route.py` updated to the Playwright path (drag asserts `mouse.down/move/up` + ref survival; screenshot asserts CDP capture, no `/computer/screenshot`). `266 passed` across the browser suite (only the pre-existing, unrelated `test_browser_image` Dockerfile assertion fails on master too).