### PR TITLE
fix(channels): let the read tool see bot-posted channel history

### DIFF
--- a/surogates/channels/channel_backfill.py
+++ b/surogates/channels/channel_backfill.py
@@ -54,18 +54,142 @@ class ChannelMeta:
     purpose: str
 
 
-def filter_messages(messages: list[dict], *, bot_user_id: str) -> list[dict]:
-    """Drop own-bot messages, other bots, and any subtyped system message."""
+# Slack system / noise message subtypes — joins, topic changes, etc. — carry
+# nothing an agent needs to read, so they are dropped on every path.
+_SYSTEM_SUBTYPES = frozenset({
+    "channel_join", "channel_leave", "channel_topic", "channel_purpose",
+    "channel_name", "channel_archive", "channel_unarchive",
+    "group_join", "group_leave", "group_topic", "group_purpose",
+    "group_name", "group_archive", "group_unarchive",
+    "pinned_item", "unpinned_item", "bot_add", "bot_remove", "tombstone",
+})
+
+
+def filter_messages(
+    messages: list[dict], *, bot_user_id: str, drop_bots: bool = True
+) -> list[dict]:
+    """Filter raw Slack messages for agent consumption.
+
+    Always drops the agent's own posts and Slack system messages (joins, topic
+    changes, …). When *drop_bots* is True — the trigger/backfill path — it also
+    drops every bot- or app-posted message and any subtyped message, so the
+    agent never wakes on or is seeded with automated posts. When False — the
+    on-demand ``fetch_channel_messages`` read path — bot/app posts are kept:
+    reading a channel's daily report bots is the whole point of that tool.
+    """
     out: list[dict] = []
     for m in messages:
         if bot_user_id and m.get("user") == bot_user_id:
             continue
-        if m.get("bot_id") or m.get("subtype"):
+        if (m.get("subtype") or "") in _SYSTEM_SUBTYPES:
             continue
-        if not (m.get("text") or "").strip() and not (m.get("files") or []):
+        if drop_bots and (m.get("bot_id") or m.get("subtype")):
+            continue
+        if (
+            not (m.get("text") or "").strip()
+            and not (m.get("files") or [])
+            and not (m.get("blocks") or [])
+        ):
             continue
         out.append(m)
     return out
+
+
+def _render_leaf(el: dict) -> str:
+    """Render one Block Kit rich-text leaf element to text."""
+    t = el.get("type")
+    if t == "text":
+        return el.get("text") or ""
+    if t == "emoji":
+        return f":{el.get('name', '')}:"
+    if t == "link":
+        url = el.get("url") or ""
+        for scheme in ("mailto:", "tel:"):
+            if url.startswith(scheme):
+                url = url[len(scheme):]
+                break
+        return el.get("text") or url
+    if t == "user":
+        return f"@{el.get('user_id', '')}"
+    if t == "usergroup":
+        return f"@{el.get('usergroup_id', '')}"
+    if t == "channel":
+        return f"#{el.get('channel_id', '')}"
+    if t == "broadcast":
+        return f"@{el.get('range', '')}"
+    return el.get("text") or ""
+
+
+def _render_leaves(elements) -> str:
+    return "".join(_render_leaf(x) for x in (elements or []))
+
+
+def _render_rich_text_container(el: dict) -> str:
+    """Render a rich_text container (section / list / quote / preformatted)."""
+    t = el.get("type")
+    if t == "rich_text_list":
+        ordered = el.get("style") == "ordered"
+        lines = []
+        for i, item in enumerate(el.get("elements") or [], start=1):
+            body = _render_leaves(item.get("elements"))
+            if body:
+                lines.append(f"{i}. {body}" if ordered else f"- {body}")
+        return "\n".join(lines)
+    body = _render_leaves(el.get("elements"))
+    if t == "rich_text_quote":
+        return "\n".join(f"> {ln}" if ln else ">" for ln in body.split("\n"))
+    return body  # rich_text_section, rich_text_preformatted
+
+
+def _render_rich_text_block(block: dict) -> str:
+    return "".join(
+        _render_rich_text_container(el) for el in (block.get("elements") or []))
+
+
+def _render_table_block(block: dict) -> str:
+    """Render a Block Kit table as pipe-delimited rows (each cell is itself a
+    rich_text block)."""
+    lines = []
+    for row in block.get("rows") or []:
+        cells = [
+            _render_rich_text_block(cell).strip().replace("\n", " ")
+            for cell in row
+        ]
+        lines.append(" | ".join(cells))
+    return "\n".join(lines)
+
+
+def _plain_text(obj) -> str:
+    return obj.get("text") or "" if isinstance(obj, dict) else ""
+
+
+def render_blocks(blocks: list[dict]) -> str:
+    """Flatten Slack Block Kit *blocks* to plain text.
+
+    Bot-posted reports (daily stats, compliance scans, …) carry their substance
+    in ``rich_text`` and ``table`` blocks while the message ``text`` field holds
+    only a short fallback summary. Rendering the blocks lets tabular report data
+    survive into the text an agent reads. Unknown block types are skipped;
+    returns ``""`` when nothing renders.
+    """
+    parts: list[str] = []
+    for b in blocks or []:
+        t = b.get("type")
+        if t == "rich_text":
+            parts.append(_render_rich_text_block(b))
+        elif t == "table":
+            parts.append(_render_table_block(b))
+        elif t in ("section", "header"):
+            parts.append(_plain_text(b.get("text")))
+            for field in b.get("fields") or []:
+                parts.append(_plain_text(field))
+        elif t == "context":
+            parts.append(" ".join(
+                _plain_text(e) or _render_leaf(e)
+                for e in (b.get("elements") or [])))
+        # divider / image / actions / … carry no readable text — skip.
+    rendered = "\n".join(p for p in parts if p and p.strip())
+    return re.sub(r"\n{3,}", "\n\n", rendered).strip()
 
 
 def _est_tokens(text: str) -> int:

