### PR TITLE
feat(tools): let the github tool perform scoped writes

### DIFF
--- a/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
+++ b/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
@@ -25,7 +25,7 @@
 - [x] Task 4: Server route + `_resolve_session` split
 - [x] Task 5: Harness API client method
 - [x] Task 6: Builtin tool + runtime/router registration
-- [ ] Task 7: Full-suite regression + branch wrap-up (in progress)
+- [x] Task 7: Full-suite regression + branch wrap-up (48 new/touched tests pass; full suite has 39 pre-existing failures identical to origin/master — zero introduced)
 
 ---
 

--- a/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
+++ b/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
@@ -22,8 +22,8 @@
 - [x] Task 1: Add `author_id` to `RawMessage` and populate it
 - [x] Task 2: Pure filter/format core + parameterized header
 - [x] Task 3: `message_fetch.py` orchestrator
-- [ ] Task 4: Server route + `_resolve_session` split (in progress)
-- [ ] Task 5: Harness API client method
+- [x] Task 4: Server route + `_resolve_session` split
+- [ ] Task 5: Harness API client method (in progress)
 - [ ] Task 6: Builtin tool + runtime/router registration
 - [ ] Task 7: Full-suite regression + branch wrap-up
 

--- a/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
+++ b/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
@@ -20,8 +20,8 @@
 ## Progress
 
 - [x] Task 1: Add `author_id` to `RawMessage` and populate it
-- [ ] Task 2: Pure filter/format core + parameterized header (in progress)
-- [ ] Task 3: `message_fetch.py` orchestrator
+- [x] Task 2: Pure filter/format core + parameterized header
+- [ ] Task 3: `message_fetch.py` orchestrator (in progress)
 - [ ] Task 4: Server route + `_resolve_session` split
 - [ ] Task 5: Harness API client method
 - [ ] Task 6: Builtin tool + runtime/router registration

--- a/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
+++ b/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
@@ -21,8 +21,8 @@
 
 - [x] Task 1: Add `author_id` to `RawMessage` and populate it
 - [x] Task 2: Pure filter/format core + parameterized header
-- [ ] Task 3: `message_fetch.py` orchestrator (in progress)
-- [ ] Task 4: Server route + `_resolve_session` split
+- [x] Task 3: `message_fetch.py` orchestrator
+- [ ] Task 4: Server route + `_resolve_session` split (in progress)
 - [ ] Task 5: Harness API client method
 - [ ] Task 6: Builtin tool + runtime/router registration
 - [ ] Task 7: Full-suite regression + branch wrap-up

--- a/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
+++ b/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
@@ -17,6 +17,16 @@
 - `limit` default 50, clamped to `1..200`. `since` accepts ISO date (`2026-07-01`) or relative (`24h`, `7d`); invalid `since` → HTTP 400. `user` accepts bare id (`U063…`) or mention (`<@U063…>`), normalized to bare id.
 - Do NOT run `uv run` in this repo; run pytest via the ambient venv (`pytest ...`).
 
+## Progress
+
+- [x] Task 1: Add `author_id` to `RawMessage` and populate it
+- [ ] Task 2: Pure filter/format core + parameterized header (in progress)
+- [ ] Task 3: `message_fetch.py` orchestrator
+- [ ] Task 4: Server route + `_resolve_session` split
+- [ ] Task 5: Harness API client method
+- [ ] Task 6: Builtin tool + runtime/router registration
+- [ ] Task 7: Full-suite regression + branch wrap-up
+
 ---
 
 ### Task 1: Add `author_id` to `RawMessage` and populate it

--- a/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
+++ b/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
@@ -24,8 +24,8 @@
 - [x] Task 3: `message_fetch.py` orchestrator
 - [x] Task 4: Server route + `_resolve_session` split
 - [x] Task 5: Harness API client method
-- [ ] Task 6: Builtin tool + runtime/router registration (in progress)
-- [ ] Task 7: Full-suite regression + branch wrap-up
+- [x] Task 6: Builtin tool + runtime/router registration
+- [ ] Task 7: Full-suite regression + branch wrap-up (in progress)
 
 ---
 

