### PR TITLE
fix(channels): drop system-event turns + stop retrying permanent delivery failures

### DIFF
--- a/surogates/channels/delivery.py
+++ b/surogates/channels/delivery.py
@@ -25,7 +25,7 @@ import json
 import logging
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, AsyncIterator
 from uuid import UUID
 
@@ -40,11 +40,61 @@ if TYPE_CHECKING:
 __all__ = [
     "DeliveryService",
     "OutboxItem",
+    "delivery_exhausted",
+    "is_permanent_delivery_error",
 ]
 
 logger = logging.getLogger(__name__)
 
 _CHANNEL_PREFIX = "surogates:delivery:"
+
+# Platform errors where re-posting the SAME message to the SAME target can
+# never succeed — the channel can't receive it (read-only/archived/not a
+# member), the message itself is invalid, or the credential is dead.  These
+# are dropped (marked dead) instead of retried.  Match is a case-insensitive
+# substring of the error string (Slack raises ``…'error': '<code>'…``).
+# Ambiguous errors (e.g. ``channel_not_found``) are left retryable and caught
+# by the age cap below.
+_PERMANENT_DELIVERY_ERRORS: frozenset[str] = frozenset({
+    # Slack — target cannot receive the message
+    "restricted_action_read_only_channel",
+    "is_archived",
+    "not_in_channel",
+    "cannot_dm_bot",
+    # Slack — the message content is invalid
+    "msg_too_long",
+    "no_text",
+    # Slack — the credential is dead
+    "account_inactive",
+    "token_revoked",
+    "invalid_auth",
+    # Telegram
+    "bot was blocked by the user",
+    "user is deactivated",
+    "bot was kicked",
+})
+
+# Give up on an undelivered item once it is older than this, whatever the
+# error — a transient failure that has not cleared in this long won't, and the
+# conversation has moved on.  Backstop against infinite retries.
+MAX_DELIVERY_AGE = timedelta(minutes=30)
+
+
+def is_permanent_delivery_error(error: str | None) -> bool:
+    """True when re-sending this message can never succeed (drop, don't retry)."""
+    if not error:
+        return False
+    low = error.lower()
+    return any(code in low for code in _PERMANENT_DELIVERY_ERRORS)
+
+
+def delivery_exhausted(created_at: datetime | None, *, now: datetime | None = None) -> bool:
+    """True when an item has been retried past :data:`MAX_DELIVERY_AGE`."""
+    if created_at is None:
+        return False
+    ref = now or datetime.now(timezone.utc)
+    at = created_at if created_at.tzinfo else created_at.replace(tzinfo=timezone.utc)
+    return (ref - at) > MAX_DELIVERY_AGE
 
 
 # ---------------------------------------------------------------------------
@@ -245,6 +295,21 @@ class DeliveryService:
             )
             await db.commit()
         logger.warning("Outbox %d failed: %s (will retry)", outbox_id, error)
+
+    async def mark_dead(self, outbox_id: int, error: str) -> None:
+        """Terminally fail an outbox item — a permanent error or age-exhausted.
+
+        Sets ``status='failed'`` so :meth:`claim_batch` never re-claims it; the
+        message is dropped rather than retried forever.
+        """
+        async with self._sf() as db:
+            await db.execute(
+                update(DeliveryOutbox)
+                .where(DeliveryOutbox.id == outbox_id)
+                .values(status="failed")
+            )
+            await db.commit()
+        logger.warning("Outbox %d dropped (no retry): %s", outbox_id, error)
 
     # ------------------------------------------------------------------
     # Real-time notifications (Redis pub/sub)

--- a/surogates/channels/dispatcher.py
+++ b/surogates/channels/dispatcher.py
@@ -37,6 +37,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, PlainTextResponse, Response
 
 from surogates.channels.credentials import resolve_channel_credentials
+from surogates.channels.delivery import delivery_exhausted, is_permanent_delivery_error
 from surogates.channels.inbound import ChannelInboundPipeline, InboundMessage, PipelineDeps
 from surogates.channels.registry import ChannelPlatform, ChannelRegistry, VerificationResult
 from surogates.channels.resolve import resolve_tenant
@@ -591,7 +592,7 @@ class ChannelDeliveryDispatcher:
                     item.id, platform.kind,
                 )
                 try:
-                    await self._delivery.mark_failed(item.id, str(exc))
+                    await self._record_delivery_failure(item, str(exc))
                 except Exception:
                     pass
 
