### PR TITLE
feat(tools): read-only github tool scoped to the agent's repos

### DIFF
--- a/surogates/tools/builtin/github.py
+++ b/surogates/tools/builtin/github.py
@@ -1,0 +1,230 @@
+"""Built-in ``github`` tool — read-only GitHub REST API for the agent's repos.
+
+The agent connects a GitHub PAT + a set of repositories in the Tools tab (the
+same credential the coding tool uses to check out and open PRs).  This tool
+lets the agent *answer questions* about those repos — issues, pull requests,
+files, commits, diffs, search — without a checkout, by proxying authenticated
+``GET`` requests to the GitHub REST API.
+
+Read-only (``GET`` only) and scoped to the configured repos: a request must
+target ``/repos/<owner>/<repo>/…`` for a configured repo, or ``/search/…``
+qualified to a configured repo.  The PAT rides in the ``Authorization`` header
+only — never in argv, the returned data, or an event.
+
+Required kwargs (injected by the harness dispatch): ``tenant``,
+``credential_vault``, ``session_config`` (carrying the agent's ``repos``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+from urllib.parse import parse_qsl
+
+from surogates.coding_agents.repo_resolve import resolve_git_pat
+from surogates.tools.registry import ToolRegistry, ToolSchema
+
+logger = logging.getLogger(__name__)
+
+_API_BASE = "https://api.github.com"
+_MAX_BODY = 30_000  # cap the returned payload; note truncation
+
+# Accept header per requested media type — lets the agent pull diffs/patches
+# and raw file contents, not just JSON.
+_MEDIA_ACCEPT = {
+    "json": "application/vnd.github+json",
+    "diff": "application/vnd.github.diff",
+    "patch": "application/vnd.github.patch",
+    "raw": "application/vnd.github.raw",
+}
+
+_SLUG_RE = re.compile(r"github\.com[:/]+([^/\s]+)/([^/\s]+?)(?:\.git)?/?$", re.IGNORECASE)
+
+
+def github_repo_slugs(repos: Sequence[Mapping[str, str]]) -> set[str]:
+    """The ``owner/repo`` slugs (lowercased) for the configured repositories."""
+    slugs: set[str] = set()
+    for repo in repos or ():
+        m = _SLUG_RE.search(repo.get("url", ""))
+        if m:
+            slugs.add(f"{m.group(1)}/{m.group(2)}".lower())
+    return slugs
+
+
+def authorize_github_read(
+    path: str, params: Mapping[str, Any] | None, repos: Sequence[Mapping[str, str]],
+) -> tuple[bool, str]:
+    """Return ``(allowed, reason)`` for a GitHub REST path against *repos*.
+
+    Allowed: ``/repos/<owner>/<repo>/…`` for a configured repo, or
+    ``/search/…`` whose ``q`` is scoped to configured repos via ``repo:``.
+    """
+    slugs = github_repo_slugs(repos)
+    if not slugs:
+        return False, "No repository is configured for this agent (Tools tab)."
+
+    path_only = "/" + path.split("?", 1)[0].strip().strip("/")
+    query = dict(parse_qsl(path.partition("?")[2]))
+    query.update({k: str(v) for k, v in (params or {}).items()})
+    segs = path_only.strip("/").split("/")
+
+    if segs[0] == "repos" and len(segs) >= 3:
+        slug = f"{segs[1]}/{segs[2]}".lower()
+        if slug in slugs:
+            return True, ""
+        return (
+            False,
+            f"'{slug}' is not a configured repository. Configured: "
+            f"{', '.join(sorted(slugs))}.",
+        )
+
+    if segs[0] == "search" and len(segs) >= 2:
+        q = query.get("q", "")
+        if re.search(r"\b(?:org|user):", q, re.IGNORECASE):
+            return False, "Search must target a configured repo (repo:<owner>/<repo>), not org:/user:."
+        repo_quals = re.findall(r"repo:(\S+)", q, re.IGNORECASE)
+        if not repo_quals:
+            return False, "Search must include a repo:<owner>/<repo> qualifier for a configured repo."
+        for rq in repo_quals:
+            if rq.lower() not in slugs:
+                return False, f"Search repo:{rq} is not a configured repository."
+        return True, ""
+
+    return (
+        False,
+        "The github tool is scoped to configured repos: use /repos/<owner>/<repo>/… "
+        "or /search with a repo:<owner>/<repo> qualifier.",
+    )
+
+
+_SCHEMA = ToolSchema(
+    name="github",
+    description=(
+        "Read-only GitHub REST API for the agent's configured repositories — "
+        "answer questions about issues, pull requests, files, commits, diffs, "
+        "and search WITHOUT checking out the repo. Give the REST 'path' (and "
+        "optional 'params'); scoped to configured repos, GET-only. Examples: "
+        "list open issues → path='/repos/{owner}/{repo}/issues', "
+        "params={'state':'open'}; a PR's diff → path='/repos/{owner}/{repo}/pulls/{n}', "
+        "media_type='diff'; a file → path='/repos/{owner}/{repo}/contents/{filepath}'; "
+        "recent commits → path='/repos/{owner}/{repo}/commits'; search issues → "
+        "path='/search/issues', params={'q':'repo:{owner}/{repo} is:open label:bug'}. "
+        "To make code changes and open a PR, use run_coding_agent instead."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "GitHub REST API path, e.g. /repos/{owner}/{repo}/issues",
+            },
+            "params": {
+                "type": "object",
+                "description": "Query parameters (e.g. {'state':'open','per_page':20}).",
+            },
+            "media_type": {
+                "type": "string",
+                "enum": ["json", "diff", "patch", "raw"],
+                "description": "Response format; 'diff'/'patch' for PR/commit diffs, "
+                               "'raw' for file contents. Default 'json'.",
+            },
+        },
+        "required": ["path"],
+        "additionalProperties": False,
+    },
+)
+
+
+def register(registry: ToolRegistry) -> None:
+    """Register the ``github`` tool."""
+    registry.register(
+        name="github",
+        schema=_SCHEMA,
+        handler=_github_handler,
+        toolset="code",
+    )
+
+
+async def _github_get(path: str, params: Mapping[str, Any], pat: str, media_type: str) -> str:
+    import httpx
+
+    path_only, _, qs = path.partition("?")
+    query = dict(parse_qsl(qs))
+    query.update({k: str(v) for k, v in (params or {}).items()})
+    accept = _MEDIA_ACCEPT.get(media_type, _MEDIA_ACCEPT["json"])
+    headers = {
+        "Authorization": f"Bearer {pat}",
+        "Accept": accept,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "surogate-agent",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.get(
+                f"{_API_BASE}/{path_only.strip('/')}", params=query, headers=headers,
+            )
+    except httpx.HTTPError as exc:
+        return json.dumps({"error": f"GitHub request failed: {exc}"})
+
+    text = resp.text or ""
+    truncated = len(text) > _MAX_BODY
+    body = text[:_MAX_BODY]
+    if resp.status_code >= 400:
+        message = body
+        try:
+            message = (json.loads(text) or {}).get("message", body)
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            pass
+        return json.dumps({"status": resp.status_code, "error": message})
+
+    data: Any = body
+    if accept == _MEDIA_ACCEPT["json"] and not truncated:
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            pass
+    result: dict[str, Any] = {"status": resp.status_code, "data": data}
+    if truncated:
+        result["truncated"] = True
+        result["note"] = f"Response truncated to {_MAX_BODY} chars; narrow the query or paginate."
+    return json.dumps(result)
+
+
+async def _github_handler(arguments: dict[str, Any], **kwargs: Any) -> str:
+    path = (arguments.get("path") or "").strip()
+    if not path:
+        return json.dumps({"error": "path is required, e.g. /repos/{owner}/{repo}/issues"})
+
+    tenant = kwargs.get("tenant")
+    vault = kwargs.get("credential_vault")
+    if tenant is None or vault is None:
+        return json.dumps({"error": "the github tool is not available on this deployment"})
+
+    effective_config = kwargs.get("session_config") or {}
+    repos = effective_config.get("repos") or []
+    if not repos:
+        return json.dumps({
+            "error": "Configure a repository in the agent's Tools tab first.",
+            "code": "repo_not_configured",
+        })
+
+    pat = await resolve_git_pat(
+        vault, org_id=tenant.org_id,
+        user_id=getattr(tenant, "user_id", None),
+        service_account_id=getattr(tenant, "service_account_id", None),
+    )
+    if not pat:
+        return json.dumps({
+            "error": "Connect a GitHub token in the agent's Tools tab first.",
+            "code": "git_pat_not_connected",
+        })
+
+    params = arguments.get("params") or {}
+    ok, reason = authorize_github_read(path, params, repos)
+    if not ok:
+        return json.dumps({"error": reason, "code": "out_of_scope"})
+
+    return await _github_get(path, params, pat, arguments.get("media_type") or "json")

--- a/surogates/tools/router.py
+++ b/surogates/tools/router.py
@@ -61,6 +61,7 @@ TOOL_LOCATIONS: dict[str, ToolLocation] = {
     "delegate_task": ToolLocation.HARNESS,
     "consult_expert": ToolLocation.HARNESS,
     "run_coding_agent": ToolLocation.HARNESS,
+    "github": ToolLocation.HARNESS,
     "todo": ToolLocation.HARNESS,
     "process": ToolLocation.HARNESS,
     "create_artifact": ToolLocation.HARNESS,

--- a/surogates/tools/runtime.py
+++ b/surogates/tools/runtime.py
@@ -58,6 +58,7 @@ class ToolRuntime:
             delegate,
             expert,
             file_ops,
+            github,
             kb_tools,
             loop_control,
             media_gen,
@@ -98,6 +99,7 @@ class ToolRuntime:
             coordinator,
             artifact,
             coding_agent,  # run_coding_agent (Claude Code / Codex)
+            github,  # github (read-only GitHub REST for the agent's repos)
             task_tools,  # spawn_task, unblock_task, cancel_task, worker_block/complete/context
             board_tools,  # share_note, read_board, expand_note (coordination board)
             arbor_tools,  # idea_tree, dispatch_experiments, merge_experiment (research missions)

--- a/tests/test_github_scope.py
+++ b/tests/test_github_scope.py
@@ -1,0 +1,74 @@
+"""The GitHub read tool is scoped to the agent's configured repositories."""
+
+from surogates.tools.builtin.github import authorize_github_read, github_repo_slugs
+
+REPOS = [
+    {"url": "https://github.com/acme/api", "default_branch": "main"},
+    {"url": "https://github.com/acme/web.git", "default_branch": "main"},
+]
+
+
+def test_slugs_parsed_from_repo_urls():
+    assert github_repo_slugs(REPOS) == {"acme/api", "acme/web"}
+
+
+def test_repos_path_for_configured_repo_allowed():
+    for path in (
+        "/repos/acme/api",
+        "/repos/acme/api/issues",
+        "/repos/acme/api/issues?state=open",
+        "/repos/acme/web/contents/README.md",
+        "/repos/acme/web/commits",
+        "/repos/acme/api/pulls/42/files", 
+    ):
+        ok, _ = authorize_github_read(path, None, REPOS)
+        assert ok, path
+
+
+def test_repos_path_case_insensitive():
+    ok, _ = authorize_github_read("/repos/ACME/API/issues", None, REPOS)
+    assert ok
+
+
+def test_repos_path_for_unconfigured_repo_denied():
+    ok, reason = authorize_github_read("/repos/other/secret/issues", None, REPOS)
+    assert not ok
+    assert "not a configured repository" in reason
+
+
+def test_search_scoped_to_configured_repo_allowed():
+    ok, _ = authorize_github_read(
+        "/search/issues", {"q": "repo:acme/api is:issue is:open"}, REPOS,
+    )
+    assert ok
+
+
+def test_search_without_repo_qualifier_denied():
+    ok, reason = authorize_github_read("/search/issues", {"q": "is:open bug"}, REPOS)
+    assert not ok
+    assert "repo:" in reason
+
+
+def test_search_with_unconfigured_repo_denied():
+    ok, reason = authorize_github_read(
+        "/search/issues", {"q": "repo:other/secret is:open"}, REPOS,
+    )
+    assert not ok
+    assert "other/secret" in reason
+
+
+def test_search_with_broadening_qualifier_denied():
+    # org:/user: would search beyond a single configured repo.
+    ok, reason = authorize_github_read("/search/code", {"q": "org:acme foo"}, REPOS)
+    assert not ok
+
+
+def test_non_repo_paths_denied():
+    for path in ("/user", "/orgs/acme/repos", "/user/repos", "/repos"):
+        ok, _ = authorize_github_read(path, None, REPOS)
+        assert not ok, path
+
+
+def test_no_configured_repos_denies_everything():
+    ok, reason = authorize_github_read("/repos/acme/api/issues", None, [])
+    assert not ok