--- a/surogates/channels/message_fetch.py
+++ b/surogates/channels/message_fetch.py
@@ -83,7 +83,7 @@ async def fetch_channel_messages(
         pages = _FILTER_MAX_PAGES if (user_query or since_cutoff is not None) else 1
         limits = BackfillLimits(max_pages=pages)
         result = await platform.fetch_channel_context(
-            creds=creds, channel_id=channel_id, limits=limits,
+            creds=creds, channel_id=channel_id, limits=limits, include_bots=True,
         )
     except Exception:
         _log.warning(

--- a/surogates/channels/platforms/slack.py
+++ b/surogates/channels/platforms/slack.py
@@ -69,6 +69,7 @@ from surogates.channels.channel_backfill import (
     ChannelMeta,
     RawMessage,
     filter_messages,
+    render_blocks,
     warm_cache as _warm_cache_fn,
 )
 from surogates.channels.inbound import InboundFileRef, InboundMessage
@@ -1261,12 +1262,17 @@ class SlackPlatform:
 
     async def fetch_channel_context(
         self, *, creds: dict, channel_id: str, limits: BackfillLimits,
+        include_bots: bool = False,
     ) -> tuple[ChannelMeta, list[RawMessage]] | None:
         """Fetch channel metadata + recent history (newest-first).
 
         Returns None for DMs/MPDMs (v1 is channel-only), when the bot is not a
         member, or on any Slack error. Bounding by count/token/age is the
         coordinator's job; here we only honour the page + time budgets.
+
+        With *include_bots* True (the on-demand read path) bot- and app-posted
+        messages are kept and their Block Kit tables are flattened into text;
+        the default (trigger/backfill path) drops them.
         """
         bot_token: str = (creds or {}).get("bot_token") or ""
         if not bot_token:
@@ -1317,7 +1323,9 @@ class SlackPlatform:
                         break
                     raise
                 msgs = hist.get("messages") or []
-                for m in filter_messages(msgs, bot_user_id=bot_user_id):
+                for m in filter_messages(
+                    msgs, bot_user_id=bot_user_id, drop_bots=not include_bots
+                ):
                     try:
                         ts = float(m.get("ts") or 0.0)
                     except (TypeError, ValueError):
@@ -1328,10 +1336,20 @@ class SlackPlatform:
                         for f in (m.get("files") or [])
                         if f.get("id")
                     )
+                    text = (m.get("text") or "").strip()
+                    blocks = m.get("blocks") or []
+                    # The `text` field is only a fallback summary for block-based
+                    # posts; render the blocks when they carry a table (report
+                    # data absent from `text`) or when `text` is empty.
+                    if blocks and (
+                        not text
+                        or any(b.get("type") == "table" for b in blocks)
+                    ):
+                        text = (render_blocks(blocks) or text).strip()
                     raw.append(RawMessage(
                         ts=ts,
                         author=author,
-                        text=(m.get("text") or "").strip(),
+                        text=text,
                         files=files,
                         author_id=(m.get("user") or ""),
                     ))

--- a/tests/test_channel_backfill_core.py
+++ b/tests/test_channel_backfill_core.py
@@ -1,7 +1,7 @@
 from surogates.channels.channel_backfill import (
     BACKFILL_HEADER,
     BackfillLimits, RawMessage, ChannelMeta,
-    filter_messages, bound_messages, format_context_block,
+    filter_messages, bound_messages, format_context_block, render_blocks,
 )
 
 DAY = 86400.0
@@ -15,6 +15,58 @@ def test_filter_drops_bots_subtypes_and_own():
     ]
     kept = filter_messages(msgs, bot_user_id="U_BOT")
     assert [m["text"] for m in kept] == ["hello"]
