### PR TITLE
fix(channels): provision channel-session workspaces; guard empty skill_view name

### DIFF
--- a/surogates/channels/identity.py
+++ b/surogates/channels/identity.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from surogates.db.models import ChannelIdentity as ChannelIdentityRow
 from surogates.db.models import Session as SessionRow
 from surogates.session.events import EventType
+from surogates.session.provisioning import stamp_workspace_config
 from surogates.session.store import SessionStore
 
 logger = logging.getLogger(__name__)
@@ -306,6 +307,8 @@ async def get_or_create_channel_session(
     config: dict,
     session_factory: async_sessionmaker[AsyncSession],
     model: str = "",
+    storage: object = None,
+    settings: object = None,
 ) -> UUID:
     """Find an existing active session for the channel routing key, or create one.
 
@@ -361,6 +364,29 @@ async def get_or_create_channel_session(
         "channel_session_key": session_key,
         **config,
     }
+    # Provision a persistent workspace (storage_bucket/storage_key_prefix/
+    # workspace_path) the same way API/web sessions do, so the worker mounts a
+    # persistent /workspace and inbound attachments can be written there. A
+    # storage failure here must NOT abort session creation — that would 500 the
+    # inbound webhook and trigger platform retries — so degrade to a
+    # workspace-less session and log instead.
+    if storage is not None and settings is not None:
+        try:
+            await stamp_workspace_config(
+                merged_config,
+                storage=storage,
+                settings=settings,
+                session_id=session_id,
+                model=model,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to provision workspace for %s session %s; "
+                "creating it without one",
+                channel,
+                session_id,
+                exc_info=True,
+            )
     await session_store.create_session(
         session_id=session_id,
         user_id=user_id,

--- a/surogates/channels/runner.py
+++ b/surogates/channels/runner.py
@@ -92,6 +92,7 @@ def _make_deps_factory(
     mate_settings_cache: Any = None,
     link_url_base: str = "",
     storage: Any = None,
+    settings: Any = None,
 ) -> Any:
     """Return a deps_factory for :class:`ChannelWebhookDispatcher`.
 
@@ -127,6 +128,18 @@ def _make_deps_factory(
         session_factory, resolve=resolve_real_identity, provision=None,
     )
     pairing = PairingStore(redis)