--- a/tests/test_github_tool.py
+++ b/tests/test_github_tool.py
@@ -1,0 +1,121 @@
+"""The github tool proxies authenticated, scoped, read-only GitHub API calls."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from uuid import uuid4
+
+import httpx
+import pytest
+import respx
+
+from surogates.tools.builtin.github import _github_handler
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+_PAT = "github_pat_11ABCDEsecret9876"
+_REPO = {"url": "https://github.com/acme/api", "default_branch": "main"}
+
+
+class _FakeVault:
+    def __init__(self, pat=None):
+        self.pat = pat
+
+    async def resolve_ref(self, ref, *, org_id, user_id=None, service_account_id=None):
+        return self.pat if ref == "vault://git_pat" else None
+
+
+def _tenant():
+    return SimpleNamespace(org_id=uuid4(), user_id=uuid4(), service_account_id=None)
+
+
+def _kwargs(pat=_PAT, repos=(_REPO,)):
+    return {
+        "tenant": _tenant(),
+        "credential_vault": _FakeVault(pat),
+        "session_config": {"repos": [dict(r) for r in repos]},
+    }
+
+
+@respx.mock
+async def test_lists_issues_and_carries_pat_in_header():
+    route = respx.get(url__regex=r"https://api\.github\.com/repos/acme/api/issues").mock(
+        return_value=httpx.Response(200, json=[{"number": 6, "title": "Bug"}]),
+    )
+    out = await _github_handler(
+        {"path": "/repos/acme/api/issues", "params": {"state": "open"}}, **_kwargs(),
+    )
+    assert route.called
+    req = route.calls.last.request
+    assert req.headers["Authorization"] == f"Bearer {_PAT}"
+    assert req.url.params["state"] == "open"
+
+    data = json.loads(out)
+    assert data["status"] == 200
+    assert data["data"][0]["title"] == "Bug"
+    # The token never leaks into the tool result.
+    assert _PAT not in out
+
+
+async def test_no_pat_returns_guidance():
+    out = await _github_handler(
+        {"path": "/repos/acme/api/issues"}, **_kwargs(pat=None),
+    )
+    assert json.loads(out)["code"] == "git_pat_not_connected"
+
+
+async def test_no_repos_returns_guidance():
+    out = await _github_handler(
+        {"path": "/repos/acme/api/issues"}, **_kwargs(repos=()),
+    )
+    assert json.loads(out)["code"] == "repo_not_configured"
+
+
+@respx.mock
+async def test_out_of_scope_repo_denied_without_calling_github():
+    route = respx.get(url__regex=r"https://api\.github\.com/.*").mock(
+        return_value=httpx.Response(200, json={}),
+    )
+    out = await _github_handler(
+        {"path": "/repos/other/secret/issues"}, **_kwargs(),
+    )
+    assert json.loads(out)["code"] == "out_of_scope"
+    assert not route.called  # never hit GitHub for an unconfigured repo
+
+
+@respx.mock
+async def test_github_error_message_surfaced():
+    respx.get(url__regex=r"https://api\.github\.com/repos/acme/api/pulls/999").mock(
+        return_value=httpx.Response(404, json={"message": "Not Found"}),
+    )
+    out = await _github_handler(
+        {"path": "/repos/acme/api/pulls/999"}, **_kwargs(),
+    )
+    data = json.loads(out)
+    assert data["status"] == 404
+    assert data["error"] == "Not Found"
+
+
+@respx.mock
+async def test_search_scoped_to_configured_repo():
+    route = respx.get(url__regex=r"https://api\.github\.com/search/issues").mock(
+        return_value=httpx.Response(200, json={"total_count": 2, "items": []}),
+    )
+    out = await _github_handler(
+        {"path": "/search/issues", "params": {"q": "repo:acme/api is:open"}}, **_kwargs(),
+    )
+    assert route.called
+    assert json.loads(out)["data"]["total_count"] == 2
+
+
+@respx.mock
+async def test_diff_media_type_sets_accept_header():
+    route = respx.get(url__regex=r"https://api\.github\.com/repos/acme/api/commits/abc").mock(
+        return_value=httpx.Response(200, text="diff --git a/x b/x"),
+    )
+    out = await _github_handler(
+        {"path": "/repos/acme/api/commits/abc", "media_type": "diff"}, **_kwargs(),
+    )
+    assert route.calls.last.request.headers["Accept"] == "application/vnd.github.diff"
+    assert "diff --git" in json.loads(out)["data"]

--- a/tests/test_github_tool_wiring.py
+++ b/tests/test_github_tool_wiring.py
@@ -1,0 +1,30 @@
+"""Wiring: the github tool is registered, harness-located, and gets its kwargs."""
+
+from __future__ import annotations
+
+import inspect
+
+from surogates.tools.registry import ToolRegistry
+from surogates.tools.runtime import ToolRuntime
+
+
+def test_github_tool_registered_and_harness_located():
+    registry = ToolRegistry()
+    ToolRuntime(registry).register_builtins()
+    assert registry.has("github")
+
+    from surogates.tools.router import TOOL_LOCATIONS, ToolLocation
+
+    # Default location is SANDBOX; an unlisted tool fails as "Unknown tool", so
+    # an explicit HARNESS entry is required for a worker-local tool.
+    assert TOOL_LOCATIONS.get("github") == ToolLocation.HARNESS
+
+
+def test_dispatch_forwards_session_config_and_vault():
+    # The handler resolves the PAT from credential_vault and the configured
+    # repos from session_config — both must be threaded by the harness dispatch.
+    import surogates.harness.tool_exec as te
+
+    src = inspect.getsource(te)
+    assert "credential_vault=" in src
+    assert "session_config=" in src


### PR DESCRIPTION
Closes the "answer questions about a repo" gap: the agent could check out a repo and open a PR (the coding tool), but had no way to *read* GitHub — so "what open issues do we have on the ops repo?" fell back to the unauthenticated public API and couldn't see private repos.

## What's here
A new harness-located `github` tool that proxies **authenticated, read-only, scoped** GitHub REST calls using the **same** `vault://git_pat` the coding tool already uses — one credential now covers both coding *and* questions (no Composio, no second token).

- **Read-only:** GET only.
- **Scoped to configured repos:** `authorize_github_read` allows `/repos/<owner>/<repo>/…` for a configured repo, or `/search/…` with a `repo:<owner>/<repo>` qualifier (rejects `org:`/`user:` and unconfigured repos) — never hits GitHub for an out-of-scope path.
- **Everything read:** issues, PRs, files (`/contents`), commits, diffs (`media_type: diff|patch`), raw file contents (`raw`), search.
- **Secret-safe:** the PAT rides only in the `Authorization` header — never in argv, the returned data, or an event. Response capped at 30 KB.
- Registered in `register_builtins`, `github → HARNESS` in `TOOL_LOCATIONS` (+ routing regression test, per the "unlisted tools fail as Unknown tool" rule).

## Testing
`test_github_scope` (10 — scoping allow/deny), `test_github_tool` (7 — respx-mocked API: header carries PAT, guidance paths, out-of-scope short-circuits, error surfacing, diff Accept), `test_github_tool_wiring` (2 — registered + HARNESS + kwargs threaded). All green; ruff clean. The lone suite failure is the pre-existing `test_worker_channel_token`, unrelated.

## Deploy
Ships in `surogates-worker`/`surogates-api` (harness tool). No sandbox rebuild (runs in the worker, not the sandbox), no DB migration.