### PR TITLE
feat(agent-workspace): boundary-partitioned workspace + memory for channel threads

### DIFF
--- a/surogates/api/routes/artifacts.py
+++ b/surogates/api/routes/artifacts.py
@@ -27,7 +27,8 @@ from surogates.artifacts.store import (
 from surogates.session.events import EventType
 from surogates.session.store import SessionNotFoundError, SessionStore
 from surogates.storage.backend import StorageBackend
-from surogates.storage.tenant import prefixed_session_workspace_prefix
+from surogates.session.attachment_ingest import workspace_root_id
+from surogates.storage.tenant import boundary_workspace_prefix
 from surogates.tenant.auth.middleware import get_current_tenant
 from surogates.tenant.context import TenantContext
 
@@ -135,7 +136,9 @@ async def list_artifacts(
         _get_storage(request),
         session_id=session_id,
         bucket=bucket,
-        key_prefix=prefixed_session_workspace_prefix(session.config, session_id),
+        key_prefix=boundary_workspace_prefix(
+            session.config, session, workspace_root_id(session),
+        ),
     )
     artifacts = await artifact_store.list()
     return ArtifactListResponse(artifacts=artifacts)
@@ -163,7 +166,9 @@ async def get_artifact(
         _get_storage(request),
         session_id=session_id,
         bucket=bucket,
-        key_prefix=prefixed_session_workspace_prefix(session.config, session_id),
+        key_prefix=boundary_workspace_prefix(
+            session.config, session, workspace_root_id(session),
+        ),
     )
     try:
         meta = await artifact_store.get_meta(artifact_id)
@@ -213,7 +218,9 @@ async def create_artifact(
         _get_storage(request),
         session_id=session_id,
         bucket=bucket,
-        key_prefix=prefixed_session_workspace_prefix(session.config, session_id),
+        key_prefix=boundary_workspace_prefix(
+            session.config, session, workspace_root_id(session),
+        ),
     )
     try:
         meta = await artifact_store.create(

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -34,6 +34,7 @@ from surogates.session.store import SessionNotFoundError, SessionStore
 from surogates.storage.tenant import (
     boundary_workspace_key,
     boundary_workspace_prefix,
+    workspace_boundary,
 )
 from surogates.runtime import (
     AgentRuntimeContext,
@@ -1148,6 +1149,20 @@ async def _cleanup_archived_workspaces(
                 archived_session.id,
             )
             continue
+        # A boundary-partitioned session (managed channel) shares its
+        # workspace with every other session in the same conversation
+        # boundary — all threads in a Slack channel key into one
+        # ``boundaries/{boundary}/workspace/`` prefix. Deleting that prefix
+        # when a single session is archived would wipe siblings' live files,
+        # so retain it: the shared workspace outlives any one session.
+        if workspace_boundary(archived_session) is not None:
+            logger.info(
+                "Archived session %s is boundary-partitioned; retaining "
+                "shared workspace",
+                archived_session.id,
+            )
+            continue
+
         from surogates.session.attachment_ingest import workspace_root_id
 
         prefix = boundary_workspace_prefix(

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -32,8 +32,8 @@ from surogates.session.models import Session
 from surogates.session.provisioning import create_agent_session
 from surogates.session.store import SessionNotFoundError, SessionStore
 from surogates.storage.tenant import (
-    prefixed_session_workspace_key,
-    prefixed_session_workspace_prefix,
+    boundary_workspace_key,
+    boundary_workspace_prefix,
 )
 from surogates.runtime import (
     AgentRuntimeContext,
@@ -582,8 +582,8 @@ async def send_message(
         inline_tasks: list[tuple[int, AttachmentRef, asyncio.Task]] = []
         total_bytes = 0
         for attachment in body.attachments:
-            storage_key = prefixed_session_workspace_key(
-                session.config, root_id, attachment.path,
+            storage_key = boundary_workspace_key(
+                session.config, session, root_id, attachment.path,
             )
             if not await storage.exists(bucket, storage_key):
                 raise HTTPException(
@@ -1148,8 +1148,12 @@ async def _cleanup_archived_workspaces(
                 archived_session.id,
             )
             continue
-        prefix = prefixed_session_workspace_prefix(
-            archived_session.config, archived_session.id,
+        from surogates.session.attachment_ingest import workspace_root_id
+
+        prefix = boundary_workspace_prefix(
+            archived_session.config,
+            archived_session,
+            workspace_root_id(archived_session),
         )
         try:
             deleted = await storage.delete_prefix(storage_bucket, prefix)

--- a/surogates/api/routes/workspace.py
+++ b/surogates/api/routes/workspace.py
@@ -25,8 +25,8 @@ from surogates.session.models import Session
 from surogates.session.store import SessionNotFoundError, SessionStore
 from surogates.storage.backend import StorageBackend
 from surogates.storage.tenant import (
-    prefixed_session_workspace_key,
-    prefixed_session_workspace_prefix,
+    boundary_workspace_key,
+    boundary_workspace_prefix,
 )
 from surogates.tenant.auth.middleware import get_current_tenant
 from surogates.tenant.context import TenantContext
@@ -249,7 +249,7 @@ def _strip_session_prefix(session: Session, root_id: str, key: str) -> str:
     sees session-relative paths (``sessions/{root}/`` is hidden, and so
     is the agent ``storage_key_prefix`` when set).
     """
-    prefix = prefixed_session_workspace_prefix(session.config, root_id)
+    prefix = boundary_workspace_prefix(session.config, session, root_id)
     if not key.startswith(prefix):
         return key
     return key[len(prefix):]
@@ -383,7 +383,7 @@ async def get_workspace_tree(
         store, session_id, tenant,
     )
 
-    prefix = prefixed_session_workspace_prefix(session.config, root_id)
+    prefix = boundary_workspace_prefix(session.config, session, root_id)
     keys = await storage.list_keys(bucket, prefix=prefix)
     relative_keys = [_strip_session_prefix(session, root_id, k) for k in keys]
     # Drop keys living under reserved prefixes (artifact storage) so
@@ -435,7 +435,7 @@ async def get_workspace_file(
     try:
         data = await storage.read(
             bucket,
-            prefixed_session_workspace_key(session.config, root_id, path),
+            boundary_workspace_key(session.config, session, root_id, path),
         )
     except KeyError:
         raise HTTPException(status_code=404, detail=f"File not found: {path}")
@@ -523,7 +523,7 @@ async def upload_file(
 
     await storage.write(
         bucket,
-        prefixed_session_workspace_key(session.config, root_id, key),
+        boundary_workspace_key(session.config, session, root_id, key),
         contents,
     )
 
@@ -547,7 +547,7 @@ async def download_file(
         store, session_id, tenant,
     )
 
-    storage_key = prefixed_session_workspace_key(session.config, root_id, path)
+    storage_key = boundary_workspace_key(session.config, session, root_id, path)
     if not await storage.exists(bucket, storage_key):
         raise HTTPException(status_code=404, detail=f"File not found: {path}")
 
@@ -597,7 +597,7 @@ async def delete_file(
     )
     require_user_writable_session(session)
 
-    storage_key = prefixed_session_workspace_key(session.config, root_id, path)
+    storage_key = boundary_workspace_key(session.config, session, root_id, path)
     if not await storage.exists(bucket, storage_key):
         raise HTTPException(status_code=404, detail=f"File not found: {path}")
 

--- a/surogates/board/tools.py
+++ b/surogates/board/tools.py
@@ -359,14 +359,17 @@ async def _expand_note_handler(arguments: dict[str, Any], **kwargs: Any) -> str:
             ArtifactNotFoundError,
             ArtifactStore,
         )
-        from surogates.storage.tenant import prefixed_session_workspace_prefix
+        from surogates.session.attachment_ingest import workspace_root_id
+        from surogates.storage.tenant import boundary_workspace_prefix
 
         artifact_store = ArtifactStore(
             storage,
             session_id=target_sid,
             bucket=bucket,
-            key_prefix=prefixed_session_workspace_prefix(
-                target.config, target_sid,
+            key_prefix=boundary_workspace_prefix(
+                target.config,
+                target,
+                workspace_root_id(target),
             ),
         )
         try:

--- a/surogates/channels/channel_media.py
+++ b/surogates/channels/channel_media.py
@@ -20,7 +20,7 @@ from pathlib import PurePosixPath
 from typing import Any
 
 from surogates.session.attachment_ingest import safe_display_name, workspace_root_id
-from surogates.storage.tenant import prefixed_session_workspace_key
+from surogates.storage.tenant import boundary_workspace_key
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +121,7 @@ async def resolve_workspace_media(
         if rel is None:
             logger.warning("[channel_media] rejecting malformed media path: %r", raw)
             continue
-        key = prefixed_session_workspace_key(session.config, root_id, rel)
+        key = boundary_workspace_key(session.config, session, root_id, rel)
         try:
             meta = await storage.stat(bucket, key)
         except KeyError:

--- a/surogates/channels/identity.py
+++ b/surogates/channels/identity.py
@@ -17,6 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from surogates.channels.memory_boundary import MANAGED_CHANNELS
 from surogates.db.models import ChannelIdentity as ChannelIdentityRow
 from surogates.db.models import Session as SessionRow
 from surogates.session.events import EventType
@@ -370,6 +371,23 @@ async def get_or_create_channel_session(
     # are reused as-is. Anything else (failed, archived, …) — including as the
     # most recent — falls through to a fresh session.
     if existing_id is not None and existing_status in _RESUMABLE_STATUSES:
+        # Backfill boundary partitioning onto sessions created before the
+        # thread's boundary was known (or before workspace partitioning
+        # existed). Managed-channel threads carry a live ``memory_boundary``
+        # on every inbound message; mirror it onto the session's memory and
+        # workspace boundaries so a resumed session joins the shared
+        # partition instead of stranding attachments in its own prefix.
+        incoming_boundary = str(config.get("memory_boundary") or "").strip()
+        if channel in MANAGED_CHANNELS and incoming_boundary:
+            existing_config = getattr(existing, "config", None) or {}
+            if existing_config.get("memory_boundary") != incoming_boundary:
+                await session_store.update_session_config_key(
+                    existing_id, "memory_boundary", incoming_boundary,
+                )
+            if existing_config.get("workspace_boundary") != incoming_boundary:
+                await session_store.update_session_config_key(
+                    existing_id, "workspace_boundary", incoming_boundary,
+                )
         if existing_status in ("completed", "paused"):
             await session_store.resume_session(existing_id, source="channel_message")
             logger.info(
@@ -384,6 +402,11 @@ async def get_or_create_channel_session(
         "channel_session_key": session_key,
         **config,
     }
+    # Pin the managed-channel thread's memory boundary as the workspace
+    # boundary so this new session shares the thread's partitioned workspace.
+    incoming_boundary = str(merged_config.get("memory_boundary") or "").strip()
+    if channel in MANAGED_CHANNELS and incoming_boundary:
+        merged_config["workspace_boundary"] = incoming_boundary
     # Provision a persistent workspace (storage_bucket/storage_key_prefix/
     # workspace_path) the same way API/web sessions do, so the worker mounts a
     # persistent /workspace and inbound attachments can be written there. A

--- a/surogates/channels/identity.py
+++ b/surogates/channels/identity.py
@@ -21,7 +21,10 @@ from surogates.channels.memory_boundary import MANAGED_CHANNELS
 from surogates.db.models import ChannelIdentity as ChannelIdentityRow
 from surogates.db.models import Session as SessionRow
 from surogates.session.events import EventType
-from surogates.session.provisioning import stamp_workspace_config
+from surogates.session.provisioning import (
+    pin_workspace_boundary,
+    stamp_workspace_config,
+)
 from surogates.session.store import SessionStore
 
 logger = logging.getLogger(__name__)
@@ -404,9 +407,7 @@ async def get_or_create_channel_session(
     }
     # Pin the managed-channel thread's memory boundary as the workspace
     # boundary so this new session shares the thread's partitioned workspace.
-    incoming_boundary = str(merged_config.get("memory_boundary") or "").strip()
-    if channel in MANAGED_CHANNELS and incoming_boundary:
-        merged_config["workspace_boundary"] = incoming_boundary
+    pin_workspace_boundary(merged_config, channel=channel)
     # Provision a persistent workspace (storage_bucket/storage_key_prefix/
     # workspace_path) the same way API/web sessions do, so the worker mounts a
     # persistent /workspace and inbound attachments can be written there. A

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -2594,7 +2594,7 @@ class AgentHarness(
             return None
         try:
             from surogates.session.attachment_ingest import workspace_root_id
-            from surogates.storage.tenant import prefixed_session_workspace_key
+            from surogates.storage.tenant import boundary_workspace_key
 
             cfg = session.config or {}
             bucket = cfg.get("storage_bucket") or ""
@@ -2605,7 +2605,7 @@ class AgentHarness(
                 )
                 return None
             root_id = workspace_root_id(session)
-            key = prefixed_session_workspace_key(cfg, root_id, path)
+            key = boundary_workspace_key(cfg, session, root_id, path)
             data = await self._storage.read(bucket, key)
             return data or None
         except Exception:

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -465,7 +465,7 @@ class ArtifactCompletionMixin:
             TurnArtifact,
             _is_internal_workspace_path,
         )
-        from surogates.storage.tenant import prefixed_session_workspace_prefix
+        from surogates.storage.tenant import boundary_workspace_prefix
 
         storage = self._storage
         if storage is None or self._turn_started_at is None:
@@ -482,7 +482,7 @@ class ArtifactCompletionMixin:
             (session.config or {}).get("sandbox_root_session_id")
             or str(session.id)
         )
-        prefix = prefixed_session_workspace_prefix(session.config, str(root_id))
+        prefix = boundary_workspace_prefix(session.config, session, str(root_id))
 
         try:
             entries = await storage.list_entries(bucket, prefix=prefix)

--- a/surogates/harness/tool_exec.py
+++ b/surogates/harness/tool_exec.py
@@ -28,8 +28,7 @@ from surogates.harness.tool_guardrails import (
     toolguard_synthetic_result,
 )
 from surogates.tools.coerce import coerce_tool_args
-from surogates.storage.keys import prefixed
-from surogates.storage.tenant import session_workspace_prefix
+from surogates.storage.tenant import boundary_workspace_prefix
 
 # ---------------------------------------------------------------------------
 # Path sanitisation — replace workspace absolute paths with __WORKSPACE__
@@ -45,17 +44,16 @@ _WORKSPACE_MOUNT_PATH = "/workspace"
 def build_workspace_source_ref(
     *,
     storage_bucket: str,
-    storage_key_prefix: str,
     workspace_prefix: str,
 ) -> str:
     """Build the ``s3://`` URI used to mount a sandbox workspace.
 
-    The agent's ``storage_key_prefix`` (``{project_id}/{agent_id}``) is
-    inserted between the bucket name and the session-scoped
-    ``workspace_prefix`` (``sessions/{root_id}/``). With an empty
-    storage prefix the call collapses to the legacy bucket-rooted URI.
+    *workspace_prefix* is the fully-resolved physical prefix (already
+    layered with the agent's ``storage_key_prefix`` and either the
+    boundary-partitioned or per-session segment), so this only prepends
+    the bucket.
     """
-    return f"s3://{storage_bucket}/{prefixed(workspace_prefix, storage_key_prefix)}"
+    return f"s3://{storage_bucket}/{workspace_prefix}"
 
 
 def _build_session_sandbox_spec(
@@ -99,7 +97,6 @@ def _build_session_sandbox_spec(
         )
 
     storage_bucket = session.config.get("storage_bucket", "")
-    storage_key_prefix = session.config.get("storage_key_prefix", "") or ""
     has_workspace_mount = any(
         r.mount_path == _WORKSPACE_MOUNT_PATH for r in sandbox_spec.resources
     )
@@ -108,8 +105,11 @@ def _build_session_sandbox_spec(
             Resource(
                 source_ref=build_workspace_source_ref(
                     storage_bucket=storage_bucket,
-                    storage_key_prefix=storage_key_prefix,
-                    workspace_prefix=session_workspace_prefix(sandbox_owner),
+                    workspace_prefix=boundary_workspace_prefix(
+                        session.config,
+                        session,
+                        sandbox_owner,
+                    ),
                 ),
                 mount_path=_WORKSPACE_MOUNT_PATH,
             ),

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -619,6 +619,32 @@ def _build_r2_memory_keys(
     }
 
 
+def local_memory_dir_for_session(
+    *,
+    session: object,
+    asset_root: Any,
+    user_id: str | None,
+):
+    """Local disk directory for a session's memory fallback.
+
+    Mirrors the namespace :func:`_build_r2_memory_keys` uses for R2 so the
+    disk fallback (test / no-cache contexts) reads and writes the same
+    partition: a boundary-scoped ``{asset_root}/boundaries/{boundary}`` for
+    channel sessions, else the per-user (or org-shared) layout.
+    """
+    from pathlib import Path
+
+    from surogates.channels.memory_boundary import session_memory_boundary
+
+    root = Path(asset_root)
+    boundary = session_memory_boundary(session)
+    if boundary is not None:
+        return root / "boundaries" / boundary
+    if user_id is not None:
+        return root / "users" / user_id / "memory"
+    return root / "shared" / "memory"
+
+
 async def run_worker(settings: Settings) -> None:
     """Bootstrap all dependencies and run the orchestrator loop.
 
@@ -1022,17 +1048,16 @@ async def run_worker(settings: Settings) -> None:
             ),
         )
 
-        # User-scoped memory dir for interactive sessions, org-shared
-        # memory dir for service-account sessions (no per-user context
-        # to carry forward).
-        from pathlib import Path
-
-        if session.user_id is not None:
-            memory_dir = (
-                Path(tenant.asset_root) / "users" / str(session.user_id) / "memory"
-            )
-        else:
-            memory_dir = Path(tenant.asset_root) / "shared" / "memory"
+        # Boundary-scoped memory dir for channel sessions (shared across a
+        # thread's participants), else the per-user layout for interactive
+        # sessions or the org-shared layout for service-account sessions.
+        # Same partition as the R2 keys so the disk fallback and the R2
+        # store never disagree on where a session's memory lives.
+        memory_dir = local_memory_dir_for_session(
+            session=session,
+            asset_root=tenant.asset_root,
+            user_id=str(session.user_id) if session.user_id else None,
+        )
 
         # R2-backed per-user memory store.  Requires both the memory
         # cache (wired at worker startup) and a storage backend; the

--- a/surogates/session/attachment_ingest.py
+++ b/surogates/session/attachment_ingest.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Literal
 
-from surogates.storage.tenant import prefixed_session_workspace_key
+from surogates.storage.tenant import boundary_workspace_key
 
 logger = logging.getLogger(__name__)
 
@@ -304,7 +304,7 @@ async def ingest_attachment_bytes(
     if _is_image_mime(mime_type) and inline_images:
         return {"image": {"data": base64.b64encode(data).decode(), "mime_type": mime_type}}
 
-    key = prefixed_session_workspace_key(session.config, root_id, path)
+    key = boundary_workspace_key(session.config, session, root_id, path)
     await storage.write(bucket, key, data)
 
     entry: dict = {

--- a/surogates/session/provisioning.py
+++ b/surogates/session/provisioning.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID, uuid4
 
+from surogates.channels.memory_boundary import MANAGED_CHANNELS
 from surogates.harness.model_metadata import get_model_info
 from surogates.sandbox.pool import sandbox_session_key
 from surogates.session.models import Session
@@ -19,6 +20,29 @@ _WORKSPACE_SHARING_FIELDS = (
     "workspace_path",
     "supports_vision",
 )
+
+# Boundary fields a child session inherits verbatim from its parent so it
+# lands in the same partitioned workspace/memory as the rest of the thread.
+_BOUNDARY_SHARING_FIELDS = (
+    "memory_boundary",
+    "workspace_boundary",
+)
+
+
+def _pin_workspace_boundary(config: dict, *, channel: str) -> None:
+    """Copy a managed channel's ``memory_boundary`` onto ``workspace_boundary``.
+
+    Managed-channel (slack/telegram) threads share one workspace across every
+    participant, keyed off the thread's ``memory_boundary``.  Pinning it into
+    ``workspace_boundary`` at provisioning time makes the partition immutable
+    for the session's life; non-managed channels (web/api/website) keep their
+    per-session workspace and get no ``workspace_boundary``.
+    """
+    if channel not in MANAGED_CHANNELS:
+        return
+    boundary = str(config.get("memory_boundary") or "").strip()
+    if boundary:
+        config["workspace_boundary"] = boundary
 
 
 async def stamp_workspace_config(
@@ -67,6 +91,7 @@ async def create_agent_session(
     sid = session_id or uuid4()
 
     merged_config = dict(config or {})
+    _pin_workspace_boundary(merged_config, channel=channel)
     await stamp_workspace_config(
         merged_config, storage=storage, settings=settings, session_id=sid, model=model,
     )
@@ -129,6 +154,10 @@ async def create_child_session(
         )
     for field in _WORKSPACE_SHARING_FIELDS:
         merged_config[field] = parent_config[field]
+
+    for field in _BOUNDARY_SHARING_FIELDS:
+        if field in parent_config:
+            merged_config[field] = parent_config[field]
 
     merged_config["sandbox_root_session_id"] = sandbox_session_key(parent)
 

--- a/surogates/session/provisioning.py
+++ b/surogates/session/provisioning.py
@@ -91,6 +91,11 @@ async def create_agent_session(
     sid = session_id or uuid4()
 
     merged_config = dict(config or {})
+    # Tool paths that receive only ``session_config`` (media_gen, vision)
+    # reconstruct a minimal session shape for boundary resolution; carry the
+    # channel so a managed-channel session without a pinned workspace_boundary
+    # still resolves its memory boundary rather than falling to per-session.
+    merged_config.setdefault("channel", channel)
     _pin_workspace_boundary(merged_config, channel=channel)
     await stamp_workspace_config(
         merged_config, storage=storage, settings=settings, session_id=sid, model=model,

--- a/surogates/session/provisioning.py
+++ b/surogates/session/provisioning.py
@@ -29,7 +29,7 @@ _BOUNDARY_SHARING_FIELDS = (
 )
 
 
-def _pin_workspace_boundary(config: dict, *, channel: str) -> None:
+def pin_workspace_boundary(config: dict, *, channel: str) -> None:
     """Copy a managed channel's ``memory_boundary`` onto ``workspace_boundary``.
 
     Managed-channel (slack/telegram) threads share one workspace across every
@@ -96,7 +96,7 @@ async def create_agent_session(
     # channel so a managed-channel session without a pinned workspace_boundary
     # still resolves its memory boundary rather than falling to per-session.
     merged_config.setdefault("channel", channel)
-    _pin_workspace_boundary(merged_config, channel=channel)
+    pin_workspace_boundary(merged_config, channel=channel)
     await stamp_workspace_config(
         merged_config, storage=storage, settings=settings, session_id=sid, model=model,
     )

--- a/surogates/storage/tenant.py
+++ b/surogates/storage/tenant.py
@@ -168,6 +168,21 @@ def boundary_workspace_key(
     return f"{boundary_workspace_prefix(config, session, session_id)}{key.lstrip('/')}"
 
 
+def workspace_session_shim(config: dict | None, session_id: object) -> Any:
+    """Minimal session shape for boundary resolution from loose config.
+
+    Tool paths that hold only ``session_config`` + ``session_id`` (not a
+    ``Session`` row) still need to resolve the boundary workspace.
+    :func:`workspace_boundary` reads ``.config`` and ``.channel``; this builds
+    exactly that shape so those callers don't each hand-roll a
+    ``SimpleNamespace``.
+    """
+    from types import SimpleNamespace
+
+    cfg = config or {}
+    return SimpleNamespace(id=session_id, channel=cfg.get("channel", ""), config=cfg)
+
+
 class TenantStorage:
     """Tenant-aware storage operations.
 

--- a/surogates/storage/tenant.py
+++ b/surogates/storage/tenant.py
@@ -120,6 +120,54 @@ def prefixed_session_workspace_key(
     )
 
 
+def workspace_boundary(session: object) -> str | None:
+    """The conversation boundary a session's workspace is partitioned by.
+
+    A pinned ``config["workspace_boundary"]`` (set at creation / inherited by a
+    child) wins; otherwise fall back through ``session_memory_boundary`` so a
+    managed-channel session created before the flag existed still fails closed
+    to its private boundary. ``None`` keeps the per-session layout (web/Studio).
+    """
+    cfg = getattr(session, "config", None) or {}
+    pinned = str(cfg.get("workspace_boundary") or "").strip()
+    if pinned:
+        return pinned
+
+    from surogates.channels.memory_boundary import session_memory_boundary
+
+    return session_memory_boundary(session)
+
+
+def boundary_workspace_prefix(
+    config: dict | None,
+    session: object,
+    session_id: UUID | str,
+) -> str:
+    """Physical object prefix for a session's workspace, boundary-partitioned.
+
+    ``{storage_key_prefix}/boundaries/{boundary}/workspace/`` for a managed
+    conversation, else the per-session prefix (fail-closed isolated).
+    """
+    boundary = workspace_boundary(session)
+    if not boundary:
+        return prefixed_session_workspace_prefix(config, session_id)
+
+    return prefixed(
+        f"boundaries/{boundary}/workspace/",
+        storage_key_prefix(config),
+    )
+
+
+def boundary_workspace_key(
+    config: dict | None,
+    session: object,
+    session_id: UUID | str,
+    key: str = "",
+) -> str:
+    """Physical object key for one file inside the boundary workspace."""
+    return f"{boundary_workspace_prefix(config, session, session_id)}{key.lstrip('/')}"
+
+
 class TenantStorage:
     """Tenant-aware storage operations.
 

--- a/surogates/tools/builtin/browser.py
+++ b/surogates/tools/builtin/browser.py
@@ -20,11 +20,11 @@ from surogates.browser.base import (
 from surogates.browser.client import KernelBrowserClient
 from surogates.browser.control import BrowserControlStore
 from surogates.browser.pool import BrowserPool
-from types import SimpleNamespace
 
 from surogates.storage.tenant import (
     boundary_workspace_key,
     boundary_workspace_prefix,
+    workspace_session_shim,
 )
 
 
@@ -97,11 +97,7 @@ async def _resolve_session_browser(
 
     try:
         storage_bucket = (session_config or {}).get("storage_bucket")
-        session_for_workspace = SimpleNamespace(
-            id=sid,
-            channel=(session_config or {}).get("channel", ""),
-            config=session_config or {},
-        )
+        session_for_workspace = workspace_session_shim(session_config, sid)
         browser_spec = spec or BrowserSpec(
             workspace_path=workspace_path,
             workspace_source_ref=(
@@ -758,11 +754,7 @@ async def _save_screenshot_to_storage(
     if not storage_bucket:
         return None
 
-    session_for_workspace = SimpleNamespace(
-        id=session_id,
-        channel=(session_config or {}).get("channel", ""),
-        config=session_config or {},
-    )
+    session_for_workspace = workspace_session_shim(session_config, session_id)
     key = build_browser_screenshot_key(
         session=session_for_workspace,
         session_id=session_id,

--- a/surogates/tools/builtin/browser.py
+++ b/surogates/tools/builtin/browser.py
@@ -20,35 +20,44 @@ from surogates.browser.base import (
 from surogates.browser.client import KernelBrowserClient
 from surogates.browser.control import BrowserControlStore
 from surogates.browser.pool import BrowserPool
-from surogates.storage.keys import prefixed
-from surogates.storage.tenant import session_workspace_key, session_workspace_prefix
+from types import SimpleNamespace
+
+from surogates.storage.tenant import (
+    boundary_workspace_key,
+    boundary_workspace_prefix,
+)
 
 
 def build_browser_session_source_ref(
     *,
     storage_bucket: str,
-    storage_key_prefix: str,
+    session: object,
     session_id: object,
 ) -> str:
-    """Return the ``s3://`` URI for the per-session browser workspace.
+    """Return the ``s3://`` URI for the session's browser workspace.
 
-    Both the session-scoped ``sessions/{id}`` segment and the agent's
-    storage key prefix (when set) live under the shared bucket.
+    Uses the same boundary-partitioned prefix as every other workspace
+    reader/writer so a managed-channel thread's browser lands in the
+    shared workspace instead of a per-session prefix.
     """
-    workspace = session_workspace_prefix(session_id).rstrip("/")
-    return f"s3://{storage_bucket}/{prefixed(workspace, storage_key_prefix)}"
+    return (
+        f"s3://{storage_bucket}/"
+        f"{boundary_workspace_prefix(session.config, session, session_id)}"
+    )
 
 
 def build_browser_screenshot_key(
     *,
-    storage_key_prefix: str,
+    session: object,
     session_id: object,
     relative_path: str,
 ) -> str:
     """Return the physical object key for a browser screenshot."""
-    return prefixed(
-        session_workspace_key(session_id, relative_path),
-        storage_key_prefix,
+    return boundary_workspace_key(
+        session.config,
+        session,
+        session_id,
+        relative_path,
     )
 from surogates.tools.registry import ToolRegistry, ToolSchema
 
@@ -88,13 +97,17 @@ async def _resolve_session_browser(
 
     try:
         storage_bucket = (session_config or {}).get("storage_bucket")
-        storage_key_prefix = (session_config or {}).get("storage_key_prefix", "") or ""
+        session_for_workspace = SimpleNamespace(
+            id=sid,
+            channel=(session_config or {}).get("channel", ""),
+            config=session_config or {},
+        )
         browser_spec = spec or BrowserSpec(
             workspace_path=workspace_path,
             workspace_source_ref=(
                 build_browser_session_source_ref(
                     storage_bucket=storage_bucket,
-                    storage_key_prefix=storage_key_prefix,
+                    session=session_for_workspace,
                     session_id=sid,
                 )
                 if storage_bucket
@@ -745,9 +758,13 @@ async def _save_screenshot_to_storage(
     if not storage_bucket:
         return None
 
-    storage_key_prefix = (session_config or {}).get("storage_key_prefix", "") or ""
+    session_for_workspace = SimpleNamespace(
+        id=session_id,
+        channel=(session_config or {}).get("channel", ""),
+        config=session_config or {},
+    )
     key = build_browser_screenshot_key(
-        storage_key_prefix=storage_key_prefix,
+        session=session_for_workspace,
         session_id=session_id,
         relative_path=relative_path,
     )

--- a/surogates/tools/builtin/media_gen.py
+++ b/surogates/tools/builtin/media_gen.py
@@ -22,7 +22,6 @@ import binascii
 import json
 import logging
 import os
-from types import SimpleNamespace
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
@@ -32,7 +31,7 @@ from uuid import uuid4
 import httpx
 
 from surogates.harness.message_utils import message_to_dict
-from surogates.storage.tenant import boundary_workspace_key
+from surogates.storage.tenant import boundary_workspace_key, workspace_session_shim
 from surogates.tools.builtin.vision import (
     _extract_response_content,
     _image_ref_to_data_url,
@@ -592,11 +591,7 @@ async def _save_media_bytes(
     if storage is not None and session_id is not None and bucket:
         key = boundary_workspace_key(
             session_config,
-            SimpleNamespace(
-                channel=session_config.get("channel", ""),
-                config=session_config,
-                id=session_id,
-            ),
+            workspace_session_shim(session_config, session_id),
             session_id,
             relative_path,
         )

--- a/surogates/tools/builtin/media_gen.py
+++ b/surogates/tools/builtin/media_gen.py
@@ -22,6 +22,7 @@ import binascii
 import json
 import logging
 import os
+from types import SimpleNamespace
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
@@ -31,7 +32,7 @@ from uuid import uuid4
 import httpx
 
 from surogates.harness.message_utils import message_to_dict
-from surogates.storage.tenant import prefixed_session_workspace_key
+from surogates.storage.tenant import boundary_workspace_key
 from surogates.tools.builtin.vision import (
     _extract_response_content,
     _image_ref_to_data_url,
@@ -589,7 +590,16 @@ async def _save_media_bytes(
             )
     bucket = (session_config or {}).get("storage_bucket")
     if storage is not None and session_id is not None and bucket:
-        key = prefixed_session_workspace_key(session_config, session_id, relative_path)
+        key = boundary_workspace_key(
+            session_config,
+            SimpleNamespace(
+                channel=session_config.get("channel", ""),
+                config=session_config,
+                id=session_id,
+            ),
+            session_id,
+            relative_path,
+        )
         try:
             await storage.write(bucket, key, data)
             saved = True

--- a/surogates/tools/builtin/vision.py
+++ b/surogates/tools/builtin/vision.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import base64
 import binascii
 import json
@@ -15,7 +17,7 @@ import httpx
 
 from surogates.harness.image_shrink import shrink_image_parts_in_messages
 from surogates.harness.message_utils import message_to_dict
-from surogates.storage.tenant import prefixed_session_workspace_key
+from surogates.storage.tenant import boundary_workspace_key
 from surogates.tools.registry import ToolRegistry, ToolSchema
 from surogates.tools.utils.url_safety import is_safe_url
 from surogates.tools.utils.workspace_sandbox import WorkspaceSandboxError, validate_path
@@ -222,8 +224,15 @@ async def _image_ref_to_data_url(
                 image_ref,
                 workspace_path=workspace_path,
             )
-            key = prefixed_session_workspace_key(
-                session_config, session_id, relative_path,
+            key = boundary_workspace_key(
+                session_config,
+                SimpleNamespace(
+                    channel=session_config.get("channel", ""),
+                    config=session_config,
+                    id=session_id,
+                ),
+                session_id,
+                relative_path,
             )
             try:
                 data = await storage.read(storage_bucket, key)

--- a/surogates/tools/builtin/vision.py
+++ b/surogates/tools/builtin/vision.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 
 import base64
 import binascii
@@ -17,7 +16,7 @@ import httpx
 
 from surogates.harness.image_shrink import shrink_image_parts_in_messages
 from surogates.harness.message_utils import message_to_dict
-from surogates.storage.tenant import boundary_workspace_key
+from surogates.storage.tenant import boundary_workspace_key, workspace_session_shim
 from surogates.tools.registry import ToolRegistry, ToolSchema
 from surogates.tools.utils.url_safety import is_safe_url
 from surogates.tools.utils.workspace_sandbox import WorkspaceSandboxError, validate_path
@@ -226,11 +225,7 @@ async def _image_ref_to_data_url(
             )
             key = boundary_workspace_key(
                 session_config,
-                SimpleNamespace(
-                    channel=session_config.get("channel", ""),
-                    config=session_config,
-                    id=session_id,
-                ),
+                workspace_session_shim(session_config, session_id),
                 session_id,
                 relative_path,
             )

--- a/tests/test_browser_tools.py
+++ b/tests/test_browser_tools.py
@@ -248,9 +248,12 @@ class TestNavigateHandler:
         )
 
         assert pool.specs[0].workspace_path == str(tmp_path)
+        # No channel/boundary in config → per-session prefix, matching the
+        # sandbox mount's ``{id}/`` shape (boundary_workspace_prefix always
+        # returns a trailing slash).
         assert (
             pool.specs[0].workspace_source_ref
-            == f"s3://agent-bucket/{session_id}"
+            == f"s3://agent-bucket/{session_id}/"
         )
 
     async def test_short_circuits_when_user_in_control(self, tenant) -> None:
@@ -806,3 +809,47 @@ async def test_browser_tool_suspends_while_user_holds_control(
     # The guard must fire before any browser provisioning or teardown.
     assert pool.ensures == []
     assert pool.destroyed == []
+
+
+def test_browser_source_ref_uses_boundary_workspace_prefix():
+    from surogates.tools.builtin.browser import build_browser_session_source_ref
+
+    session = SimpleNamespace(
+        id="session-1",
+        channel="slack",
+        config={
+            "storage_key_prefix": "project/agent",
+            "workspace_boundary": "slack:c:G1",
+        },
+    )
+
+    assert (
+        build_browser_session_source_ref(
+            storage_bucket="agent-bucket",
+            session=session,
+            session_id="session-1",
+        )
+        == "s3://agent-bucket/project/agent/boundaries/slack:c:G1/workspace/"
+    )
+
+
+def test_browser_screenshot_key_uses_boundary_workspace_prefix():
+    from surogates.tools.builtin.browser import build_browser_screenshot_key
+
+    session = SimpleNamespace(
+        id="session-1",
+        channel="slack",
+        config={
+            "storage_key_prefix": "project/agent",
+            "workspace_boundary": "slack:c:G1",
+        },
+    )
+
+    assert (
+        build_browser_screenshot_key(
+            session=session,
+            session_id="session-1",
+            relative_path="browser-screenshots/shot.png",
+        )
+        == "project/agent/boundaries/slack:c:G1/workspace/browser-screenshots/shot.png"
+    )

--- a/tests/test_channel_media.py
+++ b/tests/test_channel_media.py
@@ -73,7 +73,15 @@ class TestNormalizeWorkspacePath:
 @dataclass
 class _FakeSession:
     id: str = "11111111-1111-1111-1111-111111111111"
-    config: dict = field(default_factory=lambda: {"storage_bucket": "wsbucket"})
+    channel: str = "slack"
+    config: dict = field(
+        default_factory=lambda: {
+            "storage_bucket": "wsbucket",
+            "storage_key_prefix": "project/agent",
+            "memory_boundary": "slack:c:G1",
+            "workspace_boundary": "slack:c:G1",
+        }
+    )
 
 
 class _FakeStorage:
@@ -96,10 +104,16 @@ class _FakeStorage:
 
 
 def _key(rel: str) -> str:
-    from surogates.storage.tenant import prefixed_session_workspace_key
+    from surogates.storage.tenant import boundary_workspace_key
     from surogates.session.attachment_ingest import workspace_root_id
+
     session = _FakeSession()
-    return prefixed_session_workspace_key(session.config, workspace_root_id(session), rel)
+    return boundary_workspace_key(
+        session.config,
+        session,
+        workspace_root_id(session),
+        rel,
+    )
 
 
 class TestResolveWorkspaceMedia:

--- a/tests/test_channel_session_resume.py
+++ b/tests/test_channel_session_resume.py
@@ -50,6 +50,7 @@ class _Store:
     def __init__(self):
         self.created = None
         self.resumed: list = []
+        self.config_updates: list = []
 
     async def create_session(self, **kwargs):
         self.created = kwargs
@@ -57,6 +58,9 @@ class _Store:
 
     async def resume_session(self, session_id, *, source=""):
         self.resumed.append((session_id, source))
+
+    async def update_session_config_key(self, session_id, key, value):
+        self.config_updates.append((session_id, key, value))
 
 
 async def _call(store, factory):
@@ -136,3 +140,52 @@ async def test_resume_session_helper_flips_status_and_tags_source():
         ("status", sid, "active"),
         ("event", sid, EventType.SESSION_RESUME, {"source": "channel_message"}),
     ]
+
+
+async def _call_group(store, factory, config):
+    return await get_or_create_channel_session(
+        store, None,
+        session_key="agent:slack:channel:G1",
+        user_id=uuid4(), org_id=uuid4(), agent_id="a1",
+        channel="slack", config=config,
+        session_factory=factory,
+    )
+
+
+async def test_backfills_memory_and_workspace_boundary_on_resume():
+    sid = uuid4()
+    store = _Store()
+
+    got = await _call_group(
+        store,
+        _SessionFactory(SimpleNamespace(id=sid, status="active", config={})),
+        {
+            "slack_channel_id": "G1",
+            "memory_boundary": "slack:c:G1",
+            "multi_party": True,
+        },
+    )
+
+    assert got == sid
+    assert (sid, "memory_boundary", "slack:c:G1") in store.config_updates
+    assert (sid, "workspace_boundary", "slack:c:G1") in store.config_updates
+
+
+async def test_does_not_backfill_workspace_boundary_for_non_managed_channel_without_boundary():
+    sid = uuid4()
+    store = _Store()
+
+    got = await get_or_create_channel_session(
+        store,
+        None,
+        session_key="agent:website:visitor:v1",
+        user_id=uuid4(),
+        org_id=uuid4(),
+        agent_id="a1",
+        channel="website",
+        config={},
+        session_factory=_SessionFactory(SimpleNamespace(id=sid, status="active", config={})),
+    )
+
+    assert got == sid
+    assert all(key != "workspace_boundary" for _, key, _ in store.config_updates)

--- a/tests/test_chat_attachments.py
+++ b/tests/test_chat_attachments.py
@@ -259,7 +259,7 @@ def patched_send_message(monkeypatch):
     ``workspace_files`` (mapping ``relative_path -> size_in_bytes``) and
     runs the route end-to-end, returning ``(result, store, detector)``.
 
-    The fake ``prefixed_session_workspace_key`` is the identity function on the
+    The fake ``boundary_workspace_key`` is the identity function on the
     user-supplied path, so workspace_files keys are the same as the paths
     the client sends in.  This keeps the test's mental model simple
     without coupling it to the real session/root-id prefix.
@@ -316,8 +316,8 @@ def patched_send_message(monkeypatch):
             _get_bucket_and_root,
         )
         monkeypatch.setattr(
-            "surogates.api.routes.sessions.prefixed_session_workspace_key",
-            lambda _config, _root_id, path: path,
+            "surogates.api.routes.sessions.boundary_workspace_key",
+            lambda _config, _session, _root_id, path: path,
         )
 
         monkeypatch.setattr(

--- a/tests/test_session_provisioning.py
+++ b/tests/test_session_provisioning.py
@@ -403,3 +403,84 @@ async def test_stamp_workspace_config_supports_vision_false_for_text_model():
         model="deepseek/deepseek-v4-pro",
     )
     assert config["supports_vision"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_agent_session_pins_managed_channel_workspace_boundary():
+    session_id = uuid4()
+    org_id = uuid4()
+    user_id = uuid4()
+    created = SimpleNamespace(id=session_id)
+    store = SimpleNamespace(create_session=AsyncMock(return_value=created))
+    storage = SimpleNamespace(
+        create_bucket=AsyncMock(),
+        resolve_workspace_path=lambda bucket, sid: f"/workspace/{bucket}/{sid}",
+    )
+    settings = SimpleNamespace(storage=SimpleNamespace(bucket="tenant-bucket"))
+
+    await create_agent_session(
+        store=store,
+        storage=storage,
+        settings=settings,
+        org_id=org_id,
+        user_id=user_id,
+        agent_id="agent-a",
+        channel="slack",
+        model="gpt-4o",
+        config={"memory_boundary": "slack:c:G1"},
+        session_id=session_id,
+    )
+
+    cfg = store.create_session.await_args.kwargs["config"]
+    assert cfg["memory_boundary"] == "slack:c:G1"
+    assert cfg["workspace_boundary"] == "slack:c:G1"
+
+
+@pytest.mark.asyncio
+async def test_create_agent_session_does_not_pin_non_channel_memory_boundary():
+    session_id = uuid4()
+    store = SimpleNamespace(create_session=AsyncMock(return_value=SimpleNamespace(id=session_id)))
+    storage = SimpleNamespace(
+        create_bucket=AsyncMock(),
+        resolve_workspace_path=lambda bucket, sid: f"/workspace/{bucket}/{sid}",
+    )
+    settings = SimpleNamespace(storage=SimpleNamespace(bucket="tenant-bucket"))
+
+    await create_agent_session(
+        store=store,
+        storage=storage,
+        settings=settings,
+        org_id=uuid4(),
+        user_id=uuid4(),
+        agent_id="agent-a",
+        channel="web",
+        model="gpt-4o",
+        config={"memory_boundary": "slack:c:G1"},
+        session_id=session_id,
+    )
+
+    cfg = store.create_session.await_args.kwargs["config"]
+    assert "workspace_boundary" not in cfg
+
+
+@pytest.mark.asyncio
+async def test_create_child_session_inherits_boundary_fields_from_parent():
+    parent = _make_session(
+        channel="slack",
+        config={
+            "storage_bucket": "tenant-bucket",
+            "storage_key_prefix": "project/agent",
+            "workspace_path": "/workspace",
+            "supports_vision": True,
+            "memory_boundary": "slack:c:G1",
+            "workspace_boundary": "slack:c:G1",
+        },
+    )
+    store = SimpleNamespace(create_session=AsyncMock(return_value=SimpleNamespace(id=uuid4())))
+
+    await create_child_session(store=store, parent=parent, channel="worker")
+
+    cfg = store.create_session.await_args.kwargs["config"]
+    assert cfg["memory_boundary"] == "slack:c:G1"
+    assert cfg["workspace_boundary"] == "slack:c:G1"
+    assert cfg["sandbox_root_session_id"] == str(parent.id)

--- a/tests/test_session_workspace_cleanup.py
+++ b/tests/test_session_workspace_cleanup.py
@@ -1,0 +1,79 @@
+"""Archived-session workspace cleanup must not wipe shared boundary workspaces.
+
+A managed-channel session's workspace lives under the per-channel boundary
+prefix, shared with every other thread/session in that channel. Deleting one
+session must therefore NOT delete-prefix the shared boundary workspace, or a
+sibling's live files vanish. Non-boundary (web/api) sessions keep the old
+per-session cleanup.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from surogates.api.routes.sessions import _cleanup_archived_workspaces
+
+
+class _RecordingStorage:
+    def __init__(self) -> None:
+        self.deleted: list[tuple[str, str]] = []
+
+    async def delete_prefix(self, bucket: str, prefix: str) -> int:
+        self.deleted.append((bucket, prefix))
+        return 0
+
+
+def _session(*, channel: str, config: dict):
+    return SimpleNamespace(id=uuid4(), channel=channel, config=config)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_retains_shared_boundary_workspace():
+    storage = _RecordingStorage()
+    session = _session(
+        channel="slack",
+        config={
+            "storage_bucket": "agent-bucket",
+            "storage_key_prefix": "project/agent",
+            "memory_boundary": "slack:c:G1",
+            "workspace_boundary": "slack:c:G1",
+        },
+    )
+
+    await _cleanup_archived_workspaces(storage, [session])
+
+    # The shared boundary workspace outlives any one session — no delete.
+    assert storage.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_cleanup_deletes_non_boundary_session_workspace():
+    storage = _RecordingStorage()
+    sid = uuid4()
+    session = SimpleNamespace(
+        id=sid,
+        channel="web",
+        config={
+            "storage_bucket": "agent-bucket",
+            "storage_key_prefix": "project/agent",
+        },
+    )
+
+    await _cleanup_archived_workspaces(storage, [session])
+
+    assert storage.deleted == [
+        ("agent-bucket", f"project/agent/{sid}/")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_skips_session_without_bucket():
+    storage = _RecordingStorage()
+    session = _session(channel="web", config={})
+
+    await _cleanup_archived_workspaces(storage, [session])
+
+    assert storage.deleted == []

--- a/tests/test_tool_exec_sandbox_spec.py
+++ b/tests/test_tool_exec_sandbox_spec.py
@@ -254,3 +254,52 @@ def test_spec_workspace_path_none_when_absent():
 
     assert spec.session_id == "root-1"
     assert spec.workspace_path is None
+
+
+def test_managed_channel_mounts_boundary_workspace_prefix():
+    sid = uuid4()
+    session = _session(
+        id_=sid,
+        config={
+            "storage_bucket": "agent-a-bucket",
+            "storage_key_prefix": "project/agent",
+            "memory_boundary": "slack:c:G1",
+            "workspace_boundary": "slack:c:G1",
+        },
+    )
+
+    spec = _build_session_sandbox_spec(
+        session,
+        tenant=SimpleNamespace(),
+        sandbox_owner=sandbox_session_key(session),
+    )
+
+    sources = [r.source_ref for r in spec.resources]
+    assert sources == [
+        "s3://agent-a-bucket/project/agent/boundaries/slack:c:G1/workspace/"
+    ]
+
+
+def test_child_mounts_parent_boundary_workspace_prefix():
+    parent_id = uuid4()
+    child = _session(
+        id_=uuid4(),
+        parent_id=parent_id,
+        config={
+            "storage_bucket": "agent-a-bucket",
+            "storage_key_prefix": "project/agent",
+            "sandbox_root_session_id": str(parent_id),
+            "workspace_boundary": "slack:c:G1",
+        },
+    )
+
+    spec = _build_session_sandbox_spec(
+        child,
+        tenant=SimpleNamespace(),
+        sandbox_owner=sandbox_session_key(child),
+    )
+
+    sources = [r.source_ref for r in spec.resources]
+    assert sources == [
+        "s3://agent-a-bucket/project/agent/boundaries/slack:c:G1/workspace/"
+    ]

--- a/tests/test_worker_memory_keys.py
+++ b/tests/test_worker_memory_keys.py
@@ -36,3 +36,42 @@ def test_web_session_stays_per_user():
     s = SimpleNamespace(channel="web", config={}, id="s1")
     keys = _build_r2_memory_keys(session=s, storage_key_prefix="p/a", user_id="u1")
     assert keys["memory"] == "p/a/users/u1/memory.json"
+
+
+from pathlib import Path
+
+from surogates.orchestrator.worker import local_memory_dir_for_session
+
+
+def test_local_memory_dir_uses_boundary_namespace_for_channel_session():
+    session = SimpleNamespace(
+        channel="slack",
+        config={"memory_boundary": "slack:c:G1"},
+        id="session-1",
+    )
+
+    assert local_memory_dir_for_session(
+        session=session,
+        asset_root=Path("project/agent"),
+        user_id="user-1",
+    ) == Path("project/agent/boundaries/slack:c:G1")
+
+
+def test_local_memory_dir_keeps_user_namespace_for_web_session():
+    session = SimpleNamespace(channel="web", config={}, id="session-1")
+
+    assert local_memory_dir_for_session(
+        session=session,
+        asset_root=Path("project/agent"),
+        user_id="user-1",
+    ) == Path("project/agent/users/user-1/memory")
+
+
+def test_local_memory_dir_keeps_shared_namespace_when_no_user():
+    session = SimpleNamespace(channel="api", config={}, id="session-1")
+
+    assert local_memory_dir_for_session(
+        session=session,
+        asset_root=Path("project/agent"),
+        user_id=None,
+    ) == Path("project/agent/shared/memory")

--- a/tests/test_workspace_boundary_routing.py
+++ b/tests/test_workspace_boundary_routing.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from surogates.session.attachment_ingest import ingest_attachment_bytes, workspace_root_id
+from surogates.storage.tenant import boundary_workspace_key, boundary_workspace_prefix
+
+
+class _Storage:
+    def __init__(self, objects: dict[str, bytes] | None = None) -> None:
+        self.objects = objects or {}
+        self.writes: list[tuple[str, str, bytes]] = []
+        self.deleted_prefixes: list[tuple[str, str]] = []
+
+    async def write(self, bucket: str, key: str, data: bytes) -> None:
+        self.objects[key] = data
+        self.writes.append((bucket, key, data))
+
+    async def stat(self, bucket: str, key: str) -> dict:
+        if key not in self.objects:
+            raise KeyError(key)
+        return {"size": len(self.objects[key])}
+
+    async def read(self, bucket: str, key: str) -> bytes:
+        if key not in self.objects:
+            raise KeyError(key)
+        return self.objects[key]
+
+    async def list_keys(self, bucket: str, prefix: str) -> list[str]:
+        return [key for key in self.objects if key.startswith(prefix)]
+
+    async def delete_prefix(self, bucket: str, prefix: str) -> int:
+        self.deleted_prefixes.append((bucket, prefix))
+        keys = [key for key in self.objects if key.startswith(prefix)]
+        for key in keys:
+            del self.objects[key]
+        return len(keys)
+
+
+def _session(boundary: str = "slack:c:G1"):
+    return SimpleNamespace(
+        id="session-1",
+        channel="slack",
+        config={
+            "storage_bucket": "agent-bucket",
+            "storage_key_prefix": "project/agent",
+            "memory_boundary": boundary,
+            "workspace_boundary": boundary,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_attachment_ingest_writes_to_boundary_workspace():
+    session = _session()
+    storage = _Storage()
+
+    await ingest_attachment_bytes(
+        storage,
+        session=session,
+        root_id=workspace_root_id(session),
+        bucket="agent-bucket",
+        path="uploads/report.pdf",
+        filename="report.pdf",
+        mime_type="application/pdf",
+        data=b"%PDF",
+    )
+
+    assert storage.writes == [
+        (
+            "agent-bucket",
+            "project/agent/boundaries/slack:c:G1/workspace/uploads/report.pdf",
+            b"%PDF",
+        )
+    ]
+
+
+def test_boundary_workspace_helpers_make_distinct_private_channel_keys():
+    session_a = _session("slack:c:G1")
+    session_b = _session("slack:c:G2")
+
+    key_a = boundary_workspace_key(
+        session_a.config,
+        session_a,
+        workspace_root_id(session_a),
+        "uploads/report.pdf",
+    )
+    key_b = boundary_workspace_key(
+        session_b.config,
+        session_b,
+        workspace_root_id(session_b),
+        "uploads/report.pdf",
+    )
+
+    assert key_a != key_b
+    assert "/boundaries/slack:c:G1/workspace/" in key_a
+    assert "/boundaries/slack:c:G2/workspace/" in key_b
+
+
+def test_public_boundary_is_shared():
+    session_a = _session("public")
+    session_b = _session("public")
+
+    assert boundary_workspace_prefix(
+        session_a.config,
+        session_a,
+        workspace_root_id(session_a),
+    ) == boundary_workspace_prefix(
+        session_b.config,
+        session_b,
+        workspace_root_id(session_b),
+    )

--- a/tests/test_workspace_storage_prefix.py
+++ b/tests/test_workspace_storage_prefix.py
@@ -61,3 +61,77 @@ def test_prefixed_session_workspace_key_empty_key():
         )
         == "p-1/a-1/s-1/"
     )
+
+
+from types import SimpleNamespace
+
+from surogates.storage.tenant import (
+    boundary_workspace_key,
+    boundary_workspace_prefix,
+    workspace_boundary,
+)
+
+
+def _boundary_session(channel: str, config: dict, sid: str = "session-1"):
+    return SimpleNamespace(channel=channel, config=config, id=sid)
+
+
+def test_workspace_boundary_prefers_pinned_workspace_boundary():
+    session = _boundary_session(
+        "worker", {"workspace_boundary": "slack:c:G1", "memory_boundary": "wrong"},
+    )
+    assert workspace_boundary(session) == "slack:c:G1"
+
+
+def test_workspace_boundary_uses_managed_channel_memory_boundary():
+    session = _boundary_session("slack", {"memory_boundary": "slack:c:G1"})
+    assert workspace_boundary(session) == "slack:c:G1"
+
+
+def test_workspace_boundary_ignores_non_channel_memory_boundary():
+    session = _boundary_session("web", {"memory_boundary": "slack:c:G1"})
+    assert workspace_boundary(session) is None
+
+
+def test_boundary_workspace_prefix_uses_boundary_with_trailing_slash():
+    session = _boundary_session("slack", {"memory_boundary": "slack:c:G1"})
+    assert (
+        boundary_workspace_prefix(
+            {"storage_key_prefix": "project/agent"}, session, "root-session",
+        )
+        == "project/agent/boundaries/slack:c:G1/workspace/"
+    )
+
+
+def test_boundary_workspace_prefix_falls_back_to_session_prefix():
+    session = _boundary_session("web", {"memory_boundary": "ignored"})
+    assert (
+        boundary_workspace_prefix(
+            {"storage_key_prefix": "project/agent"}, session, "root-session",
+        )
+        == "project/agent/root-session/"
+    )
+
+
+def test_boundary_workspace_prefix_fail_closes_older_managed_session():
+    session = _boundary_session(
+        "telegram", {"channel_session_key": "agent:telegram:group:-100"},
+        sid="legacy-session",
+    )
+    assert (
+        boundary_workspace_prefix(
+            {"storage_key_prefix": "project/agent"}, session, "legacy-session",
+        )
+        == "project/agent/boundaries/telegram:iso:agent:telegram:group:-100/workspace/"
+    )
+
+
+def test_boundary_workspace_key_strips_leading_slash():
+    session = _boundary_session("slack", {"memory_boundary": "slack:c:G1"})
+    assert (
+        boundary_workspace_key(
+            {"storage_key_prefix": "project/agent"}, session, "root-session",
+            "/docs/report.pdf",
+        )
+        == "project/agent/boundaries/slack:c:G1/workspace/docs/report.pdf"
+    )


### PR DESCRIPTION
**Plan C — agent workspace partition.** Managed-channel (slack/telegram) threads now share one boundary-partitioned workspace + memory across participants instead of fragmenting per-session. Merged on top of the runtime-switch work (#112); the 3 overlapping files (worker.py, identity.py, sandbox test) were conflict-resolved to keep both branches' behavior.

- **Provisioning/resume**: managed-channel sessions pin `workspace_boundary`; children inherit it; resumed sessions backfill both memory + workspace boundary (alongside the multi_party backfill from #112).
- **Storage routing**: every live workspace read/write (workspace API, artifacts, attachment validation + cleanup, ingest, channel media, vision-inject, turn-artifact listing, board expansion, media_gen/vision) routes through `boundary_workspace_prefix/key`.
- **Sandbox + browser mounts** use the same boundary prefix.
- **Local memory dir** aligned with the R2 boundary namespace (uses the credential-principal `_mem_user` from #112).
- **Delete guard**: `_cleanup_archived_workspaces` retains the shared boundary workspace on single-session delete (siblings share it) — data-loss fix from review.
- Cleanup pass: centralized the config→session shim (`workspace_session_shim`) and reused `pin_workspace_boundary`.

Reviewed (7-finder + /simplify passes); merged-state suite green (140 tests incl. both #112 and this branch's).