### PR TITLE
fix(channels): actually deliver code-run channel updates to the channel

### DIFF
--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -61,6 +61,7 @@ class LeaseNotHeldError(Exception):
 _DELIVERABLE_EVENTS = frozenset({
     EventType.LLM_RESPONSE,
     EventType.INBOX_INPUT_REQUIRED,
+    EventType.CODE_RUN_CHANNEL_UPDATE,
 })
 
 

--- a/tests/test_code_run_channel_update_delivery.py
+++ b/tests/test_code_run_channel_update_delivery.py
@@ -1,7 +1,13 @@
 """A CODE_RUN_CHANNEL_UPDATE event is delivered to channels; PROGRESS is not."""
 
 from surogates.session.events import EventType
-from surogates.session.store import _build_channel_payload
+from surogates.session.store import _DELIVERABLE_EVENTS, _build_channel_payload
+
+
+def test_channel_update_is_gated_as_deliverable():
+    # emit_event only enqueues an outbox item for types in this set — the
+    # payload builder handling the type is not enough (this was the miss).
+    assert EventType.CODE_RUN_CHANNEL_UPDATE in _DELIVERABLE_EVENTS
 
 
 def test_channel_update_delivered_as_message():


### PR DESCRIPTION
Follow-up to #121. The `CODE_RUN_CHANNEL_UPDATE` events were being **emitted** (verified live — the heartbeats show up in the event log) but **never delivered** to Slack.

Cause: `emit_event` only enqueues an outbox item for event types in `_DELIVERABLE_EVENTS`, and #121 added the type to `_build_channel_payload` but not to that gate. So the payload builder was ready, but the enqueue step was skipped — no outbox item, no delivery.

Fix: add `CODE_RUN_CHANNEL_UPDATE` to `_DELIVERABLE_EVENTS`, plus a guard test asserting membership (the payload test alone didn't catch it).

## Testing
`test_code_run_channel_update_delivery` now asserts the type is gated as deliverable AND builds a payload. 241 store/channel tests green; ruff clean.

## Deploy
Harness change → `surogates-worker`. Restart to pick up.