### PR TITLE
fix(tasks): block tasks with an unknown agent_def instead of retrying forever

### DIFF
--- a/surogates/tasks/dispatcher.py
+++ b/surogates/tasks/dispatcher.py
@@ -178,7 +178,10 @@ async def _enqueue_ready_tasks(
     lock on the task row would block the subsequent FK validation lock
     that ``create_child_session``'s INSERT into ``sessions`` acquires.
     """
-    from surogates.tasks.spawn import _create_session_for_task
+    from surogates.tasks.spawn import (
+        UnknownAgentDefError,
+        _create_session_for_task,
+    )
 
     enqueued = 0
     # Tasks whose spawn raised within this tick.  Excluded from
@@ -247,12 +250,25 @@ async def _enqueue_ready_tasks(
                 tenant=tenant,
                 file_bundle_cache=file_bundle_cache,
             )
+        except UnknownAgentDefError as exc:
+            # Permanent config error: the referenced agent_def does not exist
+            # in the catalog / bundle, so retrying can never succeed. Block the
+            # task (a first-class "needs attention" state surfaced in the UI,
+            # self-heals via unblock_task) instead of rolling it back to
+            # 'ready' and re-attempting every tick forever — the latter spammed
+            # the worker log indefinitely for a single misconfigured task.
+            logger.warning(
+                "tasks_tick: blocking task %s (unknown agent_def): %s",
+                claimed.id, exc,
+            )
+            failed_this_tick.add(claimed.id)
+            await _block_claim(session_factory, claimed.id, reason=str(exc))
+            continue
         except ValueError as exc:
-            # Config-level error (unknown agent_def_name, missing
-            # workspace fields on the parent session). Rolling back
-            # gives a human a chance to fix the catalog / config; the
-            # within-tick exclusion prevents hot-looping on this same
-            # row for the rest of THIS tick.
+            # Other config-level error (e.g. missing workspace fields on the
+            # parent session), which may be transient. Rolling back gives a
+            # human a chance to fix the config; the within-tick exclusion
+            # prevents hot-looping on this same row for the rest of THIS tick.
             logger.warning(
                 "tasks_tick: spawn failed for task %s: %s",
                 claimed.id, exc,
@@ -297,6 +313,38 @@ async def _enqueue_ready_tasks(
         enqueued += 1
 
     return enqueued
+
+
+async def _block_claim(
+    session_factory: async_sessionmaker, task_id: UUID, *, reason: str,
+) -> None:
+    """Best-effort: move a claimed task to ``blocked`` with ``blocked_reason``
+    (a permanent config error — the referenced agent_def does not exist).
+
+    Decrements ``attempt_count`` to undo the claim's increment so the block
+    doesn't burn a retry budget: once the catalog is fixed and the task is
+    unblocked (``unblock_task`` → ``ready``), it gets a clean attempt. Unlike
+    ``_rollback_claim`` this leaves the task OUT of the ``ready`` pool, so the
+    dispatcher stops re-attempting (and re-logging) it every tick.
+    """
+    try:
+        async with session_factory() as db:
+            await db.execute(
+                update(Task)
+                .where(Task.id == task_id)
+                .values(
+                    status="blocked",
+                    blocked_reason=reason[:500],
+                    attempt_count=Task.attempt_count - 1,
+                )
+            )
+            await db.commit()
+    except Exception:
+        logger.exception(
+            "tasks_tick: block for task %s failed; finalize step will "
+            "recover by treating the attempt as crashed",
+            task_id,
+        )
 
 
 async def _rollback_claim(

--- a/surogates/tasks/spawn.py
+++ b/surogates/tasks/spawn.py
@@ -34,6 +34,18 @@ from surogates.tools.builtin.coordinator import (
 logger = logging.getLogger(__name__)
 
 
+class UnknownAgentDefError(ValueError):
+    """A task references an ``agent_def_name`` that resolves to no enabled
+    AgentDef in the tenant catalog / agent bundle.
+
+    A *permanent* config error: retrying the spawn cannot succeed until the
+    catalog or bundle is fixed. The dispatcher blocks the task (surfaced for a
+    human, self-heals via ``unblock_task``) rather than rolling it back to
+    ``ready`` and re-attempting every tick forever. Subclasses ``ValueError``
+    so existing ``except ValueError`` handlers keep catching it.
+    """
+
+
 def _build_task_worker_config(agent_def: Any | None, task: Any) -> dict[str, Any]:
     """Build the worker config dict for a task-backed Session.
 
@@ -157,7 +169,7 @@ async def _create_session_for_task(
             session_factory=session_factory, bundle=resolved_bundle,
         )
         if agent_def is None:
-            raise ValueError(
+            raise UnknownAgentDefError(
                 f"Task {task.id} references agent_def_name="
                 f"{task.agent_def_name!r}, but no enabled AgentDef with that "
                 f"name exists in the tenant catalog."

--- a/tests/integration/tasks/test_dispatcher.py
+++ b/tests/integration/tasks/test_dispatcher.py
@@ -1,7 +1,6 @@
 """Integration tests for ``tasks_tick`` (promote, finalize, enqueue)."""
 from __future__ import annotations
 
-import json
 import uuid
 from unittest.mock import AsyncMock, MagicMock
 
@@ -336,6 +335,44 @@ async def test_enqueue_claims_ready_task_and_spawns(
 
     # zadd called at least once (for our task; may be more for leftovers).
     assert redis.zadd.await_count >= 1
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_enqueue_blocks_task_with_unknown_agent_def(
+    session_factory, session_store, org_id: uuid.UUID, parent_session,
+):
+    """A ready task whose agent_def_name resolves to nothing is BLOCKED (not
+    rolled back to 'ready'), so the dispatcher stops re-attempting/logging it
+    every tick. attempt_count nets to 0 so an unblock gets a clean attempt."""
+    async with session_factory() as db:
+        t = Task(
+            org_id=org_id, parent_session_id=parent_session.id,
+            goal="research", status="ready",
+            agent_def_name="nonexistent-role",
+        )
+        db.add(t)
+        await db.commit()
+        tid = t.id
+
+    redis = AsyncMock()
+    redis.zadd = AsyncMock()
+
+    def tenant_for_task(task):
+        return MagicMock(org_id=task.org_id)
+
+    await _enqueue_ready_tasks(
+        session_factory=session_factory,
+        redis=redis,
+        session_store=session_store,
+        tenant_for_task=tenant_for_task,
+    )
+
+    async with session_factory() as db:
+        t = await db.get(Task, tid)
+        assert t.status == "blocked"  # not 'ready' → no infinite retry
+        assert t.blocked_reason and "nonexistent-role" in t.blocked_reason
+        assert t.attempt_count == 0  # claim's +1 undone
+        assert t.current_session_id is None
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/tasks/test_spawn.py
+++ b/tests/tasks/test_spawn.py
@@ -187,8 +187,13 @@ async def test_create_session_for_task_resolves_agent_def_when_set():
 
 @pytest.mark.asyncio
 async def test_create_session_for_task_unknown_agent_def_raises():
-    """If agent_def_name resolves to None, raise — silent fallback would mask config bugs."""
-    from surogates.tasks.spawn import _create_session_for_task
+    """An unknown agent_def_name raises UnknownAgentDefError (a ValueError
+    subclass) — silent fallback would mask config bugs, and the specific type
+    lets the dispatcher block (not infinitely retry) the task."""
+    from surogates.tasks.spawn import (
+        UnknownAgentDefError,
+        _create_session_for_task,
+    )
 
     task = _make_task(goal="g", agent_def_name="nonexistent")
     parent = _make_session(id=task.parent_session_id, agent_id="agent-1")
@@ -200,10 +205,11 @@ async def test_create_session_for_task_unknown_agent_def_raises():
         "surogates.tasks.spawn.resolve_agent_by_name",
         new=AsyncMock(return_value=None),
     ):
-        with pytest.raises(ValueError, match="nonexistent"):
+        with pytest.raises(UnknownAgentDefError, match="nonexistent") as exc_info:
             await _create_session_for_task(
                 task,
                 session_store=store,
                 session_factory=None,
                 tenant=MagicMock(org_id=task.org_id),
             )
+    assert isinstance(exc_info.value, ValueError)  # back-compat for except ValueError


### PR DESCRIPTION
## Problem

PROD worker logs were spammed (for ~24 days) with:

```
tasks_tick: spawn failed for task <id>: Task <id> references agent_def_name='researcher', but no enabled AgentDef with that name exists in the tenant catalog.
```

When `tasks_tick` spawns a subagent task whose `agent_def_name` resolves to no enabled AgentDef, `_create_session_for_task` raised `ValueError` and the dispatcher **rolled the task back to `ready` and decremented `attempt_count`** — deliberately, so a human could fix the catalog and it would auto-heal. But for a *permanent* misconfiguration the task can never spawn, so it was re-claimed **every tick forever**, logging a WARNING each time. (Five orphaned tasks in one org, created 2026-06-09, drove the spam; they've since been cancelled in PROD.)

## Fix

- Raise a specific **`UnknownAgentDefError(ValueError)`** from the spawn primitive (subclasses `ValueError`, so any existing `except ValueError` still catches it — no behavior change elsewhere).
- The dispatcher catches it and moves the task to **`blocked`** (with `blocked_reason`) via a new `_block_claim` helper, instead of rolling back to `ready`. `blocked` is a first-class needs-attention state: it's excluded from the claim/promote/finalize passes (so no more retry/log spam), is surfaced in the UI, and **self-heals** via `unblock_task` once the catalog/bundle is fixed. `attempt_count` is decremented so the block doesn't burn a retry.
- Other (possibly transient) `ValueError`s — e.g. missing workspace fields on the parent — keep the original rollback-to-`ready` behavior.

## Tests

- `tests/tasks/test_spawn.py`: the unknown-def spawn raises `UnknownAgentDefError` and it is a `ValueError` (back-compat).
- `tests/integration/tasks/test_dispatcher.py`: a `ready` task with an unknown `agent_def_name` ends `blocked` (not `ready`), with `blocked_reason` set, `attempt_count` net 0, and no child session — proving the infinite-retry loop is gone. Full spawn + dispatcher suites green (17 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)