### PR TITLE
fix(harness): heartbeat and bound the non-streaming LLM fallback

### DIFF
--- a/surogates/harness/llm_call.py
+++ b/surogates/harness/llm_call.py
@@ -14,11 +14,14 @@ Provides standalone async functions for calling LLMs with:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import time
 from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import urlparse
+
+import httpx
 
 from surogates.harness.message_utils import (
     message_to_dict,
@@ -128,6 +131,45 @@ STREAM_HEARTBEAT_INTERVAL: float = 15.0
 # dead-end was ~60 KB (well over); iter-4 legitimate was ~5 KB (well
 # under).  Configurable for testing only -- no env var.
 RUNAWAY_REASONING_CHAR_THRESHOLD: int = 16_000
+
+# Non-streaming fallback request timeouts.  The ``read`` budget is the
+# same reasoning-aware ceiling the streaming watchdog uses
+# (``compute_stream_stale_timeout``) so a non-streaming call gets the
+# generous reasoning window but is still bounded; ``connect``/``write``/
+# ``pool`` are tight so a hung socket cannot add minutes on top.  Without
+# this, the non-streaming fallback inherited the ``AsyncOpenAI`` default
+# (600s, no reasoning-awareness) and -- defeated by upstream keepalive
+# bytes on the proxy side -- blocked for minutes with the UI frozen.
+NON_STREAMING_CONNECT_TIMEOUT: float = 10.0
+NON_STREAMING_WRITE_TIMEOUT: float = 30.0
+NON_STREAMING_POOL_TIMEOUT: float = 10.0
+
+
+def compute_non_streaming_timeout(
+    create_kwargs: dict[str, Any],
+    *,
+    base_url: str = "",
+) -> httpx.Timeout | None:
+    """Per-request transport timeout for a non-streaming LLM call.
+
+    Returns ``None`` when the upstream is local and uncapped (mirroring
+    the streaming watchdog's local exemption), so the caller leaves the
+    client default in place rather than imposing a finite bound.
+    """
+    read = compute_stream_stale_timeout(
+        create_kwargs.get("messages"),
+        base_url=base_url,
+        model=str(create_kwargs.get("model", "")),
+    )
+    if read == float("inf"):
+        return None
+    return httpx.Timeout(
+        connect=NON_STREAMING_CONNECT_TIMEOUT,
+        read=read,
+        write=NON_STREAMING_WRITE_TIMEOUT,
+        pool=NON_STREAMING_POOL_TIMEOUT,
+    )
+
 
 _LOCAL_STREAM_HOSTS: frozenset[str] = frozenset({
     "localhost",
@@ -521,6 +563,9 @@ async def call_llm_with_retry(
                     create_kwargs=create_kwargs,
                     iteration=iteration,
                     llm_client=llm_client,
+                    store=store,
+                    turn_id=turn_id,
+                    iteration_index=iteration_index,
                 )
 
             # Response shape validation.
@@ -1054,6 +1099,9 @@ async def call_llm_streaming(
                 create_kwargs=create_kwargs,
                 iteration=iteration,
                 llm_client=llm_client,
+                store=store,
+                turn_id=turn_id,
+                iteration_index=iteration_index,
             )
         except Exception as fallback_exc:
             # The streaming error carries the real provider detail (e.g.
@@ -1534,14 +1582,74 @@ async def call_llm_streaming_inner(
 # ---------------------------------------------------------------------------
 
 
+async def _await_with_heartbeats(
+    coro: Any,
+    *,
+    session: Session,
+    store: SessionStore,
+    iteration: int,
+    turn_id: str | None,
+    iteration_index: int | None,
+) -> Any:
+    """Await *coro*, emitting ``LLM_HEARTBEAT`` while it is in flight.
+
+    A non-streaming call produces no ``llm.delta`` events, so without this
+    the session emits nothing for the whole (potentially minute-scale)
+    wait and the UI looks frozen.  Heartbeats mirror the streaming
+    watchdog's payload so the client renders them identically.  A failed
+    heartbeat emit is logged and ignored -- it must never mask the real
+    LLM result or error, which ``task.result()`` re-raises faithfully.
+    """
+    task = asyncio.ensure_future(coro)
+    start = time.monotonic()
+    try:
+        while True:
+            done, _ = await asyncio.wait(
+                {task}, timeout=STREAM_HEARTBEAT_INTERVAL,
+            )
+            if task in done:
+                return task.result()
+            try:
+                await store.emit_event(
+                    session.id,
+                    EventType.LLM_HEARTBEAT,
+                    {
+                        "iteration": iteration,
+                        "silent_for_seconds": round(time.monotonic() - start, 1),
+                        "turn_id": turn_id,
+                        "iteration_index": iteration_index,
+                        "phase": "non_streaming",
+                    },
+                )
+            except Exception:
+                logger.debug(
+                    "Non-streaming heartbeat emit failed for session %s",
+                    session.id,
+                    exc_info=True,
+                )
+    finally:
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(BaseException):
+                await task
+
+
 async def call_llm_non_streaming(
     *,
     session: Session,
     create_kwargs: dict[str, Any],
     iteration: int,
     llm_client: AsyncOpenAI,
+    store: SessionStore | None = None,
+    turn_id: str | None = None,
+    iteration_index: int | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Call the LLM without streaming. Returns (message_dict, usage_dict)."""
+    """Call the LLM without streaming. Returns (message_dict, usage_dict).
+
+    When ``store`` is provided, ``LLM_HEARTBEAT`` events are emitted while
+    the (otherwise event-silent) request is in flight, so the UI shows the
+    same "model is working" motion it gets from a streaming turn.
+    """
     # Inject prompt cache extra_body for cacheable models.
     final_kwargs = dict(create_kwargs)
     model_id = final_kwargs.get("model", "")
@@ -1551,7 +1659,30 @@ async def call_llm_non_streaming(
         merged = {**existing_extra, **cache_extra}
         final_kwargs["extra_body"] = merged
 
-    response = await llm_client.chat.completions.create(**final_kwargs)
+    # Bound the call so a stalled non-streaming response fails fast and is
+    # handled by the retry layer instead of blocking on the client default.
+    # An explicit per-request ``timeout`` overrides the client ceiling; a
+    # breach raises ``openai.APITimeoutError``, which ``call_llm_with_retry``
+    # classifies as retryable.  ``None`` (local upstream) leaves the client
+    # default in place.
+    request_timeout = compute_non_streaming_timeout(
+        final_kwargs, base_url=str(getattr(llm_client, "base_url", "") or ""),
+    )
+    if request_timeout is not None:
+        final_kwargs["timeout"] = request_timeout
+
+    create_call = llm_client.chat.completions.create(**final_kwargs)
+    if store is None:
+        response = await create_call
+    else:
+        response = await _await_with_heartbeats(
+            create_call,
+            session=session,
+            store=store,
+            iteration=iteration,
+            turn_id=turn_id,
+            iteration_index=iteration_index,
+        )
 
     # Response shape validation.
     if response is None or not getattr(response, "choices", None):

--- a/tests/test_llm_call_timeout.py
+++ b/tests/test_llm_call_timeout.py
@@ -1,0 +1,208 @@
+"""Non-streaming LLM calls must stay observable and time-bounded.
+
+Two regressions from the frozen-session incident:
+- a non-streaming fallback inherited the AsyncOpenAI default timeout and
+  could block for minutes -> give it an explicit, reasoning-aware
+  per-request timeout (the SDK's own retries are left in place);
+- a non-streaming call emits no events, so the UI looked frozen for the
+  whole wait -> emit LLM_HEARTBEAT while the request is in flight.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from surogates.harness.llm_call import (
+    NON_STREAMING_CONNECT_TIMEOUT,
+    NON_STREAMING_POOL_TIMEOUT,
+    NON_STREAMING_WRITE_TIMEOUT,
+    STREAM_STALE_TIMEOUT,
+    STREAM_STALE_TIMEOUT_REASONING,
+    call_llm_non_streaming,
+    compute_non_streaming_timeout,
+)
+from surogates.session.events import EventType
+
+_PROXY_URL = "https://proxy.test/v1"
+
+
+def _make_session():
+    return SimpleNamespace(id=uuid4(), config={}, model="glm-5.2")
+
+
+def _fake_response(model: str = "glm-5.2"):
+    message = SimpleNamespace(role="assistant", content="hello")
+    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=usage, model=model)
+
+
+def _fake_client(base_url: str = _PROXY_URL, response=None):
+    create = AsyncMock(return_value=response or _fake_response())
+    return SimpleNamespace(
+        base_url=base_url,
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+    ), create
+
+
+# --- compute_non_streaming_timeout ----------------------------------------
+
+
+def test_reasoning_model_gets_reasoning_ceiling() -> None:
+    timeout = compute_non_streaming_timeout(
+        {"model": "glm-5.2", "messages": []}, base_url=_PROXY_URL,
+    )
+    assert isinstance(timeout, httpx.Timeout)
+    assert timeout.read == STREAM_STALE_TIMEOUT_REASONING
+    assert timeout.connect == NON_STREAMING_CONNECT_TIMEOUT
+    assert timeout.write == NON_STREAMING_WRITE_TIMEOUT
+    assert timeout.pool == NON_STREAMING_POOL_TIMEOUT
+
+
+def test_plain_model_gets_base_ceiling() -> None:
+    timeout = compute_non_streaming_timeout(
+        {"model": "gpt-4o", "messages": []}, base_url=_PROXY_URL,
+    )
+    assert isinstance(timeout, httpx.Timeout)
+    assert timeout.read == STREAM_STALE_TIMEOUT
+
+
+def test_local_upstream_is_uncapped() -> None:
+    # A local model stays uncapped (mirrors the streaming watchdog), so the
+    # caller leaves the client default in place instead of a finite bound.
+    assert (
+        compute_non_streaming_timeout(
+            {"model": "glm-5.2", "messages": []},
+            base_url="http://127.0.0.1:8000/v1",
+        )
+        is None
+    )
+
+
+# --- call_llm_non_streaming applies the timeout ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_passes_reasoning_timeout() -> None:
+    client, create = _fake_client()
+    await call_llm_non_streaming(
+        session=_make_session(),
+        create_kwargs={"model": "glm-5.2", "messages": [{"role": "user", "content": "hi"}]},
+        iteration=1,
+        llm_client=client,
+    )
+    timeout = create.await_args.kwargs["timeout"]
+    assert isinstance(timeout, httpx.Timeout)
+    assert timeout.read == STREAM_STALE_TIMEOUT_REASONING
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_local_omits_timeout() -> None:
+    client, create = _fake_client(base_url="http://localhost:8000/v1")
+    await call_llm_non_streaming(
+        session=_make_session(),
+        create_kwargs={"model": "glm-5.2", "messages": []},
+        iteration=1,
+        llm_client=client,
+    )
+    assert "timeout" not in create.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_timeout_propagates() -> None:
+    # A timeout surfaces as the underlying error; the retry layer (and the
+    # SDK's own retries, left in place) handle it.
+    client, create = _fake_client()
+    create.side_effect = httpx.ReadTimeout("stalled")
+    with pytest.raises(httpx.ReadTimeout):
+        await call_llm_non_streaming(
+            session=_make_session(),
+            create_kwargs={"model": "glm-5.2", "messages": []},
+            iteration=1,
+            llm_client=client,
+        )
+
+
+# --- non-streaming heartbeats keep the UI alive during the wait ----------
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_emits_heartbeats(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "surogates.harness.llm_call.STREAM_HEARTBEAT_INTERVAL", 0.02,
+    )
+
+    async def slow_create(**kwargs):
+        await asyncio.sleep(0.07)
+        return _fake_response()
+
+    client = SimpleNamespace(
+        base_url=_PROXY_URL,
+        chat=SimpleNamespace(completions=SimpleNamespace(create=slow_create)),
+    )
+    store = SimpleNamespace(emit_event=AsyncMock())
+
+    message, _usage = await call_llm_non_streaming(
+        session=_make_session(),
+        create_kwargs={"model": "glm-5.2", "messages": []},
+        iteration=3,
+        llm_client=client,
+        store=store,
+        turn_id="t1",
+        iteration_index=2,
+    )
+
+    assert message["content"] == "hello"
+    beats = [
+        c for c in store.emit_event.await_args_list
+        if c.args[1] == EventType.LLM_HEARTBEAT
+    ]
+    assert beats, "expected at least one heartbeat during the slow call"
+    payload = beats[0].args[2]
+    assert payload["iteration"] == 3
+    assert payload["phase"] == "non_streaming"
+    assert payload["turn_id"] == "t1"
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_without_store_emits_nothing() -> None:
+    client, _create = _fake_client()
+    message, _usage = await call_llm_non_streaming(
+        session=_make_session(),
+        create_kwargs={"model": "glm-5.2", "messages": []},
+        iteration=1,
+        llm_client=client,
+    )
+    assert message["content"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_heartbeat_path_propagates_error(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "surogates.harness.llm_call.STREAM_HEARTBEAT_INTERVAL", 0.02,
+    )
+
+    async def failing_create(**kwargs):
+        await asyncio.sleep(0.03)
+        raise httpx.ReadTimeout("stalled")
+
+    client = SimpleNamespace(
+        base_url=_PROXY_URL,
+        chat=SimpleNamespace(completions=SimpleNamespace(create=failing_create)),
+    )
+    store = SimpleNamespace(emit_event=AsyncMock())
+
+    with pytest.raises(httpx.ReadTimeout):
+        await call_llm_non_streaming(
+            session=_make_session(),
+            create_kwargs={"model": "glm-5.2", "messages": []},
+            iteration=1,
+            llm_client=client,
+            store=store,
+        )


### PR DESCRIPTION
## Why

Investigation of a frozen production session (`844d37d3…`, agent `77147f7f…`) found a turn that ran **~14 minutes** with the UI frozen on "thinking". Root causes, in the harness:

1. The **non-streaming fallback** inherited the `AsyncOpenAI` defaults (600s read, `max_retries=2`), so a stalled call — defeated by upstream **keepalive bytes** on the proxy — blocked for minutes and silently tripled under SDK retries.
2. A non-streaming call emits **no events**, so the session was dead-silent for the whole wait → UI looked frozen.
3. The reasoning **token budget (4096) never reached GLM-via-OpenRouter**: it was sent only in DashScope's `thinking_budget` form, which GLM silently drops — so GLM ran away to 16k+ chars before the char-threshold guard force-killed it (and the `enable_thinking=False` recovery was dropped the same way).

## What

- **Explicit client timeouts + `max_retries=0`** on every harness `AsyncOpenAI` client, so the harness retry layer is the single source of retry truth and no call inherits the unbounded SDK default. (`session_llm.py`)
- **Per-request, reasoning-aware timeout** on the non-streaming fallback, mirroring the streaming watchdog ceiling; breaches surface as `APITimeoutError` (already classified retryable). (`llm_call.py`)
- **Heartbeats during the non-streaming wait** — `LLM_HEARTBEAT` every 15s (tagged `phase="non_streaming"`) so the UI shows motion; result/error re-raised faithfully, request cancelled cleanly on interrupt. (`llm_call.py`)
- **Emit OpenRouter's normalized `reasoning` object** in `build_thinking_extra_body` (`{enabled:false}` when disabled — disable wins over budget — else `{max_tokens:N}` clamped to OpenRouter's 1024 floor), so the 4096 cap and thinking-off recovery actually take effect on GLM. (`expert_routing.py`)

## Testing

- New: `tests/test_llm_call_timeout.py` (timeouts + heartbeats), `tests/test_thinking_reasoning_param.py` (reasoning shape); updated exact-shape assertions in `tests/test_autothink_and_self_discover.py`.
- All targeted/related suites green (47 passing); the only broad-sweep failures are pre-existing integration/testcontainers failures (verified identical on `master`).
- Passed `/code-review` and `/simplify`.

## Rollout note

The `reasoning` object is gated by model name (glm/qwen/qwq/surogate), not provider. PROD is safe (all roles route through OpenRouter, which documents `reasoning`). Validate before pointing one of those models directly at a strict non-OpenRouter endpoint (e.g. DashScope/self-hosted vLLM) that might reject an unknown field rather than dropping it.