### PR TITLE
feat(channels): confirm channel /stop with a delivered 'Stopped' message

### DIFF
--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -716,6 +716,17 @@ class AgentHarness(
                     "worker_id": self._worker_id,
                 },
             )
+        # A channel /stop aborts out-of-band and leaves the session 'active'
+        # (so the SESSION_PAUSE above never fires). The inbound handler only
+        # posted an optimistic "Stopping…" ack, so emit a deliverable
+        # confirmation here — the point at which the turn has actually halted —
+        # so the channel gets a terminal "stopped" message.
+        if reason_msg == "channel_stop":
+            await self._store.emit_event(
+                session.id,
+                EventType.SESSION_STOPPED,
+                {"reason": "channel_stop", "worker_id": self._worker_id},
+            )
         self._clear_interrupt()
 
     # ------------------------------------------------------------------

--- a/surogates/session/events.py
+++ b/surogates/session/events.py
@@ -64,6 +64,10 @@ class EventType(str, Enum):
     # Session lifecycle
     SESSION_START = "session.start"
     SESSION_PAUSE = "session.pause"
+    # A channel /stop aborted the running turn out-of-band (the session stays
+    # 'active', unlike /pause). Emitted at the abort point so channels get a
+    # delivered "stopped" confirmation after the optimistic inbound ack.
+    SESSION_STOPPED = "session.stopped"
     SESSION_RESUME = "session.resume"
     SESSION_COMPLETE = "session.complete"
     SESSION_FAIL = "session.fail"

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -62,7 +62,12 @@ _DELIVERABLE_EVENTS = frozenset({
     EventType.LLM_RESPONSE,
     EventType.INBOX_INPUT_REQUIRED,
     EventType.CODE_RUN_CHANNEL_UPDATE,
+    EventType.SESSION_STOPPED,
 })
