### PR TITLE
fix(channels): precise channel-file fetch error codes

### DIFF
--- a/surogates/api/routes/channel_files.py
+++ b/surogates/api/routes/channel_files.py
@@ -19,6 +19,7 @@ import surogates.channels.platforms  # noqa: F401  # ensure SlackPlatform self-r
 from surogates.channels.file_fetch import (
     ChannelFileForbidden,
     ChannelFileNotFound,
+    ChannelFileRateLimited,
     ChannelFileTooLarge,
     ChannelFileUnavailable,
     fetch_channel_file,
@@ -110,6 +111,10 @@ async def fetch_channel_file_route(
     except ChannelFileTooLarge as exc:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail=str(exc),
+        )
+    except ChannelFileRateLimited as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(exc),
         )
     except ChannelFileUnavailable as exc:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))

--- a/surogates/channels/errors.py
+++ b/surogates/channels/errors.py
@@ -1,0 +1,21 @@
+"""Platform-neutral channel API error signal.
+
+Channel platform adapters raise :class:`ChannelApiError` to tell the fetch
+layer *why* an API call failed, so it can return a precise status instead of
+collapsing every failure into "not found".
+"""
+
+from __future__ import annotations
+
+
+class ChannelApiError(Exception):
+    """A channel-platform API call failed.
+
+    ``reason`` is a stable token the fetch layer maps to a precise result:
+    ``"forbidden"`` (the bot cannot access the resource), ``"rate_limited"``
+    (back off and retry), or ``"unavailable"`` (transient/unknown failure).
+    """
+
+    def __init__(self, reason: str, message: str = "") -> None:
+        self.reason = reason
+        super().__init__(message or reason)

--- a/surogates/channels/file_fetch.py
+++ b/surogates/channels/file_fetch.py
@@ -16,6 +16,7 @@ from pathlib import PurePosixPath
 from typing import Any
 
 from surogates.channels.credentials import resolve_channel_credentials
