### PR TITLE
fix(channels): always resume the same session per routing key instead of a new one per message

### DIFF
--- a/surogates/channels/identity.py
+++ b/surogates/channels/identity.py
@@ -295,6 +295,12 @@ def make_cached_identity_resolver(
     return _resolver
 
 
+# Statuses whose session is reused for a routing key. completed/paused are
+# idle-but-resumable (re-activated on reuse); active/processing are in flight.
+# Any other status (failed, archived, …) starts a fresh session.
+_RESUMABLE_STATUSES = ("active", "processing", "paused", "completed")
+
+
 async def get_or_create_channel_session(
     session_store: SessionStore,
     redis: object,
@@ -310,11 +316,9 @@ async def get_or_create_channel_session(
     storage: object = None,
     settings: object = None,
 ) -> UUID:
-    """Reuse the most-recent session for the channel routing key — resuming a
-    completed one so the conversation continues — or create a new session.
-
-    Also enqueues the session to the Redis work queue so the worker picks
-    it up.
+    """Reuse the most-recent session for the channel routing key — resuming an
+    idle (completed/paused) one so the conversation continues — or create a new
+    session. The caller (the inbound pipeline) enqueues the returned session.
 
     Parameters
     ----------
@@ -341,18 +345,16 @@ async def get_or_create_channel_session(
     UUID
         The session ID (existing or newly created).
     """
-    # Check database for existing active session with this routing key.
+    # Always-resume: fetch the MOST-RECENT session for this routing key,
+    # regardless of status (order-then-decide). Deciding in Python — rather than
+    # filtering statuses in SQL — ensures a failed/terminal *most-recent* session
+    # starts fresh below instead of resurrecting an older completed one behind it.
     async with session_factory() as db:
         result = await db.execute(
             select(SessionRow)
             .where(SessionRow.user_id == user_id)
             .where(SessionRow.agent_id == agent_id)
             .where(SessionRow.channel == channel)
-            .where(
-                SessionRow.status.in_(
-                    ["active", "processing", "paused", "completed"]
-                )
-            )
             .where(
                 SessionRow.config["channel_session_key"].as_string() == session_key
             )
@@ -362,20 +364,17 @@ async def get_or_create_channel_session(
         existing = result.scalar_one_or_none()
         existing_id = existing.id if existing else None
         existing_status = existing.status if existing else None
-    if existing_id is not None:
-        # Always-resume: reuse the most-recent session for this routing key. If
-        # it has completed, re-activate it so the worker picks it up and the
-        # harness resumes it (replaying the full prior conversation) instead of
-        # starting a fresh session for every message. A failed session is not
-        # matched above, so a failure starts a new session.
-        if existing_status == "completed":
-            await session_store.update_session_status(existing_id, "active")
-            await session_store.emit_event(
-                existing_id, EventType.SESSION_RESUME, {},
-            )
+    # Reuse the session when it is in a resumable state. An idle one
+    # (completed/paused) is re-activated + resume-tagged so the worker continues
+    # it (the harness then replays the full prior conversation); active/processing
+    # are reused as-is. Anything else (failed, archived, …) — including as the
+    # most recent — falls through to a fresh session.
+    if existing_id is not None and existing_status in _RESUMABLE_STATUSES:
+        if existing_status in ("completed", "paused"):
+            await session_store.resume_session(existing_id, source="channel_message")
             logger.info(
-                "Resuming completed %s session %s (key: %s)",
-                channel, existing_id, session_key,
+                "Resuming %s session %s (status=%s, key=%s)",
+                channel, existing_id, existing_status, session_key,
             )
         return existing_id
 

--- a/surogates/channels/identity.py
+++ b/surogates/channels/identity.py
@@ -310,7 +310,8 @@ async def get_or_create_channel_session(
     storage: object = None,
     settings: object = None,
 ) -> UUID:
-    """Find an existing active session for the channel routing key, or create one.
+    """Reuse the most-recent session for the channel routing key — resuming a
+    completed one so the conversation continues — or create a new session.
 
     Also enqueues the session to the Redis work queue so the worker picks
     it up.
@@ -347,7 +348,11 @@ async def get_or_create_channel_session(
             .where(SessionRow.user_id == user_id)
             .where(SessionRow.agent_id == agent_id)
             .where(SessionRow.channel == channel)
-            .where(SessionRow.status.in_(["active", "processing", "paused"]))
+            .where(
+                SessionRow.status.in_(
+                    ["active", "processing", "paused", "completed"]
+                )
+            )
             .where(
                 SessionRow.config["channel_session_key"].as_string() == session_key
             )
@@ -355,8 +360,24 @@ async def get_or_create_channel_session(
             .limit(1)
         )
         existing = result.scalar_one_or_none()
-        if existing:
-            return existing.id
+        existing_id = existing.id if existing else None
+        existing_status = existing.status if existing else None
+    if existing_id is not None:
+        # Always-resume: reuse the most-recent session for this routing key. If
+        # it has completed, re-activate it so the worker picks it up and the
+        # harness resumes it (replaying the full prior conversation) instead of
+        # starting a fresh session for every message. A failed session is not
+        # matched above, so a failure starts a new session.
+        if existing_status == "completed":
+            await session_store.update_session_status(existing_id, "active")
+            await session_store.emit_event(
+                existing_id, EventType.SESSION_RESUME, {},
+            )
+            logger.info(
+                "Resuming completed %s session %s (key: %s)",
+                channel, existing_id, session_key,
+            )
+        return existing_id
 
     # Create a new session.
     session_id = uuid4()

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -266,6 +266,21 @@ class SessionStore:
                 raise SessionNotFoundError(f"session {session_id} not found")
             await db.commit()
 
+    async def resume_session(self, session_id: UUID, *, source: str = "") -> None:
+        """Re-activate an idle (completed/paused) session and record the resume.
+
+        Flips the status to ``active`` and emits a ``SESSION_RESUME`` event so the
+        worker continues the session. ``source`` tags the event for audit (which
+        surface triggered the resume). Centralizes the revive pair that several
+        routes and the harness otherwise open-code.
+        """
+        await self.update_session_status(session_id, "active")
+        await self.emit_event(
+            session_id,
+            EventType.SESSION_RESUME,
+            {"source": source} if source else {},
+        )
+
     async def archive_session_tree_and_delete_schedules(
         self,
         session_id: UUID,

--- a/tests/test_channel_session_resume.py
+++ b/tests/test_channel_session_resume.py
@@ -1,18 +1,16 @@
 """Channel sessions always resume the same session.
 
-An inbound channel message reuses the most-recent session for its routing key
-even when that session has ``completed`` — re-activating it so the harness
-replays the full prior conversation instead of starting a fresh session per
-message. A ``failed`` session is excluded (start fresh after a failure), and a
-key with no prior session creates a new one.
+An inbound channel message reuses the most-recent session for its routing key,
+re-activating an idle (completed/paused) one so the harness continues the
+conversation. A failed/terminal most-recent session — even with an older
+completed one behind it — starts fresh, and a key with no prior session creates
+one.
 """
 
 from __future__ import annotations
 
 from types import SimpleNamespace
 from uuid import uuid4
-
-from sqlalchemy.dialects import postgresql
 
 from surogates.channels.identity import get_or_create_channel_session
 from surogates.session.events import EventType
@@ -29,7 +27,6 @@ class _Result:
 class _DB:
     def __init__(self, value):
         self._value = value
-        self.stmt = None
 
     async def __aenter__(self):
         return self
@@ -37,34 +34,29 @@ class _DB:
     async def __aexit__(self, *exc):
         return False
 
-    async def execute(self, stmt, *a, **k):
-        self.stmt = stmt
+    async def execute(self, *a, **k):
         return _Result(self._value)
 
 
 class _SessionFactory:
     def __init__(self, value):
-        self.db = _DB(value)
+        self._value = value
 
     def __call__(self):
-        return self.db
+        return _DB(self._value)
 
 
 class _Store:
     def __init__(self):
         self.created = None
-        self.status_updates: list = []
-        self.events: list = []
+        self.resumed: list = []
 
     async def create_session(self, **kwargs):
         self.created = kwargs
         return SimpleNamespace(**kwargs)
 
-    async def update_session_status(self, session_id, status):
-        self.status_updates.append((session_id, status))
-
-    async def emit_event(self, session_id, event_type, data):
-        self.events.append((session_id, event_type, data))
+    async def resume_session(self, session_id, *, source=""):
+        self.resumed.append((session_id, source))
 
 
 async def _call(store, factory):
@@ -81,20 +73,39 @@ async def test_resumes_completed_session():
     sid = uuid4()
     store = _Store()
     got = await _call(store, _SessionFactory(SimpleNamespace(id=sid, status="completed")))
-    assert got == sid                          # reused, not a new session
-    assert store.created is None               # nothing created
-    assert store.status_updates == [(sid, "active")]   # re-activated for resume
-    assert store.events == [(sid, EventType.SESSION_RESUME, {})]  # resume emitted
+    assert got == sid
+    assert store.created is None
+    assert store.resumed == [(sid, "channel_message")]
 
 
-async def test_reuses_active_session_without_reactivation():
+async def test_resumes_paused_session():
+    # A paused session must also be re-activated on a new message — otherwise the
+    # harness's paused branch is a hard stop and the message is stranded.
+    sid = uuid4()
+    store = _Store()
+    got = await _call(store, _SessionFactory(SimpleNamespace(id=sid, status="paused")))
+    assert got == sid
+    assert store.created is None
+    assert store.resumed == [(sid, "channel_message")]
+
+
+async def test_reuses_active_session_without_resume():
     sid = uuid4()
     store = _Store()
     got = await _call(store, _SessionFactory(SimpleNamespace(id=sid, status="active")))
     assert got == sid
     assert store.created is None
-    assert store.status_updates == []          # already active — no status change
-    assert store.events == []                  # no resume event needed
+    assert store.resumed == []          # already active — no resume needed
+
+
+async def test_failed_most_recent_starts_fresh():
+    # The most-recent session for the key failed → do NOT resume it (nor an older
+    # completed one behind it, since the query no longer filters status): fresh.
+    store = _Store()
+    got = await _call(store, _SessionFactory(SimpleNamespace(id=uuid4(), status="failed")))
+    assert store.created is not None
+    assert got == store.created["session_id"]
+    assert store.resumed == []
 
 
 async def test_creates_when_no_prior_session():
@@ -102,14 +113,26 @@ async def test_creates_when_no_prior_session():
     got = await _call(store, _SessionFactory(None))
     assert store.created is not None
     assert got == store.created["session_id"]
-    assert store.status_updates == []
+    assert store.resumed == []
 
 
-async def test_lookup_includes_completed_excludes_failed():
-    factory = _SessionFactory(None)
-    await _call(_Store(), factory)
-    sql = str(factory.db.stmt.compile(
-        dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True},
-    ))
-    assert "completed" in sql          # a completed session is now reusable
-    assert "failed" not in sql         # a failed session is not resumed
+async def test_resume_session_helper_flips_status_and_tags_source():
+    from surogates.session.store import SessionStore
+
+    store = SessionStore.__new__(SessionStore)   # bypass __init__/DB
+    calls: list = []
+
+    async def _upd(sid, status):
+        calls.append(("status", sid, status))
+
+    async def _emit(sid, et, data):
+        calls.append(("event", sid, et, data))
+
+    store.update_session_status = _upd
+    store.emit_event = _emit
+    sid = uuid4()
+    await store.resume_session(sid, source="channel_message")
+    assert calls == [
+        ("status", sid, "active"),
+        ("event", sid, EventType.SESSION_RESUME, {"source": "channel_message"}),
+    ]

--- a/tests/test_channel_session_resume.py
+++ b/tests/test_channel_session_resume.py
@@ -1,0 +1,115 @@
+"""Channel sessions always resume the same session.
+
+An inbound channel message reuses the most-recent session for its routing key
+even when that session has ``completed`` — re-activating it so the harness
+replays the full prior conversation instead of starting a fresh session per
+message. A ``failed`` session is excluded (start fresh after a failure), and a
+key with no prior session creates a new one.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from sqlalchemy.dialects import postgresql
+
+from surogates.channels.identity import get_or_create_channel_session
+from surogates.session.events import EventType
+
+
+class _Result:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _DB:
+    def __init__(self, value):
+        self._value = value
+        self.stmt = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, stmt, *a, **k):
+        self.stmt = stmt
+        return _Result(self._value)
+
+
+class _SessionFactory:
+    def __init__(self, value):
+        self.db = _DB(value)
+
+    def __call__(self):
+        return self.db
+
+
+class _Store:
+    def __init__(self):
+        self.created = None
+        self.status_updates: list = []
+        self.events: list = []
+
+    async def create_session(self, **kwargs):
+        self.created = kwargs
+        return SimpleNamespace(**kwargs)
+
+    async def update_session_status(self, session_id, status):
+        self.status_updates.append((session_id, status))
+
+    async def emit_event(self, session_id, event_type, data):
+        self.events.append((session_id, event_type, data))
+
+
+async def _call(store, factory):
+    return await get_or_create_channel_session(
+        store, None,
+        session_key="agent:slack:dm:D1",
+        user_id=uuid4(), org_id=uuid4(), agent_id="a1",
+        channel="slack", config={"slack_channel_id": "D1"},
+        session_factory=factory,
+    )
+
+
+async def test_resumes_completed_session():
+    sid = uuid4()
+    store = _Store()
+    got = await _call(store, _SessionFactory(SimpleNamespace(id=sid, status="completed")))
+    assert got == sid                          # reused, not a new session
+    assert store.created is None               # nothing created
+    assert store.status_updates == [(sid, "active")]   # re-activated for resume
+    assert store.events == [(sid, EventType.SESSION_RESUME, {})]  # resume emitted
+
+
+async def test_reuses_active_session_without_reactivation():
+    sid = uuid4()
+    store = _Store()
+    got = await _call(store, _SessionFactory(SimpleNamespace(id=sid, status="active")))
+    assert got == sid
+    assert store.created is None
+    assert store.status_updates == []          # already active — no status change
+    assert store.events == []                  # no resume event needed
+
+
+async def test_creates_when_no_prior_session():
+    store = _Store()
+    got = await _call(store, _SessionFactory(None))
+    assert store.created is not None
+    assert got == store.created["session_id"]
+    assert store.status_updates == []
+
+
+async def test_lookup_includes_completed_excludes_failed():
+    factory = _SessionFactory(None)
+    await _call(_Store(), factory)
+    sql = str(factory.db.stmt.compile(
+        dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True},
+    ))
+    assert "completed" in sql          # a completed session is now reusable
+    assert "failed" not in sql         # a failed session is not resumed


### PR DESCRIPTION
## Problem

Every inbound channel message created a **new** session instead of continuing the conversation. Verified in DEV: multiple sessions shared the same `channel_session_key` (same DM / same thread), all `completed`, and `session.resume` events over 3 days = **0**.

Root cause — two halves that were never connected: the harness **completes** a session per objective and is designed for a follow-up to **revive** it ([loop.py:872](surogates/harness/loop.py#L872), stranded-message resume), but channel resolution (`get_or_create_channel_session`) reused a session only when `active`/`processing`/`paused` — **excluding `completed`** — so a follow-up never routed to the completed session; it always created a new one.

Consequences: every message re-ran the bounded backfill instead of continuing real context; in-conversation working state (tool results, fetched files, ask-question context) was lost each message; the resume/lease/cursor machinery was dead.

## Fix

`get_or_create_channel_session` now reuses the **most-recent session for the routing key** and re-activates an idle one, matching the canonical API resume pattern ([events.py:228](surogates/api/routes/events.py#L228)):

- **order-then-decide** — fetch the most-recent session *regardless of status*, then reuse it only if resumable (`active`/`processing`/`paused`/`completed`). A `failed`/terminal most-recent session starts fresh instead of resurrecting an older completed one behind it.
- **completed *and* paused** are re-activated (`status → active` + `session.resume`) via a new shared `SessionStore.resume_session(id, source=…)` helper; the resume event is tagged `{"source": "channel_message"}` for PROD audit.
- The harness then replays the **full** prior event log — real continuity, not the lossy backfill.

Per-key semantics are unchanged (`build_session_key`): a DM becomes one continuous session; thread replies continue their thread; a genuinely new thread (or a session that failed) starts fresh — as confirmed.

No harness change needed; the enqueue/worker resume path was verified end-to-end (`inbound.py` enqueues unconditionally; `wake()` acquires a fresh lease and replays the whole log; the cursor only gates *whether* to run, not *what* history loads).

## Tests

`get_or_create_channel_session`: completed→resume, paused→resume, active→reuse-no-resume, failed-most-recent→fresh, none→create; plus a `SessionStore.resume_session` unit test (flips status + emits `session.resume` with the source tag). 9 resume/workspace + 1097 channel/inbound/session/store regression pass.

## Note

Reviewed via a `/review` precision pass; fixes for paused-stranding, the failed-ordering gap, the source tag, and the shared helper are included. Like the other channel changes, this needs a **deploy** to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)