+
+# Delivered to the channel when a /stop actually halts the running turn, so the
+# user gets a terminal confirmation after the optimistic "Stopping…" ack.
+_STOPPED_CONFIRMATION = "⏹ Stopped."
 
 
 _INBOX_EVENTS = frozenset({
@@ -108,6 +113,8 @@ def _build_channel_payload(event_type: EventType, data: dict, channel: str) -> d
             run_id = data.get("run_id")
             if run_id:
                 payload["code_run"] = str(run_id)
+    elif event_type == EventType.SESSION_STOPPED:
+        payload["content"] = _STOPPED_CONFIRMATION
     elif event_type == EventType.INBOX_INPUT_REQUIRED and channel == "slack":
         questions = data.get("questions") or []
         if questions:

--- a/tests/test_channel_delivery_payload.py
+++ b/tests/test_channel_delivery_payload.py
@@ -8,7 +8,11 @@ Verifies that:
 """
 
 from surogates.session.events import EventType
-from surogates.session.store import _build_channel_payload
+from surogates.session.store import (
+    _DELIVERABLE_EVENTS,
+    _STOPPED_CONFIRMATION,
+    _build_channel_payload,
+)
 
 
 def test_intermediate_llm_response_tagged_intermediate():
@@ -34,3 +38,16 @@ def test_input_required_payload_slack_only():
     data = {"questions": [{"q": "?"}], "tool_call_id": "t1", "context": "ctx"}
     assert _build_channel_payload(EventType.INBOX_INPUT_REQUIRED, data, "slack")["input_prompt"] is True
     assert _build_channel_payload(EventType.INBOX_INPUT_REQUIRED, data, "telegram") == {}
+
+
+def test_session_stopped_is_deliverable():
+    assert EventType.SESSION_STOPPED in _DELIVERABLE_EVENTS
+
+
+def test_session_stopped_payload_confirms_stop_on_every_channel():
+    # /stop confirmation must reach any non-web channel (delivery is gated by
+    # channel elsewhere), not just Slack.
+    for channel in ("slack", "telegram", "teams"):
+        p = _build_channel_payload(EventType.SESSION_STOPPED, {}, channel)
+        assert p["content"] == _STOPPED_CONFIRMATION
+        assert not p.get("intermediate")

--- a/tests/test_channel_stop_confirmation.py
+++ b/tests/test_channel_stop_confirmation.py
@@ -1,0 +1,70 @@
+"""A channel /stop that actually halts a turn emits a deliverable confirmation.
+
+The inbound handler only posts an optimistic "Stopping…" ack. The terminal
+"stopped" confirmation is emitted from the harness abort point
+(:meth:`AgentHarness._abort_iteration_with_pause`) once the turn has really
+halted — but only for a channel /stop (reason ``channel_stop``), not for a
+REST /pause or a lease-loss interrupt.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from surogates.harness.loop import AgentHarness
+from surogates.session.events import EventType
+
+
+class _RecordingStore:
+    def __init__(self, status: str) -> None:
+        self._status = status
+        self.emitted: list[tuple[uuid.UUID, EventType, dict]] = []
+
+    async def get_session(self, session_id):
+        return SimpleNamespace(id=session_id, status=self._status)
+
+    async def emit_event(self, session_id, event_type, data):
+        self.emitted.append((session_id, event_type, data))
+        return len(self.emitted)
+
+
+def _harness(store: _RecordingStore, *, interrupt_message: str) -> AgentHarness:
+    h = AgentHarness.__new__(AgentHarness)
+    h._store = store
+    h._worker_id = "test-worker"
+    h._sandbox_pool = None
+    h._interrupt_requested = True
+    h._interrupt_message = interrupt_message
+    return h
+
+
+@pytest.mark.asyncio
+async def test_channel_stop_emits_stopped_confirmation():
+    store = _RecordingStore(status="active")
+    h = _harness(store, interrupt_message="channel_stop")
+    session = SimpleNamespace(id=uuid.uuid4(), status="active")
+
+    await h._abort_iteration_with_pause(session, saga=None)
+
+    types = [t for (_, t, _) in store.emitted]
+    assert EventType.SESSION_STOPPED in types
+    # active session → no SESSION_PAUSE (that is the /pause REST path only).
+    assert EventType.SESSION_PAUSE not in types
+
+
+@pytest.mark.asyncio
+async def test_rest_pause_does_not_emit_stopped_confirmation():
+    # A REST /pause sets status='paused' and uses its own reason string; it must
+    # emit SESSION_PAUSE but never the channel SESSION_STOPPED confirmation.
+    store = _RecordingStore(status="paused")
+    h = _harness(store, interrupt_message="Session paused by user")
+    session = SimpleNamespace(id=uuid.uuid4(), status="paused")
+
+    await h._abort_iteration_with_pause(session, saga=None)
+
+    types = [t for (_, t, _) in store.emitted]
+    assert EventType.SESSION_STOPPED not in types
+    assert EventType.SESSION_PAUSE in types


### PR DESCRIPTION
## Problem

A channel \`/stop\` (Slack etc.) published the interrupt and posted an optimistic **"⏹ Stopping the current run…"** ack — then nothing. Users saw the ack but no confirmation that the run actually halted.

Root cause: the harness abort path only emits \`SESSION_PAUSE\` when \`status == "paused"\` (the REST \`/pause\` flow sets that before signalling). A channel \`/stop\` leaves the session \`active\`, so \`SESSION_PAUSE\` never fires, and an interrupted turn produces no \`llm.response\` → no deliverable event → silence after the ack. There is no "stopped" confirmation string anywhere in the channels layer.

## Fix

Add a dedicated deliverable **\`SESSION_STOPPED\`** event, emitted at the harness abort point (\`_abort_iteration_with_pause\`) **only when the interrupt reason is \`channel_stop\`**, rendered to channels as **"⏹ Stopped."**

- Fires at the moment the turn actually halts (not optimistically).
- Scoped to channel stops — REST \`/pause\` and lease-loss interrupts are unaffected.
- Delivered to any non-web channel via the existing outbox machinery (web sessions skip the outbox).

## Tests

- \`test_channel_delivery_payload.py\`: \`SESSION_STOPPED\` is in \`_DELIVERABLE_EVENTS\` and renders the confirmation on every channel.
- \`test_channel_stop_confirmation.py\`: the abort point emits \`SESSION_STOPPED\` for \`channel_stop\` and does **not** for a REST \`/pause\` (which still emits \`SESSION_PAUSE\`).

## Follow-up (not in this PR)

If the interrupt is never delivered (harness on another worker / turn between iterations), there is nothing to abort and this stays correctly silent — that case likely warrants a separate "nothing is running" nudge. Also unverified: whether the orphan-sweeper can re-wake a stopped-but-\`active\` turn. Both need a live session trace (blocked on DB availability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)