+
+def test_filter_keeps_bots_when_drop_bots_false():
+    """The read path keeps bot/app posts (daily reports) but still drops the
+    agent's own posts and Slack system messages."""
+    msgs = [
+        {"user": "U_HUMAN", "text": "hello", "ts": "4.0"},
+        {"user": "U_WEBHOOK", "bot_id": "B1", "text": "PostHog Daily", "ts": "3.0"},
+        {"user": "U_BOT", "text": "i am agent", "ts": "2.0"},              # own bot
+        {"user": "U_HUMAN", "subtype": "channel_join", "text": "joined", "ts": "1.0"},
+    ]
+    kept = filter_messages(msgs, bot_user_id="U_BOT", drop_bots=False)
+    assert [m["text"] for m in kept] == ["hello", "PostHog Daily"]
+
+def test_filter_keeps_block_only_bot_message_when_drop_bots_false():
+    """A bot message with no text but Block Kit content is readable."""
+    msgs = [{"user": "U_WEBHOOK", "bot_id": "B1", "text": "",
+             "blocks": [{"type": "table", "rows": []}], "ts": "1.0"}]
+    kept = filter_messages(msgs, bot_user_id="U_BOT", drop_bots=False)
+    assert len(kept) == 1
+
+def test_render_blocks_flattens_rich_text_and_table():
+    blocks = [
+        {"type": "rich_text", "elements": [{"type": "rich_text_section", "elements": [
+            {"type": "emoji", "name": "bar_chart"},
+            {"type": "text", "text": " PostHog Daily", "style": {"italic": True}},
+        ]}]},
+        {"type": "table", "rows": [
+            [_cell("Metric"), _cell("24h"), _cell("Prev 24h")],
+            [_cell("Active Users (PV)"), _cell("17"), _cell("10")],
+            [_cell("Total Events"), _cell("287"), _cell("194")],
+        ]},
+    ]
+    out = render_blocks(blocks)
+    assert "PostHog Daily" in out
+    assert "Metric | 24h | Prev 24h" in out
+    assert "Active Users (PV) | 17 | 10" in out
+    assert "Total Events | 287 | 194" in out
+
+def test_render_blocks_strips_mailto_scheme_from_bare_links():
+    blocks = [{"type": "table", "rows": [
+        [{"type": "rich_text", "elements": [{"type": "rich_text_section", "elements": [
+            {"type": "link", "url": "mailto:user@example.com"}]}]}]]}]
+    assert render_blocks(blocks) == "user@example.com"
+
+def test_render_blocks_empty_returns_empty_string():
+    assert render_blocks([]) == ""
+    assert render_blocks([{"type": "divider"}]) == ""
+
+def _cell(text):
+    """A Block Kit table cell (itself a rich_text block)."""
+    return {"type": "rich_text", "elements": [
+        {"type": "rich_text_section", "elements": [{"type": "text", "text": text}]}]}
 
 def test_bound_message_cap_keeps_newest_returns_oldest_first():
     now = 100 * DAY

--- a/tests/test_channel_message_fetch.py
+++ b/tests/test_channel_message_fetch.py
@@ -16,9 +16,10 @@ def _platform(context_result, *, capture=None):
     descriptor = types.SimpleNamespace(
         vault_refs=lambda identifier: {"bot_token": "bot_token"})
 
-    async def _fetch_channel_context(*, creds, channel_id, limits):
+    async def _fetch_channel_context(*, creds, channel_id, limits, include_bots=False):
         if capture is not None:
             capture["limits"] = limits
