### PR TITLE
feat(channels): capture Slack file ids so agents can fetch channel files on demand

### DIFF
--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -61,11 +61,15 @@ class InboundFileRef:
     ``url`` is the platform's download URL (auth-gated for Slack);
     ``mime_type`` is the platform's type or a ``mimetypes.guess_type``
     fallback; ``size`` is the platform-reported byte size when known.
+    ``file_id`` is the platform's opaque file identifier (e.g. Slack's
+    ``F…`` id) that can be passed to ``fetch_channel_file`` for on-demand
+    download.  ``None`` when the platform does not provide one.
     """
     url: str
     filename: str
     mime_type: str
     size: int | None
+    file_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -575,6 +579,14 @@ class ChannelInboundPipeline:
             event_data["images"] = _images
         if _attachments:
             event_data["attachments"] = _attachments
+
+        _file_refs = [
+            {"id": f.file_id, "name": f.filename}
+            for f in (getattr(msg, "files", None) or [])
+            if getattr(f, "file_id", None)
+        ]
+        if _file_refs:
+            event_data["source"]["files"] = _file_refs
 
         await deps.session_store.emit_event(
             session_id,

--- a/surogates/channels/platforms/slack.py
+++ b/surogates/channels/platforms/slack.py
@@ -409,6 +409,7 @@ def parse(body: dict, *, bot_user_id: str) -> InboundMessage | None:
         files.append(InboundFileRef(
             url=url, filename=name, mime_type=mime,
             size=int(size) if isinstance(size, int) else None,
+            file_id=file_info.get("id"),
         ))
 
     if file_names:

--- a/surogates/harness/loop_attachments.py
+++ b/surogates/harness/loop_attachments.py
@@ -61,43 +61,74 @@ def _attachments_note_from_data(data: Any) -> str | None:
     """Pure helper: render the attachments note from a user.message data dict."""
     if not isinstance(data, dict):
         return None
+
+    # Section 1: downloaded/workspace attachments (existing behaviour preserved).
+    attachments_section: str | None = None
     attachments = data.get("attachments")
-    if not isinstance(attachments, list) or not attachments:
-        return None
+    if isinstance(attachments, list) and attachments:
+        lines = [
+            "The user attached the following files to this message. They are"
+            " available in the workspace and you can read them with your file"
+            " tools:",
+        ]
+        for item in attachments:
+            if not isinstance(item, dict):
+                continue
+            if item.get("inlined_text"):
+                # Content already in the user message text via
+                # _render_inlined_attachments — don't double-list it here.
+                continue
+            path = item.get("path")
+            filename = item.get("filename")
+            if not path or not filename:
+                continue
+            mime = item.get("mime_type") or "application/octet-stream"
+            raw_size = item.get("size")
+            if isinstance(raw_size, (int, float)) and raw_size >= 0:
+                size_str = _format_bytes(int(raw_size))
+            else:
+                size_str = "unknown size"
+            line = f"- {path} ({mime}, {size_str}) — \"{filename}\""
+            skip_reason = item.get("inline_skip_reason")
+            if skip_reason:
+                hint = _ATTACHMENT_SKIP_HINTS.get(skip_reason, "use read_file")
+                line += f" (inline skipped: {skip_reason} — {hint})"
+            lines.append(line)
 
-    lines = [
-        "The user attached the following files to this message. They are"
-        " available in the workspace and you can read them with your file"
-        " tools:",
-    ]
-    for item in attachments:
-        if not isinstance(item, dict):
-            continue
-        if item.get("inlined_text"):
-            # Content already in the user message text via
-            # _render_inlined_attachments — don't double-list it here.
-            continue
-        path = item.get("path")
-        filename = item.get("filename")
-        if not path or not filename:
-            continue
-        mime = item.get("mime_type") or "application/octet-stream"
-        raw_size = item.get("size")
-        if isinstance(raw_size, (int, float)) and raw_size >= 0:
-            size_str = _format_bytes(int(raw_size))
-        else:
-            size_str = "unknown size"
-        line = f"- {path} ({mime}, {size_str}) — \"{filename}\""
-        skip_reason = item.get("inline_skip_reason")
-        if skip_reason:
-            hint = _ATTACHMENT_SKIP_HINTS.get(skip_reason, "use read_file")
-            line += f" (inline skipped: {skip_reason} — {hint})"
-        lines.append(line)
+        if len(lines) > 1:
+            attachments_section = "\n".join(lines)
 
-    if len(lines) == 1:
-        # All items malformed or all inlined.
-        return None
-    return "\n".join(lines)
+    # Section 2: channel file ids from source.files (additive, never raises).
+    files_section: str | None = None
+    try:
+        source_files = (data.get("source") or {}).get("files")
+        if isinstance(source_files, list):
+            file_lines = []
+            for f in source_files:
+                if not isinstance(f, dict):
+                    continue
+                fid = f.get("id")
+                if not fid:
+                    continue
+                name = f.get("name") or "file"
+                file_lines.append(f"- \"{name}\" — file id {fid}")
+            if file_lines:
+                header = (
+                    "These files were shared in this channel. If one is not"
+                    " already in your workspace above, download it on demand"
+                    " with fetch_channel_file(\"<id>\"):"
+                )
+                files_section = header + "\n" + "\n".join(file_lines)
+    except Exception:
+        pass
+
+    if attachments_section and files_section:
+        return attachments_section + "\n\n" + files_section
+    if attachments_section:
+        return attachments_section
+    if files_section:
+        return files_section
+    return None
 
 
 def _render_inlined_attachments(

--- a/tests/test_chat_attachments_note.py
+++ b/tests/test_chat_attachments_note.py
@@ -243,6 +243,73 @@ def test_attachments_note_orders_files_as_provided():
     assert first_idx < second_idx
 
 
+def test_attachments_note_source_files_only_no_attachments():
+    """source.files without attachments → non-None note with fetch_channel_file and id."""
+    note = _attachments_note([_user_event({
+        "content": "here is a file",
+        "source": {"files": [{"id": "F123", "name": "report.pdf"}]},
+    })])
+    assert note is not None
+    assert "fetch_channel_file" in note
+    assert "F123" in note
+    assert "report.pdf" in note
+
+
+def test_attachments_note_both_attachments_and_source_files():
+    """Both a downloaded attachment AND source.files → note contains both sections."""
+    note = _attachments_note([_user_event({
+        "content": "see attached",
+        "attachments": [
+            {
+                "path": "uploads/doc.txt",
+                "filename": "doc.txt",
+                "mime_type": "text/plain",
+                "size": 10,
+            },
+        ],
+        "source": {"files": [{"id": "F123", "name": "report.pdf"}]},
+    })])
+    assert note is not None
+    # Existing attachments section present
+    assert "uploads/doc.txt" in note
+    assert "file tools" in note
+    # Channel file id section present
+    assert "fetch_channel_file" in note
+    assert "F123" in note
+
+
+def test_attachments_note_no_source_files_unchanged():
+    """Existing tests: no source.files → None (no regressions)."""
+    note = _attachments_note([_user_event({"content": "hi"})])
+    assert note is None
+
+
+def test_attachments_note_source_files_missing_id_skipped():
+    """A source.files entry without an 'id' field must be silently skipped."""
+    note = _attachments_note([_user_event({
+        "source": {"files": [{"name": "no-id.txt"}]},
+    })])
+    assert note is None
+
+
+def test_attachments_note_source_files_malformed_skipped():
+    """Malformed source.files (not a list) must not raise; returns None."""
+    note = _attachments_note([_user_event({
+        "source": {"files": "oops"},
+    })])
+    assert note is None
+
+
+def test_attachments_note_source_files_name_defaults_to_file():
+    """A source.files entry without a 'name' shows fallback label 'file'."""
+    note = _attachments_note([_user_event({
+        "source": {"files": [{"id": "FXYZ"}]},
+    })])
+    assert note is not None
+    assert "FXYZ" in note
+    assert "file" in note
+
+
 def test_attachments_note_inserts_adjacent_to_user_when_view_context_also_present():
     """When both notes apply, attachments must sit closest to the user message.
 