@@ -626,6 +627,17 @@ class ChannelDeliveryDispatcher:
     # Private helpers
     # ------------------------------------------------------------------
 
+    async def _record_delivery_failure(self, item: Any, error: str) -> None:
+        """Requeue a failed delivery for retry — unless it is a permanent error
+        or the item has aged past the max delivery window, in which case drop
+        it (no infinite retries)."""
+        if is_permanent_delivery_error(error) or delivery_exhausted(
+            getattr(item, "created_at", None)
+        ):
+            await self._delivery.mark_dead(item.id, error)
+        else:
+            await self._delivery.mark_failed(item.id, error)
+
     async def _deliver_item(self, platform: ChannelPlatform, item: Any) -> None:
         """Process a single outbox item: resolve creds and call platform.send.
 
@@ -639,7 +651,7 @@ class ChannelDeliveryDispatcher:
                 "[delivery] Outbox %d has no channel_identifier — marking failed",
                 item.id,
             )
-            await self._delivery.mark_failed(item.id, "missing channel_identifier")
+            await self._record_delivery_failure(item, "missing channel_identifier")
             return
 
         # 2. Resolve tenant from the routing cache.
@@ -650,8 +662,8 @@ class ChannelDeliveryDispatcher:
                 "channel may have been deprovisioned",
                 item.id, identifier,
             )
-            await self._delivery.mark_failed(
-                item.id, f"channel deprovisioned: {identifier}"
+            await self._record_delivery_failure(
+                item, f"channel deprovisioned: {identifier}"
             )
             return
 
@@ -775,7 +787,7 @@ class ChannelDeliveryDispatcher:
                 "[delivery] platform.send raised for outbox %d (%s): %s",
                 item.id, platform.kind, exc,
             )
-            await self._delivery.mark_failed(item.id, str(exc))
+            await self._record_delivery_failure(item, str(exc))
             return
 
         if result.success:
@@ -838,7 +850,7 @@ class ChannelDeliveryDispatcher:
                     )
         else:
             error = result.error or "send failed"
-            await self._delivery.mark_failed(item.id, error)
+            await self._record_delivery_failure(item, error)
 
 
 # ---------------------------------------------------------------------------

--- a/surogates/channels/platforms/slack.py
+++ b/surogates/channels/platforms/slack.py
@@ -273,6 +273,15 @@ def verify(
 # parse
 # ---------------------------------------------------------------------------
 
+# ``message`` subtypes that ARE real user messages.  Everything else with a
+# subtype is a system notification (join/leave, topic/name/purpose, archive,
+# pins, reminders, bot_add, edits/deletions, …) and must not create a turn.
+_USER_MESSAGE_SUBTYPES: frozenset[str] = frozenset({
+    "file_share",
+    "thread_broadcast",
+    "me_message",
+})
+
 
 def parse(body: dict, *, bot_user_id: str) -> InboundMessage | None:
     """Convert a Slack ``event_callback`` body to an :class:`InboundMessage`.
@@ -340,17 +349,14 @@ def parse(body: dict, *, bot_user_id: str) -> InboundMessage | None:
         is_bot = True
 
     # ------------------------------------------------------------------
-    # Gate: non-message system subtypes (edits, deletions, member join/leave)
-    # are not user messages to respond to.
+    # Gate: only real user messages carry no subtype or a content subtype
+    # (file_share / thread_broadcast / me_message).  Every other subtype is a
+    # system notification — edits/deletions, member join/leave, topic/name/
+    # purpose changes, archive, pins, reminders, bot_add, … — not a request.
+    # Other-bot messages (``is_bot``, handled above) are exempt so the
+    # allow_bots gate downstream can still see them.
     # ------------------------------------------------------------------
-    if subtype in (
-        "message_changed",
-        "message_deleted",
-        "channel_join",
-        "channel_leave",
-        "group_join",
-        "group_leave",
-    ):
+    if subtype and not is_bot and subtype not in _USER_MESSAGE_SUBTYPES:
         return None
 
     # ------------------------------------------------------------------

--- a/tests/test_channel_delivery.py
+++ b/tests/test_channel_delivery.py
@@ -13,7 +13,7 @@ Covers:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -49,7 +49,8 @@ class _FakeDeliveryService:
         self._items = items or []
         self.claimed: list[tuple[str, str]] = []  # (channel, worker_id)
         self.delivered: list[tuple[int, str | None]] = []  # (id, message_id)
