### PR TITLE
feat(harness): surface the agent's configured repos in the system prompt

### DIFF
--- a/surogates/coding_agents/repo_resolve.py
+++ b/surogates/coding_agents/repo_resolve.py
@@ -7,12 +7,50 @@ another.
 """
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping, Sequence
 from typing import Any
+
+_SLUG_RE = re.compile(r"github\.com[:/]+([^/\s]+)/([^/\s]+?)(?:\.git)?/?$", re.IGNORECASE)
 
 
 def _repo_name(value: str) -> str:
     return value.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git").lower()
+
+
+def _repo_slug(url: str) -> str | None:
+    """``owner/repo`` for a GitHub URL, or None if it isn't one."""
+    m = _SLUG_RE.search(url or "")
+    return f"{m.group(1)}/{m.group(2)}" if m else None
+
+
+def render_repos_prompt(repos: Sequence[Mapping[str, str]] | None) -> str:
+    """A system-prompt section naming the agent's configured GitHub repos.
+
+    Empty when no valid repo is configured, so the section only appears for
+    agents that actually have repositories.  Tells the agent which repos it can
+    act on (so it doesn't guess names) and to link the artifacts it mentions.
+    """
+    lines: list[str] = []
+    for repo in repos or ():
+        slug = _repo_slug(repo.get("url", ""))
+        if not slug:
+            continue
+        branch = repo.get("default_branch", "")
+        lines.append(f"- {slug}" + (f" (default branch: {branch})" if branch else ""))
+    if not lines:
+        return ""
+    return (
+        "## GitHub repositories\n"
+        "You have access to these GitHub repositories:\n"
+        + "\n".join(lines)
+        + "\n\nUse the `github` tool to read them (issues, pull requests, files, "
+        "commits, diffs, search) and `run_coding_agent` or `/code` to make changes "
+        "and open a pull request. When you reference an issue, commit, or pull "
+        "request, include its GitHub link — e.g. "
+        "`https://github.com/<owner>/<repo>/issues/<number>`, "
+        "`.../pull/<number>`, or `.../commit/<sha>`."
+    )
 
 
 def select_repo(

--- a/surogates/harness/loop_context_replay.py
+++ b/surogates/harness/loop_context_replay.py
@@ -395,5 +395,12 @@ class ContextReplayMixin:
             return cached
 
         prompt = self._prompt.build()
+        # Tell the agent which GitHub repos it can act on (so it doesn't guess
+        # names) and to link the issues/commits/PRs it mentions.
+        from surogates.coding_agents.repo_resolve import render_repos_prompt
+
+        repos_section = render_repos_prompt(self._coding_repos)
+        if repos_section:
+            prompt = f"{prompt}\n\n{repos_section}"
         self._system_prompt_cache.set(session.id, prompt)
         return prompt

--- a/tests/test_repos_prompt.py
+++ b/tests/test_repos_prompt.py
@@ -1,0 +1,39 @@
+"""The agent's configured repos are rendered into a system-prompt section."""
+
+from surogates.coding_agents.repo_resolve import render_repos_prompt
+
+REPOS = [
+    {"url": "https://github.com/invergent-ai/surogate-ops.git", "default_branch": "main"},
+    {"url": "https://github.com/invergent-ai/surogates", "default_branch": "master"},
+]
+
+
+def test_no_repos_renders_nothing():
+    assert render_repos_prompt([]) == ""
+    assert render_repos_prompt(None) == ""
+
+
+def test_lists_each_repo_slug_and_default_branch():
+    s = render_repos_prompt(REPOS)
+    assert "invergent-ai/surogate-ops" in s
+    assert "invergent-ai/surogates" in s
+    assert "main" in s and "master" in s
+
+
+def test_points_at_the_tools():
+    s = render_repos_prompt(REPOS)
+    assert "github" in s  # the read tool
+    assert "run_coding_agent" in s or "/code" in s  # the write path
+
+
+def test_instructs_to_include_links():
+    s = render_repos_prompt(REPOS)
+    assert "link" in s.lower()
+    assert "https://github.com" in s
+    # names the artifact kinds the user asked to be linked
+    low = s.lower()
+    assert "issue" in low and "commit" in low and "pull request" in low
+
+
+def test_skips_malformed_urls():
+    assert render_repos_prompt([{"url": "not-a-url", "default_branch": "x"}]) == ""

--- a/tests/test_system_prompt_repos_section.py
+++ b/tests/test_system_prompt_repos_section.py
@@ -1,0 +1,69 @@
+"""AgentHarness appends the configured-repos section to the system prompt."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from surogates.harness.budget import IterationBudget
+from surogates.harness.context import ContextCompressor
+from surogates.harness.loop import AgentHarness
+from surogates.harness.prompt import PromptBuilder
+from surogates.sandbox.pool import SandboxPool
+from surogates.session.models import Session
+from surogates.tenant.context import TenantContext
+from surogates.tools.registry import ToolRegistry
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+_REPO = {"url": "https://github.com/invergent-ai/surogate-ops.git", "default_branch": "main"}
+
+
+def _tenant() -> TenantContext:
+    return TenantContext(
+        org_id=UUID("00000000-0000-0000-0000-000000000001"),
+        user_id=UUID("00000000-0000-0000-0000-000000000002"),
+        org_config={}, user_preferences={}, permissions=frozenset(),
+        asset_root="/tmp/test",
+    )
+
+
+def _session() -> Session:
+    now = datetime.now(timezone.utc)
+    return Session(
+        id=uuid4(), user_id=uuid4(), org_id=uuid4(), agent_id="a1",
+        channel="slack", status="active", config={}, created_at=now, updated_at=now,
+    )
+
+
+def _harness(coding_repos) -> AgentHarness:
+    pb = MagicMock(spec=PromptBuilder)
+    pb.build.return_value = "BASE PROMPT"
+    return AgentHarness(
+        session_store=AsyncMock(),
+        tool_registry=ToolRegistry(),
+        llm_client=AsyncMock(),
+        tenant=_tenant(),
+        worker_id="test-worker",
+        budget=IterationBudget(max_total=10),
+        context_compressor=MagicMock(spec=ContextCompressor),
+        prompt_builder=pb,
+        sandbox_pool=MagicMock(spec=SandboxPool),
+        coding_repos=coding_repos,
+    )
+
+
+async def test_prompt_appends_repos_section():
+    prompt = await _harness((_REPO,))._build_system_prompt(_session())
+    assert prompt.startswith("BASE PROMPT")
+    assert "invergent-ai/surogate-ops" in prompt
+    assert "github" in prompt
+    assert "https://github.com" in prompt  # the link instruction
+
+
+async def test_prompt_unchanged_without_repos():
+    prompt = await _harness(())._build_system_prompt(_session())
+    assert prompt == "BASE PROMPT"


### PR DESCRIPTION
## Why
The agent's configured repos were *used* by the tools (scoping/selection) but never *told* to the agent — so it guessed repo names (`ops`, `devops`, …) and only learned the real ones reactively from the `github` tool's `out_of_scope` rejection. Observed live: it burned several turns probing names before landing on `invergent-ai/surogate-ops`.

## What
Render a **GitHub repositories** section into the system prompt when repos are configured:
- Names each `owner/repo` + default branch (so it maps "the ops repo" → `invergent-ai/surogate-ops` directly, no guessing).
- Points at the `github` tool (read) and `run_coding_agent` / `/code` (write).
- **Instructs the agent to include GitHub links** for any issue, commit, or PR it references (`.../issues/<n>`, `.../pull/<n>`, `.../commit/<sha>`).

Pure formatter `render_repos_prompt()` in `repo_resolve.py`; appended in `_build_system_prompt`. Empty (no section) for agents with no repos.

## Testing
`test_repos_prompt` (formatter: lists slugs/branches, names tools, link instruction, skips malformed URLs) + `test_system_prompt_repos_section` (harness appends the section only when repos are set). 221 prompt/harness tests green; ruff clean on changed lines.

## Deploy
Harness change → `surogates-worker`. No migration. Restart the worker to pick it up.