### PR TITLE
feat(channels): live-update one Slack message across a turn instead of spamming steps

### DIFF
--- a/surogates/channels/dispatcher.py
+++ b/surogates/channels/dispatcher.py
@@ -666,6 +666,24 @@ class ChannelDeliveryDispatcher:
             refs=platform.descriptor.vault_refs(identifier),
         )
 
+        intermediate = bool(item.payload.get("intermediate"))
+        supports_edit = getattr(platform, "supports_edit", False)
+
+        # Intermediate narration: fold into the single progress message on
+        # edit-capable platforms; suppress elsewhere so only the final answer
+        # reaches the channel.
+        if intermediate and not supports_edit:
+            await self._delivery.mark_delivered(item.id, provider_message_id=None)
+            return
+        if intermediate and self._redis is not None:
+            fresh = await self._redis.set(
+                f"channel-progress-edit:{platform.kind}:{item.session_id}",
+                "1", ex=1, nx=True,
+            )
+            if not fresh:  # a sub-second-old edit already in flight — coalesce
+                await self._delivery.mark_delivered(item.id, provider_message_id=None)
+                return
+
         # Thinking-placeholder: if inbound posted one for this session and it is
         # for this channel, edit it instead of posting a fresh reply.
         update_ts = None
@@ -764,14 +782,33 @@ class ChannelDeliveryDispatcher:
             await self._delivery.mark_delivered(
                 item.id, provider_message_id=result.message_id
             )
-            if update_ts is not None and self._redis is not None:
-                try:
-                    from surogates.channels.channel_progress import clear_placeholder
-                    await clear_placeholder(self._redis, platform.kind, item.session_id)
-                except Exception:
-                    logger.warning(
-                        "[delivery] clear placeholder failed for outbox %d — ignoring", item.id,
-                    )
+            if self._redis is not None:
+                from surogates.channels.channel_progress import (
+                    clear_placeholder,
+                    set_placeholder,
+                )
+                if intermediate:
+                    ts = result.message_id or update_ts
+                    if ts:
+                        try:
+                            await set_placeholder(
+                                self._redis, platform.kind, item.session_id,
+                                channel=item.destination.get("channel_id", ""),
+                                ts=ts,
+                                thread_ts=item.destination.get("thread_ts"),
+                            )
+                        except Exception:
+                            logger.warning(
+                                "[delivery] set_placeholder failed for outbox %d — ignoring",
+                                item.id,
+                            )
+                elif update_ts is not None:
+                    try:
+                        await clear_placeholder(self._redis, platform.kind, item.session_id)
+                    except Exception:
+                        logger.warning(
+                            "[delivery] clear placeholder failed for outbox %d — ignoring", item.id,
+                        )
             # Mark the sent message (and its thread, if any) as bot-authored.
             # Best-effort: a Redis error here must NOT re-mark the item as failed.
             if self._redis is not None and result.message_id:

--- a/surogates/channels/platforms/slack.py
+++ b/surogates/channels/platforms/slack.py
@@ -483,6 +483,7 @@ class SlackPlatform:
     """
 
     kind = "slack"
+    supports_edit = True
     topology = "webhook"
 
     _THINKING_TEXT = "_Thinking…_"

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -75,6 +75,34 @@ _INBOX_EVENTS = frozenset({
 _MAX_LISTED_DESCENDANTS = 1000
 
 
+def _build_channel_payload(event_type: EventType, data: dict, channel: str) -> dict:
+    """Extract the deliverable payload from an event. Empty dict = nothing to
+    deliver. LLM_RESPONSE rows carry ``intermediate`` (True when the assistant
+    message still has tool_calls, i.e. it is narration before a tool call rather
+    than the turn's final answer)."""
+    payload: dict[str, Any] = {}
+    if event_type == EventType.LLM_RESPONSE:
+        msg = data.get("message", {})
+        content = msg.get("content", "") if isinstance(msg, dict) else ""
+        if content and isinstance(content, str):
+            content = strip_next_action_blocks(content)
+        if content:
+            payload["content"] = content
+            payload["intermediate"] = bool(
+                isinstance(msg, dict) and msg.get("tool_calls")
+            )
+    elif event_type == EventType.INBOX_INPUT_REQUIRED and channel == "slack":
+        questions = data.get("questions") or []
+        if questions:
+            payload = {
+                "input_prompt": True,
+                "tool_call_id": (data.get("tool_call_id") or "").strip(),
+                "questions": questions,
+                "context": strip_next_action_blocks(data.get("context", "") or ""),
+            }
+    return payload
+
+
 class SessionStore:
     """Async, PostgreSQL-backed store for sessions, events, leases, and cursors.
 
@@ -799,40 +827,7 @@ class SessionStore:
                 destination = {"session_id": str(session_id)}
 
             # Build payload: extract the user-facing content from the event.
-            payload: dict[str, Any] = {}
-            if event_type == EventType.LLM_RESPONSE:
-                msg = data.get("message", {})
-                content = msg.get("content", "") if isinstance(msg, dict) else ""
-                if content and isinstance(content, str):
-                    # The <next_action> footer is harness/UI metadata.  The
-                    # web SDK strips it client-side and renders a status
-                    # pill; messaging channels deliver raw text, so strip
-                    # it server-side here.  A footer-only message strips
-                    # to "" and falls through to the nothing-to-deliver
-                    # return below.
-                    content = strip_next_action_blocks(content)
-                if content:
-                    payload["content"] = content
-            elif event_type == EventType.INBOX_INPUT_REQUIRED and channel == "slack":
-                # Only Slack renders the interactive modal.  Other channels have
-                # no input_prompt surface, and their send() reads payload[
-                # "content"] — a content-less row would post empty text (the
-                # Telegram API rejects it).  Leave payload empty so the
-                # nothing-to-deliver guard below skips non-Slack channels.
-                questions = data.get("questions") or []
-                if questions:
-                    # The model appends its <next_action> footer to free text,
-                    # including the context argument — strip it the same as the
-                    # LLM_RESPONSE content path so it never reaches the channel.
-                    payload = {
-                        "input_prompt": True,
-                        "tool_call_id": (data.get("tool_call_id") or "").strip(),
-                        "questions": questions,
-                        "context": strip_next_action_blocks(
-                            data.get("context", "") or ""
-                        ),
-                    }
-
+            payload = _build_channel_payload(event_type, data, channel)
             if not payload:
                 return  # Nothing to deliver (e.g., tool-call-only LLM_RESPONSE).
 

--- a/tests/test_channel_delivery.py
+++ b/tests/test_channel_delivery.py
@@ -1677,3 +1677,238 @@ class TestSlackMediaDelivery:
         assert platform.deleted == [{"channel": "C001", "ts": "1700.5"}]
         assert progress_key("slack", session_id) in redis.deleted
         assert delivery.delivered == [(5, "FA9")]
+
+
+# ---------------------------------------------------------------------------
+# Tests: live-progress dispatcher state machine (Task 2)
+# ---------------------------------------------------------------------------
+
+
+class _FullRedis:
+    """Fake Redis supporting get/set/delete and set(..., nx=True) for throttle tests."""
+
+    def __init__(self, store: dict | None = None) -> None:
+        self.kv: dict[str, Any] = dict(store or {})
+        self.deleted: list[str] = []
+
+    async def get(self, key: str) -> Any:
+        return self.kv.get(key)
+
+    async def set(
+        self,
+        key: str,
+        value: Any,
+        ex: int | None = None,
+        nx: bool = False,
+    ) -> Any:
+        if nx:
+            if key in self.kv:
+                return None  # already set — NX fails
+            self.kv[key] = value
+            return True
+        self.kv[key] = value
+        return True
+
+    async def delete(self, *keys: str) -> None:
+        for key in keys:
+            self.deleted.append(key)
+            self.kv.pop(key, None)
+
+    async def exists(self, key: str) -> int:
+        return 1 if key in self.kv else 0
+
+
+class _FakeEditablePlatform(_FakePlatform):
+    """_FakePlatform that declares supports_edit = True."""
+    supports_edit = True
+
+
+def _make_live_dispatcher(
+    platform=None,
+    delivery=None,
+    redis=None,
+):
+    from surogates.channels.dispatcher import ChannelDeliveryDispatcher
+
+    return ChannelDeliveryDispatcher(
+        cache=_FakeCache(_KNOWN_CACHE),
+        vault=_FakeVault(),
+        delivery_service=delivery or _FakeDeliveryService(),
+        redis=redis or _FullRedis(),
+    )
+
+
+class TestLiveProgressDispatcher:
+    """State-machine tests for live-update / intermediate-suppression behaviour."""
+
+    async def test_slack_intermediate_with_placeholder_edits_and_sets_new_placeholder(self):
+        """Intermediate + edit-capable + existing placeholder → send with update_ts;
+        clear_placeholder NOT called; set_placeholder called with result ts."""
+        import json
+        from surogates.channels.channel_progress import progress_key, read_placeholder
+
+        session_id = uuid4()
+        placeholder_ts = "111.0"
+        redis = _FullRedis({
+            progress_key("slack", session_id): json.dumps(
+                {"channel": "C001", "ts": placeholder_ts, "thread_ts": "100.0"}
+            ),
+        })
+
+        item = _FakeOutboxItem(
+            id=1,
+            session_id=session_id,
+            destination={
+                "channel_identifier": APP_ID,
+                "channel_id": "C001",
+                "thread_ts": "100.0",
+            },
+            payload={"content": "step", "intermediate": True},
+        )
+        delivery = _FakeDeliveryService(items=[item])
+        result_ts = "222.0"
+        platform = _FakeEditablePlatform(result=SendResult(success=True, message_id=result_ts))
+        dispatcher = _make_live_dispatcher(platform=platform, delivery=delivery, redis=redis)
+
+        await dispatcher._deliver_item(platform, item)
+
+        # update_ts injected from the placeholder
+        assert item.destination["update_ts"] == placeholder_ts
+        # send was called
+        assert len(platform.send_calls) == 1
+        # clear_placeholder must NOT have been called (placeholder key still present or
+        # replaced with the new ts — not deleted)
+        ph = await read_placeholder(redis, "slack", session_id)
+        assert ph is not None, "placeholder must still exist after an intermediate send"
+        # set_placeholder updated it to the new ts
+        assert ph["ts"] == result_ts
+        # mark_delivered called
+        assert delivery.delivered == [(1, result_ts)]
+        assert delivery.failed == []
+
+    async def test_slack_intermediate_no_placeholder_posts_fresh_and_sets_placeholder(self):
+        """Intermediate + no placeholder → send without update_ts; set_placeholder called."""
+        from surogates.channels.channel_progress import read_placeholder
+
+        session_id = uuid4()
+        redis = _FullRedis()  # empty — no placeholder
+
+        item = _FakeOutboxItem(
+            id=2,
+            session_id=session_id,
+            destination={
+                "channel_identifier": APP_ID,
+                "channel_id": "C001",
+                "thread_ts": "100.0",
+            },
+            payload={"content": "step", "intermediate": True},
+        )
+        delivery = _FakeDeliveryService(items=[item])
+        result_ts = "333.0"
+        platform = _FakeEditablePlatform(result=SendResult(success=True, message_id=result_ts))
+        dispatcher = _make_live_dispatcher(platform=platform, delivery=delivery, redis=redis)
+
+        await dispatcher._deliver_item(platform, item)
+
+        # no update_ts injected (no placeholder existed)
+        assert "update_ts" not in item.destination
+        # send was called
+        assert len(platform.send_calls) == 1
+        # set_placeholder called with the new ts
+        ph = await read_placeholder(redis, "slack", session_id)
+        assert ph is not None, "set_placeholder must have been called after intermediate send"
+        assert ph["ts"] == result_ts
+        assert delivery.delivered == [(2, result_ts)]
+
+    async def test_slack_final_with_placeholder_sends_and_clears(self):
+        """Final message + placeholder → send with update_ts; clear_placeholder IS called."""
+        import json
+        from surogates.channels.channel_progress import progress_key, read_placeholder
+
+        session_id = uuid4()
+        placeholder_ts = "444.0"
+        redis = _FullRedis({
+            progress_key("slack", session_id): json.dumps(
+                {"channel": "C001", "ts": placeholder_ts, "thread_ts": "100.0"}
+            ),
+        })
+
+        item = _FakeOutboxItem(
+            id=3,
+            session_id=session_id,
+            destination={
+                "channel_identifier": APP_ID,
+                "channel_id": "C001",
+                "thread_ts": "100.0",
+            },
+            payload={"content": "Here is the answer", "intermediate": False},
+        )
+        delivery = _FakeDeliveryService(items=[item])
+        platform = _FakeEditablePlatform(result=SendResult(success=True, message_id="555.0"))
+        dispatcher = _make_live_dispatcher(platform=platform, delivery=delivery, redis=redis)
+
+        await dispatcher._deliver_item(platform, item)
+
+        assert item.destination["update_ts"] == placeholder_ts
+        assert len(platform.send_calls) == 1
+        # clear_placeholder must have been called on final message
+        ph = await read_placeholder(redis, "slack", session_id)
+        assert ph is None, "clear_placeholder must be called on the final message"
+        assert delivery.delivered == [(3, "555.0")]
+
+    async def test_non_edit_platform_intermediate_suppressed(self):
+        """Intermediate on a platform without supports_edit → mark_delivered, no send."""
+        session_id = uuid4()
+        item = _FakeOutboxItem(
+            id=4,
+            session_id=session_id,
+            destination={
+                "channel_identifier": APP_ID,
+                "channel_id": "C001",
+            },
+            payload={"content": "narration step", "intermediate": True},
+        )
+        delivery = _FakeDeliveryService(items=[item])
+        # _FakePlatform has no supports_edit attribute
+        platform = _FakePlatform(result=SendResult(success=True, message_id="x"))
+        dispatcher = _make_live_dispatcher(platform=platform, delivery=delivery)
+
+        await dispatcher._deliver_item(platform, item)
+
+        # send must NOT be called for suppressed intermediates
+        assert platform.send_calls == [], "send must not be called for suppressed intermediate"
+        # mark_delivered must still be called (item consumed from outbox)
+        assert len(delivery.delivered) == 1
+        assert delivery.delivered[0][0] == 4
+        assert delivery.failed == []
+
+    async def test_slack_intermediate_throttle_coalesces_second_edit(self):
+        """Two intermediate items back-to-back: the redis nx key is already set on the
+        second → the second is mark_delivered without send."""
+        session_id = uuid4()
+        throttle_key = f"channel-progress-edit:slack:{session_id}"
+
+        # Pre-seed the throttle key to simulate a recent-in-flight edit.
+        redis = _FullRedis({throttle_key: "1"})
+
+        item = _FakeOutboxItem(
+            id=5,
+            session_id=session_id,
+            destination={
+                "channel_identifier": APP_ID,
+                "channel_id": "C001",
+            },
+            payload={"content": "another step", "intermediate": True},
+        )
+        delivery = _FakeDeliveryService(items=[item])
+        platform = _FakeEditablePlatform(result=SendResult(success=True, message_id="y"))
+        dispatcher = _make_live_dispatcher(platform=platform, delivery=delivery, redis=redis)
+
+        await dispatcher._deliver_item(platform, item)
+
+        # Throttled: send must NOT be called
+        assert platform.send_calls == [], "throttled intermediate must not call send"
+        # mark_delivered still called (coalesced away)
+        assert len(delivery.delivered) == 1
+        assert delivery.delivered[0][0] == 5
+        assert delivery.failed == []

--- a/tests/test_channel_delivery_payload.py
+++ b/tests/test_channel_delivery_payload.py
@@ -1,0 +1,36 @@
+"""Tests for the pure _build_channel_payload helper in store.py.
+
+Verifies that:
+- LLM_RESPONSE rows with tool_calls are tagged intermediate=True.
+- LLM_RESPONSE rows without tool_calls are tagged intermediate=False.
+- Tool-call-only responses (empty content) yield an empty payload.
+- INBOX_INPUT_REQUIRED is only delivered to Slack, not to other channels.
+"""
+
+from surogates.session.events import EventType
+from surogates.session.store import _build_channel_payload
+
+
+def test_intermediate_llm_response_tagged_intermediate():
+    data = {"message": {"content": "Let me try X", "tool_calls": [{"id": "t1"}]}}
+    p = _build_channel_payload(EventType.LLM_RESPONSE, data, "slack")
+    assert p["content"] == "Let me try X"
+    assert p["intermediate"] is True
+
+
+def test_final_llm_response_tagged_not_intermediate():
+    data = {"message": {"content": "Here is the answer", "tool_calls": []}}
+    p = _build_channel_payload(EventType.LLM_RESPONSE, data, "slack")
+    assert p["content"] == "Here is the answer"
+    assert p["intermediate"] is False
+
+
+def test_tool_call_only_response_yields_empty_payload():
+    data = {"message": {"content": "", "tool_calls": [{"id": "t1"}]}}
+    assert _build_channel_payload(EventType.LLM_RESPONSE, data, "slack") == {}
+
+
+def test_input_required_payload_slack_only():
+    data = {"questions": [{"q": "?"}], "tool_call_id": "t1", "context": "ctx"}
+    assert _build_channel_payload(EventType.INBOX_INPUT_REQUIRED, data, "slack")["input_prompt"] is True
+    assert _build_channel_payload(EventType.INBOX_INPUT_REQUIRED, data, "telegram") == {}


### PR DESCRIPTION
## Problem

A channel agent posted **every** intermediate reasoning step as its own Slack message ("Let me try…", "The HTML files were shared but aren't in…"), flooding the channel — a dozen+ messages per task. Cause: the delivery gate enqueues every `LLM_RESPONSE`, and the harness emits one per assistant turn including the narration before a tool call. The "Thinking…" placeholder edits only the *first* message, then clears — so steps 2..N post fresh.

## Fix

- **Gate tagging** — `_build_channel_payload` (extracted, pure) tags each `LLM_RESPONSE` with `intermediate = bool(message.tool_calls)`. Empty tool-call-only responses still enqueue nothing.
- **Slack** — one progress message per turn: intermediate steps edit it in place (`chat_update`) and **keep** the placeholder; only the **final** message (no tool_calls) clears it. If the placeholder TTL expires mid-turn, the next step posts fresh and adopts that `ts`. Sub-second edits are coalesced via a Redis `nx` key to respect the `chat.update` tier.
- **Teams/Telegram** — a `supports_edit` capability flag (Slack `True`, others default `False`): intermediate narration is suppressed (final-only), which also removes the flood, with no per-platform edit wiring in this change.

The final-answer delivery path is behavior-preserving except that the placeholder now clears on the final message rather than after the first send.

Design: `docs/superpowers/specs/2026-07-01-slack-live-progress-message.md` (on surogate-ops).

## Tests

TDD RED→GREEN: 4 gate-payload tests (intermediate/final tag, tool-only empty, input-required); 5 dispatcher state-machine tests (Slack edit-keep with/without placeholder, final-clears, non-edit-suppresses, throttle-coalesces). 236 passed across the delivery, dispatcher, progress, pipeline, and slack-platform suites; the existing real-`chat_update` placeholder test stays green.

## Note

Like the other channel changes, this only reaches the live agent once **deployed** (latest release v2.9.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)