-        self.failed: list[tuple[int, str]] = []  # (id, error)
+        self.failed: list[tuple[int, str]] = []  # (id, error) — will retry
+        self.dead: list[tuple[int, str]] = []  # (id, error) — terminal, no retry
 
     async def claim_batch(
         self, channel: str, worker_id: str, *, limit: int = 50
@@ -64,6 +65,9 @@ class _FakeDeliveryService:
 
     async def mark_failed(self, outbox_id: int, error: str) -> None:
         self.failed.append((outbox_id, error))
+
+    async def mark_dead(self, outbox_id: int, error: str) -> None:
+        self.dead.append((outbox_id, error))
 
 
 class _FakePlatform:
@@ -1911,4 +1915,85 @@ class TestLiveProgressDispatcher:
         # mark_delivered still called (coalesced away)
         assert len(delivery.delivered) == 1
         assert delivery.delivered[0][0] == 5
+        assert delivery.failed == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: permanent-error classification + age cap (no infinite retries)
+# ---------------------------------------------------------------------------
+
+
+class TestPermanentDeliveryFailures:
+    def test_is_permanent_classifies_known_codes(self):
+        from surogates.channels.delivery import is_permanent_delivery_error
+
+        # A read-only channel / archived / dead auth never succeeds on retry.
+        assert is_permanent_delivery_error(
+            "The server responded with: {'ok': False, "
+            "'error': 'restricted_action_read_only_channel'}"
+        )
+        assert is_permanent_delivery_error("is_archived")
+        assert is_permanent_delivery_error("token_revoked")
+        # Transient / unknown errors are retryable.
+        assert not is_permanent_delivery_error("ratelimited")
+        assert not is_permanent_delivery_error("network timeout")
+        assert not is_permanent_delivery_error("channel_not_found")  # age-cap handles it
+
+    async def test_permanent_result_error_marks_dead_not_failed(self):
+        item = _FakeOutboxItem(id=71, destination={"channel_identifier": APP_ID})
+        delivery = _FakeDeliveryService(items=[item])
+        platform = _FakePlatform(result=SendResult(
+            success=False,
+            error="The server responded with: {'ok': False, "
+                  "'error': 'restricted_action_read_only_channel'}",
+        ))
+        dispatcher = _make_dispatcher(
+            platform=platform, delivery=delivery, cache=_FakeCache(_KNOWN_CACHE),
+        )
+        await dispatcher.deliver_batch(platform)
+
+        assert delivery.dead and delivery.dead[0][0] == 71
+        assert delivery.failed == []  # not requeued
+
+    async def test_permanent_raised_error_marks_dead(self):
+        item = _FakeOutboxItem(id=72, destination={"channel_identifier": APP_ID})
+        delivery = _FakeDeliveryService(items=[item])
+        platform = _FakePlatform(raises=RuntimeError(
+            "chat_postMessage failed: ... 'error': 'restricted_action_read_only_channel'",
+        ))
+        dispatcher = _make_dispatcher(
+            platform=platform, delivery=delivery, cache=_FakeCache(_KNOWN_CACHE),
+        )
+        await dispatcher.deliver_batch(platform)
+
+        assert delivery.dead and delivery.dead[0][0] == 72
+        assert delivery.failed == []
+
+    async def test_transient_error_still_retries(self):
+        item = _FakeOutboxItem(id=73, destination={"channel_identifier": APP_ID})
+        delivery = _FakeDeliveryService(items=[item])
+        platform = _FakePlatform(raises=RuntimeError("ratelimited"))
+        dispatcher = _make_dispatcher(
+            platform=platform, delivery=delivery, cache=_FakeCache(_KNOWN_CACHE),
+        )
+        await dispatcher.deliver_batch(platform)
+
+        assert delivery.failed and delivery.failed[0][0] == 73
+        assert delivery.dead == []
+
+    async def test_exhausted_old_item_stops_retrying(self):
+        # A transient error on an item older than the max delivery age is given
+        # up on (marked dead) instead of retried forever.
+        old = _FakeOutboxItem(
+            id=74, destination={"channel_identifier": APP_ID},
+            created_at=datetime.now(timezone.utc) - timedelta(hours=2),
+        )
+        delivery = _FakeDeliveryService(items=[old])
+        platform = _FakePlatform(raises=RuntimeError("ratelimited"))
+        dispatcher = _make_dispatcher(
+            platform=platform, delivery=delivery, cache=_FakeCache(_KNOWN_CACHE),
+        )
+        await dispatcher.deliver_batch(platform)
+
+        assert delivery.dead and delivery.dead[0][0] == 74
         assert delivery.failed == []

--- a/tests/test_slack_system_subtype_filter.py
+++ b/tests/test_slack_system_subtype_filter.py
@@ -1,0 +1,52 @@
+"""Slack ``parse`` drops system-notification messages, keeps real user messages.
+
+Regression: a membership/system notification (any ``message`` subtype that
+isn't a real user message — join/leave, topic/name/purpose changes, archive,
+pins, bot_add, …) must NOT create a turn.  The old denylist only covered
+join/leave, so other system subtypes slipped through and the agent replied
+"no action needed" to them.
+"""
+
+from surogates.channels.platforms.slack import parse
+
+
+def _msg(**overrides):
+    event = {"type": "message", "channel": "C1", "user": "U1", "text": "hi", "ts": "100.0"}
+    event.update(overrides)
+    return {"type": "event_callback", "event": event}
+
+
+# --- system subtypes: all dropped -------------------------------------------
+
+def test_membership_and_system_subtypes_are_dropped():
+    for subtype in (
+        "channel_join", "channel_leave", "channel_topic", "channel_purpose",
+        "channel_name", "channel_archive", "channel_unarchive",
+        "group_join", "group_leave", "bot_add", "bot_remove",
+        "pinned_item", "unpinned_item", "reminder_add", "tombstone",
+    ):
+        assert parse(_msg(subtype=subtype), bot_user_id="U_BOT") is None, subtype
+
+
+# --- real user messages: all kept -------------------------------------------
+
+def test_plain_user_message_is_kept():
+    msg = parse(_msg(), bot_user_id="U_BOT")
+    assert msg is not None
+    assert msg.text == "hi"
+
+
+def test_user_message_subtypes_are_kept():
+    for subtype in ("file_share", "thread_broadcast", "me_message"):
+        assert parse(_msg(subtype=subtype), bot_user_id="U_BOT") is not None, subtype
+
+
+def test_other_bot_message_still_reaches_pipeline():
+    # A different bot's message keeps flowing (the allow_bots gate decides later),
+    # so the system-subtype allowlist must not drop it.
+    msg = parse(
+        _msg(subtype="bot_message", bot_id="B999", user="U_OTHERBOT"),
+        bot_user_id="U_BOT",
+    )
+    assert msg is not None
+    assert msg.is_bot is True


### PR DESCRIPTION
Two independent Slack/channels fixes surfaced from a local run where the agent replied "no action needed" to a membership notification and the delivery worker then spammed `chat.postMessage` with `restricted_action_read_only_channel` every 30s forever.

## 1. Only turn real user messages into turns
The Slack event filter used a **denylist** of system subtypes (`channel_join`/`leave`, `group_join`/`leave`), so other system notifications (topic/name/purpose changes, archive, pins, `bot_add`, …) slipped through and created a turn — the agent then generated a courtesy reply. Switched to an **allowlist**: a `message` with a subtype is a system notification unless it's a real user message (`file_share` / `thread_broadcast` / `me_message`) or an already-classified other-bot message.

## 2. Stop retrying permanent / aged-out deliveries
`mark_failed` re-queued every failed item every 30s with **no classification and no cap**, so a permanent error (read-only channel, archived, dead auth) retried indefinitely. Added:
- `is_permanent_delivery_error()` — unambiguously-permanent codes (`restricted_action_read_only_channel`, `is_archived`, `not_in_channel`, `token_revoked`, …) → new `mark_dead()` (terminal `status='failed'`, never re-claimed).
- `MAX_DELIVERY_AGE` (30 min) age cap — any item older than this is dropped, so ambiguous errors (`channel_not_found`) stay retryable but can't loop forever.
- The dispatcher routes all delivery-failure paths through `_record_delivery_failure()`.

## Testing
New `test_slack_system_subtype_filter` (system subtypes dropped, user subtypes + other-bot kept) and `TestPermanentDeliveryFailures` (permanent→dead, transient→retry, aged-out→dead). Full delivery suite (50) + slack suite (216) green; no behavior change for existing transient/`channel_not_found` cases (age-cap handles those).