### PR TITLE
feat(coding): channel progress updates during a coding run

### DIFF
--- a/surogates/coding_agents/run_core.py
+++ b/surogates/coding_agents/run_core.py
@@ -21,6 +21,11 @@ from surogates.coding_agents.credentials import (
     CodingAgentCredentials,
     CredentialBundle,
 )
+from surogates.coding_agents.run_progress import (
+    CHANNEL_UPDATE_INTERVAL,
+    render_code_run_ack,
+    render_code_run_update,
+)
 from surogates.coding_agents.runner import run_code_agent
 from surogates.session.events import EventType
 
@@ -157,12 +162,36 @@ async def execute_coding_run(
         extra_env = git_env
         workdir = checkout_dir
 
+    # Channel heartbeat: code-run PROGRESS renders live in the web UI but is
+    # never delivered to channels, so a Slack/Telegram user sees nothing for
+    # the minutes a run takes.  Post a throttled "still working" update for
+    # channel sessions (web/api render progress themselves).
+    wants_updates = getattr(session, "channel", "") not in ("web", "api")
+    last_update = time.monotonic()
+    if wants_updates:
+        await store.emit_event(
+            session.id,
+            EventType.CODE_RUN_CHANNEL_UPDATE,
+            {"run_id": run_id, "agent": agent, "text": render_code_run_ack(agent, repo)},
+        )
+
     async def _emit_progress(chunk: str) -> None:
+        nonlocal last_update
         await store.emit_event(
             session.id,
             EventType.CODE_RUN_PROGRESS,
             {"run_id": run_id, "agent": agent, "chunk": chunk},
         )
+        if wants_updates and time.monotonic() - last_update >= CHANNEL_UPDATE_INTERVAL:
+            last_update = time.monotonic()
+            await store.emit_event(
+                session.id,
+                EventType.CODE_RUN_CHANNEL_UPDATE,
+                {
+                    "run_id": run_id, "agent": agent,
+                    "text": render_code_run_update(repo, chunk),
+                },
+            )
 
     result = await run_code_agent(
         run_id=run_id,

--- a/surogates/coding_agents/run_progress.py
+++ b/surogates/coding_agents/run_progress.py
@@ -1,0 +1,45 @@
+"""Throttled, channel-deliverable progress for a coding run.
+
+Code-run PROGRESS events render live in the web UI (CodeRunBlock) but are not
+delivered to channels, so a Slack/Telegram user sees nothing for the minutes a
+run takes.  These helpers format a periodic heartbeat (delivered via a
+``CODE_RUN_CHANNEL_UPDATE`` event) so the channel knows the run is alive.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from surogates.coding_agents.repo_resolve import _repo_slug
+
+# Emit at most one channel update this often (seconds) during a run.
+CHANNEL_UPDATE_INTERVAL = 45.0
+
+
+def _repo_where(repo: Mapping[str, str] | None) -> str:
+    slug = _repo_slug(repo.get("url", "")) if repo else None
+    return f" on `{slug}`" if slug else ""
+
+
+def _activity_line(text: str | None, limit: int = 140) -> str:
+    """The first substantive line of a progress chunk (skipping ``›`` tool
+    markers), truncated — a short hint at what the run is doing right now."""
+    for line in (text or "").splitlines():
+        s = line.strip()
+        if s and not s.startswith("›"):
+            return s[:limit]
+    return ""
+
+
+def render_code_run_ack(agent: str, repo: Mapping[str, str] | None) -> str:
+    """The initial 'started' message posted to the channel when a run begins."""
+    return (
+        f"🛠️ On it — running {agent}{_repo_where(repo)}. "
+        "I'll post the result when it's done."
+    )
+
+
+def render_code_run_update(repo: Mapping[str, str] | None, activity: str | None) -> str:
+    """A periodic 'still working' heartbeat with a short activity hint."""
+    line = _activity_line(activity)
+    tail = f" — {line}" if line else ""
+    return f"🛠️ Still working{_repo_where(repo)}…{tail}"

--- a/surogates/session/events.py
+++ b/surogates/session/events.py
@@ -58,6 +58,7 @@ class EventType(str, Enum):
     # Credentials must NEVER appear in any of these payloads.
     CODE_RUN_STARTED = "code.run_started"
     CODE_RUN_PROGRESS = "code.run_progress"
+    CODE_RUN_CHANNEL_UPDATE = "code.run_channel_update"
     CODE_RUN_RESULT = "code.run_result"
 
     # Session lifecycle

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -95,6 +95,13 @@ def _build_channel_payload(event_type: EventType, data: dict, channel: str) -> d
             payload["intermediate"] = bool(
                 isinstance(msg, dict) and msg.get("tool_calls")
             )
+    elif event_type == EventType.CODE_RUN_CHANNEL_UPDATE:
+        # A throttled "still working" heartbeat during a coding run — delivered
+        # as a normal (non-intermediate) message so channels aren't silent for
+        # the minutes a run takes (code-run PROGRESS is web-UI-only).
+        text = data.get("text")
+        if text and isinstance(text, str):
+            payload["content"] = text
     elif event_type == EventType.INBOX_INPUT_REQUIRED and channel == "slack":
         questions = data.get("questions") or []
         if questions:

--- a/tests/test_code_run_channel_update_delivery.py
+++ b/tests/test_code_run_channel_update_delivery.py
@@ -1,0 +1,24 @@
+"""A CODE_RUN_CHANNEL_UPDATE event is delivered to channels; PROGRESS is not."""
+
+from surogates.session.events import EventType
+from surogates.session.store import _build_channel_payload
+
+
+def test_channel_update_delivered_as_message():
+    p = _build_channel_payload(
+        EventType.CODE_RUN_CHANNEL_UPDATE, {"text": "🛠️ Still working…"}, "slack",
+    )
+    assert p == {"content": "🛠️ Still working…"}
+    # not marked intermediate → delivered, not suppressed/folded
+    assert "intermediate" not in p
+
+
+def test_channel_update_empty_text_not_delivered():
+    assert _build_channel_payload(EventType.CODE_RUN_CHANNEL_UPDATE, {}, "slack") == {}
+
+
+def test_code_run_progress_still_not_delivered_to_channels():
+    # The live streaming progress remains web-UI-only.
+    assert _build_channel_payload(
+        EventType.CODE_RUN_PROGRESS, {"chunk": "editing"}, "slack",
+    ) == {}

--- a/tests/test_execute_coding_run_repo.py
+++ b/tests/test_execute_coding_run_repo.py
@@ -193,3 +193,59 @@ async def test_no_repo_run_never_checks_out():
     launch = next(p for a, p in calls if a == "launch")
     assert "workdir" not in launch
     assert "GH_TOKEN" not in launch["env"]
+
+
+async def test_emits_channel_progress_updates(monkeypatch):
+    # Channel sessions get a throttled "still working" heartbeat during the run
+    # (code-run PROGRESS is web-UI-only). Force every progress chunk to emit one.
+    import surogates.coding_agents.run_core as rc
+    monkeypatch.setattr(rc, "CHANNEL_UPDATE_INTERVAL", 0.0)
+
+    store = _FakeStore()
+    polls = [
+        {"ok": True, "done": False, "exit_code": None, "offset": 10,
+         "new_output": json.dumps({
+             "type": "assistant",
+             "message": {"content": [{"type": "text", "text": "Editing search.py"}]},
+         }) + "\n"},
+        {"ok": True, "done": True, "exit_code": 0, "offset": 40,
+         "new_output": json.dumps({
+             "type": "result", "result": "Done.",
+             "usage": {"input_tokens": 1, "output_tokens": 1},
+         }) + "\n"},
+    ]
+    execute, _calls = _sbx(polls)
+    await execute_coding_run(
+        store=store, tenant=_tenant(),
+        session=SimpleNamespace(id=uuid4(), channel="slack"),
+        credentials=_anthropic_creds(), agent="claude", provider="anthropic",
+        prompt="fix it", model=None, effort=None, read_only=False,
+        ensure_sandbox=_noop_ensure, execute=execute, should_cancel=lambda: False,
+        repo={"url": "https://github.com/acme/api", "default_branch": "main"},
+        git_pat=_PAT, now=1_700_000_000.0,
+    )
+    updates = [
+        d for et, d in store.events if et == EventType.CODE_RUN_CHANNEL_UPDATE
+    ]
+    assert any("On it" in u["text"] for u in updates)          # initial ack
+    assert any("Still working" in u["text"] for u in updates)  # throttled update
+    assert all("acme/api" in u["text"] for u in updates)
+
+
+async def test_no_channel_updates_for_web_sessions(monkeypatch):
+    import surogates.coding_agents.run_core as rc
+    monkeypatch.setattr(rc, "CHANNEL_UPDATE_INTERVAL", 0.0)
+    store = _FakeStore()
+    execute, _calls = _sbx(_done_poll())
+    await execute_coding_run(
+        store=store, tenant=_tenant(),
+        session=SimpleNamespace(id=uuid4(), channel="web"),
+        credentials=_anthropic_creds(), agent="claude", provider="anthropic",
+        prompt="fix it", model=None, effort=None, read_only=False,
+        ensure_sandbox=_noop_ensure, execute=execute, should_cancel=lambda: False,
+        repo={"url": "https://github.com/acme/api", "default_branch": "main"},
+        git_pat=_PAT, now=1_700_000_000.0,
+    )
+    assert not any(
+        et == EventType.CODE_RUN_CHANNEL_UPDATE for et, _ in store.events
+    )

--- a/tests/test_run_progress.py
+++ b/tests/test_run_progress.py
@@ -1,0 +1,42 @@
+"""Channel-deliverable code-run progress text."""
+
+from surogates.coding_agents.run_progress import (
+    render_code_run_ack,
+    render_code_run_update,
+)
+
+REPO = {"url": "https://github.com/acme/api", "default_branch": "main"}
+
+
+def test_ack_names_agent_and_repo():
+    s = render_code_run_ack("claude", REPO)
+    assert "claude" in s
+    assert "acme/api" in s
+
+
+def test_ack_without_repo_is_still_valid():
+    s = render_code_run_ack("codex", None)
+    assert "codex" in s
+    assert "on `" not in s  # no dangling repo mention
+
+
+def test_update_includes_repo_and_activity_hint():
+    s = render_code_run_update(REPO, "Editing search.py to add fuzzy match\n› Bash")
+    assert "acme/api" in s
+    assert "Editing search.py" in s  # the prose line, not the › tool marker
+
+
+def test_update_skips_bare_tool_markers():
+    s = render_code_run_update(REPO, "› Bash\n› TaskOutput")
+    assert "acme/api" in s
+    assert "›" not in s  # nothing but markers → no activity tail
+
+
+def test_update_truncates_long_activity():
+    s = render_code_run_update(REPO, "x" * 500)
+    assert len(s) < 400
+
+
+def test_update_empty_activity_ok():
+    s = render_code_run_update(REPO, "")
+    assert "acme/api" in s


### PR DESCRIPTION
## Why
A coding run takes minutes, but code-run PROGRESS renders only in the web UI (CodeRunBlock) — `_build_channel_payload` never delivers it to channels. So a Slack/Telegram user who kicks off a fix sees the "handing off…" message and then **silence** until the final PR, with no way to tell "working" from "dead."

## What
A new deliverable **`CODE_RUN_CHANNEL_UPDATE`** event that channels receive:
- `execute_coding_run` posts an initial **"🛠️ On it — running claude on `owner/repo`…"** ack when the run starts.
- Then a throttled **"🛠️ Still working on `owner/repo`… — <activity hint>"** heartbeat, at most every `CHANNEL_UPDATE_INTERVAL` (45s), pulled from the progress stream (first substantive line, `›` tool markers skipped).
- Delivered as a normal (non-intermediate) channel message via `_build_channel_payload`. **Web/api sessions are skipped** (they already render live progress); the streaming CodeRunBlock stays web-UI-only.
- No secret ever in the text.

Pairs with `/stop` (#120): `/stop` lets you kill a run, these updates let you see it's alive.

## Testing
`test_run_progress` (ack/update formatting, activity extraction, truncation), `test_code_run_channel_update_delivery` (delivered as a message; PROGRESS still not), and `test_execute_coding_run_repo` (emits ack + throttled update for a channel session; none for web). 283 coding/store tests green; ruff clean.

## Deploy
Harness change → `surogates-worker`. Restart to pick up.