+from surogates.channels.errors import ChannelApiError
 from surogates.session.attachment_ingest import (
     ingest_attachment_bytes,
     safe_display_name,
@@ -41,6 +42,10 @@ class ChannelFileForbidden(ChannelFileError):
 
 class ChannelFileTooLarge(ChannelFileError):
     """The file exceeds the per-file size cap."""
+
+
+class ChannelFileRateLimited(ChannelFileError):
+    """The channel platform is rate-limiting; the agent should retry shortly."""
 
 
 class ChannelFileUnavailable(ChannelFileError):
@@ -95,7 +100,17 @@ async def fetch_channel_file(
     if not (creds or {}).get("bot_token"):
         raise ChannelFileUnavailable("No Slack bot token for this channel.")
 
-    meta = await platform.fetch_file_meta(creds=creds, file_id=file_id)
+    try:
+        meta = await platform.fetch_file_meta(creds=creds, file_id=file_id)
+    except ChannelApiError as exc:
+        if exc.reason == "forbidden":
+            raise ChannelFileForbidden(f"Access to file {file_id} was denied.")
+        if exc.reason == "rate_limited":
+            raise ChannelFileRateLimited(
+                f"Slack is rate-limiting access to file {file_id}; "
+                "try again shortly."
+            )
+        raise ChannelFileUnavailable(f"Could not read file {file_id}.")
     if not meta:
         raise ChannelFileNotFound(f"File {file_id} was not found.")
 

--- a/surogates/channels/platforms/slack.py
+++ b/surogates/channels/platforms/slack.py
@@ -53,9 +53,13 @@ from typing import Any
 import httpx
 
 try:
+    from slack_sdk.errors import SlackApiError
     from slack_sdk.web.async_client import AsyncWebClient
 except ImportError:
     AsyncWebClient = Any  # type: ignore[misc,assignment]
+    SlackApiError = Exception  # type: ignore[misc,assignment]
+
+from surogates.channels.errors import ChannelApiError
 
 from fastapi.responses import Response
 
@@ -90,6 +94,30 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
+
+# files.info error codes that mean the file is genuinely gone (-> not found),
+# the bot cannot access it (-> forbidden), or Slack is throttling (-> retry).
+_FILE_MISSING_CODES = frozenset({"file_not_found", "file_deleted"})
+_FORBIDDEN_CODES = frozenset({
+    "not_in_channel",
+    "access_denied",
+    "file_not_visible",
+    "not_allowed_token_type",
+    "no_permission",
+})
+_RATE_LIMIT_CODES = frozenset({"ratelimited", "rate_limited"})
+
+
+def _slack_error_code(exc: SlackApiError) -> str:
+    """Extract the ``error`` string from a SlackApiError's response (or "")."""
+    resp = getattr(exc, "response", None)
+    if resp is None:
+        return ""
+    try:
+        return resp.get("error") or ""
+    except Exception:
+        return ""
+
 
 # Replay-guard window in seconds (±5 minutes matches Slack's recommendation).
 _TIMESTAMP_TOLERANCE = 300
@@ -999,13 +1027,16 @@ class SlackPlatform:
     async def fetch_file_meta(
         self, *, creds: dict, file_id: str,
     ) -> dict | None:
-        """Return Slack ``files.info`` metadata for *file_id*, or None.
+        """Return Slack ``files.info`` metadata for *file_id*.
 
         The returned object carries ``url_private_download``, ``name``,
-        ``mimetype``, ``size`` and the ``channels``/``groups``/``ims``
-        membership lists used to enforce that the file was shared in the
-        agent's own channel.  Returns None on missing token, missing
-        file_id, or any Slack error (never raises).
+        ``mimetype``, ``size`` and the membership info used to enforce that the
+        file was shared in the agent's own channel.  Returns None when the file
+        genuinely does not exist (missing token/file_id, or Slack
+        ``file_not_found``/``file_deleted``).  Raises :class:`ChannelApiError`
+        for access-denied (``"forbidden"``), rate-limit (``"rate_limited"``)
+        and transient/unknown (``"unavailable"``) failures so the caller can
+        surface a precise status instead of a blanket "not found".
         """
         bot_token = (creds or {}).get("bot_token") or ""
         if not bot_token or not file_id:
@@ -1013,11 +1044,25 @@ class SlackPlatform:
         client = self._get_client(bot_token)
         try:
             resp = await client.files_info(file=file_id)
+        except SlackApiError as exc:
+            code = _slack_error_code(exc)
+            if code in _FILE_MISSING_CODES:
+                return None
+            if code in _FORBIDDEN_CODES:
+                raise ChannelApiError("forbidden", code)
+            if code in _RATE_LIMIT_CODES:
+                raise ChannelApiError("rate_limited", code)
+            logger.warning(
+                "[SlackPlatform] files_info error %r for %s", code, file_id,
+            )
+            raise ChannelApiError("unavailable", code or "files_info_failed")
+        except ChannelApiError:
+            raise
         except Exception:
             logger.warning(
                 "[SlackPlatform] files_info failed for %s", file_id, exc_info=True,
             )
-            return None
+            raise ChannelApiError("unavailable", "files_info_failed")
         file_obj = resp.get("file")
         return file_obj if file_obj else None
 

--- a/tests/test_channel_file_fetch.py
+++ b/tests/test_channel_file_fetch.py
@@ -1,16 +1,21 @@
 import pytest
+from slack_sdk.errors import SlackApiError
 
+from surogates.channels.errors import ChannelApiError
 from surogates.channels.platforms.slack import SlackPlatform
 
 
 class _FilesClient:
-    def __init__(self, file_obj, *, raises=False):
+    def __init__(self, file_obj=None, *, error_code=None, exc=None):
         self._file = file_obj
-        self._raises = raises
+        self._error_code = error_code
+        self._exc = exc
 
     async def files_info(self, file):
-        if self._raises:
-            raise RuntimeError("file_not_found")
+        if self._exc is not None:
+            raise self._exc
+        if self._error_code is not None:
+            raise SlackApiError("boom", {"error": self._error_code})
         return {"file": self._file}
 
 
@@ -33,9 +38,32 @@ async def test_fetch_file_meta_none_without_token():
     assert await p.fetch_file_meta(creds={}, file_id="F1") is None
 
 
-async def test_fetch_file_meta_none_on_error():
-    p = _platform_with_files(_FilesClient(None, raises=True))
+async def test_fetch_file_meta_none_on_file_not_found():
+    # A genuinely-missing file resolves to None (the caller maps it to 404).
+    p = _platform_with_files(_FilesClient(error_code="file_not_found"))
     assert await p.fetch_file_meta(creds={"bot_token": "xoxb"}, file_id="F1") is None
+
+
+async def test_fetch_file_meta_raises_forbidden_on_access_denied():
+    p = _platform_with_files(_FilesClient(error_code="not_in_channel"))
+    with pytest.raises(ChannelApiError) as ei:
+        await p.fetch_file_meta(creds={"bot_token": "xoxb"}, file_id="F1")
+    assert ei.value.reason == "forbidden"
+
+
+async def test_fetch_file_meta_raises_rate_limited():
+    p = _platform_with_files(_FilesClient(error_code="ratelimited"))
+    with pytest.raises(ChannelApiError) as ei:
+        await p.fetch_file_meta(creds={"bot_token": "xoxb"}, file_id="F1")
+    assert ei.value.reason == "rate_limited"
+
+
+async def test_fetch_file_meta_raises_unavailable_on_unknown_error():
+    # A non-Slack/transport failure surfaces as "unavailable", not "not found".
+    p = _platform_with_files(_FilesClient(exc=RuntimeError("boom")))
+    with pytest.raises(ChannelApiError) as ei:
+        await p.fetch_file_meta(creds={"bot_token": "xoxb"}, file_id="F1")
+    assert ei.value.reason == "unavailable"
 
 
 from types import SimpleNamespace
@@ -45,6 +73,7 @@ from surogates.channels import file_fetch
 from surogates.channels.file_fetch import (
     ChannelFileForbidden,
     ChannelFileNotFound,
+    ChannelFileRateLimited,
     ChannelFileTooLarge,
     ChannelFileUnavailable,
     fetch_channel_file,
@@ -54,15 +83,18 @@ from surogates.channels.file_fetch import (
 class _FakePlatform:
     """Injectable stand-in: descriptor.vault_refs + the two Slack calls."""
 
-    def __init__(self, *, meta, data=b"bytes"):
+    def __init__(self, *, meta=None, data=b"bytes", meta_exc=None):
         self._meta = meta
         self._data = data
+        self._meta_exc = meta_exc
         self.descriptor = SimpleNamespace(
             vault_refs=lambda identifier: {"bot_token": "bot_token"},
         )
         self.download_calls = 0
 
     async def fetch_file_meta(self, *, creds, file_id):
+        if self._meta_exc is not None:
+            raise self._meta_exc
         return self._meta
 
     async def download_file(self, *, creds, url, max_bytes):
@@ -229,4 +261,36 @@ async def test_fetch_channel_file_refuses_foreign_shares(monkeypatch):
         await fetch_channel_file(
             platform=platform, vault=object(), storage=object(),
             session=_session(channel_id="C1"), bucket="b", file_id="F1")
+    assert platform.download_calls == 0
+
+
+async def test_fetch_channel_file_maps_forbidden_api_error(monkeypatch):
+    # A "forbidden" ChannelApiError from fetch_file_meta must surface as
+    # ChannelFileForbidden (403), not ChannelFileNotFound (404).
+    _patch_externals(monkeypatch)
+    platform = _FakePlatform(meta_exc=ChannelApiError("forbidden", "not_in_channel"))
+    with pytest.raises(ChannelFileForbidden):
+        await fetch_channel_file(
+            platform=platform, vault=object(), storage=object(),
+            session=_session(), bucket="b", file_id="F1")
+    assert platform.download_calls == 0
+
+
+async def test_fetch_channel_file_maps_rate_limited_api_error(monkeypatch):
+    _patch_externals(monkeypatch)
+    platform = _FakePlatform(meta_exc=ChannelApiError("rate_limited", "ratelimited"))
+    with pytest.raises(ChannelFileRateLimited):
+        await fetch_channel_file(
+            platform=platform, vault=object(), storage=object(),
+            session=_session(), bucket="b", file_id="F1")
+    assert platform.download_calls == 0
+
+
+async def test_fetch_channel_file_maps_unavailable_api_error(monkeypatch):
+    _patch_externals(monkeypatch)
+    platform = _FakePlatform(meta_exc=ChannelApiError("unavailable", "boom"))
+    with pytest.raises(ChannelFileUnavailable):
+        await fetch_channel_file(
+            platform=platform, vault=object(), storage=object(),
+            session=_session(), bucket="b", file_id="F1")
     assert platform.download_calls == 0

--- a/tests/test_channel_files_route.py
+++ b/tests/test_channel_files_route.py
@@ -135,3 +135,20 @@ def test_slack_platform_registered_when_route_imported():
     from surogates.api.routes import channel_files  # noqa: F401
     from surogates.channels.registry import registry
     assert registry.get("slack") is not None
+
+
+async def test_route_maps_rate_limited_to_429(monkeypatch):
+    from fastapi import HTTPException
+    from surogates.channels.file_fetch import ChannelFileRateLimited
+    session = _session(channel="slack")
+    monkeypatch.setattr(channel_files.registry, "get", lambda kind: object())
+
+    async def _raise(**_):
+        raise ChannelFileRateLimited("slow down")
+
+    monkeypatch.setattr(channel_files, "fetch_channel_file", _raise)
+    with pytest.raises(HTTPException) as ei:
+        await channel_files.fetch_channel_file_route(
+            session_id=session.id, file_id="F1",
+            request=_request(session), tenant=_Tenant())
+    assert ei.value.status_code == 429


### PR DESCRIPTION
## Precise channel-file fetch error codes

Follow-up to #103. The fetch endpoint previously collapsed every Slack `files.info` failure into a 404, so an agent told "file not found" couldn't tell a genuine miss from an access or rate-limit problem.

`SlackPlatform.fetch_file_meta` now classifies the Slack error:
- `file_not_found`/`file_deleted` → `None` → **404** (genuinely gone)
- `not_in_channel`/`access_denied`/`no_permission`/… → `ChannelFileForbidden` → **403**
- `ratelimited` → new `ChannelFileRateLimited` → **429** (back off and retry)
- transport/unknown → `ChannelFileUnavailable` → **502**

Errors travel as a platform-neutral `ChannelApiError(reason)` (new `surogates/channels/errors.py`) that the fetch layer maps to its `ChannelFile*` taxonomy, so the platform adapter stays decoupled from the fetch helper. No change to the success path or tenant-isolation logic.

Covered by new unit tests for the error classification, the fetch-layer mapping, and the route's 429 mapping. 667 passed across the channel/slack/file-fetch suites.
