### PR TITLE
feat(channels): boot catch-up — replay Slack messages missed during downtime

### DIFF
--- a/surogates/channels/channel_catchup.py
+++ b/surogates/channels/channel_catchup.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 
 import logging
 import time
+import uuid
 from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy import text
 from surogates.channels.channel_backfill import BackfillLimits, filter_messages
 from surogates.channels.credentials import resolve_channel_credentials
+from surogates.runtime.leader_lock import RedisLeaderLock
 from surogates.session.events import EventType
 
 logger = logging.getLogger(__name__)
@@ -152,27 +154,37 @@ class ChannelCatchup:
         agent_id: str = app.get("agent_id", "")
         if not (app_id and org_id and agent_id):
             return
-        platform = self._resolve_platform(app)
-        if platform is None:
+        lock = self._make_lock(app_id)
+        if not await lock.acquire():
+            logger.info("[catchup] app %s locked by another instance — skipping", app_id)
             return
-        creds = await resolve_channel_credentials(
-            vault=self._vault, kind="slack", identifier=app_id, org_id=org_id,
-            refs=platform.descriptor.vault_refs(app_id),
-        )
-        if not (creds or {}).get("bot_token"):
-            return
-        routing = _Routing(
-            org_id=org_id, agent_id=agent_id, platform="slack",
-            identifier=app_id, config=app.get("config") or {},
-        )
-        for conv_id, channel_type in await self._list_conversations(platform, creds):
-            try:
-                await self._catchup_conversation(
-                    platform=platform, routing=routing, creds=creds,
-                    conv_id=conv_id, channel_type=channel_type,
-                )
-            except Exception:
-                logger.warning("[catchup] conversation %s failed", conv_id, exc_info=True)
+        try:
+            platform = self._resolve_platform(app)
+            if platform is None:
+                return
+            creds = await resolve_channel_credentials(
+                vault=self._vault, kind="slack", identifier=app_id, org_id=org_id,
+                refs=platform.descriptor.vault_refs(app_id),
+            )
+            if not (creds or {}).get("bot_token"):
+                return
+            routing = _Routing(
+                org_id=org_id, agent_id=agent_id, platform="slack",
+                identifier=app_id, config=app.get("config") or {},
+            )
+            for conv_id, channel_type in await self._list_conversations(platform, creds):
+                try:
+                    await self._catchup_conversation(
+                        platform=platform, routing=routing, creds=creds,
+                        conv_id=conv_id, channel_type=channel_type,
+                    )
+                except Exception:
+                    logger.warning("[catchup] conversation %s failed", conv_id, exc_info=True)
+                if not await lock.heartbeat():
+                    logger.warning("[catchup] app %s lost leader lock — stopping", app_id)
+                    return
+        finally:
+            await lock.release()
 
     # -- per conversation ---------------------------------------------------
 
@@ -225,6 +237,16 @@ class ChannelCatchup:
 
     def _resolve_platform(self, app: dict) -> Any:
         return self._registry.get("slack") if self._registry is not None else None
+
+    def _make_lock(self, app_id: str) -> Any:
+        if self._lock is not None:
+            return self._lock  # injected (tests)
+        return RedisLeaderLock(
+            self._redis,
+            key=f"channel-catchup:leader:{app_id}",
+            ttl_seconds=120,
+            holder_id=uuid.uuid4().hex,
+        )
 
     async def _watermark(self, **kw: Any) -> str | None:
         return await latest_catchup_watermark(self._session_factory, **kw)

