### PR TITLE
fix(scheduled): reap active schedules that expire between ticks

### DIFF
--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -601,6 +601,11 @@ class ScheduledSession(Base):
             postgresql_where=text("status = 'active'"),
         ),
         Index("idx_scheduled_sessions_lock", "locked_until"),
+        Index(
+            "idx_scheduled_sessions_expiry",
+            "expires_at",
+            postgresql_where=text("status = 'active'"),
+        ),
         CheckConstraint(
             "(user_id IS NOT NULL)::int + (service_account_id IS NOT NULL)::int = 1",
             name="ck_scheduled_sessions_one_principal",

--- a/surogates/db/observability.sql
+++ b/surogates/db/observability.sql
@@ -144,6 +144,13 @@ CREATE INDEX IF NOT EXISTS idx_scheduled_sessions_due
 CREATE INDEX IF NOT EXISTS idx_scheduled_sessions_lock
     ON scheduled_sessions (locked_until);
 
+-- expire_active_schedules (the per-tick expiry sweep) filters+orders active
+-- schedules by expires_at.  Partial index over active rows only so the planner
+-- range-scans the expired rows instead of scanning + sorting the active set.
+CREATE INDEX IF NOT EXISTS idx_scheduled_sessions_expiry
+    ON scheduled_sessions (expires_at)
+    WHERE status = 'active';
+
 
 -- BYO Firebase self-registration: namespaced ``auth_provider`` plus
 -- partial unique index guarantees that two BYO Firebase projects can

--- a/surogates/scheduled/materialize.py
+++ b/surogates/scheduled/materialize.py
@@ -142,9 +142,10 @@ async def recover_stalled_loops(
     stale_seconds: int = DYNAMIC_LOOP_STALE_RUN_SECONDS,
     limit: int = 100,
 ) -> None:
-    """Sweep dynamic loops whose run stalled, across all tenants.
+    """Sweep dynamic loops whose run stalled, across all tenants, and reap
+    schedules that have passed their ``expires_at``.
 
-    Two failure modes:
+    Two dynamic-loop failure modes:
 
     * The worker died mid-run (run row still ``active`` but its lease
       lapsed and it hasn't progressed) — re-enqueue the same run so a
@@ -152,7 +153,19 @@ async def recover_stalled_loops(
     * The run reached a terminal state without rescheduling (never called
       ``loop_wait``) — :meth:`recover_stalled_dynamic_loops` reschedules
       it with the fallback delay.
+
+    Plus the expiry sweep: a schedule whose ``expires_at`` falls between its
+    last run and its next due instant expires *unclaimed* (the claim query
+    excludes expired rows), so it never reaches the completion code and stays
+    ``active`` forever. :meth:`expire_active_schedules` transitions those.
     """
+    expired = await scheduled_store.expire_active_schedules(limit=limit)
+    for schedule in expired:
+        logger.info(
+            "Expired schedule %s (past expires_at) → completed",
+            schedule.id,
+        )
+
     retryable = await scheduled_store.find_retryable_stalled_dynamic_loop_runs(
         stale_seconds=stale_seconds,
         limit=limit,

--- a/surogates/scheduled/store.py
+++ b/surogates/scheduled/store.py
@@ -420,6 +420,61 @@ class ScheduledSessionStore:
             await db.commit()
         return rows
 
+    async def expire_active_schedules(
+        self,
+        *,
+        agent_id: str | None = None,
+        limit: int = 100,
+    ) -> list[ScheduledSession]:
+        """Transition schedules past ``expires_at`` from ``active`` to
+        ``completed``.
+
+        The claim queries (:meth:`claim_due` / :meth:`find_due_across_tenants`)
+        exclude rows with ``expires_at <= now()``, and the expiry check in
+        :meth:`mark_run_created` only runs on a successful claim. A schedule
+        whose ``expires_at`` falls between its last run and its next due instant
+        therefore expires *unclaimed* — it can never be claimed again, so the
+        completion code never runs and the row is stuck ``active`` forever
+        (still ``next_run_at``-due, never firing). This independent sweep reaps
+        those zombies regardless of claimability.
+
+        ``agent_id=None`` sweeps across all tenants (platform ticker); passing
+        an ``agent_id`` scopes to one tenant. Returns the swept rows.
+        """
+        agent_filter = "" if agent_id is None else "AND s.agent_id = :agent_id"
+        query = text(
+            f"""
+            WITH expired AS (
+                SELECT s.id
+                FROM scheduled_sessions s
+                WHERE s.status = 'active'
+                  {agent_filter}
+                  AND s.expires_at IS NOT NULL
+                  AND s.expires_at <= now()
+                ORDER BY s.expires_at ASC
+                LIMIT :limit
+                FOR UPDATE OF s SKIP LOCKED
+            )
+            UPDATE scheduled_sessions s
+            SET status = 'completed',
+                next_run_at = NULL,
+                locked_by = NULL,
+                locked_until = NULL,
+                updated_at = now()
+            FROM expired
+            WHERE s.id = expired.id
+            RETURNING s.*
+            """
+        )
+        params: dict[str, Any] = {"limit": int(limit)}
+        if agent_id is not None:
+            params["agent_id"] = agent_id
+        async with self._sf() as db:
+            result = await db.execute(query, params)
+            rows = [ScheduledSession.model_validate(dict(row._mapping)) for row in result]
+            await db.commit()
+        return rows
+
     async def mark_run_created(
         self,
         schedule: ScheduledSession,

--- a/tests/integration/test_scheduled_materialize.py
+++ b/tests/integration/test_scheduled_materialize.py
@@ -436,6 +436,43 @@ async def test_recover_requeues_stalled_dynamic_loop_across_tenants(
     ) is not None
 
 
+async def test_recover_stalled_loops_reaps_expired_active_schedule(
+    session_factory, redis_client
+):
+    """The recovery sweep also transitions schedules past their expires_at
+    from 'active' to 'completed' — a cron loop that expired between ticks can
+    never be re-claimed, so this is the only thing that reaps it.
+    """
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+    scheduled_store = ScheduledSessionStore(session_factory)
+    now = datetime.now(timezone.utc)
+
+    zombie = await scheduled_store.create(
+        org_id=org_id,
+        user_id=user_id,
+        agent_id="agent-a",
+        name="Expired loop",
+        prompt="tick",
+        schedule=parse_schedule("1m"),
+        source="loop",
+        created_from_session_id=None,
+        next_run_at=now - timedelta(minutes=1),
+        expires_at=now - timedelta(hours=1),
+    )
+
+    await recover_stalled_loops(
+        scheduled_store=scheduled_store,
+        redis=redis_client,
+        stale_seconds=1,
+        limit=100,
+    )
+
+    reaped = await scheduled_store.get(zombie.id)
+    assert reaped.status == "completed"
+    assert reaped.next_run_at is None
+
+
 async def test_mark_run_failed_reschedules_and_releases_claim(
     session_factory, redis_client,
 ):

--- a/tests/integration/test_scheduled_store.py
+++ b/tests/integration/test_scheduled_store.py
@@ -669,3 +669,22 @@ async def test_expire_active_schedules_is_idempotent(session_factory):
     assert len(first) == 1
     second = await store.expire_active_schedules()
     assert second == []
+
+
+async def test_expiry_sweep_partial_index_exists(session_factory):
+    """The partial index backing expire_active_schedules must be created so the
+    per-tick sweep range-scans the expired rows instead of scanning+sorting the
+    whole active set."""
+    async with session_factory() as db:
+        result = await db.execute(
+            text(
+                "SELECT indexdef FROM pg_indexes "
+                "WHERE indexname = 'idx_scheduled_sessions_expiry'"
+            )
+        )
+        indexdef = result.scalar_one_or_none()
+
+    assert indexdef is not None, "idx_scheduled_sessions_expiry was not created"
+    assert "expires_at" in indexdef
+    # Partial index restricted to active rows.
+    assert "status" in indexdef and "active" in indexdef

--- a/tests/integration/test_scheduled_store.py
+++ b/tests/integration/test_scheduled_store.py
@@ -580,3 +580,92 @@ async def test_sa_principal_cancel_and_pause_resume_round_trip(session_factory):
         schedule_id=sa_schedule.id,
     )
     assert deleted is True
+
+
+async def test_expire_active_schedules_sweeps_expired_active_rows(session_factory):
+    """A cron loop whose expires_at falls between ticks expires *unclaimed*
+    (claim_due excludes expires_at <= now), so mark_run_created never runs and
+    the row is stuck status='active' forever. expire_active_schedules is the
+    independent sweep that transitions those zombies to 'completed'.
+    """
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+    store = ScheduledSessionStore(session_factory)
+    now = datetime.now(timezone.utc)
+
+    # Zombie: active, due, but already expired.
+    zombie = await store.create(
+        org_id=org_id,
+        user_id=user_id,
+        agent_id="agent-z",
+        name="Expired loop",
+        prompt="tick",
+        schedule=parse_schedule("1m"),
+        source="loop",
+        created_from_session_id=None,
+        next_run_at=now - timedelta(minutes=1),
+        expires_at=now - timedelta(hours=1),
+    )
+    # Healthy: active, no expiry — must NOT be swept. next_run_at is in the
+    # future so the row never enters other tests' cross-tenant claim pool.
+    healthy = await store.create(
+        org_id=org_id,
+        user_id=user_id,
+        agent_id="agent-h",
+        name="Live loop",
+        prompt="tick",
+        schedule=parse_schedule("1m"),
+        source="loop",
+        created_from_session_id=None,
+        next_run_at=now + timedelta(days=1),
+        expires_at=None,
+    )
+    # Active with a future expiry — must NOT be swept. Also kept not-due.
+    future = await store.create(
+        org_id=org_id,
+        user_id=user_id,
+        agent_id="agent-f",
+        name="Future-expiry loop",
+        prompt="tick",
+        schedule=parse_schedule("1m"),
+        source="loop",
+        created_from_session_id=None,
+        next_run_at=now + timedelta(days=1),
+        expires_at=now + timedelta(days=1),
+    )
+
+    swept = await store.expire_active_schedules()
+
+    assert [r.id for r in swept] == [zombie.id]
+    z = await store.get(zombie.id)
+    assert z.status == "completed"
+    assert z.next_run_at is None
+    assert (await store.get(healthy.id)).status == "active"
+    assert (await store.get(future.id)).status == "active"
+
+
+async def test_expire_active_schedules_is_idempotent(session_factory):
+    """A second sweep with nothing newly expired returns no rows and leaves
+    already-completed schedules untouched (never re-touches them)."""
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+    store = ScheduledSessionStore(session_factory)
+    now = datetime.now(timezone.utc)
+
+    await store.create(
+        org_id=org_id,
+        user_id=user_id,
+        agent_id="agent-z",
+        name="Expired loop",
+        prompt="tick",
+        schedule=parse_schedule("1m"),
+        source="loop",
+        created_from_session_id=None,
+        next_run_at=now - timedelta(minutes=1),
+        expires_at=now - timedelta(hours=1),
+    )
+
+    first = await store.expire_active_schedules()
+    assert len(first) == 1
+    second = await store.expire_active_schedules()
+    assert second == []


### PR DESCRIPTION
## Problem

A cron loop whose `expires_at` falls between its last run and its next due instant expires **unclaimed** — the claim query (`claim_due` / `find_due_across_tenants`) excludes `expires_at <= now()`, and the `active → completed` transition in `mark_run_created` only runs on a successful claim. So the row is stuck `status='active'` forever: still `next_run_at`-due, never firing. Found one such zombie in PROD (`Loop: check the weather in bucharest`, active since 2026-06-08).

## Fix

Add `ScheduledSessionStore.expire_active_schedules` — an independent, cross-tenant, `SKIP LOCKED`, idempotent sweep that transitions expired-but-active rows to `completed` (clearing `next_run_at`/locks) regardless of claimability. Wired into `recover_stalled_loops`, the platform ticker's existing per-tick recovery pass.

Adds a partial index `idx_scheduled_sessions_expiry ON scheduled_sessions(expires_at) WHERE status='active'` (model `__table_args__` for fresh DBs + idempotent `observability.sql` retrofit for existing tables) so the per-tick sweep range-scans instead of scanning+sorting the active set.

## Tests

`tests/integration/test_scheduled_store.py` + `test_scheduled_materialize.py` — sweep transitions the zombie, leaves healthy/future-expiry rows; idempotent; end-to-end via `recover_stalled_loops`; partial index exists. 30 passed.

Impact is cosmetic (a dead loop shown as "active"), not resource-burning — the claim query already excludes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)