### PR TITLE
feat(coding): summarize code-run channel heartbeats with the summary model

### DIFF
--- a/surogates/coding_agents/run_core.py
+++ b/surogates/coding_agents/run_core.py
@@ -14,6 +14,7 @@ import json
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import Any
 from uuid import uuid4
 
 from surogates.coding_agents.agents import CodeResult, build_invocation
@@ -25,6 +26,7 @@ from surogates.coding_agents.run_progress import (
     CHANNEL_UPDATE_INTERVAL,
     render_code_run_ack,
     render_code_run_update,
+    summarize_progress_activity,
 )
 from surogates.coding_agents.runner import run_code_agent
 from surogates.session.events import EventType
@@ -74,6 +76,8 @@ async def execute_coding_run(
     repo: dict | None = None,
     git_pat: str | None = None,
     branch: str | None = None,
+    summary_client: Any | None = None,
+    summary_model: str | None = None,
     now: float | None = None,
 ) -> CodingRunOutcome:
     """Run one coding agent end to end, emitting CODE_RUN_* events.
@@ -175,8 +179,13 @@ async def execute_coding_run(
             {"run_id": run_id, "agent": agent, "text": render_code_run_ack(agent, repo)},
         )
 
+    # The heartbeat summarises the whole run so far, not the tiny delta that
+    # happens to arrive at throttle time (which is often a bare tool marker).
+    transcript_parts: list[str] = []
+
     async def _emit_progress(chunk: str) -> None:
         nonlocal last_update
+        transcript_parts.append(chunk)
         await store.emit_event(
             session.id,
             EventType.CODE_RUN_PROGRESS,
@@ -184,12 +193,16 @@ async def execute_coding_run(
         )
         if wants_updates and time.monotonic() - last_update >= CHANNEL_UPDATE_INTERVAL:
             last_update = time.monotonic()
+            transcript = "".join(transcript_parts)
+            summary = await summarize_progress_activity(
+                summary_client, summary_model, transcript,
+            )
             await store.emit_event(
                 session.id,
                 EventType.CODE_RUN_CHANNEL_UPDATE,
                 {
                     "run_id": run_id, "agent": agent,
-                    "text": render_code_run_update(repo, chunk),
+                    "text": render_code_run_update(repo, summary or transcript),
                 },
             )
 

--- a/surogates/coding_agents/run_progress.py
+++ b/surogates/coding_agents/run_progress.py
@@ -4,15 +4,38 @@ Code-run PROGRESS events render live in the web UI (CodeRunBlock) but are not
 delivered to channels, so a Slack/Telegram user sees nothing for the minutes a
 run takes.  These helpers format a periodic heartbeat (delivered via a
 ``CODE_RUN_CHANNEL_UPDATE`` event) so the channel knows the run is alive.
+
+The heartbeat's activity line is written by the agent's summary model
+(:func:`summarize_progress_activity`) — a short present-tense sentence about
+what the run is doing right now — falling back to the most recent transcript
+line (:func:`_activity_line`) when no summary model is configured or the call
+fails.
 """
 from __future__ import annotations
 
+import asyncio
+import logging
 from collections.abc import Mapping
+from typing import Any
 
 from surogates.coding_agents.repo_resolve import _repo_slug
 
+logger = logging.getLogger(__name__)
+
 # Emit at most one channel update this often (seconds) during a run.
 CHANNEL_UPDATE_INTERVAL = 45.0
+
+# Only the recent transcript matters for "what is it doing now"; cap what we
+# hand the summariser so a long run doesn't grow the request unboundedly.
+_TRANSCRIPT_TAIL = 4000
+
+_SUMMARY_SYSTEM = (
+    "You report the progress of an autonomous coding agent to a chat user. "
+    "Given a transcript of what the agent has done so far, reply with ONE short "
+    "present-tense clause (max 15 words) naming what it is doing right now — "
+    "for example 'Adding fuzzy matching to the search tool and updating its "
+    "tests'. No preamble, no markdown, no quotes, no trailing period."
+)
 
 
 def _repo_where(repo: Mapping[str, str] | None) -> str:
@@ -21,13 +44,63 @@ def _repo_where(repo: Mapping[str, str] | None) -> str:
 
 
 def _activity_line(text: str | None, limit: int = 140) -> str:
-    """The first substantive line of a progress chunk (skipping ``›`` tool
-    markers), truncated — a short hint at what the run is doing right now."""
+    """The most recent substantive line of the progress transcript, truncated.
+
+    Prefers the agent's prose (its own narration); falls back to the last
+    ``›`` tool marker with the marker stripped when there is no prose yet.
+    Used as the heuristic when the summary model is unavailable — taking the
+    *last* line (not the first) so the hint reflects current activity.
+    """
+    prose = ""
+    tool = ""
     for line in (text or "").splitlines():
         s = line.strip()
-        if s and not s.startswith("›"):
-            return s[:limit]
-    return ""
+        if not s:
+            continue
+        if s.startswith("›"):
+            tool = s.lstrip("›").strip()
+        else:
+            prose = s
+    return (prose or tool)[:limit]
+
+
+async def summarize_progress_activity(
+    client: Any | None,
+    model: str | None,
+    transcript: str | None,
+    *,
+    timeout: float = 12.0,
+) -> str:
+    """One-line summary of what the run is doing now, via the summary model.
+
+    Returns ``""`` when no summary client/model is configured, the transcript
+    is empty, or the call fails for any reason — the caller falls back to
+    :func:`_activity_line` so a heartbeat is always producible.
+    """
+    tail = (transcript or "").strip()[-_TRANSCRIPT_TAIL:]
+    if client is None or not model or not tail:
+        return ""
+    try:
+        resp = await asyncio.wait_for(
+            client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": _SUMMARY_SYSTEM},
+                    {"role": "user", "content": tail},
+                ],
+                temperature=0.0,
+                max_tokens=60,
+            ),
+            timeout=timeout,
+        )
+    except Exception as exc:  # timeout, network, malformed response — never fatal
+        logger.warning("code-run progress summary failed: %r", exc)
+        return ""
+    try:
+        content = resp.choices[0].message.content
+    except (AttributeError, IndexError, TypeError):
+        return ""
+    return (content or "").strip()[:200]
 
 
 def render_code_run_ack(agent: str, repo: Mapping[str, str] | None) -> str:
@@ -39,7 +112,11 @@ def render_code_run_ack(agent: str, repo: Mapping[str, str] | None) -> str:
 
 
 def render_code_run_update(repo: Mapping[str, str] | None, activity: str | None) -> str:
-    """A periodic 'still working' heartbeat with a short activity hint."""
+    """A periodic 'still working' heartbeat with a short activity hint.
+
+    ``activity`` is a summary-model sentence when available, otherwise a raw
+    transcript from which the most recent line is extracted.
+    """
     line = _activity_line(activity)
     tail = f" — {line}" if line else ""
     return f"🛠️ Still working{_repo_where(repo)}…{tail}"

--- a/surogates/harness/loop_code_commands.py
+++ b/surogates/harness/loop_code_commands.py
@@ -215,6 +215,8 @@ class CodeCommandMixin:
                 ),
                 started_metadata={"source_event_id": source_event_id},
                 repo=repo, git_pat=git_pat, branch=branch,
+                summary_client=self._summary_client,
+                summary_model=self._summary_model,
             )
         except Exception as exc:  # provisioning/build failure — report cleanly
             logger.warning("/code run failed: %s", exc)

--- a/surogates/tools/builtin/coding_agent.py
+++ b/surogates/tools/builtin/coding_agent.py
@@ -171,6 +171,8 @@ async def _run_coding_agent_handler(arguments: dict[str, Any], **kwargs: Any) ->
         # promptly (kills the pod-side CLI) instead of polling to completion.
         should_cancel=lambda: is_interrupted(),
         repo=repo, git_pat=pat, branch=branch,
+        summary_client=kwargs.get("summary_llm_client"),
+        summary_model=kwargs.get("summary_model"),
     )
 
     if outcome.status == "not_connected":

--- a/tests/test_coding_agents_run_core.py
+++ b/tests/test_coding_agents_run_core.py
@@ -141,3 +141,108 @@ async def test_codex_writeback_surfaced():
     # Refreshed codex auth re-stored into the vault.
     stored = json.loads(creds._vault.stored["code_cred:openai"])
     assert stored["auth_json"]["tokens"]["access_token"] == "fresh"