--- a/surogates/channels/channel_catchup.py
+++ b/surogates/channels/channel_catchup.py
@@ -1,0 +1,83 @@
+"""Boot-time catch-up: replay Slack messages missed while the platform was down.
+
+On channels-process startup, for each Slack app the bot is provisioned in, list
+the bot's conversations and replay any human messages newer than the last one we
+processed (the watermark) through the normal inbound pipeline. Bounded by
+``BackfillLimits``; silent; best-effort; safe to run on every restart.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import text
+from surogates.session.events import EventType
+
+logger = logging.getLogger(__name__)
+
+
+_WATERMARK_SQL = text("""
+    SELECT COALESCE(
+        e.data #>> '{source,ts}',
+        to_char(EXTRACT(EPOCH FROM e.created_at AT TIME ZONE 'UTC'), 'FM9999999990.000000')
+    ) AS watermark
+    FROM events e
+    JOIN sessions s ON s.id = e.session_id
+    WHERE e.org_id = :org_id
+      AND s.agent_id = :agent_id
+      AND e.type = :event_type
+      AND e.data #>> '{source,platform}' = 'slack'
+      AND e.data #>> '{source,api_app_id}' = :api_app_id
+      AND e.data #>> '{source,chat_id}' = :chat_id
+      AND NOT (e.data ? 'synthetic')
+    ORDER BY watermark DESC
+    LIMIT 1
+""")
+
+
+def _watermark_from(source_ts: str | None, created_at: datetime | None) -> str | None:
+    """Pick the catch-up watermark for a conversation.
+
+    Prefers the exact stored Slack ``source.ts`` string; falls back to the latest
+    event's ``created_at`` rendered as a Slack-style ts (compatibility bridge for
+    events stored before ``source.ts`` existed); ``None`` when we have never
+    processed the conversation (first-run guard).
+    """
+    if source_ts:
+        return source_ts
+    if created_at is not None:
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        return f"{created_at.timestamp():.6f}"
+    return None
+
+
+async def latest_catchup_watermark(
+    session_factory: Any,
+    *,
+    org_id: Any,
+    agent_id: str,
+    api_app_id: str,
+    chat_id: str,
+) -> str | None:
+    """Latest Slack ts we have processed for (org, agent, Slack app, conversation).
+
+    Slack ``ts`` is compared/selected as a string (fixed ``seconds.microseconds``
+    shape) — never converted to float. Returns ``None`` when there is no
+    non-synthetic ``USER_MESSAGE`` for the conversation.
+    """
+    async with session_factory() as db:
+        result = await db.execute(
+            _WATERMARK_SQL,
+            {
+                "org_id": org_id,
+                "agent_id": agent_id,
+                "event_type": EventType.USER_MESSAGE.value,
+                "api_app_id": api_app_id,
+                "chat_id": chat_id,
+            },
+        )
+        watermark = result.scalar_one_or_none()
+    return str(watermark) if watermark else None

--- a/surogates/channels/channel_catchup.py
+++ b/surogates/channels/channel_catchup.py
@@ -214,6 +214,7 @@ class ChannelCatchup:
         self, platform: Any, routing: _Routing, creds: dict, conv_id: str, channel_type: str, m: dict,
     ) -> None:
         body = {
+            "type": "event_callback",
             "api_app_id": routing.identifier,
             "event": {
                 "type": "message",

--- a/surogates/channels/channel_catchup.py
+++ b/surogates/channels/channel_catchup.py
@@ -9,10 +9,13 @@ processed (the watermark) through the normal inbound pipeline. Bounded by
 from __future__ import annotations
 
 import logging
+import time
 from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy import text
+from surogates.channels.channel_backfill import BackfillLimits, filter_messages
+from surogates.channels.credentials import resolve_channel_credentials
 from surogates.session.events import EventType
 
 logger = logging.getLogger(__name__)
@@ -81,3 +84,228 @@ async def latest_catchup_watermark(
         )
         watermark = result.scalar_one_or_none()
     return str(watermark) if watermark is not None else None
+
+
+class _Routing:
+    """Minimal routing carrier (same shape the dispatcher builds)."""
+
+    def __init__(self, *, org_id: str, agent_id: str, platform: str, identifier: str, config: dict) -> None:
+        self.org_id = org_id
+        self.agent_id = agent_id
+        self.platform = platform
+        self.identifier = identifier
+        self.config = config
+
+
+class ChannelCatchup:
+    """Replays Slack messages missed during downtime, on channels-process boot."""
+
+    _CONV_TYPES = "public_channel,private_channel,im,mpim"
+
+    def __init__(
+        self,
+        *,
+        redis: Any,
+        session_factory: Any,
+        vault: Any,
+        platform_client: Any,
+        registry: Any,
+        pipeline: Any,
+        deps_factory: Any,
+        settings: Any,
+        limits: BackfillLimits | None = None,
+        pace_s: float = 0.5,
+        lock: Any = None,
+    ) -> None:
+        self._redis = redis
+        self._session_factory = session_factory
+        self._vault = vault
+        self._platform_client = platform_client
+        self._registry = registry
+        self._pipeline = pipeline
+        self._deps_factory = deps_factory
+        self._settings = settings
+        self._limits = limits or BackfillLimits()
+        self._pace_s = pace_s
+        self._lock = lock  # per-app leader lock; None = run unguarded
+
+    # -- top level ----------------------------------------------------------
+
+    async def run(self) -> None:
+        """Best-effort: catch up every provisioned Slack app. Never raises."""
+        try:
+            apps = await self._platform_client.list_channel_routings("slack")
+        except Exception:
+            logger.warning("[catchup] could not list slack routings", exc_info=True)
+            return
+        for app in apps:
+            try:
+                await self._catchup_app(app)
+            except Exception:
+                logger.warning(
+                    "[catchup] app %s failed", app.get("channel_identifier"), exc_info=True,
+                )
+
+    async def _catchup_app(self, app: dict) -> None:
+        app_id: str = app.get("channel_identifier", "")
+        org_id: str = app.get("org_id", "")
+        agent_id: str = app.get("agent_id", "")
+        if not (app_id and org_id and agent_id):
+            return
+        platform = self._resolve_platform(app)
+        if platform is None:
+            return
+        creds = await resolve_channel_credentials(
+            vault=self._vault, kind="slack", identifier=app_id, org_id=org_id,
+            refs=platform.descriptor.vault_refs(app_id),
+        )
+        if not (creds or {}).get("bot_token"):
+            return
+        routing = _Routing(
+            org_id=org_id, agent_id=agent_id, platform="slack",
+            identifier=app_id, config=app.get("config") or {},
+        )
+        for conv_id, channel_type in await self._list_conversations(platform, creds):
+            try:
+                await self._catchup_conversation(
+                    platform=platform, routing=routing, creds=creds,
+                    conv_id=conv_id, channel_type=channel_type,
+                )
+            except Exception:
+                logger.warning("[catchup] conversation %s failed", conv_id, exc_info=True)
+
+    # -- per conversation ---------------------------------------------------
+
+    async def _catchup_conversation(
+        self, *, platform: Any, routing: _Routing, creds: dict, conv_id: str, channel_type: str,
+    ) -> None:
+        wm = await self._watermark(
+            org_id=routing.org_id, agent_id=routing.agent_id,
+            api_app_id=routing.identifier, chat_id=conv_id,
+        )
+        if wm is None:
+            return  # first-run guard: establish on the next live message, replay nothing
+        raw = await self._fetch_history(platform, creds, conv_id, oldest=wm)
+        # Pre-filter obvious bot/subtype/empty events. Own-bot bare messages are
+        # still filtered by platform.parse(creds=...) using the cached bot user id,
+        # matching the live dispatcher path.
+        kept = [m for m in filter_messages(raw, bot_user_id="")
+                if str(m.get("ts", "")) > wm]
+        kept.sort(key=lambda m: str(m.get("ts", "")))      # ascending
+        kept = self._bound_messages(kept)
+        for m in kept:
+            await self._replay(platform, routing, creds, conv_id, channel_type, m)
+            if self._pace_s:
+                await _sleep(self._pace_s)
+
+    async def _replay(
+        self, platform: Any, routing: _Routing, creds: dict, conv_id: str, channel_type: str, m: dict,
+    ) -> None:
+        body = {
+            "api_app_id": routing.identifier,
+            "event": {
+                "type": "message",
+                "channel": conv_id,
+                "channel_type": channel_type,
+                "user": m.get("user", ""),
+                "text": m.get("text", ""),
+                "ts": str(m.get("ts", "")),
+                **({"thread_ts": m["thread_ts"]} if m.get("thread_ts") else {}),
+                **({"files": m["files"]} if m.get("files") else {}),
+            },
+        }
+        msg = await platform.parse(body, creds=creds, identifier=routing.identifier)
+        if msg is None:
+            return
+        msg = await platform.enrich(msg, creds=creds)
+        deps = self._deps_factory(platform.kind, routing, creds, platform)
+        await self._pipeline.handle(msg, routing=routing, config=routing.config, deps=deps)
+
+    # -- slack fetch helpers (overridable in tests) -------------------------
+
+    def _resolve_platform(self, app: dict) -> Any:
+        return self._registry.get("slack") if self._registry is not None else None
+
+    async def _watermark(self, **kw: Any) -> str | None:
+        return await latest_catchup_watermark(self._session_factory, **kw)
+
+    async def _list_conversations(self, platform: Any, creds: dict) -> list[tuple[str, str]]:
+        client = platform._get_client((creds or {}).get("bot_token") or "")
+        out: list[tuple[str, str]] = []
+        cursor = ""
+        while True:
+            resp = await client.conversations_list(
+                types=self._CONV_TYPES, exclude_archived=True, limit=200,
+                **({"cursor": cursor} if cursor else {}),
+            )
+            for ch in resp.get("channels") or []:
+                cid = ch.get("id")
+                if not cid:
+                    continue
+                if ch.get("is_im"):
+                    channel_type = "im"
+                elif ch.get("is_mpim"):
+                    channel_type = "mpim"
+                elif ch.get("is_private"):
+                    channel_type = "group"
+                else:
+                    channel_type = "channel"
+                # channels/groups: only those the bot is a member of
+                if channel_type in ("channel", "group") and not ch.get("is_member"):
+                    continue
+                out.append((cid, channel_type))
+            cursor = (resp.get("response_metadata") or {}).get("next_cursor") or ""
+            if not cursor:
+                break
+        return out
+
+    async def _fetch_history(self, platform: Any, creds: dict, conv_id: str, *, oldest: str) -> list[dict]:
+        client = platform._get_client((creds or {}).get("bot_token") or "")
+        floor = self._age_floor(oldest)
+        msgs: list[dict] = []
+        cursor = ""
+        for _ in range(max(1, self._limits.max_pages)):
+            resp = await client.conversations_history(
+                channel=conv_id, oldest=floor, limit=200,
+                **({"cursor": cursor} if cursor else {}),
+            )
+            msgs.extend(resp.get("messages") or [])
+            cursor = (resp.get("response_metadata") or {}).get("next_cursor") or ""
+            if not cursor or len(msgs) >= self._limits.max_messages:
+                break
+        return msgs
+
+    def _age_floor(self, watermark: str) -> str:
+        """Clamp the fetch start to the BackfillLimits age window."""
+        cutoff = _now() - self._limits.max_age_days * 86400.0
+        cutoff_ts = f"{cutoff:.6f}"
+        return watermark if watermark > cutoff_ts else cutoff_ts
+
+    def _bound_messages(self, messages: list[dict]) -> list[dict]:
+        """Apply the catch-up count and token caps to oldest-first dicts."""
+        picked: list[dict] = []
+        tokens = 0
+        for m in messages:
+            file_bits = " ".join(
+                " ".join(str(f.get(k) or "") for k in ("id", "name"))
+                for f in (m.get("files") or [])
+            )
+            body = " ".join(part for part in ((m.get("text") or ""), file_bits) if part)
+            cost = max(1, len(body) // 4) + 8
+            if picked and tokens + cost > self._limits.max_tokens:
+                break
+            if len(picked) >= self._limits.max_messages:
+                break
+            picked.append(m)
+            tokens += cost
+        return picked
+
+
+async def _sleep(seconds: float) -> None:
+    import asyncio
+
+    await asyncio.sleep(seconds)
+
+
+def _now() -> float:
+    return time.time()

--- a/surogates/channels/channel_catchup.py
+++ b/surogates/channels/channel_catchup.py
@@ -15,12 +15,16 @@ from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy import text
-from surogates.channels.channel_backfill import BackfillLimits, filter_messages
+from surogates.channels.channel_backfill import BackfillLimits, _est_tokens, filter_messages
 from surogates.channels.credentials import resolve_channel_credentials
 from surogates.runtime.leader_lock import RedisLeaderLock
 from surogates.session.events import EventType
 
 logger = logging.getLogger(__name__)
+
+
+class _LockLost(Exception):
+    """Raised inside a conversation replay when the per-app leader lock is lost."""
 
 
 _WATERMARK_SQL = text("""