+
+    async def _get_or_create(*args: Any, **kwargs: Any) -> Any:
+        """Create the channel session WITH a persistent workspace.
+
+        Injects the storage backend + settings so new channel sessions are
+        provisioned a workspace (storage_bucket/key_prefix/workspace_path) the
+        same way API/web sessions are — otherwise the worker mounts no
+        /workspace and inbound attachments are skipped.
+        """
+        return await get_or_create_channel_session(
+            *args, storage=storage, settings=settings, **kwargs
+        )
 
     def _link_prompt(code: str) -> str:
         where = (
@@ -306,7 +319,7 @@ def _make_deps_factory(
             redis=redis,
             state=state,
             firehose_append=append_channel_observation,
-            get_or_create_session=get_or_create_channel_session,
+            get_or_create_session=_get_or_create,
             enqueue_session=enqueue_session,
             resolve_identity=resolve_identity,
             session_factory=session_factory,
@@ -392,6 +405,7 @@ def build_channels_app(
         mate_settings_cache=mate_settings_cache,
         link_url_base=getattr(getattr(settings, "channels", None), "studio_url", ""),
         storage=storage,
+        settings=settings,
     )
 
     dispatcher = ChannelWebhookDispatcher(

--- a/surogates/harness/api_client.py
+++ b/surogates/harness/api_client.py
@@ -147,6 +147,13 @@ class HarnessAPIClient:
         Forwards the client's ``session_id`` (if set) to the API so that
         supporting files get auto-staged into the session workspace.
         """
+        if not name or not name.strip():
+            # An empty name would build "/v1/skills/" and 307-redirect into an
+            # opaque error; reject it with a clear message instead.
+            return json.dumps(
+                {"success": False, "error": "Skill name is required."},
+                ensure_ascii=False,
+            )
         params: dict[str, Any] = {}
         if self._session_id is not None:
             params["session_id"] = self._session_id

--- a/surogates/session/provisioning.py
+++ b/surogates/session/provisioning.py
@@ -21,6 +21,33 @@ _WORKSPACE_SHARING_FIELDS = (
 )
 
 
+async def stamp_workspace_config(
+    config: dict,
+    *,
+    storage: Any,
+    settings: Any,
+    session_id: UUID,
+    model: str,
+) -> dict:
+    """Stamp the persistent-workspace fields into *config* and ensure the bucket exists.
+
+    Sets ``storage_bucket``, ``storage_key_prefix``, ``workspace_path`` and
+    ``supports_vision`` so the worker mounts a persistent S3 ``/workspace`` for
+    the session. Shared by API/web provisioning (:func:`create_agent_session`)
+    and channel-session provisioning so both yield an identical workspace.
+    """
+    bucket = agent_session_bucket(settings.storage.bucket)
+    await storage.create_bucket(bucket)
+    config["storage_bucket"] = bucket
+    config["storage_key_prefix"] = getattr(settings.storage, "key_prefix", "") or ""
+    config["workspace_path"] = storage.resolve_workspace_path(bucket, session_id)
+    model_info = get_model_info(model)
+    config["supports_vision"] = (
+        model_info.supports_vision if model_info is not None else False
+    )
+    return config
+
+
 async def create_agent_session(
     *,
     store: SessionStore,
@@ -38,19 +65,10 @@ async def create_agent_session(
     session_id: UUID | None = None,
 ) -> Session:
     sid = session_id or uuid4()
-    bucket = agent_session_bucket(settings.storage.bucket)
-    await storage.create_bucket(bucket)
 
     merged_config = dict(config or {})
-    merged_config["storage_bucket"] = bucket
-    merged_config["storage_key_prefix"] = (
-        getattr(settings.storage, "key_prefix", "") or ""
-    )
-    merged_config["workspace_path"] = storage.resolve_workspace_path(bucket, sid)
-
-    model_info = get_model_info(model)
-    merged_config["supports_vision"] = (
-        model_info.supports_vision if model_info is not None else False
+    await stamp_workspace_config(
+        merged_config, storage=storage, settings=settings, session_id=sid, model=model,
     )
     if service_account_id is not None:
         merged_config["service_account_id"] = str(service_account_id)

--- a/surogates/tools/builtin/skills.py
+++ b/surogates/tools/builtin/skills.py
@@ -341,6 +341,16 @@ async def _skill_view_handler(
     name = arguments.get("name", "")
     file_path = arguments.get("file_path")
 
+    # Validate before either path: an empty name on the API-mediated path would
+    # build the URL "/v1/skills/", which 307-redirects to the list endpoint and
+    # surfaces an opaque error to the agent. Reject it the same way the local
+    # path already does.
+    if not name or not name.strip():
+        return json.dumps(
+            {"success": False, "error": "Skill name is required."},
+            ensure_ascii=False,
+        )
+
     # API-mediated mode: delegate to the API server.
     api_client = kwargs.get("api_client")
     if api_client is not None:
@@ -349,12 +359,6 @@ async def _skill_view_handler(
     tenant = kwargs.get("tenant")
     if tenant is None:
         return json.dumps({"error": "No tenant context available"})
-
-    if not name:
-        return json.dumps(
-            {"success": False, "error": "Skill name is required."},
-            ensure_ascii=False,
-        )
 
     skills = await _load_all_skills(**kwargs)
 

--- a/tests/test_channel_session_workspace.py
+++ b/tests/test_channel_session_workspace.py
@@ -1,0 +1,150 @@
+"""Channel sessions must be provisioned with a persistent workspace.
+
+A channel (Slack/Telegram) session created with a storage backend + settings
+should carry storage_bucket / storage_key_prefix / workspace_path in its config —
+the same fields API/web sessions get via create_agent_session — so the worker
+mounts a persistent /workspace and inbound attachments can be written there.
+Without those fields the worker mounts no workspace and attachments are skipped.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import mock
+from uuid import uuid4
+
+from surogates.channels.identity import get_or_create_channel_session
+
+
+class _Result:
+    def scalar_one_or_none(self):
+        return None
+
+
+class _DB:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, *a, **k):
+        return _Result()
+
+
+class _SessionFactory:
+    def __call__(self):
+        return _DB()
+
+
+class _Store:
+    def __init__(self):
+        self.created: dict | None = None
+
+    async def create_session(self, **kwargs):
+        self.created = kwargs
+        return SimpleNamespace(**kwargs)
+
+
+class _Storage:
+    def __init__(self):
+        self.created_bucket = None
+
+    async def create_bucket(self, bucket):
+        self.created_bucket = bucket
+
+    def resolve_workspace_path(self, bucket, sid):
+        return f"/ws/{bucket}/{sid}"
+
+
+def _settings():
+    return SimpleNamespace(
+        storage=SimpleNamespace(bucket="surogate-workspaces-dev", key_prefix="p1/a1"),
+    )
+
+
+class TestChannelSessionWorkspace:
+    async def test_provisions_workspace_when_storage_and_settings_given(self):
+        store = _Store()
+        storage = _Storage()
+        with mock.patch(
+            "surogates.session.provisioning.get_model_info",
+            return_value=SimpleNamespace(supports_vision=False),
+        ):
+            await get_or_create_channel_session(
+                store,
+                None,
+                session_key="agent:slack:dm:D1",
+                user_id=uuid4(),
+                org_id=uuid4(),
+                agent_id="a1",
+                channel="slack",
+                config={"slack_channel_id": "D1", "memory_boundary": "slack:d:D1"},
+                session_factory=_SessionFactory(),
+                storage=storage,
+                settings=_settings(),
+            )
+        cfg = store.created["config"]
+        sid = store.created["session_id"]
+        assert cfg["storage_bucket"] == "surogate-workspaces-dev"
+        assert cfg["storage_key_prefix"] == "p1/a1"
+        assert cfg["workspace_path"] == f"/ws/surogate-workspaces-dev/{sid}"
+        # Channel-specific config is preserved alongside the workspace fields.
+        assert cfg["channel_session_key"] == "agent:slack:dm:D1"
+        assert cfg["slack_channel_id"] == "D1"
+        assert storage.created_bucket == "surogate-workspaces-dev"
+
+    async def test_workspace_provision_failure_degrades_gracefully(self):
+        # A storage error while provisioning the workspace (e.g. create_bucket
+        # fails, or an empty configured bucket) must NOT abort session creation —
+        # otherwise the inbound webhook 500s and the platform retries. The session
+        # is created workspace-less and the message still processes.
+        class _FailStorage:
+            async def create_bucket(self, bucket):
+                raise RuntimeError("storage unavailable")
+
+            def resolve_workspace_path(self, bucket, sid):
+                return f"/ws/{sid}"
+
+        store = _Store()
+        with mock.patch(
+            "surogates.session.provisioning.get_model_info",
+            return_value=SimpleNamespace(supports_vision=False),
+        ):
+            sid = await get_or_create_channel_session(
+                store,
+                None,
+                session_key="agent:slack:dm:D2",
+                user_id=uuid4(),
+                org_id=uuid4(),
+                agent_id="a1",
+                channel="slack",
+                config={"slack_channel_id": "D2"},
+                session_factory=_SessionFactory(),
+                storage=_FailStorage(),
+                settings=_settings(),
+            )
+        # Session still created (no exception propagated), just without a workspace.
+        assert sid == store.created["session_id"]
+        cfg = store.created["config"]
+        assert "storage_bucket" not in cfg
+        assert cfg["channel_session_key"] == "agent:slack:dm:D2"
+
+    async def test_skips_workspace_without_storage_or_settings(self):
+        # Backward compat: a caller that does not supply storage+settings creates
+        # a session with no workspace fields (the pre-fix behavior).
+        store = _Store()
+        await get_or_create_channel_session(
+            store,
+            None,
+            session_key="k",
+            user_id=uuid4(),
+            org_id=uuid4(),
+            agent_id="a1",
+            channel="slack",
+            config={"slack_channel_id": "D1"},
+            session_factory=_SessionFactory(),
+        )
+        cfg = store.created["config"]
+        assert "storage_bucket" not in cfg
+        assert cfg["channel_session_key"] == "k"

--- a/tests/test_skill_view_handler.py
+++ b/tests/test_skill_view_handler.py
@@ -243,6 +243,58 @@ class TestDiskBackedSkill:
 
 
 @pytest.mark.asyncio
+class TestEmptyNameApiMediated:
+    """An empty/missing name must be rejected on BOTH the local and the
+    API-mediated paths. Forwarding an empty name to the API server builds
+    ``/v1/skills/`` which 307-redirects, surfacing an opaque error to the agent.
+    """
+
+    async def test_empty_name_not_forwarded_to_api(self) -> None:
+        class _ExplodingApiClient:
+            async def view_skill(self, name: str, file_path: Any = None) -> str:
+                raise AssertionError(
+                    "view_skill must not be called with an empty name"
+                )
+
+        payload = json.loads(
+            await _skill_view_handler(
+                {"name": ""},
+                api_client=_ExplodingApiClient(),
+            )
+        )
+        assert payload["success"] is False
+        assert "name is required" in payload["error"].lower()
+
+    async def test_missing_name_not_forwarded_to_api(self) -> None:
+        class _ExplodingApiClient:
+            async def view_skill(self, name: str, file_path: Any = None) -> str:
+                raise AssertionError("view_skill must not be called")
+
+        payload = json.loads(
+            await _skill_view_handler({}, api_client=_ExplodingApiClient())
+        )
+        assert payload["success"] is False
+        assert "name is required" in payload["error"].lower()
+
+    async def test_valid_name_still_delegates_to_api(self) -> None:
+        seen: dict[str, Any] = {}
+
+        class _RecordingApiClient:
+            async def view_skill(self, name: str, file_path: Any = None) -> str:
+                seen["name"] = name
+                return json.dumps({"success": True, "name": name})
+
+        payload = json.loads(
+            await _skill_view_handler(
+                {"name": "wiki"},
+                api_client=_RecordingApiClient(),
+            )
+        )
+        assert seen["name"] == "wiki"
+        assert payload["success"] is True
+
+
+@pytest.mark.asyncio
 class TestUnknownSkill:
     async def test_unknown_name_returns_helpful_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Two fixes surfaced while testing Mate channel attachments.

## Channel-session workspace provisioning
Channel (Slack/Telegram) sessions were created without `storage_bucket`, so the worker mounted no persistent `/workspace` ([tool_exec.py gates the S3 mount on it](https://github.com/invergent-ai/surogates/blob/master/surogates/harness/tool_exec.py)) and inbound document attachments were silently skipped — and the just-added outbound `MEDIA:` feature had no workspace to read produced files from. Extract `stamp_workspace_config()` (shared with `create_agent_session`) and apply it in `get_or_create_channel_session` via a deps closure that injects `storage`+`settings`. A storage failure degrades to a workspace-less session and logs, so a storage blip/misconfig can't 500 the inbound webhook and trigger platform retries.

## skill_view empty-name guard
An empty/missing `skill_view` name was forwarded to the API server, building `/v1/skills/` which 307-redirects and surfaced an opaque error to the agent in shared-runtime mode. Move the existing "name required" validation above the `api_client` delegation, and guard `api_client.view_skill` so it can never build that URL.

Tests: new RED→GREEN coverage for both fixes; 349 passing across the channels/provisioning/skills blast radius.