+
+
+class _FakeSummaryClient:
+    def __init__(self, content):
+        self._content = content
+        self.calls = []
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(create=self._create),
+        )
+
+    async def _create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=self._content))],
+        )
+
+
+async def test_channel_heartbeat_uses_summary_model(monkeypatch):
+    # Fire the heartbeat on every progress delta so a single run triggers it.
+    monkeypatch.setattr(
+        "surogates.coding_agents.run_core.CHANNEL_UPDATE_INTERVAL", 0.0,
+    )
+    store = _FakeStore()
+    creds = CodingAgentCredentials(_FakeVault({
+        "code_cred:anthropic": CredentialBundle(
+            provider="anthropic", auth_mode="oauth",
+            token_kind="setup_token", oauth_token="sk-ant-oat01-x",
+        ).to_json(),
+    }))
+    polls = [
+        {
+            "ok": True, "done": False, "exit_code": None, "offset": 40,
+            "new_output": json.dumps({
+                "type": "assistant",
+                "message": {"content": [{"type": "text",
+                                         "text": "Editing the search tool"}]},
+            }) + "\n",
+        },
+        {
+            "ok": True, "done": True, "exit_code": 0, "offset": 120,
+            "new_output": json.dumps({"type": "result", "result": "Done."}) + "\n",
+        },
+    ]
+    execute, _calls = _sbx(polls)
+    summary = _FakeSummaryClient("Adding fuzzy matching to the search tool")
+    outcome = await execute_coding_run(
+        store=store, tenant=_tenant(),
+        session=SimpleNamespace(id=uuid4(), channel="slack"),
+        credentials=creds, agent="claude", provider="anthropic",
+        prompt="add fuzzy matching", model=None, effort=None, read_only=False,
+        ensure_sandbox=_noop_ensure, execute=execute, should_cancel=lambda: False,
+        summary_client=summary, summary_model="gpt-x",
+    )
+    assert outcome.status == "ok"
+    updates = [
+        d["text"] for et, d in store.events
+        if et == EventType.CODE_RUN_CHANNEL_UPDATE
+    ]
+    # The ack plus at least one throttled heartbeat carrying the model summary.
+    assert any("Adding fuzzy matching to the search tool" in t for t in updates)
+    # The run transcript reached the summary model.
+    assert summary.calls
+    assert "Editing the search tool" in summary.calls[0]["messages"][-1]["content"]
+
+
+async def test_channel_heartbeat_falls_back_without_summary_model(monkeypatch):
+    # With no summary model, the heartbeat still carries a transcript-derived hint.
+    monkeypatch.setattr(
+        "surogates.coding_agents.run_core.CHANNEL_UPDATE_INTERVAL", 0.0,
+    )
+    store = _FakeStore()
+    creds = CodingAgentCredentials(_FakeVault({
+        "code_cred:anthropic": CredentialBundle(
+            provider="anthropic", auth_mode="oauth",
+            token_kind="setup_token", oauth_token="sk-ant-oat01-x",
+        ).to_json(),
+    }))
+    polls = [
+        {
+            "ok": True, "done": False, "exit_code": None, "offset": 40,
+            "new_output": json.dumps({
+                "type": "assistant",
+                "message": {"content": [{"type": "text",
+                                         "text": "Editing the search tool"}]},
+            }) + "\n",
+        },
+        {
+            "ok": True, "done": True, "exit_code": 0, "offset": 120,
+            "new_output": json.dumps({"type": "result", "result": "Done."}) + "\n",
+        },
+    ]
+    execute, _calls = _sbx(polls)
+    outcome = await execute_coding_run(
+        store=store, tenant=_tenant(),
+        session=SimpleNamespace(id=uuid4(), channel="slack"),
+        credentials=creds, agent="claude", provider="anthropic",
+        prompt="edit", model=None, effort=None, read_only=False,
+        ensure_sandbox=_noop_ensure, execute=execute, should_cancel=lambda: False,
+    )
+    assert outcome.status == "ok"
+    updates = [
+        d["text"] for et, d in store.events
+        if et == EventType.CODE_RUN_CHANNEL_UPDATE
+    ]
+    assert any("Editing the search tool" in t for t in updates)

--- a/tests/test_run_progress.py
+++ b/tests/test_run_progress.py
@@ -1,8 +1,13 @@
-"""Channel-deliverable code-run progress text."""
+"""Channel-deliverable code-run progress text and summary-model activity line."""
+
+from types import SimpleNamespace
+
+import pytest
 
 from surogates.coding_agents.run_progress import (
     render_code_run_ack,
     render_code_run_update,
+    summarize_progress_activity,
 )
 
 REPO = {"url": "https://github.com/acme/api", "default_branch": "main"}
