### PR TITLE
feat(harness): hide a channel agent's own-platform Composio toolkit

### DIFF
--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -3189,7 +3189,11 @@ class AgentHarness(
         so native or non-Composio tools are never caught. A no-op when the
         channel has no mapped toolkit or the agent has no Composio tools.
         """
-        toolkit = CHANNEL_NATIVE_COMPOSIO_TOOLKIT.get(session.channel or "")
+        # Ambient sessions act in a Slack channel (they carry slack_channel_id)
+        # but their session.channel is "ambient"; resolve to the slack platform
+        # like the worker does (worker.py: _platform = "slack" if _is_ambient).
+        channel = "slack" if session.channel == "ambient" else (session.channel or "")
+        toolkit = CHANNEL_NATIVE_COMPOSIO_TOOLKIT.get(channel)
         if not toolkit or not self._composio_tool_names:
             return tool_filter
         prefix = f"{toolkit}_"

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -178,6 +178,19 @@ def _build_mission_judge(*, llm_client: Any, eval_model: str) -> Any:
     )
 
 
+# Channel platforms whose native I/O supersedes a Composio toolkit. A channel
+# agent should use the native channel path, not Composio's same-named toolkit
+# (a different connection/identity). Slack only in v1; extend as needed.
+CHANNEL_NATIVE_COMPOSIO_TOOLKIT: dict[str, str] = {"slack": "SLACK"}
+
+
+def _mcp_tool_component(name: str) -> str:
+    """The bare tool component of a (possibly MCP-prefixed) tool name.
+
+    ``mcp__tool_router__SLACK_SEND_MESSAGE`` -> ``SLACK_SEND_MESSAGE``;
+    a non-prefixed name is returned unchanged.
+    """
+    return name.rsplit("__", 1)[-1]
 
 
 
@@ -3165,6 +3178,30 @@ class AgentHarness(
             mcp_allowed = self._mcp_tool_names & all_names
         return non_mcp | mcp_allowed
 
+    def _drop_native_channel_composio_tools(
+        self, tool_filter: set[str] | None, session: Session,
+    ) -> set[str] | None:
+        """Remove the session channel's own Composio toolkit from *tool_filter*.
+
+        For a Slack channel session, drop the agent's Composio ``SLACK_*`` tools
+        so it uses the native channel I/O. Only the channel's own toolkit is
+        affected; the drop set is intersected with ``self._composio_tool_names``
+        so native or non-Composio tools are never caught. A no-op when the
+        channel has no mapped toolkit or the agent has no Composio tools.
+        """
+        toolkit = CHANNEL_NATIVE_COMPOSIO_TOOLKIT.get(session.channel or "")
+        if not toolkit or not self._composio_tool_names:
+            return tool_filter
+        prefix = f"{toolkit}_"
+        drop = {
+            n for n in self._composio_tool_names
+            if _mcp_tool_component(n).startswith(prefix)
+        }
+        if not drop:
+            return tool_filter
+        names = set(self._tools.tool_names) if tool_filter is None else set(tool_filter)
+        return names - drop
+
     def _tool_filter_for_session(self, session: Session) -> set[str] | None:
         """Return the tool allow-list for a session."""
         config = session.config or {}
@@ -3235,6 +3272,7 @@ class AgentHarness(
             tool_filter = self._apply_mcp_schema_filter(
                 tool_filter, explicit_allowed=explicit_allowed,
             )
+            tool_filter = self._drop_native_channel_composio_tools(tool_filter, session)
             return self._ensure_always_available_tools(
                 tool_filter, explicit_allowed=explicit_allowed,
             )
@@ -3246,6 +3284,7 @@ class AgentHarness(
         tool_filter = self._apply_mcp_schema_filter(
             tool_filter, explicit_allowed=explicit_allowed,
         )
+        tool_filter = self._drop_native_channel_composio_tools(tool_filter, session)
         return self._ensure_always_available_tools(
             tool_filter, explicit_allowed=explicit_allowed,
         )

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -369,6 +369,7 @@ class AgentHarness(
         bundle: Any | None = None,
         turn_gate: Any | None = None,
         mcp_tool_names: frozenset[str] | None = None,
+        composio_tool_names: frozenset[str] | None = None,
         slash_commands: SlashCommandConfig | None = None,
     ) -> None:
         self._store = session_store
@@ -377,6 +378,10 @@ class AgentHarness(
         # proxy.  The registry is process-wide; this scopes the
         # model-visible schema set to the agent's own MCP tools.
         self._mcp_tool_names: frozenset[str] = frozenset(mcp_tool_names or ())
+        # Subset of ``_mcp_tool_names`` from the Composio tool-router; used to
+        # hide a channel agent's own-platform Composio toolkit (see
+        # ``_drop_native_channel_composio_tools``).
+        self._composio_tool_names: frozenset[str] = frozenset(composio_tool_names or ())
         # Per-agent slash-command gating.  Defaults to permissive so a
         # session resolved before this was wired keeps every command.
         self._slash_commands: SlashCommandConfig = (

--- a/surogates/orchestrator/mcp_client.py
+++ b/surogates/orchestrator/mcp_client.py
@@ -20,6 +20,18 @@ from surogates.tools.registry import ToolRegistry, ToolSchema
 
 logger = logging.getLogger(__name__)
 
+# Composio's tool-router is exposed as a single MCP server; its tools carry
+# one of these server-name prefixes (the second is the non-debranded fallback).
+COMPOSIO_TOOL_ROUTER_PREFIXES: tuple[str, ...] = (
+    "mcp__tool_router__",
+    "mcp__composio_tool_router__",
+)
+
+
+def is_composio_router_name(name: str) -> bool:
+    """True if *name* is an MCP tool advertised by the Composio tool-router."""
+    return name.startswith(COMPOSIO_TOOL_ROUTER_PREFIXES)
+
 
 class McpProxyClient:
     """HTTP client that proxies MCP tool calls through the MCP proxy service.
@@ -40,6 +52,9 @@ class McpProxyClient:
         # ToolRegistry across every agent it serves.  Maps agent_id ->
         # the set of mcp__ tool names that agent may use.
         self._discovered_by_agent: dict[str, set[str]] = {}
+        # Subset of the above that came from the Composio tool-router, so the
+        # harness can hide a channel agent's own-platform Composio toolkit.
+        self._composio_by_agent: dict[str, set[str]] = {}
 
     async def discover_and_register(
         self,
@@ -110,6 +125,9 @@ class McpProxyClient:
             )
 
         self._discovered_by_agent[agent_id] = current
+        self._composio_by_agent[agent_id] = {
+            n for n in current if is_composio_router_name(n)
+        }
         registered = sorted(current)
         if registered:
             logger.info(
@@ -117,6 +135,10 @@ class McpProxyClient:
                 agent_id, len(registered), ", ".join(registered),
             )
         return registered
+
+    def composio_tool_names_for_agent(self, agent_id: str) -> frozenset[str]:
+        """Return *agent_id*'s discovered Composio tool-router tool names."""
+        return frozenset(self._composio_by_agent.get(agent_id, set()))
 
     def _make_proxy_handler(self, tool_name: str):
         """Create a handler function that forwards tool calls to the proxy.

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -930,6 +930,7 @@ async def run_worker(settings: Settings) -> None:
         # unreachable — built-in tools still work; only the
         # platform/copilot MCP tools go missing in that case.
         discovered_mcp_tools: set[str] = set()
+        composio_mcp_tools: frozenset[str] = frozenset()
         if mcp_proxy_client is not None:
             try:
                 principal_user_id = session.user_id or session.service_account_id
@@ -943,18 +944,15 @@ async def run_worker(settings: Settings) -> None:
                             is_service_account=session.user_id is None,
                         )
                     )
+                    composio_mcp_tools = mcp_proxy_client.composio_tool_names_for_agent(
+                        ctx.agent_id
+                    )
             except Exception:
                 logger.warning(
                     "MCP proxy tool discovery failed for session %s; "
                     "built-in tools still available",
                     session.id, exc_info=True,
                 )
-
-        composio_mcp_tools: frozenset[str] = frozenset()
-        if mcp_proxy_client is not None:
-            composio_mcp_tools = mcp_proxy_client.composio_tool_names_for_agent(
-                ctx.agent_id
-            )
 
         # Per-session LLM bundle resolved from the AgentRuntimeContext
         # (already pulled above for ``asset_root``) + the credential

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -950,6 +950,12 @@ async def run_worker(settings: Settings) -> None:
                     session.id, exc_info=True,
                 )
 
+        composio_mcp_tools: frozenset[str] = frozenset()
+        if mcp_proxy_client is not None:
+            composio_mcp_tools = mcp_proxy_client.composio_tool_names_for_agent(
+                ctx.agent_id
+            )
+
         # Per-session LLM bundle resolved from the AgentRuntimeContext
         # (already pulled above for ``asset_root``) + the credential
         # vault.  Every agent has ``llm_main`` populated at create
@@ -1389,6 +1395,7 @@ async def run_worker(settings: Settings) -> None:
             # it to filter the shared registry's prompt schemas down to
             # this agent's own MCP tools.
             mcp_tool_names=frozenset(discovered_mcp_tools),
+            composio_tool_names=composio_mcp_tools,
             # Per-agent slash-command gating resolved from the runtime
             # config; the dispatch gate refuses disabled commands.
             slash_commands=ctx.slash_commands,

--- a/tests/harness/test_channel_composio_filter.py
+++ b/tests/harness/test_channel_composio_filter.py
@@ -1,0 +1,104 @@
+"""A Slack channel session hides Composio's SLACK toolkit from the tool set.
+
+Composio's Slack tools use a different connection/identity than the channel's
+bot, so a Slack channel agent must be steered to the native channel I/O. Other
+Composio toolkits, native tools, and non-channel sessions are untouched.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from surogates.harness.loop import AgentHarness, _mcp_tool_component
+
+
+class _Reg:
+    def __init__(self, names):
+        self.tool_names = set(names)
+
+
+def _harness(registry_names, mcp, composio):
+    h = AgentHarness.__new__(AgentHarness)
+    h._tools = _Reg(registry_names)
+    h._mcp_tool_names = frozenset(mcp)
+    h._composio_tool_names = frozenset(composio)
+    return h
+
+
+def _session(channel, config=None):
+    return SimpleNamespace(channel=channel, config=config or {})
+
+
+_SLACK = "mcp__tool_router__SLACK_SEND_MESSAGE"
+_SLACK2 = "mcp__tool_router__SLACK_FETCH_FILE"
+_GMAIL = "mcp__tool_router__GMAIL_SEND_EMAIL"
+_REG = {_SLACK, _SLACK2, _GMAIL, "read_file", "fetch_channel_file"}
+_COMPOSIO = {_SLACK, _SLACK2, _GMAIL}
+
+
+def test_mcp_tool_component_takes_last_segment():
+    assert _mcp_tool_component(_SLACK) == "SLACK_SEND_MESSAGE"
+    assert _mcp_tool_component("read_file") == "read_file"
+
+
+def test_slack_session_drops_composio_slack_only():
+    h = _harness(_REG, mcp=_COMPOSIO, composio=_COMPOSIO)
+    result = h._drop_native_channel_composio_tools(set(_REG), _session("slack"))
+    assert _SLACK not in result and _SLACK2 not in result
+    assert _GMAIL in result
+    assert {"read_file", "fetch_channel_file"} <= result
+
+
+def test_non_channel_session_keeps_composio_slack():
+    h = _harness(_REG, mcp=_COMPOSIO, composio=_COMPOSIO)
+    result = h._drop_native_channel_composio_tools(set(_REG), _session("api"))
+    assert _SLACK in result and _SLACK2 in result
+
+
+def test_unmapped_channel_is_noop():
+    h = _harness(_REG, mcp=_COMPOSIO, composio=_COMPOSIO)
+    tf = set(_REG)
+    assert h._drop_native_channel_composio_tools(tf, _session("telegram")) == tf
+
+
+def test_no_composio_is_noop_even_for_slack():
+    h = _harness(_REG, mcp=_COMPOSIO, composio=set())
+    tf = set(_REG)
+    assert h._drop_native_channel_composio_tools(tf, _session("slack")) == tf
+
+
+def test_none_filter_materialises_and_drops_for_slack():
+    h = _harness(_REG, mcp=_COMPOSIO, composio=_COMPOSIO)
+    result = h._drop_native_channel_composio_tools(None, _session("slack"))
+    assert _SLACK not in result and _GMAIL in result and "read_file" in result
+
+
+def test_none_filter_preserved_when_nothing_dropped():
+    # No Composio Slack tools to drop → None passes through (all-tools fast path).
+    h = _harness(_REG, mcp={_GMAIL}, composio={_GMAIL})
+    assert h._drop_native_channel_composio_tools(None, _session("slack")) is None
+
+
+def test_native_slack_named_tool_not_caught():
+    # A native (non-Composio) tool whose component starts with SLACK_ is safe
+    # because the drop set is intersected with _composio_tool_names only.
+    reg = _REG | {"mcp__other__SLACK_thing"}
+    h = _harness(reg, mcp=_COMPOSIO | {"mcp__other__SLACK_thing"}, composio=_COMPOSIO)
+    result = h._drop_native_channel_composio_tools(set(reg), _session("slack"))
+    assert "mcp__other__SLACK_thing" in result
+
+
+def test_ordering_drop_survives_apply_mcp_schema_filter():
+    # The integration concern: _apply_mcp_schema_filter re-adds the agent's MCP
+    # tools (incl. Composio SLACK), so the drop must run AFTER it.
+    # A foreign MCP tool is needed so _apply_mcp_schema_filter materialises the
+    # filter (it short-circuits to None when there are no foreign tools).
+    _FOREIGN = "mcp__other_router__SOME_TOOL"
+    reg = _REG | {_FOREIGN}
+    h = _harness(reg, mcp=_COMPOSIO, composio=_COMPOSIO)
+    after_mcp = h._apply_mcp_schema_filter(None, explicit_allowed=False)
+    assert _SLACK in after_mcp  # re-added by the MCP filter
+    assert _FOREIGN not in after_mcp  # foreign tool excluded
+    final = h._drop_native_channel_composio_tools(after_mcp, _session("slack"))
+    assert _SLACK not in final and _SLACK2 not in final
+    assert _GMAIL in final

--- a/tests/harness/test_channel_composio_filter.py
+++ b/tests/harness/test_channel_composio_filter.py
@@ -88,6 +88,15 @@ def test_native_slack_named_tool_not_caught():
     assert "mcp__other__SLACK_thing" in result
 
 
+def test_ambient_session_treated_as_slack():
+    # Ambient sessions act in a Slack channel but carry channel="ambient";
+    # they must drop Composio SLACK too (the worker resolves ambient → slack).
+    h = _harness(_REG, mcp=_COMPOSIO, composio=_COMPOSIO)
+    result = h._drop_native_channel_composio_tools(set(_REG), _session("ambient"))
+    assert _SLACK not in result and _SLACK2 not in result
+    assert _GMAIL in result
+
+
 def test_ordering_drop_survives_apply_mcp_schema_filter():
     # The integration concern: _apply_mcp_schema_filter re-adds the agent's MCP
     # tools (incl. Composio SLACK), so the drop must run AFTER it.

--- a/tests/runtime/test_mcp_client_composio_subset.py
+++ b/tests/runtime/test_mcp_client_composio_subset.py
@@ -1,0 +1,69 @@
+"""McpProxyClient tracks the Composio-router subset of each agent's MCP tools.
+
+The channel-toolkit filter needs to know which discovered MCP tools came from
+the Composio tool-router (vs other MCP servers), so a Slack channel agent can
+have its Composio SLACK toolkit hidden without touching other MCP tools.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from surogates.orchestrator.mcp_client import (
+    McpProxyClient,
+    is_composio_router_name,
+)
+from surogates.tools.registry import ToolRegistry
+
+
+class _FakeResp:
+    status_code = 200
+
+    def __init__(self, names):
+        self._names = names
+
+    def json(self):
+        return {
+            "tools": [
+                {"name": n, "description": "", "parameters": {}}
+                for n in self._names
+            ]
+        }
+
+
+def test_is_composio_router_name_recognizes_both_prefixes():
+    assert is_composio_router_name("mcp__tool_router__SLACK_SEND_MESSAGE")
+    assert is_composio_router_name("mcp__composio_tool_router__SLACK_SEND_MESSAGE")
+    assert not is_composio_router_name("mcp__github__list_issues")
+    assert not is_composio_router_name("read_file")
+    assert not is_composio_router_name("")
+
+
+async def test_composio_subset_tracked_per_agent(monkeypatch):
+    reg = ToolRegistry()
+    client = McpProxyClient(base_url="http://proxy", registry=reg)
+
+    async def fake_post(url, headers=None, params=None, json=None):
+        return _FakeResp([
+            "mcp__tool_router__SLACK_SEND_MESSAGE",
+            "mcp__tool_router__GMAIL_SEND_EMAIL",
+            "mcp__github__list_issues",
+        ])
+
+    monkeypatch.setattr(client._client, "post", fake_post)
+
+    await client.discover_and_register(
+        org_id=UUID(int=1), user_id=UUID(int=2), session_id=UUID(int=3),
+        agent_id="agent-A",
+    )
+
+    composio = client.composio_tool_names_for_agent("agent-A")
+    assert composio == frozenset({
+        "mcp__tool_router__SLACK_SEND_MESSAGE",
+        "mcp__tool_router__GMAIL_SEND_EMAIL",
+    })
+    # Non-Composio MCP tools are NOT in the Composio subset.
+    assert "mcp__github__list_issues" not in composio
+    # Unknown agent → empty.
+    assert client.composio_tool_names_for_agent("agent-Z") == frozenset()
+    await client.close()


### PR DESCRIPTION
Hide Composio's `SLACK` toolkit from Slack-channel (and ambient) agents so they use the native channel I/O instead of a second, mis-identified Slack connection.

- **`mcp_client.py`**: track the Composio tool-router subset of each agent's discovered MCP tools (`is_composio_router_name` / `_composio_by_agent` / `composio_tool_names_for_agent`).
- **`worker.py`**: thread the subset into `AgentHarness`, inside the same principal guard as discovery.
- **`loop.py`**: `CHANNEL_NATIVE_COMPOSIO_TOOLKIT = {"slack": "SLACK"}` + `_drop_native_channel_composio_tools`, wired into **both** return paths of `_tool_filter_for_session` **after** `_apply_mcp_schema_filter` (which re-adds the agent's MCP set — `SLACK_*` included — so the drop must run after it). Ambient sessions (`channel="ambient"`, a Slack-context session) are resolved to `slack`, mirroring the worker's `_platform = "slack" if _is_ambient`.

Reviewed via SDD (two task reviews + an opus whole-branch review) plus a precision pass that caught the ambient-session gap. 21 tests across the harness / mcp-client / tool-filter blast radius.