### PR TITLE
feat(harness): steer the agent to the coding tool for fixes, not manual git

### DIFF
--- a/surogates/coding_agents/repo_resolve.py
+++ b/surogates/coding_agents/repo_resolve.py
@@ -44,12 +44,16 @@ def render_repos_prompt(repos: Sequence[Mapping[str, str]] | None) -> str:
         "## GitHub repositories\n"
         "You have access to these GitHub repositories:\n"
         + "\n".join(lines)
-        + "\n\nUse the `github` tool to read them (issues, pull requests, files, "
-        "commits, diffs, search) and `run_coding_agent` or `/code` to make changes "
-        "and open a pull request. When you reference an issue, commit, or pull "
-        "request, include its GitHub link — e.g. "
-        "`https://github.com/<owner>/<repo>/issues/<number>`, "
-        "`.../pull/<number>`, or `.../commit/<sha>`."
+        + "\n\nUse the `github` tool to READ them (issues, pull requests, files, "
+        "commits, diffs, search). To FIX an issue or make ANY code change, use "
+        "`run_coding_agent` (Claude Code / Codex on the connected plan) or `/code` "
+        "— it checks the repo out with credentials, makes the change, and opens a "
+        "pull request for review. Do NOT `git clone`, `gh`, or push from the "
+        "terminal: it has no git credentials; only the coding tool's checkout is "
+        "authenticated. When you reference an issue, commit, or pull request, "
+        "include its GitHub link — e.g. "
+        "`https://github.com/<owner>/<repo>/issues/<number>`, `.../pull/<number>`, "
+        "or `.../commit/<sha>`."
     )
 
 

--- a/tests/test_repos_prompt.py
+++ b/tests/test_repos_prompt.py
@@ -26,6 +26,16 @@ def test_points_at_the_tools():
     assert "run_coding_agent" in s or "/code" in s  # the write path
 
 
+def test_steers_away_from_manual_git():
+    # The terminal has no git auth; the agent must use the coding tool to make
+    # changes, not git clone / gh directly.
+    s = render_repos_prompt(REPOS)
+    low = s.lower()
+    assert "do not" in low or "don't" in low
+    assert "git clone" in low or "gh" in low
+    assert "run_coding_agent" in s
+
+
 def test_instructs_to_include_links():
     s = render_repos_prompt(REPOS)
     assert "link" in s.lower()


### PR DESCRIPTION
Follow-up to #118. Observed in a live session: asked to "fix #136", the agent read the issue fine via the `github` tool (200), then tried to **`git clone` + `gh` in the terminal** to make the fix — which fails because the terminal has no git credentials by design (the PAT lives only inside the `run_coding_agent` checkout sandbox). It never called `run_coding_agent`.

Strengthen the repos prompt to steer it: **read** with `github`; to **fix an issue / make any code change**, use `run_coding_agent` (Claude Code / Codex on the connected plan) or `/code`; and explicitly **do NOT `git clone`/`gh`/push from the terminal** — only the coding tool's checkout is authenticated.

Everything is already wired (verified on the live agent: `/code` enabled, a Claude Code plan connected under the agent SA, PAT + repos configured) — this just points the model at the right tool.

## Testing
Added `test_steers_away_from_manual_git`; formatter + harness-wiring tests green.

## Deploy
Harness change → `surogates-worker`. Restart to pick up; applies to sessions that wake after.