### PR TITLE
feat(channels): /stop command interrupts the running turn from a channel

### DIFF
--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -156,6 +156,16 @@ class InboundOutcome(str, Enum):
     DROPPED = "dropped"
     """Message discarded (duplicate, mention gate, bot filter, empty body)."""
 
+    INTERRUPTED = "interrupted"
+    """A ``/stop`` command — the running turn was interrupted out-of-band; no
+    session message was emitted or enqueued."""
+
+
+def is_stop_command(text: str | None) -> bool:
+    """True for a bare ``/stop`` (or ``/cancel``) message — a request to
+    interrupt the running turn, not a prompt to process."""
+    return (text or "").strip().lower() in ("/stop", "/cancel")
+
 
 # ---------------------------------------------------------------------------
 # Dependency bundle
@@ -563,6 +573,32 @@ class ChannelInboundPipeline:
 
         # Remember in Redis-backed state for thread-gate lookups.
         await deps.state.remember_session(session_key, str(session_id))
+
+        # ------------------------------------------------------------------
+        # /stop — interrupt the running turn OUT-OF-BAND.  A normal message
+        # would queue behind the busy worker and never reach it in time (a
+        # long coding run, say), so publish the interrupt directly: the
+        # worker's interrupt listener picks it up and cancels the in-flight
+        # run.  No USER_MESSAGE is emitted and the session is not enqueued.
+        # ------------------------------------------------------------------
+        if is_stop_command(msg.text):
+            from surogates.config import INTERRUPT_CHANNEL_PREFIX
+            try:
+                await deps.redis.publish(
+                    f"{INTERRUPT_CHANNEL_PREFIX}:{session_id}", "channel_stop",
+                )
+            except Exception:
+                logger.warning(
+                    "[channels] /stop interrupt publish failed", exc_info=True,
+                )
+            if deps.input_nudge is not None:
+                try:
+                    await deps.input_nudge(
+                        session_id, msg, "⏹ Stopping the current run…",
+                    )
+                except Exception:
+                    logger.warning("[channels] /stop ack failed", exc_info=True)
+            return InboundOutcome.INTERRUPTED
 
         # While a question is pending, a plain in-thread reply is NOT the answer
         # (the user must use the Answer button / modal). Intercept: nudge and

--- a/tests/test_channel_pipeline.py
+++ b/tests/test_channel_pipeline.py
@@ -65,6 +65,11 @@ class _FakeRedis:
         self.zsets: dict[str, dict[str, float]] = {}
         self.kv: dict[str, Any] = {}
         self.lists: dict[str, list[str]] = {}
+        self.published: list[tuple[str, str]] = []
+
+    async def publish(self, channel: str, message: str) -> int:
+        self.published.append((channel, message))
+        return 1
 
     async def zadd(self, key: str, mapping: dict) -> None:
         if key not in self.zsets:

--- a/tests/test_inbound_stop_command.py
+++ b/tests/test_inbound_stop_command.py
@@ -1,0 +1,82 @@
+"""A ``/stop`` channel message interrupts the running turn out-of-band."""
+
+from surogates.channels.inbound import (
+    ChannelInboundPipeline,
+    InboundOutcome,
+    is_stop_command,
+)
+from surogates.session.events import EventType
+
+from tests.test_channel_pipeline import (
+    SESSION_ID,
+    _make_config,
+    _make_deps,
+    _make_msg,
+    _make_routing,
+)
+
+
+def test_is_stop_command():
+    assert is_stop_command("/stop")
+    assert is_stop_command("  /STOP ")  # leading-space (Slack) + case-insensitive
+    assert is_stop_command("/cancel")
+    assert not is_stop_command("stop")  # must be the slash form
+    assert not is_stop_command("/stop the retries")  # only a bare command
+    assert not is_stop_command("")
+    assert not is_stop_command(None)
+
+
+async def _run(deps, text):
+    return await ChannelInboundPipeline().handle(
+        _make_msg(is_dm=True, identifier="D1", ts="800.0", text=text),
+        routing=_make_routing(),
+        config=_make_config(),
+        deps=deps,
+    )
+
+
+async def test_stop_command_publishes_interrupt_and_suppresses_turn():
+    deps = _make_deps()
+    nudges: list[str] = []
+
+    async def input_nudge(session_id, msg, text):
+        nudges.append(text)
+
+    deps.input_nudge = input_nudge
+
+    result = await _run(deps, "/stop")
+
+    assert result == InboundOutcome.INTERRUPTED
+    # interrupt published on the session's channel — out-of-band, so it reaches
+    # the busy worker's listener instead of queuing behind the running tool.
+    assert deps.redis.published == [
+        (f"surogates:interrupt:{SESSION_ID}", "channel_stop"),
+    ]
+    # NOT enqueued for normal processing, and no USER_MESSAGE emitted.
+    assert not deps._enqueued
+    assert not any(
+        et == EventType.USER_MESSAGE for _, et, _ in deps.session_store.events
+    )
+    # acked back to the channel.
+    assert nudges and "Stopping" in nudges[0]
+
+
+async def test_leading_space_stop_still_interrupts():
+    # Slack users prefix a space so Slack doesn't eat the "/"; the text arrives
+    # stripped, so it must still be recognised.
+    deps = _make_deps()
+    deps.input_nudge = lambda *a: _noop()
+    assert await _run(deps, " /stop") == InboundOutcome.INTERRUPTED
+    assert deps.redis.published
+
+
+async def test_normal_message_is_not_interrupted():
+    deps = _make_deps()
+    result = await _run(deps, "please fix the login bug")
+    assert result == InboundOutcome.PROCESSED
+    assert deps.redis.published == []
+    assert deps._enqueued
+
+
+async def _noop():
+    return None


### PR DESCRIPTION
## Why
Stopping a run only works via the web UI's Stop button (which publishes a Redis interrupt on `surogates:interrupt:<session_id>`). From a channel there was **no way to stop a run** — a "stop" message is just queued as a normal `user.message`, and while a tool is running (e.g. a multi-minute coding run) the worker is busy, so the message isn't read until the run finishes. That's why stop messages did nothing.

## What
Detect a bare **`/stop`** (or `/cancel`) at the inbound edge (`ChannelInboundPipeline.handle`, right after the session resolves) and publish the interrupt **out-of-band** on the session's channel — bypassing the blocked message queue. The worker's interrupt listener picks it up → `harness.interrupt()` → the in-flight run's `should_cancel` fires → the pod-side CLI is killed. No `USER_MESSAGE` is emitted, the session isn't enqueued, and the channel gets a short "⏹ Stopping…" ack.

Works from Slack with the leading-space trick (` /stop`) — Slack otherwise intercepts a leading `/` as a native command.

(Verified the mechanism live: publishing `surogates:interrupt:<sid>` to the running worker stopped an in-progress Claude Code run.)

## Testing
`test_inbound_stop_command` — `is_stop_command` matching (incl. leading-space/case, and NOT matching `stop` or `/stop <text>`), the intercept publishes the interrupt + acks + suppresses the turn (no enqueue, no USER_MESSAGE), and a normal message is unaffected. Full inbound/channel suite (126) green; ruff clean.

## Deploy
Harness change → `surogates-worker` (the runtime that runs the inbound pipeline). Restart to pick up.