### PR TITLE
fix(orchestrator): tolerate bare-string interrupt payloads (/stop was silently dropped)

### DIFF
--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -582,10 +582,13 @@ class ChannelInboundPipeline:
         # run.  No USER_MESSAGE is emitted and the session is not enqueued.
         # ------------------------------------------------------------------
         if is_stop_command(msg.text):
+            import json as _json
+
             from surogates.config import INTERRUPT_CHANNEL_PREFIX
             try:
                 await deps.redis.publish(
-                    f"{INTERRUPT_CHANNEL_PREFIX}:{session_id}", "channel_stop",
+                    f"{INTERRUPT_CHANNEL_PREFIX}:{session_id}",
+                    _json.dumps({"reason": "channel_stop"}),
                 )
             except Exception:
                 logger.warning(

--- a/surogates/orchestrator/dispatcher.py
+++ b/surogates/orchestrator/dispatcher.py
@@ -40,6 +40,32 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _parse_interrupt_reason(data: Any) -> str:
+    """Extract the interrupt reason from a pub/sub payload, tolerantly.
+
+    Accepts the canonical JSON (``{"reason": ...}``) or a bare string — some
+    publishers send just the reason (``channel_stop``, ``mission_cancel_cascade``).
+    Never raises: a malformed payload must not drop the interrupt signal.
+    """
+    if data is None:
+        return "interrupted"
+    if isinstance(data, bytes):
+        data = data.decode(errors="replace")
+    data = str(data).strip()
+    if not data:
+        return "interrupted"
+    try:
+        payload = json.loads(data)
+    except (ValueError, TypeError):
+        return data  # a bare-string publish IS the reason
+    if isinstance(payload, dict):
+        return str(payload.get("reason") or "interrupted")
+    if isinstance(payload, str) and payload:
+        return payload
+    return "interrupted"
+
+
 # Maximum number of retry attempts for a single session.
 _MAX_RETRIES: int = 3
 
@@ -769,8 +795,6 @@ class Orchestrator:
         when a session is paused.  This listener delivers the signal to
         the running harness on this worker.
         """
-        import json as _json
-
         pubsub = self.redis.pubsub()
         await pubsub.psubscribe(f"{INTERRUPT_CHANNEL_PREFIX}:*")
         logger.info("Interrupt listener subscribed to %s:*", INTERRUPT_CHANNEL_PREFIX)
@@ -792,12 +816,7 @@ class Orchestrator:
                     session_id_str = channel.rsplit(":", 1)[-1]
                     session_id = UUID(session_id_str)
 
-                    data = message.get("data", b"{}")
-                    if isinstance(data, bytes):
-                        data = data.decode()
-                    payload = _json.loads(data) if data else {}
-                    reason = payload.get("reason", "interrupted")
-
+                    reason = _parse_interrupt_reason(message.get("data"))
                     await self._handle_interrupt_signal(session_id, reason)
                 except Exception:
                     logger.warning(

--- a/tests/test_inbound_stop_command.py
+++ b/tests/test_inbound_stop_command.py
@@ -49,9 +49,13 @@ async def test_stop_command_publishes_interrupt_and_suppresses_turn():
     assert result == InboundOutcome.INTERRUPTED
     # interrupt published on the session's channel — out-of-band, so it reaches
     # the busy worker's listener instead of queuing behind the running tool.
-    assert deps.redis.published == [
-        (f"surogates:interrupt:{SESSION_ID}", "channel_stop"),
-    ]
+    # Data is canonical JSON so the listener's json.loads doesn't choke.
+    import json
+
+    assert len(deps.redis.published) == 1
+    ch, data = deps.redis.published[0]
+    assert ch == f"surogates:interrupt:{SESSION_ID}"
+    assert json.loads(data) == {"reason": "channel_stop"}
     # NOT enqueued for normal processing, and no USER_MESSAGE emitted.
     assert not deps._enqueued
     assert not any(

--- a/tests/test_interrupt_reason.py
+++ b/tests/test_interrupt_reason.py
@@ -1,0 +1,25 @@
+"""The interrupt listener parses reasons tolerantly — never drops a signal."""
+
+from surogates.orchestrator.dispatcher import _parse_interrupt_reason
+
+
+def test_canonical_json_reason():
+    assert _parse_interrupt_reason('{"reason": "channel_stop"}') == "channel_stop"
+    assert _parse_interrupt_reason(b'{"reason": "session deleted"}') == "session deleted"
+
+
+def test_bare_string_is_the_reason():
+    # Publishers that send just the reason (mission cascade, older callers) must
+    # not crash the listener — the whole point of this fix.
+    assert _parse_interrupt_reason("channel_stop") == "channel_stop"
+    assert _parse_interrupt_reason(b"mission_cancel_cascade") == "mission_cancel_cascade"
+
+
+def test_empty_or_none_defaults():
+    assert _parse_interrupt_reason(None) == "interrupted"
+    assert _parse_interrupt_reason("") == "interrupted"
+    assert _parse_interrupt_reason(b"") == "interrupted"
+
+
+def test_json_without_reason_defaults():
+    assert _parse_interrupt_reason('{"foo": 1}') == "interrupted"


### PR DESCRIPTION
## The bug
The interrupt listener parsed the pub/sub payload with `json.loads(data)` and read `payload["reason"]`. But `/stop` (#120) published the **bare string** `"channel_stop"`, so `json.loads` raised `JSONDecodeError`, the exception was caught as a warning, and **the interrupt was dropped** — `/stop` silently did nothing:

```
WARNING Failed to process interrupt message: {... 'data': b'channel_stop'}
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

The mission-cancel cascade (`missions/commands.py` → `"mission_cancel_cascade"`) publishes a bare string the same way, so it was silently broken too.

## The fix
- Extract `_parse_interrupt_reason(data)` — accepts the canonical `{"reason": ...}` JSON **or** a bare string (the reason), decodes bytes, and never raises. The listener uses it, so no malformed payload can drop an interrupt again.
- `/stop` now publishes the canonical `{"reason": "channel_stop"}` JSON.

Both belt (tolerant listener, also fixes the cascade) and suspenders (correct publish format).

## Testing
`test_interrupt_reason` (JSON reason, bare string, empty/None default, JSON-without-reason default) + updated `test_inbound_stop_command` (asserts the JSON payload). 190 dispatcher/inbound tests green; ruff clean.

## Deploy
Harness change → `surogates-worker`. Restart to pick up. This is what makes `/stop` actually stop a run.