+            capture["include_bots"] = include_bots
         return context_result
 
     return types.SimpleNamespace(
@@ -28,6 +29,20 @@ def _platform(context_result, *, capture=None):
 class _Vault:
     async def resolve_ref(self, ref, *, org_id):
         return "xoxb-token"
+
+
+async def test_read_path_requests_bot_messages():
+    """The on-demand tool must read bot/app posts (daily reports), so it asks
+    fetch_channel_context to include them."""
+    capture = {}
+    meta = ChannelMeta(name="reports", topic="", purpose="")
+    msgs = [RawMessage(ts=NOW - 10, author="bot", text="PostHog Daily", author_id="U1")]
+    platform = _platform((meta, msgs), capture=capture)
+    await fetch_channel_messages(
+        platform=platform, vault=_Vault(),
+        session=_session({"channel_identifier": "A1", "slack_channel_id": "C1"}),
+        limit=50, since=None, user=None, now=NOW)
+    assert capture["include_bots"] is True
 
 
 async def test_happy_path_filters_and_formats():

--- a/tests/test_slack_fetch_channel_context.py
+++ b/tests/test_slack_fetch_channel_context.py
@@ -163,6 +163,60 @@ async def test_fetch_handles_non_dict_slack_response():
     assert msgs[0].author == "name-U1"                     # users_info.get survived
 
 
+def _cell(text):
+    return {"type": "rich_text", "elements": [
+        {"type": "rich_text_section", "elements": [{"type": "text", "text": text}]}]}
+
+
+_REPORT_MSG = {
+    "user": "U_WEBHOOK", "bot_id": "B_REPORT", "ts": "5.0",
+    "text": ":bar_chart: PostHog Daily",   # fallback summary; tables live in blocks
+    "blocks": [
+        {"type": "rich_text", "elements": [{"type": "rich_text_section", "elements": [
+            {"type": "text", "text": "PostHog Daily"}]}]},
+        {"type": "table", "rows": [
+            [_cell("Metric"), _cell("24h")],
+            [_cell("Active Users (PV)"), _cell("17")],
+        ]},
+    ],
+}
+
+
+async def test_fetch_drops_bot_messages_by_default():
+    """The trigger/backfill path (include_bots=False) still drops bot posts."""
+    info = {"name": "reports", "is_im": False, "is_mpim": False}
+    page = {"messages": [
+        dict(_REPORT_MSG),
+        {"user": "U1", "text": "human msg", "ts": "4.0"},
+    ], "has_more": False, "response_metadata": {"next_cursor": ""}}
+    p = _platform_with(FakeClient(info, [page]))
+    out = await p.fetch_channel_context(
+        creds={"bot_token": "xoxb"}, channel_id="C1", limits=BackfillLimits())
+    assert out is not None
+    _meta, msgs = out
+    assert [m.text for m in msgs] == ["human msg"]   # bot report dropped
+
+
+async def test_fetch_include_bots_keeps_reports_and_renders_tables():
+    """The read path (include_bots=True) keeps bot reports and flattens their
+    Block Kit tables into the message text an agent reads."""
+    info = {"name": "reports", "is_im": False, "is_mpim": False}
+    page = {"messages": [
+        dict(_REPORT_MSG),
+        {"user": "U1", "text": "human msg", "ts": "4.0"},
+    ], "has_more": False, "response_metadata": {"next_cursor": ""}}
+    p = _platform_with(FakeClient(info, [page]))
+    out = await p.fetch_channel_context(
+        creds={"bot_token": "xoxb"}, channel_id="C1",
+        limits=BackfillLimits(), include_bots=True)
+    assert out is not None
+    _meta, msgs = out
+    assert [m.author_id for m in msgs] == ["U_WEBHOOK", "U1"]   # report kept
+    report_text = msgs[0].text
+    assert "Metric | 24h" in report_text
+    assert "Active Users (PV) | 17" in report_text     # table data recovered
+
+
 async def test_fetch_populates_author_id():
     """author_id carries the raw Slack user id; author stays the display name."""
     info = {"name": "surogate", "is_im": False, "is_mpim": False}


### PR DESCRIPTION
## Problem

A Surogate agent responding in a Slack channel could only ever see the **single human message that triggered it** — never the channel's historical bot-posted reports (e.g. daily "PostHog Daily" stat tables). On #surogate-reports this reduced 25 real messages to 1.

**Root cause:** `fetch_channel_messages` (the agent's on-demand read tool) and the backfill seed shared one filter (`filter_messages`) that dropped every message carrying a `bot_id` or `subtype`. That's correct for the **wake/trigger** and **backfill** paths (don't auto-wake on or seed automated posts), but wrong for the **read** tool, whose whole purpose is to let the agent read what's in the channel — including report bots. Verified against live PROD data: the shared filter dropped 18 of 18 report posts.

## Fix

1. **Split trigger vs. read.** `filter_messages` gains a `drop_bots` flag (default `True`, so the wake/backfill paths are unchanged); `fetch_channel_context` gains `include_bots`, set `True` only on the `fetch_channel_messages` read path. System/noise subtypes (joins, topic changes, …) are still dropped on every path.

2. **Block Kit rendering.** Report bots carry their stat tables in Block Kit `table`/`rich_text` blocks while the message `text` field holds only a short summary. New `render_blocks` flattens those blocks (tables → pipe-delimited rows) and is applied when a message has tabular blocks or an empty `text` field. Also strips `mailto:`/`tel:` schemes from bare links so per-user email keys read cleanly.

## Verification

Replayed the patched code against live PROD #surogate-reports data:

- Read path: **1 → 19** messages now visible (the 6 still dropped are `channel_join`/`channel_name` system messages).
- The newest report renders with its full stat table (Active Users, Total Events, per-user Top Users, AI summary).
- TDD (red→green); 51 tests passing across the touched suites. The 2 unrelated `test_worker_channel_token` failures pre-exist on a clean tree.

## Rollout note

Ships in `surogates`, which runs in PROD as `runtime-worker` — needs a `surogates` wheel release + rollout before the live agent benefits.