@@ -99,6 +103,16 @@ class _Routing:
         self.config = config
 
 
+def _retry_after_seconds(exc: Exception) -> float | None:
+    response = getattr(exc, "response", None)
+    headers = response.get("headers") if isinstance(response, dict) else getattr(response, "headers", {})
+    raw = (headers or {}).get("Retry-After") or (headers or {}).get("retry-after")
+    try:
+        return float(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
 class ChannelCatchup:
     """Replays Slack messages missed during downtime, on channels-process boot."""
 
@@ -154,7 +168,7 @@ class ChannelCatchup:
         agent_id: str = app.get("agent_id", "")
         if not (app_id and org_id and agent_id):
             return
-        lock = self._make_lock(app_id)
+        lock = self._make_lock(org_id, agent_id, app_id)
         if not await lock.acquire():
             logger.info("[catchup] app %s locked by another instance — skipping", app_id)
             return
@@ -172,17 +186,25 @@ class ChannelCatchup:
                 org_id=org_id, agent_id=agent_id, platform="slack",
                 identifier=app_id, config=app.get("config") or {},
             )
+            hb = (routing.config or {}).get("history_backfill")
+            limits = BackfillLimits.from_config(hb) if hb else self._limits
             for conv_id, channel_type in await self._list_conversations(platform, creds):
+                if not await lock.heartbeat():
+                    logger.warning("[catchup] app %s lost leader lock — stopping", app_id)
+                    return
                 try:
                     await self._catchup_conversation(
                         platform=platform, routing=routing, creds=creds,
                         conv_id=conv_id, channel_type=channel_type,
+                        lock=lock, limits=limits,
                     )
-                except Exception:
-                    logger.warning("[catchup] conversation %s failed", conv_id, exc_info=True)
-                if not await lock.heartbeat():
+                except _LockLost:
                     logger.warning("[catchup] app %s lost leader lock — stopping", app_id)
                     return
+                except Exception:
+                    logger.warning("[catchup] conversation %s failed", conv_id, exc_info=True)
+                if self._pace_s:
+                    await _sleep(self._pace_s)
         finally:
             await lock.release()
 
@@ -190,6 +212,7 @@ class ChannelCatchup:
 
     async def _catchup_conversation(
         self, *, platform: Any, routing: _Routing, creds: dict, conv_id: str, channel_type: str,
+        lock: Any, limits: BackfillLimits,
     ) -> None:
         wm = await self._watermark(
             org_id=routing.org_id, agent_id=routing.agent_id,
@@ -197,18 +220,20 @@ class ChannelCatchup:
         )
         if wm is None:
             return  # first-run guard: establish on the next live message, replay nothing
-        raw = await self._fetch_history(platform, creds, conv_id, oldest=wm)
+        raw = await self._fetch_history(platform, creds, conv_id, oldest=wm, limits=limits)
         # Pre-filter obvious bot/subtype/empty events. Own-bot bare messages are
         # still filtered by platform.parse(creds=...) using the cached bot user id,
         # matching the live dispatcher path.
         kept = [m for m in filter_messages(raw, bot_user_id="")
                 if str(m.get("ts", "")) > wm]
         kept.sort(key=lambda m: str(m.get("ts", "")))      # ascending
-        kept = self._bound_messages(kept)
+        kept = self._bound_messages(kept, limits)
         for m in kept:
             await self._replay(platform, routing, creds, conv_id, channel_type, m)
             if self._pace_s:
                 await _sleep(self._pace_s)
+            if not await lock.heartbeat():
+                raise _LockLost()
 
     async def _replay(
         self, platform: Any, routing: _Routing, creds: dict, conv_id: str, channel_type: str, m: dict,
@@ -239,12 +264,12 @@ class ChannelCatchup:
     def _resolve_platform(self, app: dict) -> Any:
         return self._registry.get("slack") if self._registry is not None else None
 
-    def _make_lock(self, app_id: str) -> Any:
+    def _make_lock(self, org_id: str, agent_id: str, app_id: str) -> Any:
         if self._lock is not None:
             return self._lock  # injected (tests)
         return RedisLeaderLock(
             self._redis,
-            key=f"channel-catchup:leader:{app_id}",
+            key=f"channel-catchup:leader:{org_id}:{agent_id}:{app_id}",
             ttl_seconds=120,
             holder_id=uuid.uuid4().hex,
         )
@@ -252,14 +277,27 @@ class ChannelCatchup:
     async def _watermark(self, **kw: Any) -> str | None:
         return await latest_catchup_watermark(self._session_factory, **kw)
 
+    async def _call_with_retry(self, make_call: Any, *, attempts: int = 3) -> Any:
+        """Call an async Slack op, honoring Retry-After on rate-limit errors."""
+        for i in range(max(1, attempts)):
+            try:
+                return await make_call()
+            except Exception as exc:
+                delay = _retry_after_seconds(exc)
+                if delay is None or i == attempts - 1:
+                    raise
+                await _sleep(delay)
+
     async def _list_conversations(self, platform: Any, creds: dict) -> list[tuple[str, str]]:
         client = platform._get_client((creds or {}).get("bot_token") or "")
         out: list[tuple[str, str]] = []
         cursor = ""
         while True:
-            resp = await client.conversations_list(
-                types=self._CONV_TYPES, exclude_archived=True, limit=200,
-                **({"cursor": cursor} if cursor else {}),
+            resp = await self._call_with_retry(
+                lambda: client.conversations_list(
+                    types=self._CONV_TYPES, exclude_archived=True, limit=200,
+                    **({"cursor": cursor} if cursor else {}),
+                )
             )
             for ch in resp.get("channels") or []:
                 cid = ch.get("id")
@@ -282,30 +320,36 @@ class ChannelCatchup:
                 break
         return out
 
-    async def _fetch_history(self, platform: Any, creds: dict, conv_id: str, *, oldest: str) -> list[dict]:
+    async def _fetch_history(
+        self, platform: Any, creds: dict, conv_id: str, *, oldest: str, limits: BackfillLimits,
+    ) -> list[dict]:
         client = platform._get_client((creds or {}).get("bot_token") or "")
-        floor = self._age_floor(oldest)
+        floor = self._age_floor(oldest, limits)
         msgs: list[dict] = []
         cursor = ""
-        for _ in range(max(1, self._limits.max_pages)):
-            resp = await client.conversations_history(
-                channel=conv_id, oldest=floor, limit=200,
-                **({"cursor": cursor} if cursor else {}),
+        for _ in range(max(1, limits.max_pages)):
+            resp = await self._call_with_retry(
+                lambda: client.conversations_history(
+                    channel=conv_id, oldest=floor, limit=200,
+                    **({"cursor": cursor} if cursor else {}),
+                )
             )
             msgs.extend(resp.get("messages") or [])
             cursor = (resp.get("response_metadata") or {}).get("next_cursor") or ""
-            if not cursor or len(msgs) >= self._limits.max_messages:
+            if not cursor or len(msgs) >= limits.max_messages:
                 break
         return msgs
 
-    def _age_floor(self, watermark: str) -> str:
+    def _age_floor(self, watermark: str, limits: BackfillLimits) -> str:
         """Clamp the fetch start to the BackfillLimits age window."""
-        cutoff = _now() - self._limits.max_age_days * 86400.0
+        cutoff = _now() - limits.max_age_days * 86400.0
         cutoff_ts = f"{cutoff:.6f}"
         return watermark if watermark > cutoff_ts else cutoff_ts
 
-    def _bound_messages(self, messages: list[dict]) -> list[dict]:
-        """Apply the catch-up count and token caps to oldest-first dicts."""
+    def _bound_messages(self, messages: list[dict], limits: BackfillLimits) -> list[dict]:
+        # Mirrors channel_backfill.bound_messages' count/token caps but iterates
+        # string-ts dicts (not RawMessage floats) to keep ts de-dupe float-free;
+        # the age cap is applied earlier at fetch via _age_floor.
         picked: list[dict] = []
         tokens = 0
         for m in messages:
@@ -314,10 +358,10 @@ class ChannelCatchup:
                 for f in (m.get("files") or [])
             )
             body = " ".join(part for part in ((m.get("text") or ""), file_bits) if part)
-            cost = max(1, len(body) // 4) + 8
-            if picked and tokens + cost > self._limits.max_tokens:
+            cost = _est_tokens(body) + 8
+            if picked and tokens + cost > limits.max_tokens:
                 break
-            if len(picked) >= self._limits.max_messages:
+            if len(picked) >= limits.max_messages:
                 break
             picked.append(m)
             tokens += cost

--- a/surogates/channels/channel_catchup.py
+++ b/surogates/channels/channel_catchup.py
@@ -80,4 +80,4 @@ async def latest_catchup_watermark(
             },
         )
         watermark = result.scalar_one_or_none()
-    return str(watermark) if watermark else None
+    return str(watermark) if watermark is not None else None

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -568,6 +568,7 @@ class ChannelInboundPipeline:
                 "user_id": msg.platform_user_id,
                 "user_name": msg.user_name,
                 "thread_id": msg.thread_key,
+                "ts": msg.ts,
             },
         }
         if _images:

--- a/surogates/channels/runner.py
+++ b/surogates/channels/runner.py
@@ -22,6 +22,7 @@ from typing import Any
 from fastapi import FastAPI
 from fastapi.responses import Response
 
+from surogates.channels.channel_catchup import ChannelCatchup
 from surogates.channels.channel_observations import append_channel_observation
 from surogates.channels.dispatcher import (
     ChannelDeliveryDispatcher,
@@ -352,7 +353,7 @@ def build_channels_app(
     mate_settings_cache: Any = None,
     registry: ChannelRegistry | None = None,
     storage: Any = None,
-) -> tuple[FastAPI, ChannelDeliveryDispatcher, ChannelWebhookReconciler]:
+) -> tuple[FastAPI, ChannelDeliveryDispatcher, ChannelWebhookReconciler, ChannelCatchup]:
     """Construct the channel webhook FastAPI app and related dispatchers.
 
     This is a pure-construction function — no network I/O, no serving.
@@ -389,9 +390,10 @@ def build_channels_app(
 
     Returns
     -------
-    tuple[FastAPI, ChannelDeliveryDispatcher, ChannelWebhookReconciler]
-        ``(app, delivery_dispatcher, reconciler)`` — the caller starts the
-        delivery loops and reconciler as asyncio tasks, then serves ``app``.
+    tuple[FastAPI, ChannelDeliveryDispatcher, ChannelWebhookReconciler, ChannelCatchup]
+        ``(app, delivery_dispatcher, reconciler, channel_catchup)`` — the caller
+        starts the delivery loops, reconciler, and catch-up as asyncio tasks,
+        then serves ``app``.
     """
     if registry is None:
         from surogates.channels.registry import registry as _global_registry
@@ -435,6 +437,17 @@ def build_channels_app(
         registry=registry,
     )
 
+    channel_catchup = ChannelCatchup(
+        redis=redis,
+        session_factory=session_factory,
+        vault=vault,
+        platform_client=platform_client,
+        registry=registry,
+        pipeline=pipeline,
+        deps_factory=deps_factory,
+        settings=settings,
+    )
+
     app = dispatcher.build_app()
     # Hand the per-message identity caches to the caller so it can wire the
     # cross-process invalidator (link_channel publishes channel_identity_changed