--- a/tests/test_inbound_attachments.py
+++ b/tests/test_inbound_attachments.py
@@ -174,3 +174,79 @@ async def test_none_attachments_keeps_existing_event_shape():
     assert ev[2]["content"] == "hello"
     assert "images" not in ev[2]
     assert "attachments" not in ev[2]
+
+
+# ---------------------------------------------------------------------------
+# Test 4: source.files persisted when msg.files carry file_ids
+# ---------------------------------------------------------------------------
+
+
+def _file_with_id() -> InboundFileRef:
+    return InboundFileRef(
+        url="https://files.slack.com/p1",
+        filename="report.pdf",
+        mime_type="application/pdf",
+        size=2048,
+        file_id="F0ABCDE1234",
+    )
+
+
+async def test_user_message_event_carries_source_files_when_file_ids_present():
+    """USER_MESSAGE source.files must list ids+names for files that have a file_id."""
+    deps = _make_deps()
+    msg = replace(
+        _make_msg(is_dm=True, identifier="D1", ts="103.0"),
+        files=[_file_with_id()],
+    )
+
+    result = await ChannelInboundPipeline().handle(
+        msg,
+        routing=_make_routing(),
+        config=_make_config(),
+        deps=deps,
+    )
+
+    assert result == InboundOutcome.PROCESSED
+    ev = next(e for e in deps.session_store.events if e[1] == EventType.USER_MESSAGE)
+    data = ev[2]
+    assert data["source"]["files"] == [{"id": "F0ABCDE1234", "name": "report.pdf"}]
+
+
+async def test_user_message_event_no_source_files_when_no_file_ids():
+    """USER_MESSAGE must NOT add source.files when no files carry a file_id."""
+    deps = _make_deps()
+    # _file() has no file_id (defaults to None)
+    msg = replace(
+        _make_msg(is_dm=True, identifier="D1", ts="104.0"),
+        files=[_file()],
+    )
+
+    result = await ChannelInboundPipeline().handle(
+        msg,
+        routing=_make_routing(),
+        config=_make_config(),
+        deps=deps,
+    )
+
+    assert result == InboundOutcome.PROCESSED
+    ev = next(e for e in deps.session_store.events if e[1] == EventType.USER_MESSAGE)
+    data = ev[2]
+    assert "files" not in data["source"]
+
+
+async def test_user_message_event_no_source_files_when_no_files_at_all():
+    """USER_MESSAGE must NOT add source.files when msg.files is empty."""
+    deps = _make_deps()
+    msg = _make_msg(is_dm=True, identifier="D1", ts="105.0")
+
+    result = await ChannelInboundPipeline().handle(
+        msg,
+        routing=_make_routing(),
+        config=_make_config(),
+        deps=deps,
+    )
+
+    assert result == InboundOutcome.PROCESSED
+    ev = next(e for e in deps.session_store.events if e[1] == EventType.USER_MESSAGE)
+    data = ev[2]
+    assert "files" not in data["source"]