--- a/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
+++ b/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
@@ -1,0 +1,1035 @@
+# fetch_channel_messages Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Slack-channel agents an on-demand `fetch_channel_messages` tool to read recent channel history (with `limit`/`since`/`user` filters), and reframe the one-time backfill snapshot so the model uses it.
+
+**Architecture:** A thin builtin tool (`toolset="channels"`) delegates over the session-scoped harness API client to a new server route, which resolves the bot token from the vault and calls the existing `SlackPlatform.fetch_channel_context` primitive, then a pure filter/format core. Mirrors the existing `fetch_channel_file` path end-to-end. The bot token never leaves the server.
+
+**Tech Stack:** Python 3.12, FastAPI, pytest, Slack `AsyncWebClient` (already wired), frozen dataclasses.
+
+## Global Constraints
+
+- Base branch: `master` (surogates repo). Feature branch already created: `feat/fetch-channel-messages-tool`.
+- surogates-only change; no ops-server change.
+- Conventional Commits (`type(scope): subject`). No Plan/Task/Phase numbers in code or commit messages.
+- Channel-only (DMs/MPDMs already excluded by `fetch_channel_context`). No thread replies, no cursor pagination exposed to the model, no server-side search.
+- `limit` default 50, clamped to `1..200`. `since` accepts ISO date (`2026-07-01`) or relative (`24h`, `7d`); invalid `since` → HTTP 400. `user` accepts bare id (`U063…`) or mention (`<@U063…>`), normalized to bare id.
+- Do NOT run `uv run` in this repo; run pytest via the ambient venv (`pytest ...`).
+
+---
+
+### Task 1: Add `author_id` to `RawMessage` and populate it
+
+`RawMessage` currently carries only a resolved display-name `author`. The `user` filter needs the raw Slack user id, so add an `author_id` field (defaulted, so existing positional/keyword construction keeps working) and populate it in the platform.
+
+**Files:**
+- Modify: `surogates/channels/channel_backfill.py` (the `RawMessage` dataclass, ~line 41)
+- Modify: `surogates/channels/platforms/slack.py:1300-1305` (the `RawMessage(...)` construction)
+- Test: `tests/test_slack_fetch_channel_context.py`
+
+**Interfaces:**
+- Produces: `RawMessage(ts: float, author: str, text: str, files: tuple[tuple[str,str],...] = (), author_id: str = "")`
+
+- [ ] **Step 1: Write the failing test** — add to `tests/test_slack_fetch_channel_context.py`:
+
+```python
+async def test_fetch_channel_context_populates_author_id(monkeypatch):
+    """author_id carries the raw Slack user id; author stays the display name."""
+    from surogates.channels.channel_backfill import BackfillLimits
+    from surogates.channels.platforms.slack import SlackPlatform
+
+    platform = SlackPlatform()
+
+    class _FakeClient:
+        async def conversations_info(self, channel):
+            return {"channel": {"name": "surogate", "topic": {}, "purpose": {}}}
+
+        async def conversations_history(self, **kwargs):
+            return {"messages": [
+                {"ts": "1720000000.0", "user": "U063C2DB7GW", "text": "hi"},
+            ], "has_more": False, "response_metadata": {}}
+
+    monkeypatch.setattr(platform, "_get_client", lambda token: _FakeClient())
+    monkeypatch.setattr(platform, "_resolve_bot_user_id", _amock(return_value="UBOT"))
+    monkeypatch.setattr(platform, "_resolve_user_name", _amock(return_value="Flavius"))
+
+    result = await platform.fetch_channel_context(
+        creds={"bot_token": "xoxb-x"}, channel_id="C1",
+        limits=BackfillLimits(),
+    )
+    assert result is not None
+    _meta, msgs = result
+    assert msgs[0].author == "Flavius"
+    assert msgs[0].author_id == "U063C2DB7GW"
+```
+
+If `_amock` does not already exist in this test module, add near the top:
+
+```python
+def _amock(*, return_value):
+    async def _f(*a, **k):
+        return return_value
+    return _f
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_slack_fetch_channel_context.py::test_fetch_channel_context_populates_author_id -v`
+Expected: FAIL with `AttributeError: 'RawMessage' object has no attribute 'author_id'`
+
+- [ ] **Step 3: Add the field** — in `surogates/channels/channel_backfill.py`, the `RawMessage` dataclass:
+
+```python
+@dataclass(frozen=True)
+class RawMessage:
+    ts: float
+    author: str
+    text: str
+    files: tuple[tuple[str, str], ...] = ()
+    author_id: str = ""
+```
+
+- [ ] **Step 4: Populate it** — in `surogates/channels/platforms/slack.py`, the `raw.append(RawMessage(...))` block (~line 1300):
+
+```python
+                    raw.append(RawMessage(
+                        ts=ts,
+                        author=author,
+                        text=(m.get("text") or "").strip(),
+                        files=files,
+                        author_id=(m.get("user") or ""),
+                    ))
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_slack_fetch_channel_context.py -v`
+Expected: PASS (new test + existing tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add surogates/channels/channel_backfill.py surogates/channels/platforms/slack.py tests/test_slack_fetch_channel_context.py
+git commit -m "feat(channels): carry raw author_id on RawMessage for user filtering"
+```
+
+---
+
+### Task 2: Pure filter/format core + parameterized header
+
+Add the pure, I/O-free query core to `channel_backfill.py`: `parse_since`, `normalize_user`, `filter_messages_for_query`, and a `header:` parameter on `format_context_block`. Reframe the backfill default header away from "before the agent joined".
+
+**Files:**
+- Modify: `surogates/channels/channel_backfill.py` (`format_context_block` ~line 101; add new helpers)
+- Test: `tests/test_channel_messages_core.py` (new)
+- Test: existing backfill tests that assert the header string (find and update)
+
+**Interfaces:**
+- Produces:
+  - `BACKFILL_HEADER: str` and `MESSAGES_HEADER: str` module constants
+  - `def parse_since(value: str | None, *, now: float) -> float | None` — epoch cutoff, or `None` when `value` is falsy; raises `ValueError` on an unparseable value
+  - `def normalize_user(value: str | None) -> str` — strips `<@…>` / leading `@`, returns bare id (or `""`)
+  - `def filter_messages_for_query(messages: list[RawMessage], *, since_cutoff: float | None, user_id: str, limit: int) -> list[RawMessage]` — newest-first in, drops older than cutoff, keeps only matching `author_id` when `user_id` is set, takes newest `limit`, returns **oldest-first**
+  - `def format_context_block(meta: ChannelMeta, messages: list[RawMessage], *, now: float, header: str = BACKFILL_HEADER) -> str | None`
+
+- [ ] **Step 1: Write the failing tests** — create `tests/test_channel_messages_core.py`:
+
+```python
+import pytest
+
+from surogates.channels.channel_backfill import (
+    BACKFILL_HEADER,
+    ChannelMeta,
+    RawMessage,
+    filter_messages_for_query,
+    format_context_block,
+    normalize_user,
+    parse_since,
+)
+
+NOW = 1_720_000_000.0  # fixed reference epoch
+
+
+def _msg(ts, uid, text="x"):
+    return RawMessage(ts=ts, author=f"name-{uid}", text=text, author_id=uid)
+
+
+def test_normalize_user_strips_mention_and_at():
+    assert normalize_user("<@U063>") == "U063"
+    assert normalize_user("@U063") == "U063"
+    assert normalize_user("U063") == "U063"
+    assert normalize_user(None) == ""
+
+
+def test_parse_since_relative_and_iso_and_none():
+    assert parse_since(None, now=NOW) is None
+    assert parse_since("24h", now=NOW) == NOW - 24 * 3600
+    assert parse_since("7d", now=NOW) == NOW - 7 * 86400
+    # ISO date -> midnight UTC epoch of that date
+    assert parse_since("2024-07-03", now=NOW) == 1_719_964_800.0
+
+
+def test_parse_since_invalid_raises():
+    with pytest.raises(ValueError):
+        parse_since("banana", now=NOW)
+
+
+def test_filter_by_user_and_limit_returns_oldest_first():
+    msgs = [  # newest-first, as fetch_channel_context returns
+        _msg(NOW - 10, "U1"), _msg(NOW - 20, "U2"),
+        _msg(NOW - 30, "U1"), _msg(NOW - 40, "U1"),
+    ]
+    out = filter_messages_for_query(msgs, since_cutoff=None, user_id="U1", limit=2)
+    assert [m.ts for m in out] == [NOW - 30, NOW - 10]  # newest 2 of U1, oldest-first
+
+
+def test_filter_by_since_drops_older():
+    msgs = [_msg(NOW - 10, "U1"), _msg(NOW - 100, "U1")]
+    out = filter_messages_for_query(
+        msgs, since_cutoff=NOW - 50, user_id="", limit=50)
+    assert [m.ts for m in out] == [NOW - 10]
+
+
+def test_format_block_uses_custom_header():
+    meta = ChannelMeta(name="surogate", topic="", purpose="")
+    block = format_context_block(
+        meta, [_msg(NOW - 10, "U1", "hello")], now=NOW, header="[channel messages]")
+    assert block.startswith("[channel messages]")
+    assert "hello" in block
+
+
+def test_format_block_default_header_is_not_pre_join():
+    meta = ChannelMeta(name="surogate", topic="", purpose="")
+    block = format_context_block(meta, [_msg(NOW - 10, "U1", "hi")], now=NOW)
+    assert block.startswith(BACKFILL_HEADER)
+    assert "before the agent joined" not in block
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_channel_messages_core.py -v`
+Expected: FAIL with `ImportError` (helpers not defined)
+
+- [ ] **Step 3: Implement the helpers** — in `surogates/channels/channel_backfill.py`. Add near the top after imports (ensure `from datetime import datetime, timezone` and `import re` are present):
+
+```python
+BACKFILL_HEADER = (
+    "[recent channel history — snapshot; use fetch_channel_messages "
+    "for more or newer messages]"
+)
+MESSAGES_HEADER = "[channel messages]"
+
+_REL_SINCE = re.compile(r"^\s*(\d+)\s*([hd])\s*$", re.IGNORECASE)
+
+
+def normalize_user(value: str | None) -> str:
+    """Strip a Slack mention wrapper to a bare user id ('<@U063>' -> 'U063')."""
+    v = (value or "").strip()
+    if v.startswith("<@") and v.endswith(">"):
+        v = v[2:-1].split("|", 1)[0]
+    elif v.startswith("@"):
+        v = v[1:]
+    return v.strip()
+
+
+def parse_since(value: str | None, *, now: float) -> float | None:
+    """Return an epoch cutoff for *value*, or None when empty.
+
+    Accepts relative windows ('24h', '7d') evaluated against *now*, or an ISO
+    date ('2026-07-01') meaning midnight UTC on that date. Raises ValueError on
+    anything else so the caller can surface a 400 rather than broaden silently.
+    """
+    v = (value or "").strip()
+    if not v:
+        return None
+    m = _REL_SINCE.match(v)
+    if m:
+        n = int(m.group(1))
+        unit = m.group(2).lower()
+        return now - n * (3600 if unit == "h" else 86400)
+    try:
+        d = datetime.strptime(v, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        raise ValueError(f"Unparseable 'since' value: {value!r}") from exc
+    return d.timestamp()
+
+
+def filter_messages_for_query(
+    messages: list["RawMessage"], *, since_cutoff: float | None,
+    user_id: str, limit: int,
+) -> list["RawMessage"]:
+    """Filter newest-first *messages* by since/user, take newest *limit*,
+    return oldest-first for natural reading order."""
+    out = []
+    for m in messages:  # newest-first
+        if since_cutoff is not None and m.ts < since_cutoff:
+            continue
+        if user_id and m.author_id != user_id:
+            continue
+        out.append(m)
+        if len(out) >= max(1, limit):
+            break
+    return list(reversed(out))
+```
+
+- [ ] **Step 4: Parameterize the header** — change `format_context_block`'s signature and first line:
+
+```python
+def format_context_block(
+    meta: ChannelMeta, messages: list[RawMessage], *, now: float,
+    header: str = BACKFILL_HEADER,
+) -> str | None:
+    if not messages:
+        return None
+    lines = [header]
+```
+
+- [ ] **Step 5: Update existing backfill header assertions**
+
+Run: `grep -rn "before the agent joined" tests/`
+For each hit, update the expected string to `BACKFILL_HEADER` (import it) or to a substring check like `assert block.startswith("[recent channel history")`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest tests/test_channel_messages_core.py tests/test_channel_backfill_core.py tests/test_channel_memory_flush.py -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add surogates/channels/channel_backfill.py tests/test_channel_messages_core.py tests/
+git commit -m "feat(channels): channel-message query core + reframe backfill header"
+```
+
+---
+
+### Task 3: `message_fetch.py` orchestrator
+
+Mirror `file_fetch.py`: resolve creds from the vault, call `fetch_channel_context`, run the pure core, return a JSON-able dict. Missing config/token/None → empty result with a `note` (not an exception); invalid `since` → `ValueError` (route maps to 400).
+
+**Files:**
+- Create: `surogates/channels/message_fetch.py`
+- Test: `tests/test_channel_message_fetch.py` (new)
+
+**Interfaces:**
+- Consumes: `parse_since`, `normalize_user`, `filter_messages_for_query`, `format_context_block`, `MESSAGES_HEADER`, `BackfillLimits`, `ChannelMeta` (Task 2); `resolve_channel_credentials`; `platform.descriptor.vault_refs`, `platform.fetch_channel_context`
+- Produces: `async def fetch_channel_messages(*, platform, vault, session, limit: int, since: str | None, user: str | None, now: float) -> dict` returning `{"messages_block": str | None, "count": int, "channel": str, "note": str | None}`. Raises `ValueError` on bad `since`.
+
+- [ ] **Step 1: Write the failing tests** — create `tests/test_channel_message_fetch.py`:
+
+```python
+import types
+
+import pytest
+
+from surogates.channels.channel_backfill import ChannelMeta, RawMessage
+from surogates.channels.message_fetch import fetch_channel_messages
+
+NOW = 1_720_000_000.0
+
+
+def _session(cfg):
+    return types.SimpleNamespace(config=cfg, org_id="org-1")
+
+
+def _platform(context_result):
+    descriptor = types.SimpleNamespace(vault_refs=lambda identifier: {"bot_token": "bot_token"})
+
+    async def _fetch_channel_context(*, creds, channel_id, limits):
+        return context_result
+
+    return types.SimpleNamespace(descriptor=descriptor, fetch_channel_context=_fetch_channel_context)
+
+
+class _Vault:
+    async def resolve_ref(self, ref, *, org_id):
+        return "xoxb-token"
+
+
+async def test_happy_path_filters_and_formats():
+    meta = ChannelMeta(name="surogate", topic="", purpose="")
+    msgs = [RawMessage(ts=NOW - 10, author="Flavius", text="hi", author_id="U1")]
+    platform = _platform((meta, msgs))
+    out = await fetch_channel_messages(
+        platform=platform, vault=_Vault(),
+        session=_session({"channel_identifier": "A1", "slack_channel_id": "C1"}),
+        limit=50, since=None, user="<@U1>", now=NOW)
+    assert out["count"] == 1
+    assert out["channel"] == "surogate"
+    assert "hi" in out["messages_block"]
+    assert out["note"] is None
+
+
+async def test_missing_channel_config_returns_note():
+    platform = _platform((ChannelMeta("x", "", ""), []))
+    out = await fetch_channel_messages(
+        platform=platform, vault=_Vault(),
+        session=_session({}), limit=50, since=None, user=None, now=NOW)
+    assert out["count"] == 0
+    assert out["messages_block"] is None
+    assert "channel" in out["note"].lower()
+
+
+async def test_no_bot_token_returns_note():
+    class _EmptyVault:
+        async def resolve_ref(self, ref, *, org_id):
+            return None
+    out = await fetch_channel_messages(
+        platform=_platform((ChannelMeta("x", "", ""), [])), vault=_EmptyVault(),
+        session=_session({"channel_identifier": "A1", "slack_channel_id": "C1"}),
+        limit=50, since=None, user=None, now=NOW)
+    assert out["count"] == 0
+    assert "token" in out["note"].lower()
+
+
+async def test_context_none_returns_note():
+    out = await fetch_channel_messages(
+        platform=_platform(None), vault=_Vault(),
+        session=_session({"channel_identifier": "A1", "slack_channel_id": "C1"}),
+        limit=50, since=None, user=None, now=NOW)
+    assert out["count"] == 0
+    assert out["note"]
+
+
+async def test_invalid_since_raises():
+    with pytest.raises(ValueError):
+        await fetch_channel_messages(
+            platform=_platform((ChannelMeta("x", "", ""), [])), vault=_Vault(),
+            session=_session({"channel_identifier": "A1", "slack_channel_id": "C1"}),
+            limit=50, since="banana", user=None, now=NOW)
+```
+
+Ensure `tests/` runs async tests (repo already uses `pytest-asyncio`; if this file needs it, add `pytestmark = pytest.mark.asyncio` at top, matching sibling test files).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_channel_message_fetch.py -v`
+Expected: FAIL with `ModuleNotFoundError: surogates.channels.message_fetch`
+
+- [ ] **Step 3: Implement the orchestrator** — create `surogates/channels/message_fetch.py`:
+
+```python
+"""On-demand Slack channel message fetch — resolve creds, pull history, format.
+
+The privileged half of the ``fetch_channel_messages`` tool: given a channel
+session it resolves the bot token from the vault, calls the Slack
+``fetch_channel_context`` primitive, and runs the pure query core. The bot token
+never leaves the server. Missing configuration or credentials yield an empty
+result with a human-readable ``note`` rather than an error; an unparseable
+``since`` raises ``ValueError`` so the route can return a 400.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from surogates.channels.channel_backfill import (
+    MESSAGES_HEADER,
+    BackfillLimits,
+    filter_messages_for_query,
+    format_context_block,
+    normalize_user,
+    parse_since,
+)
+from surogates.channels.credentials import resolve_channel_credentials
+
+_MAX_LIMIT = 200
+_DEFAULT_LIMIT = 50
+
+
+def _clamp_limit(limit: Any) -> int:
+    try:
+        n = int(limit)
+    except (TypeError, ValueError):
+        return _DEFAULT_LIMIT
+    return max(1, min(_MAX_LIMIT, n))
+
+
+def _empty(note: str, channel: str = "") -> dict:
+    return {"messages_block": None, "count": 0, "channel": channel, "note": note}
+
+
+async def fetch_channel_messages(
+    *, platform: Any, vault: Any, session: Any,
+    limit: Any, since: str | None, user: str | None, now: float,
+) -> dict:
+    cfg = getattr(session, "config", None) or {}
+    identifier = cfg.get("channel_identifier") or ""
+    channel_id = cfg.get("slack_channel_id") or ""
+    if not identifier or not channel_id:
+        return _empty("This session is not bound to a Slack channel.")
+
+    since_cutoff = parse_since(since, now=now)  # may raise ValueError
+    user_id = normalize_user(user)
+    n = _clamp_limit(limit)
+
+    refs = platform.descriptor.vault_refs(identifier)
+    creds = await resolve_channel_credentials(
+        vault=vault, kind="slack", identifier=identifier,
+        org_id=str(session.org_id), refs=refs,
+    )
+    if not (creds or {}).get("bot_token"):
+        return _empty("No Slack bot token is configured for this channel.")
+
+    limits = BackfillLimits(max_messages=n, max_pages=1)
+    result = await platform.fetch_channel_context(
+        creds=creds, channel_id=channel_id, limits=limits,
+    )
+    if result is None:
+        return _empty(
+            "Could not read this channel's history (the bot may not be a "
+            "member, or Slack returned an error).")
+
+    meta, messages = result
+    picked = filter_messages_for_query(
+        messages, since_cutoff=since_cutoff, user_id=user_id, limit=n)
+    if not picked:
+        scope = f" from that user" if user_id else ""
+        return _empty(f"No messages found{scope} in the requested window.",
+                      channel=meta.name)
+    block = format_context_block(meta, picked, now=now, header=MESSAGES_HEADER)
+    return {
+        "messages_block": block, "count": len(picked),
+        "channel": meta.name, "note": None,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_channel_message_fetch.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add surogates/channels/message_fetch.py tests/test_channel_message_fetch.py
+git commit -m "feat(channels): message_fetch orchestrator over fetch_channel_context"
+```
+
+---
+
+### Task 4: Server route + `_resolve_session` split
+
+Split the file route's bucket resolver so the message route can resolve a session without needing a workspace bucket, then add `POST /sessions/{session_id}/channel-messages`.
+
+**Files:**
+- Modify: `surogates/api/routes/channel_files.py`
+- Test: `tests/test_channel_messages_route.py` (new)
+
+**Interfaces:**
+- Consumes: `fetch_channel_messages` (Task 3), `effective_channel_platform`, `registry`, `get_current_tenant`
+- Produces: route `POST /sessions/{session_id}/channel-messages` accepting body `{"limit": int?, "since": str?, "user": str?}`, returning the Task 3 dict; refactored `async def _resolve_session(store, session_id, tenant) -> Any`.
+
+- [ ] **Step 1: Write the failing tests** — create `tests/test_channel_messages_route.py`. Like `tests/test_channel_files_route.py`, call the route function **directly** (no TestClient); monkeypatch `channel_files.registry.get` and `channel_files.fetch_channel_messages`, and pass a fake `request` built from `SimpleNamespace`. The repo runs pytest in `asyncio_mode=auto`, so no marker is needed.
+
+```python
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from surogates.api.routes import channel_files
+from surogates.api.routes.channel_files import _ChannelMessagesBody
+
+
+class _Store:
+    def __init__(self, session):
+        self._session = session
+
+    async def get_session(self, session_id):
+        return self._session
+
+
+def _session(*, channel="slack", config=None):
+    return SimpleNamespace(
+        id=uuid4(), org_id=uuid4(), channel=channel,
+        config=config if config is not None
+        else {"channel_identifier": "T1", "slack_channel_id": "C1"},
+    )
+
+
+class _Tenant:
+    def __init__(self, owns=True):
+        self._owns = owns
+
+    def owns_session(self, org_id, session_id):
+        return self._owns
+
+
+def _request(session):
+    state = SimpleNamespace(session_store=_Store(session), credential_vault=object())
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+async def test_messages_route_happy_path(monkeypatch):
+    session = _session(channel="slack")
+    monkeypatch.setattr(channel_files.registry, "get", lambda kind: object())
+
+    async def _fake(**kwargs):
+        return {"messages_block": "…hi…", "count": 1, "channel": "surogate", "note": None}
+
+    monkeypatch.setattr(channel_files, "fetch_channel_messages", _fake)
+    out = await channel_files.fetch_channel_messages_route(
+        session_id=session.id, body=_ChannelMessagesBody(limit=10),
+        request=_request(session), tenant=_Tenant())
+    assert out["count"] == 1
+    assert out["messages_block"]
+
+
+async def test_messages_route_non_slack_400():
+    session = _session(channel="web")
+    with pytest.raises(HTTPException) as ei:
+        await channel_files.fetch_channel_messages_route(
+            session_id=session.id, body=_ChannelMessagesBody(),
+            request=_request(session), tenant=_Tenant())
+    assert ei.value.status_code == 400
+
+
+async def test_messages_route_foreign_session_404():
+    session = _session(channel="slack")
+    with pytest.raises(HTTPException) as ei:
+        await channel_files.fetch_channel_messages_route(
+            session_id=session.id, body=_ChannelMessagesBody(),
+            request=_request(session), tenant=_Tenant(owns=False))
+    assert ei.value.status_code == 404
+
+
+async def test_messages_route_invalid_since_400(monkeypatch):
+    session = _session(channel="slack")
+    monkeypatch.setattr(channel_files.registry, "get", lambda kind: object())
+
+    async def _raise(**kwargs):
+        raise ValueError("bad since")
+
+    monkeypatch.setattr(channel_files, "fetch_channel_messages", _raise)
+    with pytest.raises(HTTPException) as ei:
+        await channel_files.fetch_channel_messages_route(
+            session_id=session.id, body=_ChannelMessagesBody(since="banana"),
+            request=_request(session), tenant=_Tenant())
+    assert ei.value.status_code == 400
+
+
+async def test_messages_route_missing_config_empty(monkeypatch):
+    session = _session(channel="slack", config={})
+    monkeypatch.setattr(channel_files.registry, "get", lambda kind: object())
+
+    async def _fake(**kwargs):
+        return {"messages_block": None, "count": 0, "channel": "",
+                "note": "This session is not bound to a Slack channel."}
+
+    monkeypatch.setattr(channel_files, "fetch_channel_messages", _fake)
+    out = await channel_files.fetch_channel_messages_route(
+        session_id=session.id, body=_ChannelMessagesBody(),
+        request=_request(session), tenant=_Tenant())
+    assert out["count"] == 0
+    assert out["note"]
+```
+
+Confirm `effective_channel_platform(_session(channel="web"))` returns a non-`"slack"` value (it reads `session.channel` for non-ambient sessions); if the helper needs other fields, add them to `_session`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_channel_messages_route.py -v`
+Expected: FAIL (route returns 404 / not found)
+
+- [ ] **Step 3: Refactor the resolver** — in `surogates/api/routes/channel_files.py`, replace `_resolve_session_bucket` with a split:
+
+```python
+async def _resolve_session(
+    store: SessionStore, session_id: UUID, tenant: TenantContext,
+) -> Any:
+    try:
+        session = await store.get_session(session_id)
+    except SessionNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Session {session_id} not found.",
+        )
+    if not tenant.owns_session(session.org_id, session_id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Session {session_id} not found.",
+        )
+    return session
+
+
+async def _resolve_session_bucket(
+    store: SessionStore, session_id: UUID, tenant: TenantContext,
+) -> tuple[Any, str]:
+    session = await _resolve_session(store, session_id, tenant)
+    bucket = session.config.get("storage_bucket")
+    if not bucket:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Session {session_id} has no agent bucket.",
+        )
+    return session, bucket
+```
+
+- [ ] **Step 4: Add the route** — in the same file. Add imports at top:
+
+```python
+import time
+from pydantic import BaseModel
+from surogates.channels.message_fetch import fetch_channel_messages
+```
+
+Add the request model and route:
+
+```python
+class _ChannelMessagesBody(BaseModel):
+    limit: int | None = None
+    since: str | None = None
+    user: str | None = None
+
+
+@router.post("/sessions/{session_id}/channel-messages")
+async def fetch_channel_messages_route(
+    session_id: UUID,
+    body: _ChannelMessagesBody,
+    request: Request,
+    tenant: TenantContext = Depends(get_current_tenant),
+) -> dict:
+    """Read recent messages from this session's Slack channel."""
+    store = _get_session_store(request)
+    session = await _resolve_session(store, session_id, tenant)
+
+    channel = effective_channel_platform(session)
+    if channel != "slack":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Channel-message fetch is only supported for Slack sessions.",
+        )
+
+    platform = registry.get("slack")
+    if platform is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Slack platform is not available.",
+        )
+
+    try:
+        return await fetch_channel_messages(
+            platform=platform,
+            vault=request.app.state.credential_vault,
+            session=session,
+            limit=body.limit if body.limit is not None else 50,
+            since=body.since,
+            user=body.user,
+            now=time.time(),
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_channel_messages_route.py tests/test_channel_files_route.py -v`
+Expected: PASS (new route + file route unaffected by the split)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add surogates/api/routes/channel_files.py tests/test_channel_messages_route.py
+git commit -m "feat(channels): add channel-messages read route"
+```
+
+---
+
+### Task 5: Harness API client method
+
+Add `fetch_channel_messages` to the session-scoped API client, mirroring `fetch_channel_file`.
+
+**Files:**
+- Modify: `surogates/harness/api_client.py` (after `fetch_channel_file`, ~line 355)
+- Test: `tests/test_api_client_channel_message.py` (new)
+
+**Interfaces:**
+- Consumes: `self._session_id`; `self._post(path, body=None)` — `_post`'s body is a **positional** dict (it sends `json=body` internally). Ctor is `HarnessAPIClient(base_url=..., token=..., session_id=...)`.
+- Produces: `async def fetch_channel_messages(self, *, limit: int | None = None, since: str | None = None, user: str | None = None) -> str` returning a JSON string `{"success": True, ...}` or the standard error envelope.
+
+- [ ] **Step 1: Write the failing tests** — create `tests/test_api_client_channel_message.py`, mirroring `tests/test_api_client_channel_file.py`:
+
+```python
+import json
+
+from surogates.harness.api_client import HarnessAPIClient
+
+
+def _client(session_id="11111111-1111-1111-1111-111111111111"):
+    return HarnessAPIClient(base_url="http://api", token="t", session_id=session_id)
+
+
+async def test_requires_session_id():
+    c = HarnessAPIClient(base_url="http://api", token="t", session_id=None)
+    out = json.loads(await c.fetch_channel_messages(limit=10))
+    assert out["success"] is False
+
+
+async def test_posts_to_channel_messages_path(monkeypatch):
+    c = _client()
+    captured = {}
+
+    async def _fake_post(path, body=None):
+        captured["path"] = path
+        captured["body"] = body
+        return {"count": 2, "messages_block": "…", "channel": "surogate", "note": None}
+
+    monkeypatch.setattr(c, "_post", _fake_post)
+    out = json.loads(await c.fetch_channel_messages(limit=10, since="7d", user="<@U1>"))
+    assert out["success"] is True
+    assert captured["path"] == (
+        "/v1/sessions/11111111-1111-1111-1111-111111111111/channel-messages")
+    assert captured["body"] == {"limit": 10, "since": "7d", "user": "<@U1>"}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_api_client_channel_message.py -v`
+Expected: FAIL with `AttributeError: ... has no attribute 'fetch_channel_messages'`
+
+- [ ] **Step 3: Implement the method** — in `surogates/harness/api_client.py`, right after `fetch_channel_file`:
+
+```python
+    async def fetch_channel_messages(
+        self, *, limit: int | None = None, since: str | None = None,
+        user: str | None = None,
+    ) -> str:
+        """Read recent messages from this session's Slack channel.
+
+        Requires a session-scoped client. Returns a JSON string with the
+        formatted ``messages_block`` (and ``count``/``channel``/``note``), or
+        the standard error envelope.
+        """
+        if self._session_id is None:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        "Channel-message fetch requires a session-scoped API "
+                        "client; session_id is not set."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+        try:
+            data = await self._post(
+                f"/v1/sessions/{self._session_id}/channel-messages",
+                {"limit": limit, "since": since, "user": user},
+            )
+            return json.dumps({"success": True, **data}, ensure_ascii=False)
+        except httpx.HTTPStatusError as exc:
+            return _error_response(exc)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_api_client_channel_message.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add surogates/harness/api_client.py tests/test_api_client_channel_message.py
+git commit -m "feat(harness): api_client.fetch_channel_messages"
+```
+
+---
+
+### Task 6: Builtin tool + runtime/router registration
+
+Create the tool, register its module in the runtime, and route it to the harness (matching `fetch_channel_file`). Unlisted tools default to the sandbox executor and fail as "Unknown tool", so the `TOOL_LOCATIONS` entry is required.
+
+**Files:**
+- Create: `surogates/tools/builtin/channel_messages.py`
+- Modify: `surogates/tools/runtime.py` (import list ~line 50-107)
+- Modify: `surogates/tools/router.py:121` (`TOOL_LOCATIONS`)
+- Test: `tests/test_fetch_channel_messages_tool.py` (new)
+- Test: check/adjust any native-channel-tool enumeration (`tests/harness/test_channel_composio_filter.py`)
+
+**Interfaces:**
+- Consumes: `ToolRegistry`, `ToolSchema`, `api_client.fetch_channel_messages` (Task 5)
+- Produces: tool name `fetch_channel_messages`, `toolset="channels"`; `register(registry)`.
+
+- [ ] **Step 1: Write the failing tests** — create `tests/test_fetch_channel_messages_tool.py`, mirroring `tests/test_fetch_channel_file_tool.py`:
+
+```python
+import json
+
+from surogates.tools.builtin.channel_messages import _fetch_channel_messages_handler
+from surogates.tools.router import TOOL_LOCATIONS, ToolLocation
+
+
+async def test_missing_api_client_returns_error():
+    out = json.loads(await _fetch_channel_messages_handler({"limit": 10}))
+    assert out["success"] is False
+
+
+async def test_delegates_with_parsed_args():
+    calls = {}
+
+    class _Client:
+        async def fetch_channel_messages(self, *, limit, since, user):
+            calls.update(limit=limit, since=since, user=user)
+            return json.dumps({"success": True, "count": 0})
+
+    out = await _fetch_channel_messages_handler(
+        {"limit": "25", "since": "7d", "user": "<@U1>"}, api_client=_Client())
+    assert json.loads(out)["success"] is True
+    assert calls == {"limit": 25, "since": "7d", "user": "<@U1>"}
+
+
+def test_tool_routed_to_harness():
+    assert TOOL_LOCATIONS["fetch_channel_messages"] == ToolLocation.HARNESS
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_fetch_channel_messages_tool.py -v`
+Expected: FAIL with `ModuleNotFoundError` / `KeyError`
+
+- [ ] **Step 3: Create the tool** — `surogates/tools/builtin/channel_messages.py`:
+
+```python
+"""The ``fetch_channel_messages`` builtin tool.
+
+Lets a Slack-channel agent read recent messages posted in its own channel,
+optionally narrowed by a time window or a specific user. Thin delegate to the
+session-scoped harness API client; the privileged history fetch runs
+server-side with the channel's bot token.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from surogates.tools.registry import ToolRegistry, ToolSchema
+
+FETCH_CHANNEL_MESSAGES_SCHEMA = ToolSchema(
+    name="fetch_channel_messages",
+    description=(
+        "Read recent messages posted in this Slack channel (including messages "
+        "from other users). Use this to catch up on the conversation or to see "
+        "what a specific person said. Optionally narrow by 'since' (e.g. '24h', "
+        "'7d', or a date like '2026-07-01') and by 'user' (a Slack user id such "
+        "as 'U063C2DB7GW' or a mention like '<@U063C2DB7GW>'). Returns messages "
+        "oldest-to-newest. Only messages in this channel are accessible."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "limit": {
+                "type": "integer",
+                "description": "How many recent messages to return (default 50, max 200).",
+            },
+            "since": {
+                "type": "string",
+                "description": "Only messages newer than this: '24h', '7d', or a date '2026-07-01'.",
+            },
+            "user": {
+                "type": "string",
+                "description": "Only messages from this Slack user id or mention (e.g. '<@U063C2DB7GW>').",
+            },
+        },
+        "required": [],
+    },
+)
+
+
+def _coerce_limit(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+async def _fetch_channel_messages_handler(
+    arguments: dict[str, Any], **kwargs: Any,
+) -> str:
+    api_client = kwargs.get("api_client")
+    if api_client is None:
+        return json.dumps(
+            {
+                "success": False,
+                "error": (
+                    "Channel-message fetch requires a session-scoped API client."
+                ),
+            },
+            ensure_ascii=False,
+        )
+    return await api_client.fetch_channel_messages(
+        limit=_coerce_limit(arguments.get("limit")),
+        since=(arguments.get("since") or None),
+        user=(arguments.get("user") or None),
+    )
+
+
+def register(registry: ToolRegistry) -> None:
+    """Register the fetch_channel_messages tool."""
+    registry.register(
+        name="fetch_channel_messages",
+        schema=FETCH_CHANNEL_MESSAGES_SCHEMA,
+        handler=_fetch_channel_messages_handler,
+        toolset="channels",
+    )
+```
+
+- [ ] **Step 4: Register in the runtime** — in `surogates/tools/runtime.py`, add `channel_messages` to the `from surogates.tools.builtin import (...)` block (near `channel_files`) and to the module tuple that gets iterated (near line 107):
+
+```python
+            channel_files,     # fetch_channel_file (pull a shared channel file)
+            channel_messages,  # fetch_channel_messages (read recent channel messages)
+```
+
+- [ ] **Step 5: Route to the harness** — in `surogates/tools/router.py`, right after the `"fetch_channel_file"` entry (line 121):
+
+```python
+    "fetch_channel_file": ToolLocation.HARNESS,
+    # Channel message read — same rationale: needs the session-scoped API
+    # client to call the ops server; no sandbox isolation.
+    "fetch_channel_messages": ToolLocation.HARNESS,
+```
+
+- [ ] **Step 6: Check the Composio native-tool filter** — run `pytest tests/harness/test_channel_composio_filter.py -v`. If it enumerates the exact set of native channel tools and now fails because `fetch_channel_messages` is present, add the new tool name to that expected set. If it passes, leave it.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `pytest tests/test_fetch_channel_messages_tool.py tests/harness/test_channel_composio_filter.py -v`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add surogates/tools/builtin/channel_messages.py surogates/tools/runtime.py surogates/tools/router.py tests/test_fetch_channel_messages_tool.py
+git commit -m "feat(tools): fetch_channel_messages builtin + harness routing"
+```
+
+---
+
+### Task 7: Full-suite regression + branch wrap-up
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the channel + tool test subset**
+
+Run: `pytest tests/ -k "channel or api_client or router or backfill or slack" -q`
+Expected: PASS (no regressions)
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `pytest tests/ -q`
+Expected: PASS (or only pre-existing unrelated failures — confirm by comparing against `master` if anything fails)
+
+- [ ] **Step 3: Push and open a PR** (only if the user asks to push)
+
+```bash
+git push -u origin feat/fetch-channel-messages-tool
+gh pr create --base master --title "feat(channels): fetch_channel_messages live tool" \
+  --body "Adds an on-demand tool for Slack-channel agents to read recent channel messages (limit/since/user), backed by the existing fetch_channel_context primitive, and reframes the backfill snapshot header. See docs/superpowers/specs/2026-07-03-fetch-channel-messages-tool-design.md."
+```

--- a/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
+++ b/docs/superpowers/plans/2026-07-03-fetch-channel-messages-tool.md
@@ -23,8 +23,8 @@
 - [x] Task 2: Pure filter/format core + parameterized header
 - [x] Task 3: `message_fetch.py` orchestrator
 - [x] Task 4: Server route + `_resolve_session` split
-- [ ] Task 5: Harness API client method (in progress)
-- [ ] Task 6: Builtin tool + runtime/router registration
+- [x] Task 5: Harness API client method
+- [ ] Task 6: Builtin tool + runtime/router registration (in progress)
 - [ ] Task 7: Full-suite regression + branch wrap-up
 
 ---

--- a/docs/superpowers/specs/2026-07-03-fetch-channel-messages-tool-design.md
+++ b/docs/superpowers/specs/2026-07-03-fetch-channel-messages-tool-design.md
@@ -1,0 +1,124 @@
+# fetch_channel_messages — live Slack channel history tool
+
+## Problem
+
+A Slack-channel agent has no way to read channel messages on demand. The only
+channel-facing runtime tool is `fetch_channel_file` (`toolset="channels"`), which
+pulls *files*, not messages. Channel message history reaches the agent only as a
+one-time backfill snapshot (`channel_backfill.py`), seeded as a synthetic user
+message on the session's first turn. That snapshot:
+
+- is labelled `[channel context - history before the agent joined]`, which frames
+  it as stale/pre-join and irrelevant;
+- is bounded (`max_messages=200`, `max_tokens=8000`, `max_age_days=7`,
+  `max_pages=1`) and never refreshes;
+- covers only messages before the agent joined — nothing posted afterward.
+
+Observed failure (PROD agent `308504f3-74e2-41b3-8078-c17da42fd818`, session
+`8c62ce25`): asked to "look at the latest messages from `<@U063C2DB7GW>` in the
+surogate channel", the agent replied it had no way to browse channel history —
+even though the backfill block was present in its context. Two root causes: (a)
+there is genuinely no live message-reading tool, and (b) the backfill framing led
+the model to ignore the history it did have.
+
+## Goal
+
+Give channel agents an on-demand tool to fetch recent channel messages, and
+reframe the backfill snapshot so the model uses it and knows the live tool exists.
+
+## Non-goals (YAGNI)
+
+- DMs / MPDMs — already excluded by `fetch_channel_context` (channel-only, v1).
+- Thread replies (`conversations.replies`) — single flat channel history only.
+- Cursor pagination exposed to the model — one bounded page, same as backfill.
+- Server-side full-text search — the model filters from the returned block.
+
+## Design
+
+The existing primitive `SlackPlatform.fetch_channel_context(creds, channel_id,
+limits)` (`channels/platforms/slack.py`) already fetches channel meta + a bounded,
+newest-first `list[RawMessage]` via `conversations.history` using the bot token.
+The tool is a thin, session-scoped wrapper over it; the bot token never leaves the
+server.
+
+### Components
+
+1. **Builtin tool** — `surogates/tools/builtin/channel_messages.py`, registered
+   with `toolset="channels"`, mirroring `channel_files.py`. Parameters:
+   - `limit` (int, optional, default 50, capped 200) — how many recent messages.
+   - `since` (str, optional) — ISO date (`2026-07-01`) or relative (`7d`, `24h`).
+   - `user` (str, optional) — Slack user id (`U063…`) or mention (`<@U063…>`);
+     the mention wrapper is stripped to the bare id.
+
+   Handler validates it has a session-scoped `api_client` (else structured error),
+   then delegates to `api_client.fetch_channel_messages(limit, since, user)`.
+
+2. **Harness API client** — `fetch_channel_messages(...)` in
+   `surogates/harness/api_client.py`, alongside `fetch_channel_file`. Requires
+   `self._session_id`; `POST /v1/sessions/{sid}/channel-messages` with a JSON
+   body `{limit, since, user}`. Returns the same `{"success": True, **data}` /
+   error-envelope shape as `fetch_channel_file`.
+
+3. **Server route** — `POST /sessions/{session_id}/channel-messages` in
+   `surogates/api/routes/channel_files.py`. Reuses the session-store lookup and
+   tenant-ownership guard, and the `effective_channel_platform(session) == "slack"`
+   check. Resolves `bot_token` from the credential vault via
+   `resolve_channel_credentials`, derives the channel id from the session source,
+   builds a `BackfillLimits` (defaults, `max_pages=1`), calls
+   `platform.fetch_channel_context(...)`, then runs the pure filter/format core and
+   returns `{"messages_block": <str|None>, "count": <int>, "channel": <name>}`.
+
+4. **Filter + format core** — a pure function in `channel_backfill.py`
+   (no I/O, unit-testable): given `meta`, `messages`, and `{since, user, limit}`,
+   filter by `since` (drop older) and `user` (match `RawMessage.author`/id), take
+   the newest `limit`, and render via the shared formatter. `RawMessage` currently
+   carries a resolved display-name `author`; to filter by id the core needs the
+   raw user id — extend `RawMessage`/`fetch_channel_context` to also carry the
+   Slack user id (`author_id`), or filter on the id inside the platform before
+   name resolution. Chosen: add `author_id` to `RawMessage` so the core stays pure
+   and the block can still show display names. (Confirm during implementation that
+   no other `RawMessage` construction site breaks.)
+
+5. **Backfill reframe** — parameterize `format_context_block`'s header (currently
+   the hardcoded `[channel context - history before the agent joined]` at
+   `channel_backfill.py:106`) with a `header:` argument. Backfill passes a neutral
+   header such as `[recent channel history — snapshot; call fetch_channel_messages
+   for more or newer messages]`; the tool passes its own (e.g. `[channel messages]`
+   with the applied filters noted). One formatter, two callers.
+
+### Data flow
+
+```
+agent → fetch_channel_messages(limit, since, user)          [tool, sandbox side]
+      → api_client.fetch_channel_messages → POST .../channel-messages
+      → route: resolve session + creds + channel_id          [server side]
+      → SlackPlatform.fetch_channel_context (conversations.history, bot token)
+      → filter_and_format(meta, messages, since, user, limit) [pure core]
+      → {messages_block, count, channel} → JSON to the tool → model
+```
+
+### Error handling
+
+- No session-scoped client / no `session_id` → structured `{"success": False,
+  error}` from the tool/client (no HTTP call).
+- Non-Slack session → 400 (mirrors file route).
+- Slack error / bot not a member / DM → `fetch_channel_context` returns `None` →
+  route returns `{"messages_block": None, "count": 0}` with a clear note, not a 500.
+- Empty result after filtering → `messages_block: None`, `count: 0`, note that no
+  messages matched.
+
+## Testing
+
+- **Pure core** (`test_channel_backfill_*` sibling): since filter, user filter
+  (by id and by mention form), limit cap, empty input, header parameterization.
+- **Tool handler** (like `test_fetch_channel_file_tool.py`): missing api_client
+  error; delegates with parsed args; `<@U…>` → bare id normalization.
+- **Route** (like `test_channel_files_route.py`): happy path, non-Slack 400,
+  tenant-ownership 404, `fetch_channel_context` returns None → empty block.
+- **Regression**: existing backfill tests still pass after header parameterization.
+
+## Rollout
+
+surogates change only (base `master`). No ops-server change required — the tool
+ships in the harness/runtime image. Existing channel sessions gain the tool on
+next runtime deploy; the reframed backfill header applies to newly seeded blocks.

--- a/docs/superpowers/specs/2026-07-03-fetch-channel-messages-tool-design.md
+++ b/docs/superpowers/specs/2026-07-03-fetch-channel-messages-tool-design.md
@@ -51,7 +51,12 @@ server.
      the mention wrapper is stripped to the bare id.
 
    Handler validates it has a session-scoped `api_client` (else structured error),
-   then delegates to `api_client.fetch_channel_messages(limit, since, user)`.
+   normalizes `limit`/`user`, then delegates to
+   `api_client.fetch_channel_messages(limit=limit, since=since, user=user)`.
+   Add the tool to `surogates/tools/runtime.py`'s builtin module list and to
+   `TOOL_LOCATIONS` in `surogates/tools/router.py` so it is routed through the
+   harness like `fetch_channel_file`. Update channel-tool allow-list tests that
+   currently enumerate native channel tools.
 
 2. **Harness API client** — `fetch_channel_messages(...)` in
    `surogates/harness/api_client.py`, alongside `fetch_channel_file`. Requires
@@ -60,61 +65,89 @@ server.
    error-envelope shape as `fetch_channel_file`.
 
 3. **Server route** — `POST /sessions/{session_id}/channel-messages` in
-   `surogates/api/routes/channel_files.py`. Reuses the session-store lookup and
-   tenant-ownership guard, and the `effective_channel_platform(session) == "slack"`
-   check. Resolves `bot_token` from the credential vault via
-   `resolve_channel_credentials`, derives the channel id from the session source,
-   builds a `BackfillLimits` (defaults, `max_pages=1`), calls
-   `platform.fetch_channel_context(...)`, then runs the pure filter/format core and
-   returns `{"messages_block": <str|None>, "count": <int>, "channel": <name>}`.
+   `surogates/api/routes/channel_files.py` (served externally under `/v1` by the
+   app router prefix). Reuses the session-store lookup and tenant-ownership guard,
+   and the `effective_channel_platform(session) == "slack"` check. Do not reuse
+   `_resolve_session_bucket` directly: message history does not need a workspace
+   bucket, so split the existing helper into a bucket-free `_resolve_session(...)`
+   plus the current bucket wrapper for file fetches.
+
+   Resolve `bot_token` from the credential vault with
+   `platform.descriptor.vault_refs(identifier)` and `resolve_channel_credentials`,
+   where `identifier = session.config["channel_identifier"]`. Read the Slack
+   channel id from `session.config["slack_channel_id"]`; if either value is
+   missing, return an empty result with a clear `note` instead of attempting a
+   Slack call. Build a `BackfillLimits` with `max_messages` set to the requested
+   capped limit and `max_pages=1`, call `platform.fetch_channel_context(...)`,
+   then run the pure filter/format core and return
+   `{"messages_block": <str|None>, "count": <int>, "channel": <name>, "note": <str|None>}`.
 
 4. **Filter + format core** — a pure function in `channel_backfill.py`
    (no I/O, unit-testable): given `meta`, `messages`, and `{since, user, limit}`,
-   filter by `since` (drop older) and `user` (match `RawMessage.author`/id), take
-   the newest `limit`, and render via the shared formatter. `RawMessage` currently
-   carries a resolved display-name `author`; to filter by id the core needs the
-   raw user id — extend `RawMessage`/`fetch_channel_context` to also carry the
-   Slack user id (`author_id`), or filter on the id inside the platform before
-   name resolution. Chosen: add `author_id` to `RawMessage` so the core stays pure
-   and the block can still show display names. (Confirm during implementation that
-   no other `RawMessage` construction site breaks.)
+   filter by `since` (drop older) and `user` (match `RawMessage.author_id`, with
+   mention form already normalized), take the newest `limit`, reverse to
+   oldest-first, and render via the shared formatter. Parse `since` in one helper:
+   ISO dates mean midnight UTC on that date, and relative windows (`24h`, `7d`)
+   are evaluated against the route's `now`. Invalid `since` values produce a
+   structured 400 rather than silently broadening the query.
+
+   `RawMessage` currently carries a resolved display-name `author`; to filter by
+   id the core needs the raw Slack user id. Chosen: add
+   `author_id: str = ""` to `RawMessage` so existing tests and construction sites
+   using `RawMessage(ts, author, text)` keep working, while
+   `SlackPlatform.fetch_channel_context` populates it from `m["user"]`. The block
+   continues to show display names via `author`.
 
 5. **Backfill reframe** — parameterize `format_context_block`'s header (currently
    the hardcoded `[channel context - history before the agent joined]` at
    `channel_backfill.py:106`) with a `header:` argument. Backfill passes a neutral
-   header such as `[recent channel history — snapshot; call fetch_channel_messages
+   header such as `[recent channel history — snapshot; use fetch_channel_messages
    for more or newer messages]`; the tool passes its own (e.g. `[channel messages]`
    with the applied filters noted). One formatter, two callers.
 
 ### Data flow
 
 ```
-agent → fetch_channel_messages(limit, since, user)          [tool, sandbox side]
+agent → fetch_channel_messages(limit, since, user)          [tool, harness side]
       → api_client.fetch_channel_messages → POST .../channel-messages
-      → route: resolve session + creds + channel_id          [server side]
+      → route: resolve session + creds + config slack_channel_id [server side]
       → SlackPlatform.fetch_channel_context (conversations.history, bot token)
       → filter_and_format(meta, messages, since, user, limit) [pure core]
-      → {messages_block, count, channel} → JSON to the tool → model
+      → {messages_block, count, channel, note} → JSON to the tool → model
 ```
 
 ### Error handling
 
 - No session-scoped client / no `session_id` → structured `{"success": False,
   error}` from the tool/client (no HTTP call).
+- Invalid `limit` → clamp to `1..200`; missing limit defaults to 50. Invalid
+  `since` → 400 with a clear detail string.
 - Non-Slack session → 400 (mirrors file route).
+- Missing `channel_identifier`, missing `slack_channel_id`, or no Slack bot token
+  → empty result with `count: 0` and a clear `note` (configuration issue, not a
+  server crash).
 - Slack error / bot not a member / DM → `fetch_channel_context` returns `None` →
-  route returns `{"messages_block": None, "count": 0}` with a clear note, not a 500.
+  route returns `{"messages_block": None, "count": 0, "note": <str>}` rather than
+  a 500.
 - Empty result after filtering → `messages_block: None`, `count: 0`, note that no
   messages matched.
 
 ## Testing
 
-- **Pure core** (`test_channel_backfill_*` sibling): since filter, user filter
-  (by id and by mention form), limit cap, empty input, header parameterization.
+- **Pure core** (`test_channel_backfill_*` sibling): since filter, user-id
+  filter, limit cap, empty input, header parameterization.
 - **Tool handler** (like `test_fetch_channel_file_tool.py`): missing api_client
-  error; delegates with parsed args; `<@U…>` → bare id normalization.
+  error; delegates with parsed args; `<@U…>` → bare id normalization; harness
+  routing is registered.
+- **Harness API client** (like `test_api_client_channel_file.py`): posts to the
+  session-scoped `/v1/sessions/{sid}/channel-messages` path with a JSON body,
+  requires `session_id`, maps HTTP errors to the standard error envelope.
 - **Route** (like `test_channel_files_route.py`): happy path, non-Slack 400,
-  tenant-ownership 404, `fetch_channel_context` returns None → empty block.
+  tenant-ownership 404, missing channel config returns empty result, no bot token
+  returns empty result, `fetch_channel_context` returns None → empty block.
+- **Slack platform** (`test_slack_fetch_channel_context.py`): `RawMessage.author_id`
+  is populated from the message `user` id while `author` remains the resolved
+  display name.
 - **Regression**: existing backfill tests still pass after header parameterization.
 
 ## Rollout

--- a/surogates/api/routes/channel_files.py
+++ b/surogates/api/routes/channel_files.py
@@ -9,10 +9,12 @@ the server.
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel
 
 import surogates.channels.platforms  # noqa: F401  # ensure SlackPlatform self-registers in this process
 
@@ -24,6 +26,7 @@ from surogates.channels.file_fetch import (
     ChannelFileUnavailable,
     fetch_channel_file,
 )
+from surogates.channels.message_fetch import fetch_channel_messages
 from surogates.channels.platform_resolve import effective_channel_platform
 from surogates.channels.registry import registry
 from surogates.session.store import SessionNotFoundError, SessionStore
@@ -45,9 +48,9 @@ def _get_session_store(request: Request) -> SessionStore:
     return store
 
 
-async def _resolve_session_bucket(
+async def _resolve_session(
     store: SessionStore, session_id: UUID, tenant: TenantContext,
-) -> tuple[Any, str]:
+) -> Any:
     try:
         session = await store.get_session(session_id)
     except SessionNotFoundError:
@@ -60,6 +63,13 @@ async def _resolve_session_bucket(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session {session_id} not found.",
         )
+    return session
+
+
+async def _resolve_session_bucket(
+    store: SessionStore, session_id: UUID, tenant: TenantContext,
+) -> tuple[Any, str]:
+    session = await _resolve_session(store, session_id, tenant)
     bucket = session.config.get("storage_bucket")
     if not bucket:
         raise HTTPException(
@@ -118,3 +128,50 @@ async def fetch_channel_file_route(
         )
     except ChannelFileUnavailable as exc:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+
+class _ChannelMessagesBody(BaseModel):
+    limit: int | None = None
+    since: str | None = None
+    user: str | None = None
+
+
+@router.post("/sessions/{session_id}/channel-messages")
+async def fetch_channel_messages_route(
+    session_id: UUID,
+    body: _ChannelMessagesBody,
+    request: Request,
+    tenant: TenantContext = Depends(get_current_tenant),
+) -> dict:
+    """Read recent messages from this session's Slack channel."""
+    store = _get_session_store(request)
+    session = await _resolve_session(store, session_id, tenant)
+
+    # Ambient sessions carry a slack channel_id but channel="ambient".
+    channel = effective_channel_platform(session)
+    if channel != "slack":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Channel-message fetch is only supported for Slack sessions.",
+        )
+
+    platform = registry.get("slack")
+    if platform is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Slack platform is not available.",
+        )
+
+    try:
+        return await fetch_channel_messages(
+            platform=platform,
+            vault=request.app.state.credential_vault,
+            session=session,
+            limit=body.limit if body.limit is not None else 50,
+            since=body.since,
+            user=body.user,
+            now=time.time(),
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))