@@ -445,7 +458,7 @@ def build_channels_app(
     async def _health() -> Response:
         return Response(status_code=200)
 
-    return app, delivery_dispatcher, reconciler
+    return app, delivery_dispatcher, reconciler, channel_catchup
 
 
 async def run_channels(settings: Any, kind: str | None = None) -> None:
@@ -507,7 +520,7 @@ async def run_channels(settings: Any, kind: str | None = None) -> None:
     from surogates.storage.backend import create_backend
     storage = create_backend(settings)
 
-    app, delivery_dispatcher, reconciler = build_channels_app(
+    app, delivery_dispatcher, reconciler, channel_catchup = build_channels_app(
         settings,
         redis=redis,
         session_factory=sf,
@@ -557,6 +570,12 @@ async def run_channels(settings: Any, kind: str | None = None) -> None:
         name="channel-reconciler",
     )
     tasks.append(reconciler_task)
+
+    catchup_task = asyncio.create_task(
+        channel_catchup.run(),
+        name="channel-catchup",
+    )
+    tasks.append(catchup_task)
 
     # Serve via uvicorn.
     channels_settings = getattr(settings, "channels", None)

--- a/tests/test_channel_catchup.py
+++ b/tests/test_channel_catchup.py
@@ -386,6 +386,23 @@ class _HeldLock:
         return None
 
 
+class _HeartbeatFailsLock:
+    """acquire() succeeds, heartbeat() fails on first call — exercises the
+    mid-loop abort + release-in-finally path."""
+
+    def __init__(self) -> None:
+        self.released = False
+
+    async def acquire(self) -> bool:
+        return True
+
+    async def heartbeat(self) -> bool:
+        return False
+
+    async def release(self) -> None:
+        self.released = True
+
+
 class TestChannelCatchupLock:
     async def test_app_skipped_when_lock_not_acquired(self):
         client = _FakeSlackClient(
@@ -400,3 +417,36 @@ class TestChannelCatchupLock:
         await cu.run()
         assert pipeline.handled == []         # app skipped, nothing replayed
         assert client.history_calls == []
+
+    async def test_heartbeat_abort_stops_loop_and_releases_lock(self):
+        # Two conversations, both with a replayable message newer than their watermark.
+        # The heartbeat fails after the first conversation is processed, so only C1
+        # should be fetched/replayed and the lock must still be released via finally.
+        lock = _HeartbeatFailsLock()
+        client = _FakeSlackClient(
+            conversations=[
+                {"id": "C1", "is_member": True},
+                {"id": "C2", "is_member": True},
+            ],
+            history={
+                "C1": [{"user": "U1", "text": "first",  "ts": "1712345691.000000"}],
+                "C2": [{"user": "U2", "text": "second", "ts": "1712345692.000000"}],
+            },
+        )
+        pipeline = _FakePipeline()
+        cu = _catchup(
+            client=client,
+            pipeline=pipeline,
+            routings=_ROUTINGS,
+            watermarks={"C1": "1712345680.000000", "C2": "1712345680.000000"},
+        )
+        cu._make_lock = lambda app_id: lock
+        await cu.run()
+
+        # Only C1 was processed — the loop stopped before fetching C2.
+        assert len(client.history_calls) == 1
+        assert client.history_calls[0]["channel"] == "C1"
+        # Exactly one message replayed.
+        assert len(pipeline.handled) == 1
+        # The finally block must have fired despite the early return.
+        assert lock.released is True

--- a/tests/test_channel_catchup.py
+++ b/tests/test_channel_catchup.py
@@ -151,6 +151,8 @@ class _FakePlatform:
         return self._client
 
     async def parse(self, body: Any, *, creds: dict | None = None, identifier: str | None = None):
+        if body.get("type") != "event_callback":
+            return None
         ev = body["event"]
         if ev.get("user") == "UBOT" or ev.get("bot_id") or ev.get("subtype"):
             return None

--- a/tests/test_channel_catchup.py
+++ b/tests/test_channel_catchup.py
@@ -218,7 +218,7 @@ def _catchup(*, client, pipeline, routings, watermarks, limits=None):
     )
     cu._resolve_platform = lambda app: platform        # inject the fake platform (sync)
     cu._watermark = _wm(watermarks)                    # inject watermarks (async)
-    cu._make_lock = lambda app_id: _AcquiredLock()
+    cu._make_lock = lambda *a, **k: _AcquiredLock()
     return cu
 
 
@@ -415,7 +415,7 @@ class TestChannelCatchupLock:
         cu = _catchup(client=client, pipeline=pipeline, routings=_ROUTINGS,
                       watermarks={"C1": "1712345680.000000"})
         cu._lock = _HeldLock()                # lock held elsewhere
-        cu._make_lock = lambda app_id: cu._lock
+        cu._make_lock = lambda *a, **k: cu._lock
         await cu.run()
         assert pipeline.handled == []         # app skipped, nothing replayed
         assert client.history_calls == []
@@ -442,13 +442,135 @@ class TestChannelCatchupLock:
             routings=_ROUTINGS,
             watermarks={"C1": "1712345680.000000", "C2": "1712345680.000000"},
         )
-        cu._make_lock = lambda app_id: lock
+        cu._make_lock = lambda *a, **k: lock
         await cu.run()
 
-        # Only C1 was processed — the loop stopped before fetching C2.
-        assert len(client.history_calls) == 1
-        assert client.history_calls[0]["channel"] == "C1"
-        # Exactly one message replayed.
-        assert len(pipeline.handled) == 1
-        # The finally block must have fired despite the early return.
+        # The lock is lost before the first conversation (top-of-loop heartbeat),
+        # so nothing is fetched or replayed and the lock is still released.
+        assert client.history_calls == []
+        assert pipeline.handled == []
         assert lock.released is True
+
+    async def test_heartbeat_lost_mid_conversation_stops_and_releases(self):
+        # A lock that succeeds once (first top-of-loop heartbeat for C1) then fails
+        # (the per-message heartbeat inside _catchup_conversation).
+        class _MidConvLock:
+            def __init__(self) -> None:
+                self.released = False
+                self._calls = 0
+
+            async def acquire(self) -> bool:
+                return True
+
+            async def heartbeat(self) -> bool:
+                self._calls += 1
+                return self._calls <= 1  # True on 1st call, False on 2nd
+
+            async def release(self) -> None:
+                self.released = True
+
+        lock = _MidConvLock()
+        client = _FakeSlackClient(
+            conversations=[{"id": "C1", "is_member": True}],
+            history={"C1": [
+                {"user": "U1", "text": "first",  "ts": "1712345691.000000"},
+                {"user": "U1", "text": "second", "ts": "1712345692.000000"},
+            ]},
+        )
+        pipeline = _FakePipeline()
+        cu = _catchup(
+            client=client,
+            pipeline=pipeline,
+            routings=_ROUTINGS,
+            watermarks={"C1": "1712345680.000000"},
+        )
+        cu._make_lock = lambda *a, **k: lock
+        await cu.run()
+
+        # Exactly one message replayed before per-message heartbeat failed.
+        assert len(pipeline.handled) == 1
+        assert lock.released is True
+
+    async def test_lock_key_scoped_per_routing(self):
+        # Two routings sharing the same channel_identifier but different agent_id.
+        # _make_lock must be called with distinct (org, agent, app) tuples.
+        routings = [
+            {"org_id": "org-1", "agent_id": "agent-1", "channel_identifier": "A1", "config": {}},
+            {"org_id": "org-1", "agent_id": "agent-2", "channel_identifier": "A1", "config": {}},
+        ]
+        client = _FakeSlackClient(
+            conversations=[{"id": "C1", "is_member": True}],
+            history={"C1": [{"user": "U1", "text": "hi", "ts": "1712345691.000000"}]},
+        )
+        pipeline = _FakePipeline()
+        seen: list[tuple] = []
+        cu = _catchup(client=client, pipeline=pipeline, routings=routings,
+                      watermarks={"C1": "1712345680.000000"})
+        cu._make_lock = lambda *a, **k: (seen.append(a), _AcquiredLock())[1]
+        await cu.run()
+
+        # Must have been called twice with distinct (org, agent, app) triples.
+        assert len(seen) == 2
+        assert seen[0] != seen[1]
+        # Each call carries the same app_id but different agent_ids.
+        org_0, agent_0, app_0 = seen[0]
+        org_1, agent_1, app_1 = seen[1]
+        assert app_0 == "A1" and app_1 == "A1"
+        assert agent_0 != agent_1
+
+    async def test_per_routing_history_backfill_overrides_limits(self):
+        # Routing declares max_messages=1 via history_backfill config;
+        # the _catchup instance default is 200.  Only one message must replay.
+        routings = [{"org_id": "org-1", "agent_id": "agent-1",
+                     "channel_identifier": "A1",
+                     "config": {"history_backfill": {"max_messages": 1}}}]
+        client = _FakeSlackClient(
+            conversations=[{"id": "C1", "is_member": True}],
+            history={"C1": [
+                {"user": "U1", "text": "c", "ts": "1712345687.000000"},
+                {"user": "U1", "text": "b", "ts": "1712345686.000000"},
+                {"user": "U1", "text": "a", "ts": "1712345685.000000"},
+            ]},
+        )
+        pipeline = _FakePipeline()
+        cu = _catchup(client=client, pipeline=pipeline, routings=routings,
+                      watermarks={"C1": "1712345680.000000"})
+        await cu.run()
+        assert len(pipeline.handled) == 1
+
+    async def test_fetch_history_retries_on_rate_limit(self):
+        import surogates.channels.channel_catchup as cc
+        from unittest import mock
+
+        class _RateLimited(Exception):
+            def __init__(self) -> None:
+                super().__init__("ratelimited")
+                self.response = {"headers": {"Retry-After": "0"}}
+
+        class _RetryingClient(_FakeSlackClient):
+            def __init__(self, *args, **kwargs) -> None:
+                super().__init__(*args, **kwargs)
+                self.call_count = 0
+
+            async def conversations_history(self, **kwargs: Any) -> dict:
+                self.call_count += 1
+                if self.call_count == 1:
+                    raise _RateLimited()
+                return await super().conversations_history(**kwargs)
+
+        client = _RetryingClient(
+            conversations=[{"id": "C1", "is_member": True}],
+            history={"C1": [{"user": "U1", "text": "ok", "ts": "1712345691.000000"}]},
+        )
+        pipeline = _FakePipeline()
+        cu = _catchup(client=client, pipeline=pipeline, routings=_ROUTINGS,
+                      watermarks={"C1": "1712345680.000000"})
+
+        async def _noop_sleep(s: float) -> None:
+            pass
+
+        with mock.patch.object(cc, "_sleep", _noop_sleep):
+            await cu.run()
+
+        assert client.call_count == 2
+        assert len(pipeline.handled) == 1

--- a/tests/test_channel_catchup.py
+++ b/tests/test_channel_catchup.py
@@ -1,0 +1,82 @@
+"""Tests for the boot catch-up watermark + replay."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from surogates.channels.channel_catchup import (
+    _watermark_from,
+    latest_catchup_watermark,
+)
+
+
+class TestWatermarkFrom:
+    def test_prefers_exact_ts(self):
+        created = datetime(2024, 4, 5, 12, 0, 0, tzinfo=timezone.utc)
+        assert _watermark_from("1712345678.123456", created) == "1712345678.123456"
+
+    def test_falls_back_to_created_at(self):
+        created = datetime(2024, 4, 5, 12, 0, 0, 500000, tzinfo=timezone.utc)
+        assert _watermark_from(None, created) == f"{created.timestamp():.6f}"
+
+    def test_none_when_no_events(self):
+        assert _watermark_from(None, None) is None
+
+
+# --- watermark query (mocked db) ---------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, value: str | None) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self) -> str | None:
+        return self._value
+
+
+class _FakeDB:
+    def __init__(self, value: str | None) -> None:
+        self._value = value
+        self.executed = False
+
+    async def __aenter__(self) -> "_FakeDB":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+    async def execute(self, _stmt: Any, _params: dict[str, Any] | None = None) -> _FakeResult:
+        self.executed = True
+        return _FakeResult(self._value)
+
+
+def _sf(value: str | None):
+    def factory() -> _FakeDB:
+        return _FakeDB(value)
+
+    return factory
+
+
+class TestLatestCatchupWatermark:
+    async def test_returns_exact_ts(self):
+        wm = await latest_catchup_watermark(
+            _sf("1712345678.123456"),
+            org_id="org-1", agent_id="agent-1", api_app_id="A1", chat_id="C1",
+        )
+        assert wm == "1712345678.123456"
+
+    async def test_falls_back_to_created_at(self):
+        created = datetime(2024, 4, 5, 12, 0, 0, tzinfo=timezone.utc)
+        wm = await latest_catchup_watermark(
+            _sf(f"{created.timestamp():.6f}"),
+            org_id="org-1", agent_id="agent-1", api_app_id="A1", chat_id="C1",
+        )
+        assert wm == f"{created.timestamp():.6f}"
+
+    async def test_none_when_never_seen(self):
+        wm = await latest_catchup_watermark(
+            _sf(None),
+            org_id="org-1", agent_id="agent-1", api_app_id="A1", chat_id="C1",
+        )
+        assert wm is None

--- a/tests/test_channel_catchup.py
+++ b/tests/test_channel_catchup.py
@@ -99,3 +99,231 @@ class TestLatestCatchupWatermark:
         assert params["api_app_id"] == "A1"
         assert params["chat_id"] == "C1"
         assert params["event_type"] == EventType.USER_MESSAGE.value
+
+
+# --- ChannelCatchup replay tests ---------------------------------------------
+
+from dataclasses import dataclass
+
+from surogates.channels.channel_backfill import BackfillLimits
+from surogates.channels.channel_catchup import ChannelCatchup
+
+
+@dataclass
+class _Msg:
+    """Stand-in InboundMessage (only the fields the catch-up reads/passes)."""
+    identifier: str
+    ts: str
+    text: str = "hi"
+    is_bot: bool = False
+
+
+class _FakeSlackClient:
+    """Records conversations_list / conversations_history; returns canned data."""
+
+    def __init__(self, conversations: list[dict], history: dict[str, list[dict]]) -> None:
+        self._conversations = conversations
+        self._history = history  # channel_id -> newest-first messages
+        self.history_calls: list[dict] = []
+
+    async def conversations_list(self, **kwargs: Any) -> dict:
+        return {"channels": self._conversations, "response_metadata": {"next_cursor": ""}}
+
+    async def conversations_history(self, **kwargs: Any) -> dict:
+        self.history_calls.append(kwargs)
+        return {"messages": list(self._history.get(kwargs["channel"], [])),
+                "response_metadata": {"next_cursor": ""}}
+
+
+class _FakePlatform:
+    kind = "slack"
+
+    def __init__(self, client: _FakeSlackClient) -> None:
+        self._client = client
+        from surogates.channels.registry import ChannelDescriptor
+        self.descriptor = ChannelDescriptor(
+            vault_refs=lambda ident: {"bot_token": "bot_token"},
+            config_keys=("bot_token",),
+            webhook_registration="manual",
+        )
+
+    def _get_client(self, bot_token: str) -> _FakeSlackClient:
+        return self._client
+
+    async def parse(self, body: Any, *, creds: dict | None = None, identifier: str | None = None):
+        ev = body["event"]
+        if ev.get("user") == "UBOT" or ev.get("bot_id") or ev.get("subtype"):
+            return None
+        return _Msg(identifier=ev["channel"], ts=ev["ts"], text=ev.get("text", ""))
+
+    async def enrich(self, msg: Any, *, creds: dict) -> Any:
+        return msg
+
+
+class _FakePipeline:
+    def __init__(self) -> None:
+        self.handled: list[Any] = []
+
+    async def handle(self, msg: Any, *, routing: Any, config: dict, deps: Any):
+        self.handled.append(msg)
+
+
+class _FakeVault:
+    async def resolve_ref(self, ref: str, *, org_id: str) -> str | None:
+        return "xoxb-token"
+
+
+class _FakePlatformClient:
+    def __init__(self, routings: list[dict]) -> None:
+        self._routings = routings
+
+    async def list_channel_routings(self, kind: str) -> list[dict]:
+        return list(self._routings)
+
+
+def _wm(watermarks: dict[str, str | None]):
+    """An async stand-in for ChannelCatchup._watermark (which is awaited)."""
+    async def _w(**kw: Any) -> str | None:
+        return watermarks.get(kw["chat_id"])
+    return _w
+
+
+def _catchup(*, client, pipeline, routings, watermarks, limits=None):
+    platform = _FakePlatform(client)
+    cu = ChannelCatchup(
+        redis=None,
+        session_factory=_sf(None),             # bypassed by the _watermark injection
+        vault=_FakeVault(),
+        platform_client=_FakePlatformClient(routings),
+        registry=None,
+        pipeline=pipeline,
+        deps_factory=lambda kind, routing, creds, plat: object(),
+        settings=None,
+        limits=limits or BackfillLimits(),
+        pace_s=0.0,
+        lock=None,  # no-op until the lock wiring is added
+    )
+    cu._resolve_platform = lambda app: platform        # inject the fake platform (sync)
+    cu._watermark = _wm(watermarks)                    # inject watermarks (async)
+    return cu
+
+
+_ROUTINGS = [{"org_id": "org-1", "agent_id": "agent-1",
+              "channel_identifier": "A1", "config": {}}]
+
+
+class TestChannelCatchupReplay:
+    async def test_replays_only_messages_newer_than_watermark(self):
+        client = _FakeSlackClient(
+            conversations=[{"id": "C1", "is_member": True}],
+            history={"C1": [
+                {"user": "U1", "text": "new",  "ts": "1712345680.000000"},  # > wm → replay
+                {"user": "U1", "text": "seen", "ts": "1712345670.000000"},  # <= wm → skip
+            ]},
+        )
+        pipeline = _FakePipeline()
+        cu = _catchup(client=client, pipeline=pipeline, routings=_ROUTINGS,
+                      watermarks={"C1": "1712345675.000000"})
+        await cu.run()
+        assert [m.ts for m in pipeline.handled] == ["1712345680.000000"]
+
+    async def test_first_run_conversation_is_skipped(self):
+        client = _FakeSlackClient(
+            conversations=[{"id": "C2", "is_member": True}],
+            history={"C2": [{"user": "U1", "text": "hi", "ts": "1712345680.000000"}]},
+        )
+        pipeline = _FakePipeline()
+        cu = _catchup(client=client, pipeline=pipeline, routings=_ROUTINGS,
+                      watermarks={"C2": None})  # never seen
+        await cu.run()
+        assert pipeline.handled == []
+        assert client.history_calls == []  # no fetch for a first-run conversation
+
+    async def test_bot_and_subtype_messages_are_skipped(self):
+        client = _FakeSlackClient(
+            conversations=[{"id": "C1", "is_member": True}],
+            history={"C1": [
+                {"user": "UBOT", "text": "mine", "ts": "1712345681.000000"},
+                {"bot_id": "B1", "text": "bot",  "ts": "1712345682.000000"},
+                {"user": "U1", "subtype": "channel_join", "ts": "1712345683.000000"},
+                {"user": "U1", "text": "real", "ts": "1712345684.000000"},
+            ]},
+        )
+        pipeline = _FakePipeline()
+        cu = _catchup(client=client, pipeline=pipeline, routings=_ROUTINGS,
+                      watermarks={"C1": "1712345680.000000"})
+        await cu.run()
+        assert [m.ts for m in pipeline.handled] == ["1712345684.000000"]
+
+    async def test_replays_oldest_first(self):
+        client = _FakeSlackClient(
+            conversations=[{"id": "C1", "is_member": True}],
+            history={"C1": [  # Slack returns newest-first
+                {"user": "U1", "text": "b", "ts": "1712345686.000000"},
+                {"user": "U1", "text": "a", "ts": "1712345685.000000"},
+            ]},
+        )
+        pipeline = _FakePipeline()
+        cu = _catchup(client=client, pipeline=pipeline, routings=_ROUTINGS,
+                      watermarks={"C1": "1712345680.000000"})
+        await cu.run()
+        assert [m.ts for m in pipeline.handled] == ["1712345685.000000", "1712345686.000000"]
+
+    async def test_respects_message_cap(self):
+        client = _FakeSlackClient(
+            conversations=[{"id": "C1", "is_member": True}],
+            history={"C1": [
+                {"user": "U1", "text": "c", "ts": "1712345687.000000"},
+                {"user": "U1", "text": "b", "ts": "1712345686.000000"},
+                {"user": "U1", "text": "a", "ts": "1712345685.000000"},
+            ]},
+        )
+        pipeline = _FakePipeline()
+        cu = _catchup(
+            client=client,
+            pipeline=pipeline,
+            routings=_ROUTINGS,
+            watermarks={"C1": "1712345680.000000"},
+            limits=BackfillLimits(max_messages=2),
+        )
+        await cu.run()
+        assert len(pipeline.handled) == 2
+
+    async def test_private_channel_replays_with_group_channel_type(self):
+        class _InspectingPlatform(_FakePlatform):
+            def __init__(self, client: _FakeSlackClient) -> None:
+                super().__init__(client)
+                self.channel_types: list[str] = []
+
+            async def parse(self, body: Any, *, creds: dict | None = None, identifier: str | None = None):
+                self.channel_types.append(body["event"]["channel_type"])
+                return await super().parse(body, creds=creds, identifier=identifier)
+
+        client = _FakeSlackClient(
+            conversations=[{"id": "G1", "is_member": True, "is_private": True}],
+            history={"G1": [{"user": "U1", "text": "private", "ts": "1712345688.000000"}]},
+        )
+        platform = _InspectingPlatform(client)
+        pipeline = _FakePipeline()
+        cu = _catchup(client=client, pipeline=pipeline, routings=_ROUTINGS,
+                      watermarks={"G1": "1712345680.000000"})
+        cu._resolve_platform = lambda app: platform
+        await cu.run()
+        assert platform.channel_types == ["group"]
+
+    async def test_per_conversation_isolation(self):
+        class _Boom(_FakeSlackClient):
+            async def conversations_history(self, **kwargs):
+                if kwargs["channel"] == "C1":
+                    raise RuntimeError("slack 500")
+                return await super().conversations_history(**kwargs)
+
+        client = _Boom(
+            conversations=[{"id": "C1", "is_member": True}, {"id": "C2", "is_member": True}],
+            history={"C2": [{"user": "U1", "text": "ok", "ts": "1712345690.000000"}]},
+        )
+        pipeline = _FakePipeline()
+        cu = _catchup(client=client, pipeline=pipeline, routings=_ROUTINGS,
+                      watermarks={"C1": "1712345680.000000", "C2": "1712345680.000000"})
+        await cu.run()  # C1 raises, C2 still processed
+        assert [m.ts for m in pipeline.handled] == ["1712345690.000000"]

--- a/tests/test_channel_catchup.py
+++ b/tests/test_channel_catchup.py
@@ -39,6 +39,7 @@ class _FakeDB:
     def __init__(self, value: str | None) -> None:
         self._value = value
         self.executed = False
+        self.params: dict[str, Any] | None = None
 
     async def __aenter__(self) -> "_FakeDB":
         return self
@@ -48,13 +49,17 @@ class _FakeDB:
 
     async def execute(self, _stmt: Any, _params: dict[str, Any] | None = None) -> _FakeResult:
         self.executed = True
+        self.params = _params
         return _FakeResult(self._value)
 
 
 def _sf(value: str | None):
-    def factory() -> _FakeDB:
-        return _FakeDB(value)
+    db = _FakeDB(value)
 
+    def factory() -> _FakeDB:
+        return db
+
+    factory.db = db  # type: ignore[attr-defined]
     return factory
 
 
@@ -80,3 +85,17 @@ class TestLatestCatchupWatermark:
             org_id="org-1", agent_id="agent-1", api_app_id="A1", chat_id="C1",
         )
         assert wm is None
+
+    async def test_forwards_scoping_params(self):
+        from surogates.session.events import EventType
+
+        sf = _sf("1712345678.123456")
+        await latest_catchup_watermark(
+            sf, org_id="org-1", agent_id="agent-1", api_app_id="A1", chat_id="C1",
+        )
+        params = sf.db.params  # type: ignore[attr-defined]
+        assert params["org_id"] == "org-1"
+        assert params["agent_id"] == "agent-1"
+        assert params["api_app_id"] == "A1"
+        assert params["chat_id"] == "C1"
+        assert params["event_type"] == EventType.USER_MESSAGE.value

--- a/tests/test_channel_catchup.py
+++ b/tests/test_channel_catchup.py
@@ -327,3 +327,35 @@ class TestChannelCatchupReplay:
                       watermarks={"C1": "1712345680.000000", "C2": "1712345680.000000"})
         await cu.run()  # C1 raises, C2 still processed
         assert [m.ts for m in pipeline.handled] == ["1712345690.000000"]
+
+    async def test_fetch_oldest_clamped_to_age_window(self):
+        import surogates.channels.channel_catchup as cc
+        from unittest import mock
+
+        client = _FakeSlackClient(
+            conversations=[{"id": "C1", "is_member": True}],
+            history={"C1": [{"user": "U1", "text": "x", "ts": "1712345690.000000"}]},
+        )
+        cu = _catchup(client=client, pipeline=_FakePipeline(), routings=_ROUTINGS,
+                      watermarks={"C1": "1000000000.000000"})  # far older than 7d
+        fixed_now = 1712345700.0
+        with mock.patch.object(cc, "_now", lambda: fixed_now):
+            await cu.run()
+        # watermark is far older than the 7-day window → oldest clamps to now-7d
+        cutoff = f"{(fixed_now - 7 * 86400.0):.6f}"
+        assert client.history_calls[0]["oldest"] == cutoff
+
+    async def test_fetch_oldest_is_watermark_when_recent(self):
+        import surogates.channels.channel_catchup as cc
+        from unittest import mock
+
+        client = _FakeSlackClient(
+            conversations=[{"id": "C1", "is_member": True}],
+            history={"C1": []},
+        )
+        cu = _catchup(client=client, pipeline=_FakePipeline(), routings=_ROUTINGS,
+                      watermarks={"C1": "1712345695.000000"})  # within 7d of fixed_now
+        fixed_now = 1712345700.0
+        with mock.patch.object(cc, "_now", lambda: fixed_now):
+            await cu.run()
+        assert client.history_calls[0]["oldest"] == "1712345695.000000"

--- a/tests/test_channel_catchup.py
+++ b/tests/test_channel_catchup.py
@@ -188,6 +188,17 @@ def _wm(watermarks: dict[str, str | None]):
     return _w
 
 
+class _AcquiredLock:
+    async def acquire(self) -> bool:
+        return True
+
+    async def heartbeat(self) -> bool:
+        return True
+
+    async def release(self) -> None:
+        return None
+
+
 def _catchup(*, client, pipeline, routings, watermarks, limits=None):
     platform = _FakePlatform(client)
     cu = ChannelCatchup(
@@ -201,10 +212,11 @@ def _catchup(*, client, pipeline, routings, watermarks, limits=None):
         settings=None,
         limits=limits or BackfillLimits(),
         pace_s=0.0,
-        lock=None,  # no-op until the lock wiring is added
+        lock=None,
     )
     cu._resolve_platform = lambda app: platform        # inject the fake platform (sync)
     cu._watermark = _wm(watermarks)                    # inject watermarks (async)
+    cu._make_lock = lambda app_id: _AcquiredLock()
     return cu
 
 
@@ -359,3 +371,32 @@ class TestChannelCatchupReplay:
         with mock.patch.object(cc, "_now", lambda: fixed_now):
             await cu.run()
         assert client.history_calls[0]["oldest"] == "1712345695.000000"
+
+
+class _HeldLock:
+    """A lock that is already held by someone else — acquire returns False."""
+
+    async def acquire(self) -> bool:
+        return False
+
+    async def heartbeat(self) -> bool:
+        return True
+
+    async def release(self) -> None:
+        return None
+
+
+class TestChannelCatchupLock:
+    async def test_app_skipped_when_lock_not_acquired(self):
+        client = _FakeSlackClient(
+            conversations=[{"id": "C1", "is_member": True}],
+            history={"C1": [{"user": "U1", "text": "hi", "ts": "1712345690.000000"}]},
+        )
+        pipeline = _FakePipeline()
+        cu = _catchup(client=client, pipeline=pipeline, routings=_ROUTINGS,
+                      watermarks={"C1": "1712345680.000000"})
+        cu._lock = _HeldLock()                # lock held elsewhere
+        cu._make_lock = lambda app_id: cu._lock
+        await cu.run()
+        assert pipeline.handled == []         # app skipped, nothing replayed
+        assert client.history_calls == []

--- a/tests/test_channel_pipeline.py
+++ b/tests/test_channel_pipeline.py
@@ -643,6 +643,9 @@ async def test_user_message_event_content_matches_text():
 
     ev = next(e for e in deps.session_store.events if e[1] == EventType.USER_MESSAGE)
     assert ev[2]["content"] == "What is the plan?"
+    # the catch-up watermark relies on the Slack ts being stored
+    emitted_source = ev[2]["source"]
+    assert emitted_source["ts"] == msg.ts
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_channels.py
+++ b/tests/test_cli_channels.py
@@ -301,7 +301,7 @@ class TestBuildChannelsApp:
         settings.channels = {}
 
         result = build_channels_app(settings, registry=empty_reg, **self._make_deps())
-        app, delivery_dispatcher, reconciler = result
+        app, delivery_dispatcher, reconciler, catchup = result
         assert isinstance(app, FastAPI)
 
     def test_health_route_returns_200(self):
@@ -311,7 +311,7 @@ class TestBuildChannelsApp:
         settings = MagicMock()
         settings.channels = {}
 
-        app, _, _ = build_channels_app(settings, registry=empty_reg, **self._make_deps())
+        app, _, _, _ = build_channels_app(settings, registry=empty_reg, **self._make_deps())
         client = TestClient(app)
         resp = client.get("/health")
         assert resp.status_code == 200
@@ -325,7 +325,7 @@ class TestBuildChannelsApp:
         settings.channels = {}
 
         # Should not raise.
-        app, delivery, reconciler = build_channels_app(
+        app, delivery, reconciler, catchup = build_channels_app(
             settings, registry=empty_reg, **self._make_deps()
         )
         assert delivery is not None
@@ -339,7 +339,7 @@ class TestBuildChannelsApp:
         settings = MagicMock()
         settings.channels = {}
 
-        _, delivery, _ = build_channels_app(settings, registry=empty_reg, **self._make_deps())
+        _, delivery, _, _ = build_channels_app(settings, registry=empty_reg, **self._make_deps())
         assert isinstance(delivery, ChannelDeliveryDispatcher)
 
     def test_reconciler_returned(self):
@@ -350,7 +350,7 @@ class TestBuildChannelsApp:
         settings = MagicMock()
         settings.channels = {}
 
-        _, _, reconciler = build_channels_app(settings, registry=empty_reg, **self._make_deps())
+        _, _, reconciler, _ = build_channels_app(settings, registry=empty_reg, **self._make_deps())
         assert isinstance(reconciler, ChannelWebhookReconciler)
 
 


### PR DESCRIPTION
## What

On channels-process boot, automatically replay Slack messages users sent while the platform (webhook included) was down, so the agent answers them. Hands-free (runs every boot), silent (no apology note), and safe to re-run on every restart without double-answering. Built for DEV's frequent-restart need; the per-app leader lock makes it safe under multiple instances.

## How

A new `ChannelCatchup` unit (`surogates/channels/channel_catchup.py`), constructed in `build_channels_app` and started as a best-effort boot task in `run_channels` (never blocks serving):

1. **Enumerate** the bot's Slack apps via `list_channel_routings("slack")`, resolve creds, page `conversations.list` (channels + DMs/MPIMs, member-filtered).
2. **Watermark** — per (org, agent, app, conversation), the latest Slack `ts` we processed, derived from `USER_MESSAGE` events in SQL (`COALESCE(source.ts, created_at)`). No watermark → first-run guard (skip, replay nothing). `ts` is compared as a string everywhere — never `float()` (it's the de-dupe key). This relies on a one-line add of `source.ts` to the `USER_MESSAGE` event in `inbound.py`.
3. **Fetch** `conversations.history(oldest=max(watermark, now−7d))` bounded by `BackfillLimits` (≤7d / ≤200 msgs / ≤8k tokens), honoring per-routing `history_backfill` config and retrying on Slack 429 `Retry-After`.
4. **Replay** each genuinely-new human message by reconstructing the Slack `event_callback` body and running it through the live inbound path (`platform.parse` → `enrich` → `ChannelInboundPipeline.handle`) — so identity, mention-gating, session creation, file auto-download, and the worker reply are all reused. De-dupe is exact via the stored `ts`; the watermark advances as replays emit their own `USER_MESSAGE`, so a second boot replays nothing.

Concurrency is guarded by a per-(org, agent, app) `RedisLeaderLock` (SET-NX owner token, heartbeat before each conversation **and** per replayed message, compare-token release in `finally`), so two booting instances never double-answer.

Scope: Slack only (v1); the mechanism generalizes per-platform later. Telegram, deep thread-reply gaps, and prod tuning are out of scope.

## Review trail

Built via brainstorm → spec → plan → subagent-driven development: three task gates (spec + quality) + a whole-branch final review that caught one Critical (replayed body missing the top-level `event_callback` type → every replay silently dropped in prod while mocked tests stayed green; fixed in `39e5364`). A follow-up `/review` precision pass surfaced and fixed four more (`3359136`): lock-TTL-vs-heartbeat double-replay, lock keyed by app alone, ignored per-routing limits, and missing Retry-After backoff. Four lower-severity findings (narrow `auth.test` self-replay, `_Routing`/dispatcher duplication, per-message `deps_factory`, the `_watermark_from` parallel helper) are logged as follow-ups.

## Tests

New `tests/test_channel_catchup.py` (22 tests): watermark (exact-ts / created_at fallback / scoping / none), replay (gap-select, oldest-first, bot/subtype filter, caps, first-run skip, per-conversation isolation, age-clamp), lock (held-skip, heartbeat-abort, mid-conversation heartbeat, per-routing key scope), per-routing limit override, and 429 retry. Full channels/inbound/slack surface green (243 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