--- a/tests/test_slack_attachments_parse.py
+++ b/tests/test_slack_attachments_parse.py
@@ -73,3 +73,33 @@ def test_parse_sanitizes_null_byte_in_filename_in_text_marker():
     msg = parse(body, bot_user_id="U_BOT")
     assert msg is not None
     assert "\x00" not in msg.text
+
+
+def test_parse_captures_slack_file_id_on_inbound_ref():
+    """The Slack file_info 'id' (F…) must be preserved on InboundFileRef.file_id."""
+    body = _event([
+        {
+            "id": "F0ABCDE1234",
+            "url_private_download": "https://files.slack.com/d1",
+            "name": "report.pdf",
+            "mimetype": "application/pdf",
+            "size": 1234,
+        },
+    ])
+    msg = parse(body, bot_user_id="U_BOT")
+    assert msg is not None
+    assert msg.files[0].file_id == "F0ABCDE1234"
+
+
+def test_parse_file_id_is_none_when_slack_omits_id():
+    """When Slack does not provide an 'id', file_id must be None (not raise)."""
+    body = _event([
+        {
+            "url_private": "https://files.slack.com/p3",
+            "name": "notes.txt",
+            "mimetype": "text/plain",
+        },
+    ])
+    msg = parse(body, bot_user_id="U_BOT")
+    assert msg is not None
+    assert msg.files[0].file_id is None


### PR DESCRIPTION
## Problem

The Slack adapter dropped the `F…` file id when building `InboundFileRef` (kept only url/filename/mime/size), so live-shared channel files left no id anywhere the agent could see. `fetch_channel_file(file_id)` — the on-demand download tool — then had nothing to reference, and agents reported *"the file ID isn't captured in my channel history."* Only the pre-join backfill path exposed ids, so DMs, live messages, and cross-session files had none.

## Fix

- **Capture** — `InboundFileRef` gains an optional `file_id`, populated from `file_info["id"]` in the Slack adapter.
- **Persist** — each `USER_MESSAGE` event records `source.files = [{id, name}, …]` (durable and event-queryable, independent of whether the bytes were downloaded, inlined, or skipped).
- **Surface** — the harness attachment note renders a second section from `source.files` telling the agent it can `fetch_channel_file("<id>")`, listing each `- "name" — file id F…`. Renders even when nothing landed in the workspace. The existing "attached files → read_file" section is preserved verbatim.

`fetch_channel_file`'s own `_shared_in_channel` validation already checks Slack's `files.info` share lists, so no server-side change is needed — the only missing link was giving the agent an id to pass.

## Tests

TDD RED→GREEN per part. New coverage: Slack parse carries `file_id`; the event persists `source.files` (and omits it when no ids); the note surfaces the fetch line (including a files-only, nothing-downloaded case) while existing note tests stay byte-for-byte green. 238 passed across note-rendering, inbound, pipeline, catch-up, and slack-platform suites. Six files changed (3 production + 3 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)