### PR TITLE
fix(logging): silence botocore DEBUG log flood in worker

### DIFF
--- a/surogates/cli/main.py
+++ b/surogates/cli/main.py
@@ -44,6 +44,15 @@ def _configure_logging(level: str) -> None:
     ):
         logging.getLogger(name).setLevel(logging.WARNING)
 
+    # Suppress urllib3's InsecureRequestWarning / connection warnings so
+    # they don't spam stderr outside the logging machinery.
+    try:
+        import urllib3
+
+        urllib3.disable_warnings()
+    except Exception:
+        pass
+
 
 # -- subcommands -------------------------------------------------------------
 

--- a/surogates/cli/main.py
+++ b/surogates/cli/main.py
@@ -24,7 +24,10 @@ def _configure_logging(level: str) -> None:
         format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
         stream=sys.stderr,
     )
-    # Silence noisy third-party loggers.
+    # Silence noisy third-party loggers.  The AWS/S3 clients are
+    # pathologically chatty at DEBUG (~40 lines per S3 call) and will
+    # flood the worker log whenever log_level is DEBUG, so clamp them to
+    # WARNING regardless of the root level.
     for name in (
         "uvicorn.access",
         "httpcore",
@@ -32,7 +35,12 @@ def _configure_logging(level: str) -> None:
         "hpack",
         "openai",
         "sse_starlette",
-        "kubernetes_asyncio"
+        "kubernetes_asyncio",
+        "botocore",
+        "aiobotocore",
+        "boto3",
+        "urllib3",
+        "s3transfer",
     ):
         logging.getLogger(name).setLevel(logging.WARNING)
 


### PR DESCRIPTION
## Problem

The worker (and other `surogates <subcommand>` processes) floods stderr with botocore/aiobotocore DEBUG logs (~dozens of lines per S3 `ListObjectsV2` call) whenever `log_level=DEBUG`.

`cli/main.py::_configure_logging` — the logging setup actually used by every subcommand — silenced httpx/openai/uvicorn but not the AWS/S3 client loggers. (`logging_config.py::configure_logging` already clamps them, but the worker path never calls it.)

## Fix

- Clamp `botocore`, `aiobotocore`, `boto3`, `urllib3`, `s3transfer` to `WARNING` in `_configure_logging`, so they can't flood the log regardless of root level.
- Call `urllib3.disable_warnings()` (guarded) to suppress its InsecureRequestWarning/connection warnings.