@@ -26,10 +31,19 @@ def test_update_includes_repo_and_activity_hint():
     assert "Editing search.py" in s  # the prose line, not the › tool marker
 
 
-def test_update_skips_bare_tool_markers():
-    s = render_code_run_update(REPO, "› Bash\n› TaskOutput")
+def test_update_uses_most_recent_prose_line():
+    # Later prose supersedes earlier prose — the hint tracks current activity.
+    s = render_code_run_update(REPO, "Reading the module\n› Edit\nNow wiring the CLI")
+    assert "Now wiring the CLI" in s
+    assert "Reading the module" not in s
+
+
+def test_update_falls_back_to_last_tool_name():
+    # No prose yet → show the last tool (marker stripped) rather than nothing.
+    s = render_code_run_update(REPO, "› Bash\n› Edit")
     assert "acme/api" in s
-    assert "›" not in s  # nothing but markers → no activity tail
+    assert "Edit" in s
+    assert "›" not in s
 
 
 def test_update_truncates_long_activity():
@@ -40,3 +54,65 @@ def test_update_truncates_long_activity():
 def test_update_empty_activity_ok():
     s = render_code_run_update(REPO, "")
     assert "acme/api" in s
+
+
+# --- summary-model activity line -------------------------------------------
+
+
+class _FakeSummaryClient:
+    """Minimal ``client.chat.completions.create`` shim capturing its kwargs."""
+
+    def __init__(self, content, *, raises=None):
+        self._content = content
+        self._raises = raises
+        self.calls = []
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(create=self._create),
+        )
+
+    async def _create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._raises is not None:
+            raise self._raises
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=self._content))],
+        )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_summarize_returns_model_line_and_sends_transcript():
+    client = _FakeSummaryClient("Adding fuzzy matching to the search tool")
+    out = await summarize_progress_activity(
+        client, "gpt-x", "Editing search.py\n› Edit\nWiring the CLI",
+    )
+    assert out == "Adding fuzzy matching to the search tool"
+    # The transcript reaches the model as the user message.
+    user = client.calls[0]["messages"][-1]
+    assert user["role"] == "user"
+    assert "Editing search.py" in user["content"]
+    assert client.calls[0]["model"] == "gpt-x"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_summarize_no_client_returns_empty():
+    assert await summarize_progress_activity(None, "gpt-x", "did stuff") == ""
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_summarize_no_model_returns_empty():
+    client = _FakeSummaryClient("x")
+    assert await summarize_progress_activity(client, "", "did stuff") == ""
+    assert client.calls == []  # never called without a model
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_summarize_empty_transcript_returns_empty():
+    client = _FakeSummaryClient("x")
+    assert await summarize_progress_activity(client, "gpt-x", "   ") == ""
+    assert client.calls == []
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_summarize_swallows_errors():
+    client = _FakeSummaryClient(None, raises=RuntimeError("boom"))
+    assert await summarize_progress_activity(client, "gpt-x", "did stuff") == ""


### PR DESCRIPTION
## What

During a coding run, the periodic "🛠️ Still working…" heartbeat posted to Slack/Telegram carried only the small progress *delta* that happened to arrive at throttle time. That delta is frequently a bare `› Edit` tool marker, so the heartbeat rendered as a bare **"Still working on `repo`…"** with no activity detail.

## Change

- **`summarize_progress_activity(client, model, transcript)`** — asks the agent's summary model for one short present-tense clause describing what the run is doing now (e.g. *"Adding fuzzy matching to the search tool and updating its tests"*). Returns `""` on no-client / no-model / empty-transcript / any failure.
- **`execute_coding_run`** now accumulates the full readable transcript and, at each throttled heartbeat, summarizes it — passing the summary as the update text. Falls back to the transcript's most-recent line when the summary model is unavailable.
- **`_activity_line`** now takes the *last* substantive line (most recent activity) instead of the first, and falls back to the last tool name when there's no prose yet.
- The summary client/model are plumbed from the tool dispatch kwargs (`run_coding_agent`) and from the harness (`/code` slash path).

## Tests

- `test_run_progress.py`: summary-model line (success, no-client, no-model, empty-transcript, error-swallowed), most-recent-prose, tool-name fallback.
- `test_coding_agents_run_core.py`: a slack session emits a heartbeat carrying the model summary and forwards the transcript to the model; and a fallback heartbeat when no summary model is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)