--- a/surogates/channels/channel_backfill.py
+++ b/surogates/channels/channel_backfill.py
@@ -43,6 +43,7 @@ class RawMessage:
     author: str
     text: str
     files: tuple[tuple[str, str], ...] = ()
+    author_id: str = ""
 
 
 @dataclass(frozen=True)

--- a/surogates/channels/channel_backfill.py
+++ b/surogates/channels/channel_backfill.py
@@ -10,6 +10,7 @@ import contextlib
 import dataclasses
 import json
 import logging
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
@@ -99,12 +100,76 @@ def _fmt_ts(ts: float) -> str:
     return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
 
 
+BACKFILL_HEADER = (
+    "[recent channel history — snapshot; use fetch_channel_messages "
+    "for more or newer messages]"
+)
+MESSAGES_HEADER = "[channel messages]"
+
+_REL_SINCE = re.compile(r"^\s*(\d+)\s*([hd])\s*$", re.IGNORECASE)
+
+
+def normalize_user(value: str | None) -> str:
+    """Strip a Slack mention wrapper to a bare user id ('<@U063>' -> 'U063').
+
+    Handles the ``<@ID>`` mention form (including the ``<@ID|handle>`` variant)
+    and a leading ``@``; returns the bare id, or ``""`` when *value* is empty.
+    """
+    v = (value or "").strip()
+    if v.startswith("<@") and v.endswith(">"):
+        v = v[2:-1].split("|", 1)[0]
+    elif v.startswith("@"):
+        v = v[1:]
+    return v.strip()
+
+
+def parse_since(value: str | None, *, now: float) -> float | None:
+    """Return an epoch cutoff for *value*, or None when empty.
+
+    Accepts relative windows ('24h', '7d') evaluated against *now*, or an ISO
+    date ('2026-07-01') meaning midnight UTC on that date. Raises ValueError on
+    anything else so the caller can surface a 400 rather than broaden silently.
+    """
+    v = (value or "").strip()
+    if not v:
+        return None
+    m = _REL_SINCE.match(v)
+    if m:
+        n = int(m.group(1))
+        unit = m.group(2).lower()
+        return now - n * (3600 if unit == "h" else 86400)
+    try:
+        d = datetime.strptime(v, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        raise ValueError(f"Unparseable 'since' value: {value!r}") from exc
+    return d.timestamp()
+
+
+def filter_messages_for_query(
+    messages: list[RawMessage], *, since_cutoff: float | None,
+    user_id: str, limit: int,
+) -> list[RawMessage]:
+    """Filter newest-first *messages* by since/user, take the newest *limit*,
+    and return them oldest-first for natural reading order."""
+    out: list[RawMessage] = []
+    for m in messages:  # newest-first
+        if since_cutoff is not None and m.ts < since_cutoff:
+            continue
+        if user_id and m.author_id != user_id:
+            continue
+        out.append(m)
+        if len(out) >= max(1, limit):
+            break
+    return list(reversed(out))
+
+
 def format_context_block(
-    meta: ChannelMeta, messages: list[RawMessage], *, now: float
+    meta: ChannelMeta, messages: list[RawMessage], *, now: float,
+    header: str = BACKFILL_HEADER,
 ) -> str | None:
     if not messages:
         return None
-    lines = ["[channel context - history before the agent joined]"]
+    lines = [header]
     lines.append(f"Channel: #{meta.name}" if meta.name else "Channel: (unnamed)")
     if meta.topic:
         lines.append(f"Topic: {meta.topic}")

--- a/surogates/channels/message_fetch.py
+++ b/surogates/channels/message_fetch.py
@@ -1,0 +1,91 @@
+"""On-demand Slack channel message fetch — resolve creds, pull history, format.
+
+The privileged half of the ``fetch_channel_messages`` tool: given a channel
+session it resolves the bot token from the vault, calls the Slack
+``fetch_channel_context`` primitive, and runs the pure query core. The bot token
+never leaves the server. Missing configuration or credentials yield an empty
+result with a human-readable ``note`` rather than an error; an unparseable
+``since`` raises ``ValueError`` so the route can return a 400.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from surogates.channels.channel_backfill import (
+    MESSAGES_HEADER,
+    BackfillLimits,
+    filter_messages_for_query,
+    format_context_block,
+    normalize_user,
+    parse_since,
+)
+from surogates.channels.credentials import resolve_channel_credentials
+
+_MAX_LIMIT = 200
+_DEFAULT_LIMIT = 50
+
+
+def _clamp_limit(limit: Any) -> int:
+    try:
+        n = int(limit)
+    except (TypeError, ValueError):
+        return _DEFAULT_LIMIT
+    return max(1, min(_MAX_LIMIT, n))
+
+
+def _empty(note: str, channel: str = "") -> dict:
+    return {"messages_block": None, "count": 0, "channel": channel, "note": note}
+
+
+async def fetch_channel_messages(
+    *, platform: Any, vault: Any, session: Any,
+    limit: Any, since: str | None, user: str | None, now: float,
+) -> dict:
+    """Fetch recent messages for a Slack-channel session.
+
+    Returns ``{"messages_block", "count", "channel", "note"}``. ``messages_block``
+    is a formatted, oldest-first text block (or ``None`` when empty); ``note``
+    explains why a result is empty. Raises ``ValueError`` on an unparseable
+    ``since`` value.
+    """
+    cfg = getattr(session, "config", None) or {}
+    identifier = cfg.get("channel_identifier") or ""
+    channel_id = cfg.get("slack_channel_id") or ""
+    if not identifier or not channel_id:
+        return _empty("This session is not bound to a Slack channel.")
+
+    since_cutoff = parse_since(since, now=now)  # may raise ValueError
+    user_id = normalize_user(user)
+    n = _clamp_limit(limit)
+
+    refs = platform.descriptor.vault_refs(identifier)
+    creds = await resolve_channel_credentials(
+        vault=vault, kind="slack", identifier=identifier,
+        org_id=str(session.org_id), refs=refs,
+    )
+    if not (creds or {}).get("bot_token"):
+        return _empty("No Slack bot token is configured for this channel.")
+
+    limits = BackfillLimits(max_messages=n, max_pages=1)
+    result = await platform.fetch_channel_context(
+        creds=creds, channel_id=channel_id, limits=limits,
+    )
+    if result is None:
+        return _empty(
+            "Could not read this channel's history (the bot may not be a "
+            "member, or Slack returned an error).")
+
+    meta, messages = result
+    picked = filter_messages_for_query(
+        messages, since_cutoff=since_cutoff, user_id=user_id, limit=n)
+    if not picked:
+        scope = " from that user" if user_id else ""
+        return _empty(
+            f"No messages found{scope} in the requested window.",
+            channel=meta.name)
+    block = format_context_block(meta, picked, now=now, header=MESSAGES_HEADER)
+    return {
+        "messages_block": block, "count": len(picked),
+        "channel": meta.name, "note": None,
+    }

--- a/surogates/channels/platforms/slack.py
+++ b/surogates/channels/platforms/slack.py
@@ -1302,6 +1302,7 @@ class SlackPlatform:
                         author=author,
                         text=(m.get("text") or "").strip(),
                         files=files,
+                        author_id=(m.get("user") or ""),
                     ))
                 cursor = (hist.get("response_metadata") or {}).get("next_cursor") or ""
                 if not hist.get("has_more") or not cursor:

--- a/surogates/harness/api_client.py
+++ b/surogates/harness/api_client.py
@@ -352,6 +352,36 @@ class HarnessAPIClient:
         except httpx.HTTPStatusError as exc:
             return _error_response(exc)
 
+    async def fetch_channel_messages(
+        self, *, limit: int | None = None, since: str | None = None,
+        user: str | None = None,
+    ) -> str:
+        """Read recent messages from this session's Slack channel.
+
+        Requires a session-scoped client. Returns a JSON string with the
+        formatted ``messages_block`` (and ``count``/``channel``/``note``), or
+        the standard error envelope.
+        """
+        if self._session_id is None:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        "Channel-message fetch requires a session-scoped API "
+                        "client; session_id is not set."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+        try:
+            data = await self._post(
+                f"/v1/sessions/{self._session_id}/channel-messages",
+                {"limit": limit, "since": since, "user": user},
+            )
+            return json.dumps({"success": True, **data}, ensure_ascii=False)
+        except httpx.HTTPStatusError as exc:
+            return _error_response(exc)
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/surogates/tools/builtin/channel_messages.py
+++ b/surogates/tools/builtin/channel_messages.py
@@ -1,0 +1,84 @@
+"""The ``fetch_channel_messages`` builtin tool.
+
+Lets a Slack-channel agent read recent messages posted in its own channel,
+optionally narrowed by a time window or a specific user. Thin delegate to the
+session-scoped harness API client; the privileged history fetch runs
+server-side with the channel's bot token.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from surogates.tools.registry import ToolRegistry, ToolSchema
+
+FETCH_CHANNEL_MESSAGES_SCHEMA = ToolSchema(
+    name="fetch_channel_messages",
+    description=(
+        "Read recent messages posted in this Slack channel (including messages "
+        "from other users). Use this to catch up on the conversation or to see "
+        "what a specific person said. Optionally narrow by 'since' (e.g. '24h', "
+        "'7d', or a date like '2026-07-01') and by 'user' (a Slack user id such "
+        "as 'U063C2DB7GW' or a mention like '<@U063C2DB7GW>'). Returns messages "
+        "oldest-to-newest. Only messages in this channel are accessible."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "limit": {
+                "type": "integer",
+                "description": "How many recent messages to return (default 50, max 200).",
+            },
+            "since": {
+                "type": "string",
+                "description": "Only messages newer than this: '24h', '7d', or a date '2026-07-01'.",
+            },
+            "user": {
+                "type": "string",
+                "description": "Only messages from this Slack user id or mention (e.g. '<@U063C2DB7GW>').",
+            },
+        },
+        "required": [],
+    },
+)
+
+
+def _coerce_limit(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+async def _fetch_channel_messages_handler(
+    arguments: dict[str, Any], **kwargs: Any,
+) -> str:
+    api_client = kwargs.get("api_client")
+    if api_client is None:
+        return json.dumps(
+            {
+                "success": False,
+                "error": (
+                    "Channel-message fetch requires a session-scoped API client."
+                ),
+            },
+            ensure_ascii=False,
+        )
+    return await api_client.fetch_channel_messages(
+        limit=_coerce_limit(arguments.get("limit")),
+        since=(arguments.get("since") or None),
+        user=(arguments.get("user") or None),
+    )
+
+
+def register(registry: ToolRegistry) -> None:
+    """Register the fetch_channel_messages tool."""
+    registry.register(
+        name="fetch_channel_messages",
+        schema=FETCH_CHANNEL_MESSAGES_SCHEMA,
+        handler=_fetch_channel_messages_handler,
+        toolset="channels",
+    )

--- a/surogates/tools/builtin/github.py
+++ b/surogates/tools/builtin/github.py
@@ -1,15 +1,20 @@
-"""Built-in ``github`` tool — read-only GitHub REST API for the agent's repos.
+"""Built-in ``github`` tool — scoped GitHub REST API for the agent's repos.
 
 The agent connects a GitHub PAT + a set of repositories in the Tools tab (the
 same credential the coding tool uses to check out and open PRs).  This tool
-lets the agent *answer questions* about those repos — issues, pull requests,
-files, commits, diffs, search — without a checkout, by proxying authenticated
-``GET`` requests to the GitHub REST API.
+lets the agent both *answer questions* about those repos — issues, pull
+requests, files, commits, diffs, search — and *act* on them — open/close/comment
+issues and PRs, add labels, write files — without a checkout, by proxying
+authenticated requests to the GitHub REST API.
 
-Read-only (``GET`` only) and scoped to the configured repos: a request must
-target ``/repos/<owner>/<repo>/…`` for a configured repo, or ``/search/…``
-qualified to a configured repo.  The PAT rides in the ``Authorization`` header
-only — never in argv, the returned data, or an event.
+Scoped to the configured repos: a request must target ``/repos/<owner>/<repo>/…``
+for a configured repo, or (read-only) ``/search/…`` qualified to a configured
+repo.  ``GET`` is read-only; ``POST``/``PATCH``/``PUT``/``DELETE`` writes are
+allowed on sub-resources of a configured repo but never on the repository
+itself (no root-level delete/rename) or admin endpoints like ``transfer``.  A
+write needs the connected PAT to carry the matching scope — the tool does not
+widen the token.  The PAT rides in the ``Authorization`` header only — never in
+argv, the returned data, or an event.
 
 Required kwargs (injected by the harness dispatch): ``tenant``,
 ``credential_vault``, ``session_config`` (carrying the agent's ``repos``).
@@ -43,6 +48,14 @@ _MEDIA_ACCEPT = {
 
 _SLUG_RE = re.compile(r"github\.com[:/]+([^/\s]+)/([^/\s]+?)(?:\.git)?/?$", re.IGNORECASE)
 
+_WRITE_METHODS = frozenset({"POST", "PATCH", "PUT", "DELETE"})
+_METHODS = frozenset({"GET"}) | _WRITE_METHODS
+
+# Repo sub-resources that reconfigure or hand off the whole repository — writes
+# to these are refused even for a configured repo (they are not day-to-day
+# issue/PR/content edits and are hard or impossible to undo).
+_PROTECTED_REPO_SUBRESOURCES = frozenset({"transfer"})
+
 
 def github_repo_slugs(repos: Sequence[Mapping[str, str]]) -> set[str]:
     """The ``owner/repo`` slugs (lowercased) for the configured repositories."""
@@ -54,14 +67,22 @@ def github_repo_slugs(repos: Sequence[Mapping[str, str]]) -> set[str]:
     return slugs
 
 
-def authorize_github_read(
-    path: str, params: Mapping[str, Any] | None, repos: Sequence[Mapping[str, str]],
+def authorize_github_request(
+    method: str,
+    path: str,
+    params: Mapping[str, Any] | None,
+    repos: Sequence[Mapping[str, str]],
 ) -> tuple[bool, str]:
-    """Return ``(allowed, reason)`` for a GitHub REST path against *repos*.
+    """Return ``(allowed, reason)`` for a GitHub REST call against *repos*.
 
-    Allowed: ``/repos/<owner>/<repo>/…`` for a configured repo, or
-    ``/search/…`` whose ``q`` is scoped to configured repos via ``repo:``.
+    Allowed: ``/repos/<owner>/<repo>/…`` for a configured repo (any method), or
+    ``/search/…`` (``GET`` only) whose ``q`` is scoped to configured repos via
+    ``repo:``.  Writes (``POST``/``PATCH``/``PUT``/``DELETE``) are further
+    refused on the repository itself and on protected admin sub-resources.
     """
+    method = method.upper()
+    is_write = method in _WRITE_METHODS
+
     slugs = github_repo_slugs(repos)
     if not slugs:
         return False, "No repository is configured for this agent (Tools tab)."
@@ -73,15 +94,31 @@ def authorize_github_read(
 
     if segs[0] == "repos" and len(segs) >= 3:
         slug = f"{segs[1]}/{segs[2]}".lower()
-        if slug in slugs:
-            return True, ""
-        return (
-            False,
-            f"'{slug}' is not a configured repository. Configured: "
-            f"{', '.join(sorted(slugs))}.",
-        )
+        if slug not in slugs:
+            return (
+                False,
+                f"'{slug}' is not a configured repository. Configured: "
+                f"{', '.join(sorted(slugs))}.",
+            )
+        if is_write:
+            if len(segs) == 3:
+                return (
+                    False,
+                    f"Refusing a repository-level {method} on '{slug}': the github "
+                    "tool will not delete or reconfigure the repo itself, only its "
+                    "sub-resources (issues, pulls, comments, labels, contents, …).",
+                )
+            if segs[3].lower() in _PROTECTED_REPO_SUBRESOURCES:
+                return (
+                    False,
+                    f"Refusing a {method} on '{slug}/{segs[3]}': this admin action "
+                    "is blocked by the github tool.",
+                )
+        return True, ""
 
     if segs[0] == "search" and len(segs) >= 2:
+        if is_write:
+            return False, "Search is read-only; use GET."
         q = query.get("q", "")
         if re.search(r"\b(?:org|user):", q, re.IGNORECASE):
             return False, "Search must target a configured repo (repo:<owner>/<repo>), not org:/user:."
@@ -103,16 +140,23 @@ def authorize_github_read(
 _SCHEMA = ToolSchema(
     name="github",
     description=(
-        "Read-only GitHub REST API for the agent's configured repositories — "
-        "answer questions about issues, pull requests, files, commits, diffs, "
-        "and search WITHOUT checking out the repo. Give the REST 'path' (and "
-        "optional 'params'); scoped to configured repos, GET-only. Examples: "
-        "list open issues → path='/repos/{owner}/{repo}/issues', "
-        "params={'state':'open'}; a PR's diff → path='/repos/{owner}/{repo}/pulls/{n}', "
-        "media_type='diff'; a file → path='/repos/{owner}/{repo}/contents/{filepath}'; "
-        "recent commits → path='/repos/{owner}/{repo}/commits'; search issues → "
+        "GitHub REST API for the agent's configured repositories, WITHOUT "
+        "checking out the repo. Read (GET, the default): issues, pull requests, "
+        "files, commits, diffs, search. Write (set 'method' to POST/PATCH/PUT/"
+        "DELETE with a 'body'): open/close/comment issues and PRs, add labels, "
+        "write files. Scoped to configured repos; writes act only on the repo's "
+        "sub-resources, never on the repository itself (no root delete/rename) "
+        "and need the connected token to carry write scope. Read examples: list "
+        "open issues → path='/repos/{owner}/{repo}/issues', params={'state':'open'}; "
+        "a PR's diff → path='/repos/{owner}/{repo}/pulls/{n}', media_type='diff'; a "
+        "file → path='/repos/{owner}/{repo}/contents/{filepath}'; search issues → "
         "path='/search/issues', params={'q':'repo:{owner}/{repo} is:open label:bug'}. "
-        "To make code changes and open a PR, use run_coding_agent instead."
+        "Write examples: open an issue → method='POST', "
+        "path='/repos/{owner}/{repo}/issues', body={'title':'…','body':'…'}; comment "
+        "→ method='POST', path='/repos/{owner}/{repo}/issues/{n}/comments', "
+        "body={'body':'…'}; close → method='PATCH', "
+        "path='/repos/{owner}/{repo}/issues/{n}', body={'state':'closed'}. To make "
+        "code changes across many files and open a PR, prefer run_coding_agent."
     ),
     parameters={
         "type": "object",
@@ -121,9 +165,20 @@ _SCHEMA = ToolSchema(
                 "type": "string",
                 "description": "GitHub REST API path, e.g. /repos/{owner}/{repo}/issues",
             },
+            "method": {
+                "type": "string",
+                "enum": ["GET", "POST", "PATCH", "PUT", "DELETE"],
+                "description": "HTTP method. Default 'GET' (read-only). Use POST/PATCH/"
+                               "PUT/DELETE to write; pass the payload in 'body'.",
+            },
             "params": {
                 "type": "object",
                 "description": "Query parameters (e.g. {'state':'open','per_page':20}).",
+            },
+            "body": {
+                "type": "object",
+                "description": "JSON request body for write methods (e.g. "
+                               "{'title':'Bug','body':'…'} when creating an issue).",
             },
             "media_type": {
                 "type": "string",
@@ -148,7 +203,14 @@ def register(registry: ToolRegistry) -> None:
     )
 
 
-async def _github_get(path: str, params: Mapping[str, Any], pat: str, media_type: str) -> str:
+async def _github_request(
+    method: str,
+    path: str,
+    params: Mapping[str, Any],
+    body: Mapping[str, Any] | None,
+    pat: str,
+    media_type: str,
+) -> str:
     import httpx
 
     path_only, _, qs = path.partition("?")
@@ -161,27 +223,30 @@ async def _github_get(path: str, params: Mapping[str, Any], pat: str, media_type
         "X-GitHub-Api-Version": "2022-11-28",
         "User-Agent": "surogate-agent",
     }
+    request_kwargs: dict[str, Any] = {"params": query, "headers": headers}
+    if method != "GET" and body is not None:
+        request_kwargs["json"] = body
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.get(
-                f"{_API_BASE}/{path_only.strip('/')}", params=query, headers=headers,
+            resp = await client.request(
+                method, f"{_API_BASE}/{path_only.strip('/')}", **request_kwargs,
             )
     except httpx.HTTPError as exc:
         return json.dumps({"error": f"GitHub request failed: {exc}"})
 
     text = resp.text or ""
     truncated = len(text) > _MAX_BODY
-    body = text[:_MAX_BODY]
+    body_text = text[:_MAX_BODY]
     if resp.status_code >= 400:
-        message = body
+        message = body_text
         try:
-            message = (json.loads(text) or {}).get("message", body)
+            message = (json.loads(text) or {}).get("message", body_text)
         except (json.JSONDecodeError, TypeError, AttributeError):
             pass
         return json.dumps({"status": resp.status_code, "error": message})
 
-    data: Any = body
-    if accept == _MEDIA_ACCEPT["json"] and not truncated:
+    data: Any = body_text or None
+    if accept == _MEDIA_ACCEPT["json"] and text and not truncated:
         try:
             data = json.loads(text)
         except json.JSONDecodeError:
@@ -197,6 +262,12 @@ async def _github_handler(arguments: dict[str, Any], **kwargs: Any) -> str:
     path = (arguments.get("path") or "").strip()
     if not path:
         return json.dumps({"error": "path is required, e.g. /repos/{owner}/{repo}/issues"})
+
+    method = (arguments.get("method") or "GET").strip().upper()
+    if method not in _METHODS:
+        return json.dumps({
+            "error": f"Unsupported method '{method}'. Use one of {sorted(_METHODS)}.",
+        })
 
     tenant = kwargs.get("tenant")
     vault = kwargs.get("credential_vault")
@@ -223,8 +294,11 @@ async def _github_handler(arguments: dict[str, Any], **kwargs: Any) -> str:
         })
 
     params = arguments.get("params") or {}
-    ok, reason = authorize_github_read(path, params, repos)
+    ok, reason = authorize_github_request(method, path, params, repos)
     if not ok:
         return json.dumps({"error": reason, "code": "out_of_scope"})
 
-    return await _github_get(path, params, pat, arguments.get("media_type") or "json")
+    return await _github_request(
+        method, path, params, arguments.get("body"), pat,
+        arguments.get("media_type") or "json",
+    )

--- a/surogates/tools/router.py
+++ b/surogates/tools/router.py
@@ -119,6 +119,9 @@ TOOL_LOCATIONS: dict[str, ToolLocation] = {
     # call the ops server endpoint that downloads/ingests the Slack file;
     # no sandbox isolation needed or available.
     "fetch_channel_file": ToolLocation.HARNESS,
+    # Channel message read — same rationale: needs the session-scoped API
+    # client to call the ops server; no sandbox isolation.
+    "fetch_channel_messages": ToolLocation.HARNESS,
     # Sandbox (code execution, file mutation, need isolation)
     "terminal": ToolLocation.SANDBOX,
     "read_file": ToolLocation.SANDBOX,

--- a/surogates/tools/runtime.py
+++ b/surogates/tools/runtime.py
@@ -52,6 +52,7 @@ class ToolRuntime:
             ask_user_question,
             browser,
             channel_files,
+            channel_messages,
             coding_agent,
             coordinator,
             cron,
@@ -105,6 +106,7 @@ class ToolRuntime:
             arbor_tools,  # idea_tree, dispatch_experiments, merge_experiment (research missions)
             mate_ambient,  # mate_ambient_post (gated ambient channel post)
             channel_files,  # fetch_channel_file (pull a shared channel file)
+            channel_messages,  # fetch_channel_messages (read recent channel messages)
         ]
 
         for mod in modules:

--- a/surogates/tools/runtime.py
+++ b/surogates/tools/runtime.py
@@ -100,7 +100,7 @@ class ToolRuntime:
             coordinator,
             artifact,
             coding_agent,  # run_coding_agent (Claude Code / Codex)
-            github,  # github (read-only GitHub REST for the agent's repos)
+            github,  # github (scoped GitHub REST — read + writes — for the agent's repos)
             task_tools,  # spawn_task, unblock_task, cancel_task, worker_block/complete/context
             board_tools,  # share_note, read_board, expand_note (coordination board)
             arbor_tools,  # idea_tree, dispatch_experiments, merge_experiment (research missions)

--- a/tests/test_api_client_channel_message.py
+++ b/tests/test_api_client_channel_message.py
@@ -1,0 +1,31 @@
+import json
+
+from surogates.harness.api_client import HarnessAPIClient
+
+
+def _client(session_id="11111111-1111-1111-1111-111111111111"):
+    return HarnessAPIClient(base_url="http://api", token="t", session_id=session_id)
+
+
+async def test_requires_session_id():
+    c = HarnessAPIClient(base_url="http://api", token="t", session_id=None)
+    out = json.loads(await c.fetch_channel_messages(limit=10))
+    assert out["success"] is False
+
+
+async def test_posts_to_channel_messages_path(monkeypatch):
+    c = _client()
+    captured = {}
+
+    async def _fake_post(path, body=None):
+        captured["path"] = path
+        captured["body"] = body
+        return {"count": 2, "messages_block": "…", "channel": "surogate", "note": None}
+
+    monkeypatch.setattr(c, "_post", _fake_post)
+    out = json.loads(await c.fetch_channel_messages(limit=10, since="7d", user="<@U1>"))
+    assert out["success"] is True
+    assert out["count"] == 2
+    assert captured["path"] == (
+        "/v1/sessions/11111111-1111-1111-1111-111111111111/channel-messages")
+    assert captured["body"] == {"limit": 10, "since": "7d", "user": "<@U1>"}

--- a/tests/test_channel_backfill_core.py
+++ b/tests/test_channel_backfill_core.py
@@ -1,4 +1,5 @@
 from surogates.channels.channel_backfill import (
+    BACKFILL_HEADER,
     BackfillLimits, RawMessage, ChannelMeta,
     filter_messages, bound_messages, format_context_block,
 )
@@ -42,7 +43,7 @@ def test_format_block_has_header_and_oldest_first():
             RawMessage(ts=now - 1, author="Bob", text="second")]
     block = format_context_block(meta, msgs, now=now)
     assert block is not None
-    assert "[channel context" in block and "[/channel context]" in block
+    assert block.startswith(BACKFILL_HEADER) and "[/channel context]" in block
     assert "#eng-infra" in block and "keep prod up" in block
     assert block.index("Alice: first") < block.index("Bob: second")
 

--- a/tests/test_channel_message_fetch.py
+++ b/tests/test_channel_message_fetch.py
@@ -1,0 +1,94 @@
+import types
+
+import pytest
+
+from surogates.channels.channel_backfill import ChannelMeta, RawMessage
+from surogates.channels.message_fetch import fetch_channel_messages
+
+NOW = 1_720_000_000.0
+
+
+def _session(cfg):
+    return types.SimpleNamespace(config=cfg, org_id="org-1")
+
+
+def _platform(context_result):
+    descriptor = types.SimpleNamespace(
+        vault_refs=lambda identifier: {"bot_token": "bot_token"})
+
+    async def _fetch_channel_context(*, creds, channel_id, limits):
+        return context_result
+
+    return types.SimpleNamespace(
+        descriptor=descriptor, fetch_channel_context=_fetch_channel_context)
+
+
+class _Vault:
+    async def resolve_ref(self, ref, *, org_id):
+        return "xoxb-token"
+
+
+async def test_happy_path_filters_and_formats():
+    meta = ChannelMeta(name="surogate", topic="", purpose="")
+    msgs = [RawMessage(ts=NOW - 10, author="Flavius", text="hi", author_id="U1")]
+    platform = _platform((meta, msgs))
+    out = await fetch_channel_messages(
+        platform=platform, vault=_Vault(),
+        session=_session({"channel_identifier": "A1", "slack_channel_id": "C1"}),
+        limit=50, since=None, user="<@U1>", now=NOW)
+    assert out["count"] == 1
+    assert out["channel"] == "surogate"
+    assert "hi" in out["messages_block"]
+    assert out["note"] is None
+
+
+async def test_missing_channel_config_returns_note():
+    platform = _platform((ChannelMeta("x", "", ""), []))
+    out = await fetch_channel_messages(
+        platform=platform, vault=_Vault(),
+        session=_session({}), limit=50, since=None, user=None, now=NOW)
+    assert out["count"] == 0
+    assert out["messages_block"] is None
+    assert "channel" in out["note"].lower()
+
+
+async def test_no_bot_token_returns_note():
+    class _EmptyVault:
+        async def resolve_ref(self, ref, *, org_id):
+            return None
+
+    out = await fetch_channel_messages(
+        platform=_platform((ChannelMeta("x", "", ""), [])), vault=_EmptyVault(),
+        session=_session({"channel_identifier": "A1", "slack_channel_id": "C1"}),
+        limit=50, since=None, user=None, now=NOW)
+    assert out["count"] == 0
+    assert "token" in out["note"].lower()
+
+
+async def test_context_none_returns_note():
+    out = await fetch_channel_messages(
+        platform=_platform(None), vault=_Vault(),
+        session=_session({"channel_identifier": "A1", "slack_channel_id": "C1"}),
+        limit=50, since=None, user=None, now=NOW)
+    assert out["count"] == 0
+    assert out["note"]
+
+
+async def test_no_matching_messages_returns_note_with_channel():
+    meta = ChannelMeta(name="surogate", topic="", purpose="")
+    msgs = [RawMessage(ts=NOW - 10, author="Flavius", text="hi", author_id="U1")]
+    out = await fetch_channel_messages(
+        platform=_platform((meta, msgs)), vault=_Vault(),
+        session=_session({"channel_identifier": "A1", "slack_channel_id": "C1"}),
+        limit=50, since=None, user="U2", now=NOW)
+    assert out["count"] == 0
+    assert out["channel"] == "surogate"
+    assert "user" in out["note"].lower()
+
+
+async def test_invalid_since_raises():
+    with pytest.raises(ValueError):
+        await fetch_channel_messages(
+            platform=_platform((ChannelMeta("x", "", ""), [])), vault=_Vault(),
+            session=_session({"channel_identifier": "A1", "slack_channel_id": "C1"}),
+            limit=50, since="banana", user=None, now=NOW)

--- a/tests/test_channel_messages_core.py
+++ b/tests/test_channel_messages_core.py
@@ -1,0 +1,82 @@
+import pytest
+
+from surogates.channels.channel_backfill import (
+    BACKFILL_HEADER,
+    ChannelMeta,
+    RawMessage,
+    filter_messages_for_query,
+    format_context_block,
+    normalize_user,
+    parse_since,
+)
+
+NOW = 1_720_000_000.0  # fixed reference epoch
+
+
+def _msg(ts, uid, text="x"):
+    return RawMessage(ts=ts, author=f"name-{uid}", text=text, author_id=uid)
+
+
+def test_normalize_user_strips_mention_and_at():
+    assert normalize_user("<@U063>") == "U063"
+    assert normalize_user("<@U063|flavius>") == "U063"
+    assert normalize_user("@U063") == "U063"
+    assert normalize_user("U063") == "U063"
+    assert normalize_user(None) == ""
+    assert normalize_user("  ") == ""
+
+
+def test_parse_since_relative_and_iso_and_none():
+    assert parse_since(None, now=NOW) is None
+    assert parse_since("", now=NOW) is None
+    assert parse_since("24h", now=NOW) == NOW - 24 * 3600
+    assert parse_since("7d", now=NOW) == NOW - 7 * 86400
+    # ISO date -> midnight UTC epoch of that date
+    assert parse_since("2024-07-03", now=NOW) == 1_719_964_800.0
+
+
+def test_parse_since_invalid_raises():
+    with pytest.raises(ValueError):
+        parse_since("banana", now=NOW)
+    with pytest.raises(ValueError):
+        parse_since("2024-13-01", now=NOW)
+
+
+def test_filter_by_user_and_limit_returns_oldest_first():
+    msgs = [  # newest-first, as fetch_channel_context returns
+        _msg(NOW - 10, "U1"), _msg(NOW - 20, "U2"),
+        _msg(NOW - 30, "U1"), _msg(NOW - 40, "U1"),
+    ]
+    out = filter_messages_for_query(msgs, since_cutoff=None, user_id="U1", limit=2)
+    assert [m.ts for m in out] == [NOW - 30, NOW - 10]  # newest 2 of U1, oldest-first
+
+
+def test_filter_by_since_drops_older():
+    msgs = [_msg(NOW - 10, "U1"), _msg(NOW - 100, "U1")]
+    out = filter_messages_for_query(
+        msgs, since_cutoff=NOW - 50, user_id="", limit=50)
+    assert [m.ts for m in out] == [NOW - 10]
+
+
+def test_filter_empty_input_returns_empty():
+    assert filter_messages_for_query([], since_cutoff=None, user_id="", limit=50) == []
+
+
+def test_format_block_uses_custom_header():
+    meta = ChannelMeta(name="surogate", topic="", purpose="")
+    block = format_context_block(
+        meta, [_msg(NOW - 10, "U1", "hello")], now=NOW, header="[channel messages]")
+    assert block.startswith("[channel messages]")
+    assert "hello" in block
+
+
+def test_format_block_default_header_is_not_pre_join():
+    meta = ChannelMeta(name="surogate", topic="", purpose="")
+    block = format_context_block(meta, [_msg(NOW - 10, "U1", "hi")], now=NOW)
+    assert block.startswith(BACKFILL_HEADER)
+    assert "before the agent joined" not in block
+
+
+def test_format_block_empty_messages_returns_none():
+    meta = ChannelMeta(name="surogate", topic="", purpose="")
+    assert format_context_block(meta, [], now=NOW) is None

--- a/tests/test_channel_messages_route.py
+++ b/tests/test_channel_messages_route.py
@@ -1,0 +1,101 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from surogates.api.routes import channel_files
+from surogates.api.routes.channel_files import _ChannelMessagesBody
+
+
+class _Store:
+    def __init__(self, session):
+        self._session = session
+
+    async def get_session(self, session_id):
+        return self._session
+
+
+def _session(*, channel="slack", config=None):
+    return SimpleNamespace(
+        id=uuid4(), org_id=uuid4(), channel=channel,
+        config=config if config is not None
+        else {"channel_identifier": "T1", "slack_channel_id": "C1"},
+    )
+
+
+class _Tenant:
+    def __init__(self, owns=True):
+        self._owns = owns
+
+    def owns_session(self, org_id, session_id):
+        return self._owns
+
+
+def _request(session):
+    state = SimpleNamespace(session_store=_Store(session), credential_vault=object())
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+async def test_messages_route_happy_path(monkeypatch):
+    session = _session(channel="slack")
+    monkeypatch.setattr(channel_files.registry, "get", lambda kind: object())
+
+    async def _fake(**kwargs):
+        return {"messages_block": "…hi…", "count": 1, "channel": "surogate", "note": None}
+
+    monkeypatch.setattr(channel_files, "fetch_channel_messages", _fake)
+    out = await channel_files.fetch_channel_messages_route(
+        session_id=session.id, body=_ChannelMessagesBody(limit=10),
+        request=_request(session), tenant=_Tenant())
+    assert out["count"] == 1
+    assert out["messages_block"]
+
+
+async def test_messages_route_non_slack_400():
+    session = _session(channel="web")
+    with pytest.raises(HTTPException) as ei:
+        await channel_files.fetch_channel_messages_route(
+            session_id=session.id, body=_ChannelMessagesBody(),
+            request=_request(session), tenant=_Tenant())
+    assert ei.value.status_code == 400
+
+
+async def test_messages_route_foreign_session_404():
+    session = _session(channel="slack")
+    with pytest.raises(HTTPException) as ei:
+        await channel_files.fetch_channel_messages_route(
+            session_id=session.id, body=_ChannelMessagesBody(),
+            request=_request(session), tenant=_Tenant(owns=False))
+    assert ei.value.status_code == 404
+
+
+async def test_messages_route_invalid_since_400(monkeypatch):
+    session = _session(channel="slack")
+    monkeypatch.setattr(channel_files.registry, "get", lambda kind: object())
+
+    async def _raise(**kwargs):
+        raise ValueError("bad since")
+
+    monkeypatch.setattr(channel_files, "fetch_channel_messages", _raise)
+    with pytest.raises(HTTPException) as ei:
+        await channel_files.fetch_channel_messages_route(
+            session_id=session.id, body=_ChannelMessagesBody(since="banana"),
+            request=_request(session), tenant=_Tenant())
+    assert ei.value.status_code == 400
+
+
+async def test_messages_route_missing_config_empty(monkeypatch):
+    session = _session(channel="slack", config={})
+    monkeypatch.setattr(channel_files.registry, "get", lambda kind: object())
+
+    async def _fake(**kwargs):
+        return {"messages_block": None, "count": 0, "channel": "",
+                "note": "This session is not bound to a Slack channel."}
+
+    monkeypatch.setattr(channel_files, "fetch_channel_messages", _fake)
+    out = await channel_files.fetch_channel_messages_route(
+        session_id=session.id, body=_ChannelMessagesBody(),
+        request=_request(session), tenant=_Tenant())
+    assert out["count"] == 0
+    assert out["note"]

--- a/tests/test_fetch_channel_messages_tool.py
+++ b/tests/test_fetch_channel_messages_tool.py
@@ -1,0 +1,40 @@
+import json
+
+from surogates.tools.builtin.channel_messages import _fetch_channel_messages_handler
+from surogates.tools.router import TOOL_LOCATIONS, ToolLocation
+
+
+async def test_missing_api_client_returns_error():
+    out = json.loads(await _fetch_channel_messages_handler({"limit": 10}))
+    assert out["success"] is False
+
+
+async def test_delegates_with_parsed_args():
+    calls = {}
+
+    class _Client:
+        async def fetch_channel_messages(self, *, limit, since, user):
+            calls.update(limit=limit, since=since, user=user)
+            return json.dumps({"success": True, "count": 0})
+
+    out = await _fetch_channel_messages_handler(
+        {"limit": "25", "since": "7d", "user": "<@U1>"}, api_client=_Client())
+    assert json.loads(out)["success"] is True
+    assert calls == {"limit": 25, "since": "7d", "user": "<@U1>"}
+
+
+async def test_blank_since_and_user_become_none():
+    calls = {}
+
+    class _Client:
+        async def fetch_channel_messages(self, *, limit, since, user):
+            calls.update(limit=limit, since=since, user=user)
+            return json.dumps({"success": True})
+
+    await _fetch_channel_messages_handler(
+        {"since": "", "user": ""}, api_client=_Client())
+    assert calls == {"limit": None, "since": None, "user": None}
+
+
+def test_tool_routed_to_harness():
+    assert TOOL_LOCATIONS["fetch_channel_messages"] == ToolLocation.HARNESS

--- a/tests/test_github_scope.py
+++ b/tests/test_github_scope.py
@@ -1,6 +1,6 @@
-"""The GitHub read tool is scoped to the agent's configured repositories."""
+"""The GitHub tool is scoped to the agent's configured repositories."""
 
-from surogates.tools.builtin.github import authorize_github_read, github_repo_slugs
+from surogates.tools.builtin.github import authorize_github_request, github_repo_slugs
 
 REPOS = [
     {"url": "https://github.com/acme/api", "default_branch": "main"},
@@ -19,39 +19,39 @@ def test_repos_path_for_configured_repo_allowed():
         "/repos/acme/api/issues?state=open",
         "/repos/acme/web/contents/README.md",
         "/repos/acme/web/commits",
-        "/repos/acme/api/pulls/42/files", 
+        "/repos/acme/api/pulls/42/files",
     ):
-        ok, _ = authorize_github_read(path, None, REPOS)
+        ok, _ = authorize_github_request("GET", path, None, REPOS)
         assert ok, path
 
 
 def test_repos_path_case_insensitive():
-    ok, _ = authorize_github_read("/repos/ACME/API/issues", None, REPOS)
+    ok, _ = authorize_github_request("GET", "/repos/ACME/API/issues", None, REPOS)
     assert ok
 
 
 def test_repos_path_for_unconfigured_repo_denied():
-    ok, reason = authorize_github_read("/repos/other/secret/issues", None, REPOS)
+    ok, reason = authorize_github_request("GET", "/repos/other/secret/issues", None, REPOS)
     assert not ok
     assert "not a configured repository" in reason
 
 
 def test_search_scoped_to_configured_repo_allowed():
-    ok, _ = authorize_github_read(
-        "/search/issues", {"q": "repo:acme/api is:issue is:open"}, REPOS,
+    ok, _ = authorize_github_request(
+        "GET", "/search/issues", {"q": "repo:acme/api is:issue is:open"}, REPOS,
     )
     assert ok
 
 
 def test_search_without_repo_qualifier_denied():
-    ok, reason = authorize_github_read("/search/issues", {"q": "is:open bug"}, REPOS)
+    ok, reason = authorize_github_request("GET", "/search/issues", {"q": "is:open bug"}, REPOS)
     assert not ok
     assert "repo:" in reason
 
 
 def test_search_with_unconfigured_repo_denied():
-    ok, reason = authorize_github_read(
-        "/search/issues", {"q": "repo:other/secret is:open"}, REPOS,
+    ok, reason = authorize_github_request(
+        "GET", "/search/issues", {"q": "repo:other/secret is:open"}, REPOS,
     )
     assert not ok
     assert "other/secret" in reason
@@ -59,16 +59,67 @@ def test_search_with_unconfigured_repo_denied():
 
 def test_search_with_broadening_qualifier_denied():
     # org:/user: would search beyond a single configured repo.
-    ok, reason = authorize_github_read("/search/code", {"q": "org:acme foo"}, REPOS)
+    ok, reason = authorize_github_request("GET", "/search/code", {"q": "org:acme foo"}, REPOS)
     assert not ok
 
 
 def test_non_repo_paths_denied():
     for path in ("/user", "/orgs/acme/repos", "/user/repos", "/repos"):
-        ok, _ = authorize_github_read(path, None, REPOS)
+        ok, _ = authorize_github_request("GET", path, None, REPOS)
         assert not ok, path
 
 
 def test_no_configured_repos_denies_everything():
-    ok, reason = authorize_github_read("/repos/acme/api/issues", None, [])
+    ok, reason = authorize_github_request("GET", "/repos/acme/api/issues", None, [])
     assert not ok
+
+
+# --- writes -----------------------------------------------------------------
+
+
+def test_write_to_sub_resource_of_configured_repo_allowed():
+    for method, path in (
+        ("POST", "/repos/acme/api/issues"),
+        ("POST", "/repos/acme/api/issues/5/comments"),
+        ("PATCH", "/repos/acme/api/issues/5"),
+        ("PUT", "/repos/acme/api/contents/notes.md"),
+        ("POST", "/repos/acme/api/pulls/7/reviews"),
+        ("PUT", "/repos/acme/api/pulls/7/merge"),
+        ("DELETE", "/repos/acme/api/issues/comments/99"),
+    ):
+        ok, reason = authorize_github_request(method, path, None, REPOS)
+        assert ok, f"{method} {path}: {reason}"
+
+
+def test_write_to_unconfigured_repo_denied():
+    ok, reason = authorize_github_request("POST", "/repos/other/secret/issues", None, REPOS)
+    assert not ok
+    assert "not a configured repository" in reason
+
+
+def test_write_to_repo_root_denied():
+    # Deleting or reconfiguring the repository itself is refused.
+    for method in ("DELETE", "PATCH", "PUT", "POST"):
+        ok, reason = authorize_github_request(method, "/repos/acme/api", None, REPOS)
+        assert not ok, method
+        assert "repository-level" in reason
+
+
+def test_write_to_protected_admin_subresource_denied():
+    ok, reason = authorize_github_request("POST", "/repos/acme/api/transfer", None, REPOS)
+    assert not ok
+    assert "transfer" in reason
+
+
+def test_reading_repo_root_still_allowed():
+    # GET on the repo root remains fine — only writes to it are blocked.
+    ok, _ = authorize_github_request("GET", "/repos/acme/api", None, REPOS)
+    assert ok
+
+
+def test_write_to_search_denied():
+    ok, reason = authorize_github_request(
+        "POST", "/search/issues", {"q": "repo:acme/api is:open"}, REPOS,
+    )
+    assert not ok
+    assert "read-only" in reason

--- a/tests/test_github_tool.py
+++ b/tests/test_github_tool.py
@@ -1,4 +1,4 @@
-"""The github tool proxies authenticated, scoped, read-only GitHub API calls."""
+"""The github tool proxies authenticated, scoped GitHub API calls (read + write)."""
 
 from __future__ import annotations
 
@@ -119,3 +119,78 @@ async def test_diff_media_type_sets_accept_header():
     )
     assert route.calls.last.request.headers["Accept"] == "application/vnd.github.diff"
     assert "diff --git" in json.loads(out)["data"]
+
+
+@respx.mock
+async def test_post_creates_issue_with_body():
+    route = respx.post(url__regex=r"https://api\.github\.com/repos/acme/api/issues").mock(
+        return_value=httpx.Response(201, json={"number": 12, "title": "Bug"}),
+    )
+    out = await _github_handler(
+        {
+            "path": "/repos/acme/api/issues",
+            "method": "POST",
+            "body": {"title": "Bug", "body": "It broke"},
+        },
+        **_kwargs(),
+    )
+    assert route.called
+    req = route.calls.last.request
+    assert req.method == "POST"
+    assert req.headers["Authorization"] == f"Bearer {_PAT}"
+    assert json.loads(req.content) == {"title": "Bug", "body": "It broke"}
+
+    data = json.loads(out)
+    assert data["status"] == 201
+    assert data["data"]["number"] == 12
+    assert _PAT not in out
+
+
+@respx.mock
+async def test_patch_closes_issue():
+    route = respx.patch(url__regex=r"https://api\.github\.com/repos/acme/api/issues/5").mock(
+        return_value=httpx.Response(200, json={"number": 5, "state": "closed"}),
+    )
+    out = await _github_handler(
+        {
+            "path": "/repos/acme/api/issues/5",
+            "method": "patch",  # case-insensitive
+            "body": {"state": "closed"},
+        },
+        **_kwargs(),
+    )
+    assert route.calls.last.request.method == "PATCH"
+    assert json.loads(out)["data"]["state"] == "closed"
+
+
+@respx.mock
+async def test_delete_returns_empty_body_as_null():
+    route = respx.delete(
+        url__regex=r"https://api\.github\.com/repos/acme/api/issues/comments/9",
+    ).mock(return_value=httpx.Response(204))
+    out = await _github_handler(
+        {"path": "/repos/acme/api/issues/comments/9", "method": "DELETE"}, **_kwargs(),
+    )
+    assert route.calls.last.request.method == "DELETE"
+    data = json.loads(out)
+    assert data["status"] == 204
+    assert data["data"] is None
+
+
+@respx.mock
+async def test_write_to_repo_root_blocked_without_calling_github():
+    route = respx.route(url__regex=r"https://api\.github\.com/.*").mock(
+        return_value=httpx.Response(200, json={}),
+    )
+    out = await _github_handler(
+        {"path": "/repos/acme/api", "method": "DELETE"}, **_kwargs(),
+    )
+    assert json.loads(out)["code"] == "out_of_scope"
+    assert not route.called  # never hit GitHub for a blocked repo-level delete
+
+
+async def test_unsupported_method_rejected():
+    out = await _github_handler(
+        {"path": "/repos/acme/api/issues", "method": "HEAD"}, **_kwargs(),
+    )
+    assert "Unsupported method" in json.loads(out)["error"]

--- a/tests/test_slack_fetch_channel_context.py
+++ b/tests/test_slack_fetch_channel_context.py
@@ -161,3 +161,18 @@ async def test_fetch_handles_non_dict_slack_response():
     assert meta.name == "eng" and meta.purpose == "prod"   # info_resp.get survived
     assert [m.text for m in msgs] == ["hello"]             # hist.get('messages') survived
     assert msgs[0].author == "name-U1"                     # users_info.get survived
+
+
+async def test_fetch_populates_author_id():
+    """author_id carries the raw Slack user id; author stays the display name."""
+    info = {"name": "surogate", "is_im": False, "is_mpim": False}
+    page = {"messages": [
+        {"user": "U063C2DB7GW", "text": "hi", "ts": "3.0"},
+    ], "has_more": False, "response_metadata": {"next_cursor": ""}}
+    p = _platform_with(FakeClient(info, [page]))
+    out = await p.fetch_channel_context(
+        creds={"bot_token": "xoxb"}, channel_id="C1", limits=BackfillLimits())
+    assert out is not None
+    _meta, msgs = out
+    assert msgs[0].author == "name-U063C2DB7GW"   # display name resolved
+    assert msgs[0].author_id == "U063C2DB7GW"     # raw Slack id preserved


### PR DESCRIPTION
## What

The built-in `github` tool was GET-only by design, so an agent could answer questions about its configured repos but had to fall back to the coding agent for any change — even a one-line issue comment. This makes it method-aware.

- New **`method`** arg — `GET` (default, unchanged) plus `POST`/`PATCH`/`PUT`/`DELETE`.
- New **`body`** arg — JSON payload for writes.
- `_github_get` → `_github_request`, dispatching via `client.request(method, …)`; empty responses (e.g. `204` from DELETE) return `data: null`.
- Schema description rewritten to advertise writes with worked examples (open issue, comment, close) — this is what the agent reads, so it stops describing itself as GET-only.

## Guardrails

Writes stay scoped to configured repos and are refused on:
- the **repo root** `/repos/{owner}/{repo}` — no accidental repo delete/rename;
- **protected admin sub-resources** (`transfer`);
- `/search` — search remains read-only.

Actual permission still comes from the connected PAT's own scopes; the tool doesn't widen the token.

## Tests

30 pass across `test_github_scope.py`, `test_github_tool.py`, `test_github_tool_wiring.py`, including create/close issue, DELETE→null, repo-root block, `transfer` block, search-write block, and unsupported-method rejection.

## Deploy note

Lives in the harness wheel that surogate-ops pins — reaching PROD agents needs a surogates release + dependent bundle/runtime bump.