### PR TITLE
feat(channels): replace slack answer button with the submitted answer

### DIFF
--- a/surogates/channels/platforms/slack.py
+++ b/surogates/channels/platforms/slack.py
@@ -789,6 +789,7 @@ class SlackPlatform:
             ANSWER_ACTION_ID,
             MODAL_CALLBACK_ID,
             ModalErrors,
+            build_answered_blocks,
             build_question_modal,
             parse_modal_submission,
         )
@@ -825,10 +826,19 @@ class SlackPlatform:
                 )
                 if not pending:
                     return Response(status_code=200)
+                # Carry the clicked message's coordinates through the modal so
+                # the submit handler can replace the Answer button with the
+                # submitted answer.  view_submission payloads don't include them.
+                container = payload.get("container") or {}
+                message = payload.get("message") or {}
+                channel_id = (payload.get("channel") or {}).get("id") or ""
+                message_ts = container.get("message_ts") or message.get("ts") or ""
                 view = build_question_modal(
                     session_id=session_id,
                     tool_call_id=pending["tool_call_id"],
                     questions=pending["questions"],
+                    channel=channel_id,
+                    message_ts=message_ts,
                 )
                 await self._get_client((creds or {}).get("bot_token") or "").views_open(
                     trigger_id=payload.get("trigger_id"),
@@ -854,12 +864,33 @@ class SlackPlatform:
                 parsed = parse_modal_submission(view, pending["questions"])
                 if isinstance(parsed, ModalErrors):
                     return JSONResponse(parsed.to_response(), status_code=200)
-                await interactive_input.resolve_input_response(
+                resolved = await interactive_input.resolve_input_response(
                     deps.session_store,
                     session_id=parsed.session_id,
                     tool_call_id=parsed.tool_call_id,
                     responses=parsed.responses,
                 )
+                # On the winning submit, replace the now-dead Answer button with
+                # the submitted answer.  Stale/duplicate submits (resolved False)
+                # leave the message the first submitter already updated.
+                channel_id = meta.get("channel") or ""
+                message_ts = meta.get("message_ts") or ""
+                if resolved and channel_id and message_ts:
+                    answered_text, answered_blocks = build_answered_blocks(parsed.responses)
+                    try:
+                        await self._get_client(
+                            (creds or {}).get("bot_token") or ""
+                        ).chat_update(
+                            channel=channel_id,
+                            ts=message_ts,
+                            text=answered_text,
+                            blocks=answered_blocks,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "[SlackPlatform] /interact answered chat_update failed",
+                            exc_info=True,
+                        )
             except Exception:
                 logger.warning("[SlackPlatform] /interact view_submission resolve failed", exc_info=True)
             return Response(status_code=200)

--- a/surogates/channels/platforms/slack_interactive.py
+++ b/surogates/channels/platforms/slack_interactive.py
@@ -68,11 +68,35 @@ def build_input_prompt_blocks(
     return text, blocks
 
 
+def build_answered_blocks(responses: list[dict]) -> tuple[str, list[dict]]:
+    """Render a resolved input prompt: the submitted answer(s), no button.
+
+    Replaces the original Answer-button message via ``chat.update`` once the
+    user submits the modal, so the thread shows what was answered instead of a
+    now-dead button.  ``responses`` are the ``parse_modal_submission`` entries
+    (each ``{"question", "answer", "is_other"}``).
+    """
+    blocks: list[dict] = [
+        {"type": "section", "text": _mrkdwn("✅ *Answered*")},
+    ]
+    summary: list[str] = []
+    for response in responses:
+        question = (response.get("question") or "").strip()
+        answer = (response.get("answer") or "").strip()
+        body = f"*{question}*\n> {answer}" if question else f"> {answer}"
+        blocks.append({"type": "section", "text": _mrkdwn(body)})
+        summary.append(f"{question}: {answer}" if question else answer)
+    text = "Answered — " + "; ".join(summary) if summary else "Answered"
+    return text, blocks
+
+
 def build_question_modal(
     *,
     session_id: str,
     tool_call_id: str,
     questions: list[dict],
+    channel: str = "",
+    message_ts: str = "",
 ) -> dict:
     blocks: list[dict] = []
     for index, question in enumerate(questions):
@@ -130,7 +154,12 @@ def build_question_modal(
         "type": "modal",
         "callback_id": MODAL_CALLBACK_ID,
         "private_metadata": json.dumps(
-            {"session_id": str(session_id), "tool_call_id": str(tool_call_id)},
+            {
+                "session_id": str(session_id),
+                "tool_call_id": str(tool_call_id),
+                "channel": str(channel),
+                "message_ts": str(message_ts),
+            },
             separators=(",", ":"),
         ),
         "title": _plain("Answer", limit=24),

--- a/tests/test_slack_input_interactive.py
+++ b/tests/test_slack_input_interactive.py
@@ -9,6 +9,7 @@ class _Client:
         self.views_open_raises = views_open_raises
         self.views = []
         self.messages = []
+        self.updates = []
 
     async def views_open(self, **kwargs):
         if self.views_open_raises:
@@ -19,6 +20,10 @@ class _Client:
     async def chat_postMessage(self, **kwargs):
         self.messages.append(kwargs)
         return {"ts": "901.0"}
+
+    async def chat_update(self, **kwargs):
+        self.updates.append(kwargs)
+        return {"ok": True}
 
 
 class _Store:
@@ -52,10 +57,17 @@ def _block_actions_form(session_id="s1", tool_call_id="tc1"):
     return {"payload": json.dumps(payload)}
 
 
-def _view_submission_form(session_id="s1", tool_call_id="tc1", value="blue"):
+def _view_submission_form(
+    session_id="s1", tool_call_id="tc1", value="blue", channel="", message_ts=""
+):
     view = {
         "callback_id": "surogates_input_modal",
-        "private_metadata": json.dumps({"session_id": session_id, "tool_call_id": tool_call_id}),
+        "private_metadata": json.dumps({
+            "session_id": session_id,
+            "tool_call_id": tool_call_id,
+            "channel": channel,
+            "message_ts": message_ts,
+        }),
         "state": {"values": {"q0_other": {"q0_other": {
             "type": "plain_text_input",
             "value": value,
@@ -87,6 +99,66 @@ async def test_answer_click_opens_modal(monkeypatch):
     assert result.status_code == 200
     assert client.views[0]["trigger_id"] == "trig1"
     assert client.views[0]["view"]["callback_id"] == "surogates_input_modal"
+    meta = json.loads(client.views[0]["view"]["private_metadata"])
+    assert meta["channel"] == "C1"
+    assert meta["message_ts"] == "100.0"
+
+
+async def test_view_submission_updates_message_on_success(monkeypatch):
+    from surogates.session import interactive_input
+
+    async def fake_pending(store, *, session_id, tool_call_id=None):
+        return {"tool_call_id": "tc1", "questions": [{"prompt": "Anything?"}], "context": ""}
+
+    async def fake_resolve(store, *, session_id, tool_call_id, responses):
+        return True
+
+    monkeypatch.setattr(interactive_input, "pending_input_for_session", fake_pending)
+    monkeypatch.setattr(interactive_input, "resolve_input_response", fake_resolve)
+    client = _Client()
+
+    result = await _platform_with(client).handle_interactive(
+        "/slack/{app_id}/interact",
+        _view_submission_form(channel="C1", message_ts="100.0", value="use a tunnel"),
+        request=SimpleNamespace(),
+        creds={"bot_token": "x"},
+        routing=None,
+        deps=_Deps(),
+    )
+
+    assert result.status_code == 200
+    assert len(client.updates) == 1
+    update = client.updates[0]
+    assert update["channel"] == "C1"
+    assert update["ts"] == "100.0"
+    assert all(b.get("type") != "actions" for b in update["blocks"])
+    assert "use a tunnel" in json.dumps(update["blocks"])
+
+
+async def test_view_submission_no_update_when_resolve_is_stale(monkeypatch):
+    from surogates.session import interactive_input
+
+    async def fake_pending(store, *, session_id, tool_call_id=None):
+        return {"tool_call_id": "tc1", "questions": [{"prompt": "Anything?"}], "context": ""}
+
+    async def fake_resolve(store, *, session_id, tool_call_id, responses):
+        return False  # already answered by a concurrent submit
+
+    monkeypatch.setattr(interactive_input, "pending_input_for_session", fake_pending)
+    monkeypatch.setattr(interactive_input, "resolve_input_response", fake_resolve)
+    client = _Client()
+
+    result = await _platform_with(client).handle_interactive(
+        "/slack/{app_id}/interact",
+        _view_submission_form(channel="C1", message_ts="100.0"),
+        request=SimpleNamespace(),
+        creds={"bot_token": "x"},
+        routing=None,
+        deps=_Deps(),
+    )
+
+    assert result.status_code == 200
+    assert client.updates == []
 
 
 async def test_view_submission_resolves(monkeypatch):

--- a/tests/test_slack_interactive_blocks.py
+++ b/tests/test_slack_interactive_blocks.py
@@ -42,7 +42,12 @@ def test_modal_has_deterministic_ids_and_metadata():
 
     assert view["type"] == "modal"
     assert view["callback_id"] == MODAL_CALLBACK_ID
-    assert json.loads(view["private_metadata"]) == {"session_id": "s1", "tool_call_id": "tc1"}
+    assert json.loads(view["private_metadata"]) == {
+        "session_id": "s1",
+        "tool_call_id": "tc1",
+        "channel": "",
+        "message_ts": "",
+    }
     block_ids = [b["block_id"] for b in view["blocks"]]
     assert block_ids == ["q0_choice", "q0_other", "q1_other"]
 
@@ -108,3 +113,39 @@ def test_parse_free_text_answer():
     assert parsed.responses == [
         {"question": "Anything else?", "answer": "use a tunnel", "is_other": True},
     ]
+
+
+def test_modal_embeds_message_coords_in_metadata():
+    view = build_question_modal(
+        session_id="s1",
+        tool_call_id="tc1",
+        questions=[Q_FREE],
+        channel="C1",
+        message_ts="100.0",
+    )
+
+    meta = json.loads(view["private_metadata"])
+    assert meta["session_id"] == "s1"
+    assert meta["tool_call_id"] == "tc1"
+    assert meta["channel"] == "C1"
+    assert meta["message_ts"] == "100.0"
+
+
+def test_answered_blocks_render_qa_without_button():
+    from surogates.channels.platforms.slack_interactive import build_answered_blocks
+
+    text, blocks = build_answered_blocks(
+        [
+            {"question": "Which color?", "answer": "blue", "is_other": False},
+            {"question": "Anything else?", "answer": "make it bold", "is_other": True},
+        ],
+    )
+
+    # The button is gone: no actions block survives the replacement.
+    assert all(b.get("type") != "actions" for b in blocks)
+    flat = json.dumps(blocks)
+    assert "Answered" in flat
+    assert "Which color?" in flat and "blue" in flat
+    assert "Anything else?" in flat and "make it bold" in flat
+    # Fallback text carries the answers for notifications/accessibility.
+    assert "blue" in text and "make it bold" in text


### PR DESCRIPTION
When a user submits the ask_user_question modal on Slack, replace the original prompt message's Answer button with the submitted answer.

## What
- On the winning modal submit, `chat.update` the original message: drop the Answer button, render `✅ Answered` plus each question and its submitted answer.
- The button-click stashes the message channel + ts in the modal `private_metadata` (view_submission payloads omit them), so the submit handler knows which message to edit.
- The update runs only when `resolve_input_response` wins, so stale/duplicate submits leave the first submitter's update intact. Missing coords / update failures are best-effort and never break the ack.

## Why
Previously the Answer button stayed live after submission — clicking it again reopened a modal for an already-answered question. Replacing it closes the loop visually.

## Tests
New coverage in `test_slack_interactive_blocks` (answered-block builder, modal metadata carries coords) and `test_slack_input_interactive` (updates message on winning submit, no update on stale). 84 tests green across the interactive-input surface.