### PR TITLE
fix(channels): degrade catch-up listing on missing Slack conversation-type scope

### DIFF
--- a/surogates/channels/channel_catchup.py
+++ b/surogates/channels/channel_catchup.py
@@ -113,6 +113,27 @@ def _retry_after_seconds(exc: Exception) -> float | None:
         return None
 
 
+# conversations.list returns `missing_scope` and aborts the WHOLE listing when
+# the app token lacks a requested type's read scope; map the needed scope back
+# to the conversation type so we can drop it and re-list the readable ones.
+_SCOPE_TO_TYPE = {
+    "channels:read": "public_channel",
+    "groups:read": "private_channel",
+    "im:read": "im",
+    "mpim:read": "mpim",
+}
+
+
+def _missing_scope(exc: Exception) -> str | None:
+    """Return the scope Slack reported as missing, or None if not a scope error."""
+    response = getattr(exc, "response", None)
+    if response is None or not hasattr(response, "get"):
+        return None
+    if response.get("error") != "missing_scope":
+        return None
+    return response.get("needed") or None
+
+
 class ChannelCatchup:
     """Replays Slack messages missed during downtime, on channels-process boot."""
 
@@ -290,12 +311,33 @@ class ChannelCatchup:
 
     async def _list_conversations(self, platform: Any, creds: dict) -> list[tuple[str, str]]:
         client = platform._get_client((creds or {}).get("bot_token") or "")
+        types = [t for t in (p.strip() for p in self._CONV_TYPES.split(",")) if t]
+        # A token missing one type's read scope makes Slack abort the WHOLE
+        # listing; drop the un-granted type and re-list the readable ones so the
+        # rest of the app's conversations still catch up.
+        while types:
+            try:
+                return await self._list_for_types(client, types)
+            except Exception as exc:
+                scope = _missing_scope(exc)
+                drop = _SCOPE_TO_TYPE.get(scope) if scope else None
+                if drop is None or drop not in types:
+                    raise
+                types.remove(drop)
+                logger.info(
+                    "[catchup] app token missing %s — skipping %s conversations",
+                    scope, drop,
+                )
+        return []
+
+    async def _list_for_types(self, client: Any, types: list[str]) -> list[tuple[str, str]]:
         out: list[tuple[str, str]] = []
         cursor = ""
+        joined = ",".join(types)
         while True:
             resp = await self._call_with_retry(
                 lambda: client.conversations_list(
-                    types=self._CONV_TYPES, exclude_archived=True, limit=200,
+                    types=joined, exclude_archived=True, limit=200,
                     **({"cursor": cursor} if cursor else {}),
                 )
             )

--- a/tests/test_channel_catchup.py
+++ b/tests/test_channel_catchup.py
@@ -374,6 +374,44 @@ class TestChannelCatchupReplay:
             await cu.run()
         assert client.history_calls[0]["oldest"] == "1712345695.000000"
 
+    async def test_list_conversations_degrades_on_missing_scope(self):
+        # The app token lacks mpim:read, so Slack aborts the WHOLE
+        # conversations.list when the request includes the mpim type. Catch-up
+        # must drop the un-granted type and still list the readable channels,
+        # rather than failing the entire app's catch-up.
+        class _MissingScope(Exception):
+            def __init__(self) -> None:
+                super().__init__("missing_scope")
+                self.response = {"error": "missing_scope", "needed": "mpim:read"}
+
+        class _ScopedClient(_FakeSlackClient):
+            def __init__(self, *a: Any, **k: Any) -> None:
+                super().__init__(*a, **k)
+                self.list_types: list[str] = []
+
+            async def conversations_list(self, **kwargs: Any) -> dict:
+                types = kwargs.get("types") or ""
+                self.list_types.append(types)
+                if "mpim" in types:
+                    raise _MissingScope()
+                return {"channels": self._conversations,
+                        "response_metadata": {"next_cursor": ""}}
+
+        client = _ScopedClient(
+            conversations=[{"id": "C1", "is_member": True}],
+            history={"C1": [{"user": "U1", "text": "hi", "ts": "1712345691.000000"}]},
+        )
+        pipeline = _FakePipeline()
+        cu = _catchup(client=client, pipeline=pipeline, routings=_ROUTINGS,
+                      watermarks={"C1": "1712345680.000000"})
+        await cu.run()
+
+        # The readable channel's message was still replayed despite the missing scope.
+        assert [m.ts for m in pipeline.handled] == ["1712345691.000000"]
+        # First attempt included mpim (raised); the retry dropped it.
+        assert any("mpim" in t for t in client.list_types)
+        assert any("mpim" not in t for t in client.list_types)
+
 
 class _HeldLock:
     """A lock that is already held by someone else — acquire returns False."""


### PR DESCRIPTION
## Problem

Boot catch-up requested all conversation types (`public_channel,private_channel,im,mpim`) in a single `conversations.list` call. Slack aborts the **entire** listing with `missing_scope` when the app token lacks any requested type's read scope, so one un-granted scope (observed: app `A0ASHN5GN2G` has `mpim:history` but not `mpim:read`) killed catch-up for the **whole app** — channels and DMs it could read never got processed.

```
[catchup] app A0ASHN5GN2G failed
SlackApiError: {'ok': False, 'error': 'missing_scope', 'needed': 'mpim:read', 'provided': '...,mpim:history,...'}
```

## Fix

`_list_conversations` now degrades gracefully: on a `missing_scope` error it maps the reported `needed` scope to its conversation type, drops that type, and re-lists the readable ones. Handles multiple missing scopes; re-raises anything that isn't a mappable scope error (preserving the existing per-app skip for genuine failures). Only the un-granted conversation type is skipped — the rest of the app catches up normally.

## Tests

`test_list_conversations_degrades_on_missing_scope` — a client that raises `missing_scope` for `mpim` and asserts the readable channel's message still replays (RED before → GREEN after). Full channels/inbound/slack surface green (234 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)