### PR TITLE
feat(loop): surface web/api loop results inline in the conversation

### DIFF
--- a/docs/background-jobs/index.md
+++ b/docs/background-jobs/index.md
@@ -163,6 +163,32 @@ ends the schedule early. Use `/loop list` and `/loop cancel <id>` to
 manage them. See [Commands](../commands/index.md) for the full slash-command
 reference.
 
+### Run result delivery
+
+A scheduled run executes on its own `channel="scheduled"` child session, so
+each run's output is surfaced back to the conversation that created the loop:
+
+- **Channel-origin loops** (Slack, Telegram, Teams): a run's deliverable
+  events resolve to the **parent** session's channel and routing config, so
+  every run is posted back into the origin channel. Without this resolution a
+  run strands under the `scheduled` channel, which no delivery loop drains.
+- **Web / API-origin loops**: a run's final answer is emitted as a
+  `loop.result` event on the **parent** session and appears inline in the
+  originating conversation — web clients receive it over the session SSE
+  stream, API clients by polling `GET /sessions/{id}/events`. For these runs
+  the otherwise-redundant `inbox.task_complete` card is suppressed. A
+  `loop.result` is never replayed into the parent agent's context and never
+  wakes (re-enqueues) the parent; a run with no text output emits nothing.
+
+### Expiry reaping
+
+Because the claim query skips rows whose `expires_at` has passed, a loop that
+expires in the gap between its last run and its next due instant would
+otherwise remain `active` forever — due, but never firing. The platform
+ticker's periodic recovery pass sweeps any `active` schedule past its
+`expires_at` (across all tenants) and transitions it to `completed`, so an
+expired loop never lingers as a non-firing `active` row.
+
 ## `training_collector` -- Expert Training Data Export
 
 The training collector extracts successful conversation trajectories from the event log and writes them as JSONL files to the tenant's Garage bucket.

--- a/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
+++ b/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
@@ -14,7 +14,7 @@
 
 - [x] Task 1: Backend event type + replay/outbox guards
 - [x] Task 2: Backend parent-resolution helper
-- [ ] Task 3: Backend inline emission + inbox suppression + cursor fallback
+- [x] Task 3: Backend inline emission + inbox suppression + cursor fallback
 - [ ] Task 4: SDK event registration + reducer
 - [ ] Task 5: SDK chat-thread affordance
 - [ ] Task 6: Surogates web raw event type

--- a/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
+++ b/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
@@ -16,7 +16,7 @@
 - [x] Task 2: Backend parent-resolution helper
 - [x] Task 3: Backend inline emission + inbox suppression + cursor fallback
 - [x] Task 4: SDK event registration + reducer
-- [ ] Task 5: SDK chat-thread affordance
+- [x] Task 5: SDK chat-thread affordance
 - [ ] Task 6: Surogates web raw event type
 - [ ] Task 7: Ops observability view
 - [ ] Task 8: Ops frontend thread rendering

--- a/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
+++ b/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
@@ -18,7 +18,7 @@
 - [x] Task 4: SDK event registration + reducer
 - [x] Task 5: SDK chat-thread affordance
 - [x] Task 6: Surogates web raw event type
-- [ ] Task 7: Ops observability view
+- [x] Task 7: Ops observability view
 - [ ] Task 8: Ops frontend thread rendering
 - [ ] Task 9: Final verification
 

--- a/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
+++ b/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
@@ -19,7 +19,7 @@
 - [x] Task 5: SDK chat-thread affordance
 - [x] Task 6: Surogates web raw event type
 - [x] Task 7: Ops observability view
-- [ ] Task 8: Ops frontend thread rendering
+- [x] Task 8: Ops frontend thread rendering
 - [ ] Task 9: Final verification
 
 ---

--- a/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
+++ b/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
@@ -20,7 +20,7 @@
 - [x] Task 6: Surogates web raw event type
 - [x] Task 7: Ops observability view
 - [x] Task 8: Ops frontend thread rendering
-- [ ] Task 9: Final verification
+- [x] Task 9: Final verification
 
 ---
 

--- a/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
+++ b/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
@@ -17,7 +17,7 @@
 - [x] Task 3: Backend inline emission + inbox suppression + cursor fallback
 - [x] Task 4: SDK event registration + reducer
 - [x] Task 5: SDK chat-thread affordance
-- [ ] Task 6: Surogates web raw event type
+- [x] Task 6: Surogates web raw event type
 - [ ] Task 7: Ops observability view
 - [ ] Task 8: Ops frontend thread rendering
 - [ ] Task 9: Final verification

--- a/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
+++ b/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
@@ -13,7 +13,7 @@
 ## Progress
 
 - [x] Task 1: Backend event type + replay/outbox guards
-- [ ] Task 2: Backend parent-resolution helper
+- [x] Task 2: Backend parent-resolution helper
 - [ ] Task 3: Backend inline emission + inbox suppression + cursor fallback
 - [ ] Task 4: SDK event registration + reducer
 - [ ] Task 5: SDK chat-thread affordance

--- a/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
+++ b/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
@@ -10,6 +10,20 @@
 
 ---
 
+## Progress
+
+- [x] Task 1: Backend event type + replay/outbox guards
+- [ ] Task 2: Backend parent-resolution helper
+- [ ] Task 3: Backend inline emission + inbox suppression + cursor fallback
+- [ ] Task 4: SDK event registration + reducer
+- [ ] Task 5: SDK chat-thread affordance
+- [ ] Task 6: Surogates web raw event type
+- [ ] Task 7: Ops observability view
+- [ ] Task 8: Ops frontend thread rendering
+- [ ] Task 9: Final verification
+
+---
+
 ## Scope And Repos
 
 - Spec: `/work/surogates/docs/superpowers/specs/2026-07-03-loop-result-inline-delivery-design.md`.

--- a/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
+++ b/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
@@ -1,0 +1,902 @@
+# Loop-result inline delivery (web/api) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface each web/api-originated loop run's final answer inline in the originating conversation by emitting a new `loop.result` event on the parent session, and stop creating the redundant expiring inbox card for those runs.
+
+**Architecture:** At loop-run completion the harness emits a new `loop.result` event onto the *parent* web/api session's event log (never the outbox, never a parent wake). `emit_event` already publishes to `surogates:session:{id}`, so the parent's SSE/poll stream delivers it. Because `loop.result` is a new event type, the context-replay whitelist ignores it, keeping the parent agent's context untouched. Frontends render it as an assistant-style message.
+
+**Tech Stack:** Python 3.12 async (surogates harness), pytest + testcontainers Postgres, TypeScript/React (`sdk/agent-chat-react`, `web`, `surogate-ops/frontend`), SQL view (`surogates/db/observability.sql`).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-03-loop-result-inline-delivery-design.md` — authoritative.
+- Run backend tests with the repo venv: `/work/surogates/.venv/bin/pytest`. Never `uv run` (it reinstalls pinned wheels).
+- Conventional Commits for every commit (`type(scope): subject`). No `Co-Authored-By` trailer. Never reference plan/task/phase/step numbers in code comments or commit messages.
+- Gating is by parent **channel** (`web` or `api`), not by loop kind — cron and dynamic loops both qualify.
+- `loop.result` must NOT be added to `SessionStore._DELIVERABLE_EVENTS` and must NOT be consumed by `_rebuild_messages`.
+- Emission is best-effort: a failure must never abort run completion, status update, cursor advancement, or dynamic-loop finalization.
+- Two repos are touched: `/work/surogates` (backend, SDK, web host, SQL view) and `/work/surogate-ops` (ops frontend). Commit within each repo separately.
+
+---
+
+## File Structure
+
+Backend (`/work/surogates`):
+- `surogates/session/events.py` — add `EventType.LOOP_RESULT`.
+- `surogates/harness/loop_messages.py` — add `_resolve_loop_result_parent` helper.
+- `surogates/harness/loop_artifact_completion.py` — emit `loop.result`, suppress inbox card, fix cursor fallback.
+- `tests/test_loop_result_delivery.py` — new unit tests (gating + emission + suppression + cursor + no-wake).
+- `tests/test_loop_result_replay_safety.py` — replay + `_DELIVERABLE_EVENTS` guards.
+
+Frontend SDK (`/work/surogates/sdk/agent-chat-react`):
+- `src/types.ts` — add `"loop.result"` to `AgentChatEventType`; add `loopResult?` to `AgentChatMessage`.
+- `src/runtime/events.ts` — add `"loop.result"` to `AGENT_CHAT_LISTENED_EVENTS`.
+- `src/runtime/reducer.ts` — add `case "loop.result"`.
+- `src/components/chat/chat-thread.tsx` — render the loop affordance.
+- `src/runtime/reducer.test.ts` (or existing reducer test file) — reducer test.
+
+Web host (`/work/surogates/web`):
+- `src/types/session.ts` — add `"loop.result"` to the raw session event type.
+
+Ops (`/work/surogates/surogates/db` + `/work/surogate-ops/frontend`):
+- `surogates/db/observability.sql` — add `'loop.result'` to `v_session_messages`.
+- `frontend/src/types/session.ts` — add `EventType.LOOP_RESULT`.
+- `frontend/src/components/sessions/session-thread.tsx` — render loop.result as an agent turn.
+
+---
+
+## Task 1: Add the `loop.result` event type (backend)
+
+**Files:**
+- Modify: `surogates/session/events.py` (near `INBOX_TASK_COMPLETE`, ~line 217)
+- Test: `tests/test_loop_result_replay_safety.py`
+
+**Interfaces:**
+- Produces: `EventType.LOOP_RESULT` with value `"loop.result"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_loop_result_replay_safety.py`:
+
+```python
+from surogates.session.events import EventType
+from surogates.session.store import _DELIVERABLE_EVENTS
+
+
+def test_loop_result_event_type_exists():
+    assert EventType.LOOP_RESULT.value == "loop.result"
+
+
+def test_loop_result_is_not_a_deliverable_event():
+    # loop.result is surfaced on web/api parents via SSE, never the outbox.
+    assert EventType.LOOP_RESULT not in _DELIVERABLE_EVENTS
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_replay_safety.py -q`
+Expected: FAIL with `AttributeError: LOOP_RESULT`.
+
+- [ ] **Step 3: Add the enum member**
+
+In `surogates/session/events.py`, immediately after the `INBOX_*` block:
+
+```python
+    # Loop-run result surfaced inline on a web/api parent conversation.
+    LOOP_RESULT = "loop.result"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_replay_safety.py -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /work/surogates
+git add surogates/session/events.py tests/test_loop_result_replay_safety.py
+git commit -m "feat(events): add loop.result event type"
+```
+
+---
+
+## Task 2: `_resolve_loop_result_parent` gating helper (backend)
+
+**Files:**
+- Modify: `surogates/harness/loop_messages.py` (add helper next to `_should_notify_parent_on_completion`, ~line 239)
+- Test: `tests/test_loop_result_delivery.py`
+
+**Interfaces:**
+- Consumes: a `session` with `.channel`, `.parent_id`; an async `store.get_session(uuid) -> Session` (raises `SessionNotFoundError` when missing).
+- Produces: `async def resolve_loop_result_parent(session, store) -> Session | None` — returns the parent `Session` only for a scheduled child (`channel == "scheduled"`) with a `parent_id` whose parent channel is `web` or `api`; otherwise `None` (including lookup failure).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_loop_result_delivery.py`:
+
+```python
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from surogates.harness.loop_messages import resolve_loop_result_parent
+from surogates.session.store import SessionNotFoundError
+
+
+class _FakeStore:
+    def __init__(self, parent):
+        self._parent = parent
+
+    async def get_session(self, sid):
+        if self._parent is None or self._parent.id != sid:
+            raise SessionNotFoundError(str(sid))
+        return self._parent
+
+
+def _child(channel="scheduled", parent_id=None):
+    return SimpleNamespace(id=uuid4(), channel=channel, parent_id=parent_id)
+
+
+def _parent(channel):
+    return SimpleNamespace(id=uuid4(), channel=channel, parent_id=None)
+
+
+@pytest.mark.parametrize("parent_channel", ["web", "api"])
+async def test_resolves_parent_for_web_and_api(parent_channel):
+    parent = _parent(parent_channel)
+    child = _child(parent_id=parent.id)
+    got = await resolve_loop_result_parent(child, _FakeStore(parent))
+    assert got is parent
+
+
+@pytest.mark.parametrize("parent_channel", ["slack", "telegram", "teams"])
+async def test_skips_channel_parents(parent_channel):
+    parent = _parent(parent_channel)
+    child = _child(parent_id=parent.id)
+    assert await resolve_loop_result_parent(child, _FakeStore(parent)) is None
+
+
+async def test_skips_non_scheduled_child():
+    parent = _parent("web")
+    child = _child(channel="worker", parent_id=parent.id)
+    assert await resolve_loop_result_parent(child, _FakeStore(parent)) is None
+
+
+async def test_skips_when_no_parent_id():
+    child = _child(parent_id=None)
+    assert await resolve_loop_result_parent(child, _FakeStore(None)) is None
+
+
+async def test_skips_when_parent_missing():
+    child = _child(parent_id=uuid4())
+    assert await resolve_loop_result_parent(child, _FakeStore(None)) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_delivery.py -q`
+Expected: FAIL with `ImportError: cannot import name 'resolve_loop_result_parent'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `surogates/harness/loop_messages.py`, add (imports `SessionNotFoundError` lazily to avoid a cycle):
+
+```python
+async def resolve_loop_result_parent(session: Any, store: Any) -> Any | None:
+    """Return the parent session a loop run should surface its result into.
+
+    A scheduled run (``channel == "scheduled"``) whose parent conversation
+    is a pull-based surface (``web`` or ``api``) has no outbox path, so its
+    per-run answer is delivered by emitting a ``loop.result`` event on the
+    parent.  Channel parents (slack/telegram/teams) already receive each run
+    through the outbox and are skipped; detached runs (no parent) and missing
+    parents return ``None``.
+    """
+    if session.channel != "scheduled" or session.parent_id is None:
+        return None
+    from surogates.session.store import SessionNotFoundError
+
+    try:
+        parent = await store.get_session(session.parent_id)
+    except SessionNotFoundError:
+        return None
+    if parent is None or parent.channel not in ("web", "api"):
+        return None
+    return parent
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_delivery.py -q`
+Expected: PASS (9 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /work/surogates
+git add surogates/harness/loop_messages.py tests/test_loop_result_delivery.py
+git commit -m "feat(harness): add loop-result parent resolution helper"
+```
+
+---
+
+## Task 3: Emit `loop.result`, suppress inbox card, fix cursor fallback (backend)
+
+**Files:**
+- Modify: `surogates/harness/loop_artifact_completion.py` (`_complete_session`, lines ~596–662)
+- Test: `tests/test_loop_result_delivery.py` (append)
+
+**Interfaces:**
+- Consumes: `resolve_loop_result_parent` (Task 2); `EventType.LOOP_RESULT` (Task 1); `self._store.get_events(session_id) -> list[Event]`; `extract_final_response(events, fallback="") -> str`; `self._store.emit_event(session_id, type, data) -> int`.
+- Produces: a `loop.result` event on the parent for web/api scheduled runs; no `inbox.task_complete` for those runs; correct cursor advancement.
+
+- [ ] **Step 1: Write the failing test (append to `tests/test_loop_result_delivery.py`)**
+
+```python
+from surogates.session.events import EventType
+
+
+class _RecordingStore:
+    """Captures emit_event calls and serves child events for extraction."""
+
+    def __init__(self, parent, child_events):
+        self._parent = parent
+        self._child_events = child_events
+        self.emitted = []          # (session_id, type, data)
+        self.enqueued = []         # parent re-enqueue attempts
+        self.next_id = 1000
+
+    async def get_session(self, sid):
+        if self._parent is not None and self._parent.id == sid:
+            return self._parent
+        from surogates.session.store import SessionNotFoundError
+        raise SessionNotFoundError(str(sid))
+
+    async def get_events(self, sid):
+        return self._child_events
+
+    async def emit_event(self, sid, etype, data):
+        self.next_id += 1
+        self.emitted.append((sid, etype, data))
+        return self.next_id
+
+    async def update_session_status(self, *a, **k):
+        pass
+
+    async def advance_harness_cursor(self, *a, **k):
+        pass
+
+
+def _evt(etype, content):
+    return SimpleNamespace(type=etype.value if hasattr(etype, "value") else etype,
+                           data={"message": {"content": content}})
+
+
+def _bare_harness(store):
+    # _complete_session lives on ArtifactCompletionMixin. Build a bare host and
+    # set only the attributes the method touches.
+    from surogates.harness.loop_artifact_completion import ArtifactCompletionMixin
+
+    h = type("_H", (ArtifactCompletionMixin,), {})()
+    h._store = store
+    h._worker_id = "w"
+    h._sandbox_pool = None
+    h._memory_manager = None
+    h._turn_summarizer = None
+    h._redis = None
+    h._session_factory = None
+    h._tenant = SimpleNamespace(user_id=uuid4(), service_account_id=None)
+    return h
+```
+
+Concrete tests (append to the same file):
+
+```python
+    parent = _parent("web")
+    child = SimpleNamespace(
+        id=uuid4(), channel="scheduled", parent_id=parent.id,
+        org_id=uuid4(), agent_id="a", title="t",
+        created_at=__import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+        config={"scheduled_session_id": str(uuid4())},
+        task_id=None,
+    )
+    store = _RecordingStore(parent, child_events=[_evt(EventType.LLM_RESPONSE, "Weather: 22C")])
+    h = _bare_harness(store)
+
+    await h._complete_session(
+        child,
+        messages=[{"role": "assistant", "content": "Weather: 22C"}],
+        lease=SimpleNamespace(lease_token="t"),
+        reason="stop",
+    )
+
+    loop_results = [e for e in store.emitted if e[1] == EventType.LOOP_RESULT]
+    assert len(loop_results) == 1
+    sid, _, data = loop_results[0]
+    assert sid == parent.id                       # emitted on the PARENT
+    assert data["content"] == "Weather: 22C"      # full final response
+    assert data["run_session_id"] == str(child.id)
+    # inbox card suppressed for this run
+    assert not any(e[1] == EventType.INBOX_TASK_COMPLETE for e in store.emitted)
+
+
+async def test_slack_parent_scheduled_run_keeps_inbox_and_no_loop_result():
+    parent = _parent("slack")
+    child = SimpleNamespace(
+        id=uuid4(), channel="scheduled", parent_id=parent.id,
+        org_id=uuid4(), agent_id="a", title="t",
+        created_at=__import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+        config={"scheduled_session_id": str(uuid4())}, task_id=None,
+    )
+    store = _RecordingStore(parent, child_events=[_evt(EventType.LLM_RESPONSE, "hi")])
+    h = _bare_harness(store)
+    await h._complete_session(child, messages=[{"role": "assistant", "content": "hi"}],
+                              lease=SimpleNamespace(lease_token="t"), reason="stop")
+    assert not any(e[1] == EventType.LOOP_RESULT for e in store.emitted)
+    assert any(e[1] == EventType.INBOX_TASK_COMPLETE for e in store.emitted)
+```
+
+Add a `_bare_harness(store)` helper in the test file per the fixture note.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_delivery.py -q`
+Expected: FAIL — `loop.result` never emitted / inbox still present.
+
+- [ ] **Step 3: Implement in `_complete_session`**
+
+Replace the SESSION_COMPLETE + INBOX_TASK_COMPLETE block (lines ~596–615) and the cursor block (lines ~650–653):
+
+```python
+        session_complete_event_id = await self._store.emit_event(
+            session.id,
+            EventType.SESSION_COMPLETE,
+            complete_data,
+        )
+
+        outcome = (
+            "success"
+            if reason in {"stop", "done", "complete", "completed"}
+            else reason
+        )
+
+        # Surface web/api loop runs inline on the origin conversation instead
+        # of an expiring inbox card. Best-effort; never abort completion.
+        loop_result_parent = None
+        try:
+            loop_result_parent = await resolve_loop_result_parent(session, self._store)
+        except Exception:
+            logger.debug("loop.result parent resolution failed for %s", session.id,
+                         exc_info=True)
+        if loop_result_parent is not None:
+            try:
+                child_events = await self._store.get_events(session.id)
+                content = extract_final_response(child_events, fallback="").strip()
+                if content:
+                    await self._store.emit_event(
+                        loop_result_parent.id,
+                        EventType.LOOP_RESULT,
+                        {
+                            "run_session_id": str(session.id),
+                            "scheduled_session_id": str(
+                                session.config.get("scheduled_session_id") or ""
+                            ),
+                            "content": content,
+                            "outcome": outcome,
+                            "duration_seconds": _seconds_since(session.created_at),
+                            "run_completed_at": datetime.now(timezone.utc).isoformat(),
+                        },
+                    )
+            except Exception:
+                logger.warning("Failed to emit loop.result on parent %s for run %s",
+                               loop_result_parent.id, session.id, exc_info=True)
+
+        # Inbox card: skip for web/api loop runs (delivered inline above).
+        inbox_event_id: int | None = None
+        if loop_result_parent is None:
+            inbox_event_id = await self._store.emit_event(
+                session.id,
+                EventType.INBOX_TASK_COMPLETE,
+                {
+                    "outcome": outcome,
+                    "summary": _last_assistant_message_excerpt(messages),
+                    "duration_seconds": _seconds_since(session.created_at),
+                    "session_title": session.title or "Task complete",
+                    "error": None,
+                },
+            )
+```
+
+And the cursor fallback (lines ~650–653):
+
+```python
+        # Advance cursor to the latest child event. When the inbox card is
+        # suppressed, fall back to the child's SESSION_COMPLETE event id.
+        cursor_target = (
+            through_event_id
+            if through_event_id is not None
+            else (inbox_event_id if inbox_event_id is not None
+                  else session_complete_event_id)
+        )
+```
+
+Add imports at the top of `loop_artifact_completion.py` if absent:
+
+```python
+from datetime import datetime, timezone
+
+from surogates.harness.loop_messages import resolve_loop_result_parent
+from surogates.harness.message_utils import extract_final_response
+```
+
+(`_seconds_since` and `_last_assistant_message_excerpt` already exist in this module — reuse them. There is no `_utcnow` here, so use `datetime.now(timezone.utc)` for `run_completed_at`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_delivery.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Add cursor + no-wake tests (append) and run**
+
+```python
+async def test_parent_not_re_enqueued_by_surfacing():
+    parent = _parent("web")
+    child = SimpleNamespace(id=uuid4(), channel="scheduled", parent_id=parent.id,
+                            org_id=uuid4(), agent_id="a", title="t",
+                            created_at=__import__("datetime").datetime.now(
+                                __import__("datetime").timezone.utc),
+                            config={"scheduled_session_id": str(uuid4())}, task_id=None)
+    store = _RecordingStore(parent, [_evt(EventType.LLM_RESPONSE, "x")])
+    h = _bare_harness(store)
+    await h._complete_session(child, messages=[{"role": "assistant", "content": "x"}],
+                              lease=SimpleNamespace(lease_token="t"), reason="stop")
+    assert store.enqueued == []   # no parent wake
+
+
+async def test_empty_final_response_emits_no_loop_result_but_completes():
+    parent = _parent("web")
+    child = SimpleNamespace(id=uuid4(), channel="scheduled", parent_id=parent.id,
+                            org_id=uuid4(), agent_id="a", title="t",
+                            created_at=__import__("datetime").datetime.now(
+                                __import__("datetime").timezone.utc),
+                            config={"scheduled_session_id": str(uuid4())}, task_id=None)
+    store = _RecordingStore(parent, child_events=[])   # no llm.response
+    h = _bare_harness(store)
+    await h._complete_session(child, messages=[], lease=SimpleNamespace(lease_token="t"),
+                              reason="stop")
+    assert not any(e[1] == EventType.LOOP_RESULT for e in store.emitted)
+```
+
+Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_delivery.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /work/surogates
+git add surogates/harness/loop_artifact_completion.py tests/test_loop_result_delivery.py
+git commit -m "feat(harness): deliver web/api loop results inline on the parent conversation"
+```
+
+---
+
+## Task 4: Replay-safety guard (backend)
+
+**Files:**
+- Test: `tests/test_loop_result_replay_safety.py` (append)
+
+**Interfaces:**
+- Consumes: `LoopContextReplay._rebuild_messages` (in `surogates/harness/loop_context_replay.py`) or the class that owns it.
+
+This is a guard test that locks in existing whitelist behavior: `_rebuild_messages`
+(on `ContextReplayMixin`) branches on known event types via an if/elif chain, so
+`loop.result` — a new type — is never appended to the agent's message history. It
+requires no production change and should pass immediately once wired to the real
+class.
+
+- [ ] **Step 1: Write the test (append to `tests/test_loop_result_replay_safety.py`)**
+
+```python
+from types import SimpleNamespace
+
+from surogates.session.events import EventType
+
+
+def _event(etype, data, eid):
+    return SimpleNamespace(type=etype.value, data=data, id=eid)
+
+
+def _rebuild(events):
+    from surogates.harness.loop_context_replay import ContextReplayMixin
+
+    host = type("_H", (ContextReplayMixin,), {})()
+    return host._rebuild_messages(events)
+
+
+def test_rebuild_messages_ignores_loop_result():
+    events = [
+        _event(EventType.LLM_RESPONSE,
+               {"message": {"role": "assistant", "content": "real"}}, 1),
+        _event(EventType.LOOP_RESULT, {"content": "loop output"}, 2),
+    ]
+    rebuilt = _rebuild(events)
+    joined = " ".join(str(m.get("content", "")) for m in rebuilt)
+    assert "real" in joined
+    assert "loop output" not in joined
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_replay_safety.py -q`
+Expected: PASS (guard test — `loop.result` is not a handled branch, so it is ignored).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /work/surogates
+git add tests/test_loop_result_replay_safety.py
+git commit -m "test(harness): guard that loop.result stays out of replay + outbox"
+```
+
+---
+
+## Task 5: SDK type + listened-events registration
+
+**Files:**
+- Modify: `sdk/agent-chat-react/src/types.ts` (`AgentChatEventType` ~line 478; `AgentChatMessage` ~line 61)
+- Modify: `sdk/agent-chat-react/src/runtime/events.ts` (`AGENT_CHAT_LISTENED_EVENTS` ~line 11)
+
+**Interfaces:**
+- Produces: `"loop.result"` is a valid `AgentChatEventType` and a listened event; `AgentChatMessage.loopResult?` metadata field.
+
+- [ ] **Step 1: Add to the type union**
+
+In `src/types.ts`, append to `AgentChatEventType` (before the terminating `;`):
+
+```typescript
+  | "turn.summary"
+  | "loop.result";
+```
+
+- [ ] **Step 2: Add the message metadata field**
+
+In `AgentChatMessage`, add after `turnSummary?`:
+
+```typescript
+  /** Present when this message was produced by a scheduled loop run
+   * surfaced inline on the parent conversation. */
+  loopResult?: {
+    runSessionId?: string;
+    scheduledSessionId?: string;
+    runCompletedAt?: string;
+  };
+```
+
+- [ ] **Step 3: Register the listened event**
+
+In `src/runtime/events.ts`, add `"loop.result"` to `AGENT_CHAT_LISTENED_EVENTS` (after `"turn.summary"`):
+
+```typescript
+  "turn.summary",
+  "loop.result",
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd /work/surogates/sdk/agent-chat-react && npm run typecheck` (or the SDK's `tsc --noEmit`).
+Expected: no new type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /work/surogates
+git add sdk/agent-chat-react/src/types.ts sdk/agent-chat-react/src/runtime/events.ts
+git commit -m "feat(agent-chat): register loop.result event type"
+```
+
+---
+
+## Task 6: SDK reducer case for `loop.result`
+
+**Files:**
+- Modify: `sdk/agent-chat-react/src/runtime/reducer.ts` (add case near `case "skill.invoked":`)
+- Test: `sdk/agent-chat-react/src/runtime/reducer.test.ts` (create if absent, else append)
+
+**Interfaces:**
+- Consumes: reducer `(state, event) -> state`, `withMessages`, `AgentChatMessage` (with `loopResult`).
+- Produces: a completed assistant-role message appended for a `loop.result` event, `isRunning` untouched.
+
+- [ ] **Step 1: Write the failing test**
+
+In the reducer test file:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { agentChatReducer, initialAgentChatState } from "./reducer";
+
+describe("loop.result", () => {
+  it("appends a completed assistant message and does not set isRunning", () => {
+    const state = { ...initialAgentChatState(), isRunning: false };
+    const next = agentChatReducer(state, {
+      type: "loop.result",
+      eventId: 42,
+      data: {
+        content: "Weather in Bucharest: 22C",
+        run_session_id: "r1",
+        scheduled_session_id: "s1",
+        run_completed_at: "2026-07-03T05:01:00Z",
+      },
+    });
+    const msg = next.messages[next.messages.length - 1];
+    expect(msg.role).toBe("assistant");
+    expect(msg.content).toBe("Weather in Bucharest: 22C");
+    expect(msg.status).toBe("complete");
+    expect(msg.loopResult?.runSessionId).toBe("r1");
+    expect(next.isRunning).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /work/surogates/sdk/agent-chat-react && npx vitest run src/runtime/reducer.test.ts`
+Expected: FAIL — no assistant message appended (unhandled type returns state unchanged).
+
+- [ ] **Step 3: Implement the case**
+
+In `reducer.ts`, add before `case "artifact.created":`:
+
+```typescript
+    case "loop.result":
+      return withMessages(nextState, [
+        ...nextState.messages,
+        {
+          id: `evt-${event.eventId}`,
+          role: "assistant",
+          content: stringValue(event.data.content),
+          createdAt: new Date(),
+          status: "complete",
+          loopResult: {
+            runSessionId: stringValue(event.data.run_session_id) || undefined,
+            scheduledSessionId:
+              stringValue(event.data.scheduled_session_id) || undefined,
+            runCompletedAt: stringValue(event.data.run_completed_at) || undefined,
+          },
+        },
+      ]);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /work/surogates/sdk/agent-chat-react && npx vitest run src/runtime/reducer.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /work/surogates
+git add sdk/agent-chat-react/src/runtime/reducer.ts sdk/agent-chat-react/src/runtime/reducer.test.ts
+git commit -m "feat(agent-chat): reduce loop.result into an assistant message"
+```
+
+---
+
+## Task 7: SDK thread affordance
+
+**Files:**
+- Modify: `sdk/agent-chat-react/src/components/chat/chat-thread.tsx`
+
+**Interfaces:**
+- Consumes: `AgentChatMessage.loopResult`.
+
+- [ ] **Step 1: Render the affordance**
+
+Find where an assistant message bubble is rendered in `chat-thread.tsx`. Add a
+small metadata line, shown only when `message.loopResult` is set. Example
+(adapt to the file's existing JSX/classnames):
+
+```tsx
+{message.loopResult && (
+  <div className="text-xs text-muted-foreground/70 mb-1">
+    From loop
+    {message.loopResult.runCompletedAt
+      ? ` · ${new Date(message.loopResult.runCompletedAt).toLocaleTimeString()}`
+      : ""}
+  </div>
+)}
+```
+
+- [ ] **Step 2: Typecheck + build**
+
+Run: `cd /work/surogates/sdk/agent-chat-react && npm run typecheck && npm run build`
+Expected: clean.
+
+- [ ] **Step 3: Manual verification note**
+
+The affordance is visual; verify in a host app after Task 8/10 wiring. No unit
+test required for the JSX label.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /work/surogates
+git add sdk/agent-chat-react/src/components/chat/chat-thread.tsx
+git commit -m "feat(agent-chat): show 'From loop' affordance on loop.result messages"
+```
+
+---
+
+## Task 8: Web host raw event type
+
+**Files:**
+- Modify: `web/src/types/session.ts`
+
+**Interfaces:**
+- Consumes: raw session event type union. The chat adapter opens the raw SSE
+  stream and delegates filtering to the SDK runtime (no adapter change needed).
+
+- [ ] **Step 1: Add the type**
+
+In `web/src/types/session.ts`, add `"loop.result"` wherever the raw session
+event `type` union / enum is declared (mirror how `"llm.response"` /
+`"inbox.task_complete"` appear).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd /work/surogates/web && npm run typecheck`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /work/surogates
+git add web/src/types/session.ts
+git commit -m "feat(web): accept loop.result raw session event"
+```
+
+---
+
+## Task 9: Ops observability view
+
+**Files:**
+- Modify: `surogates/db/observability.sql` (`v_session_messages`, ~line 660)
+
+**Interfaces:**
+- Produces: `loop.result` rows appear in `v_session_messages`.
+
+- [ ] **Step 1: Add the type to the view whitelist**
+
+In the `WHERE e.type IN (...)` list of `v_session_messages`, add `'loop.result'`:
+
+```sql
+    'user.feedback',
+    'loop.result'
+);
+```
+
+- [ ] **Step 2: Verify the SQL is well-formed**
+
+Run (against the PROD-style test DB or a local psql): apply the `CREATE OR
+REPLACE VIEW v_session_messages` statement and confirm no syntax error, e.g.:
+
+```bash
+# local dev DB only
+psql "$SUROGATES_DATABASE_URL" -c "$(sed -n '/CREATE OR REPLACE VIEW v_session_messages/,/);/p' surogates/db/observability.sql)"
+psql "$SUROGATES_DATABASE_URL" -c "SELECT 1 FROM v_session_messages LIMIT 1;"
+```
+
+Expected: `CREATE VIEW` then a clean select (0+ rows).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /work/surogates
+git add surogates/db/observability.sql
+git commit -m "feat(observability): surface loop.result in v_session_messages"
+```
+
+---
+
+## Task 10: Ops frontend thread rendering
+
+**Files:**
+- Modify: `/work/surogate-ops/frontend/src/types/session.ts` (`EventType` object, ~line 28)
+- Modify: `/work/surogate-ops/frontend/src/components/sessions/session-thread.tsx` (~line 200)
+
+**Interfaces:**
+- Consumes: `EventType.LOOP_RESULT`; the `AgentTurn` component (reads message content).
+
+- [ ] **Step 1: Add the enum entry**
+
+In `frontend/src/types/session.ts`, add to the `EventType` object:
+
+```typescript
+  LOOP_RESULT: "loop.result",
+```
+
+- [ ] **Step 2: Include loop.result in the turn filter and render as an agent turn**
+
+In `session-thread.tsx`, extend the `turns` filter and render:
+
+```tsx
+  const turns = useMemo(
+    () =>
+      messages.filter(
+        (m) =>
+          m.type === EventType.USER_MESSAGE ||
+          m.type === EventType.LLM_RESPONSE ||
+          m.type === EventType.LOOP_RESULT,
+      ),
+    [messages],
+  );
+```
+
+and in the map, route `LOOP_RESULT` through `AgentTurn`:
+
+```tsx
+      {turns.map((m) =>
+        m.type === EventType.USER_MESSAGE ? (
+          <UserTurn key={m.eventId} msg={m} />
+        ) : (
+          <AgentTurn
+            key={m.eventId}
+            msg={m}
+            agentLabel={agentLabel}
+            feedback={feedbackMap.get(m.eventId)}
+          />
+        ),
+      )}
+```
+
+- [ ] **Step 3: Ensure AgentTurn reads loop.result content**
+
+Inspect `AgentTurn`: if it extracts content from `data.message.content`
+(llm.response shape), add a fallback to `data.content` so a `loop.result`
+event renders its text. Keep it minimal:
+
+```tsx
+  const text =
+    msg.data?.message?.content ?? msg.data?.content ?? "";
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd /work/surogate-ops/frontend && npm run typecheck`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /work/surogate-ops
+git add frontend/src/types/session.ts frontend/src/components/sessions/session-thread.tsx
+git commit -m "feat(sessions): render loop.result as an agent turn in the thread"
+```
+
+---
+
+## Final verification
+
+- [ ] **Backend suite**
+
+Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_delivery.py tests/test_loop_result_replay_safety.py tests/test_channel_delivery.py -q`
+Expected: all pass.
+
+- [ ] **SDK suite + build**
+
+Run: `cd /work/surogates/sdk/agent-chat-react && npx vitest run && npm run build`
+Expected: pass + clean build.
+
+- [ ] **Hosts typecheck**
+
+Run: `cd /work/surogates/web && npm run typecheck` and `cd /work/surogate-ops/frontend && npm run typecheck`
+Expected: clean.
+
+- [ ] **End-to-end (staging/local)**
+
+Create a `/loop … every 1 minute` from a web session; after the next tick,
+confirm the run's answer appears inline in that conversation and that no
+`inbox.task_complete` card is created for the run (query `inbox_items` for the
+run session id → 0 rows).

--- a/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
+++ b/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
@@ -15,7 +15,7 @@
 - [x] Task 1: Backend event type + replay/outbox guards
 - [x] Task 2: Backend parent-resolution helper
 - [x] Task 3: Backend inline emission + inbox suppression + cursor fallback
-- [ ] Task 4: SDK event registration + reducer
+- [x] Task 4: SDK event registration + reducer
 - [ ] Task 5: SDK chat-thread affordance
 - [ ] Task 6: Surogates web raw event type
 - [ ] Task 7: Ops observability view

--- a/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
+++ b/docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md
@@ -1,67 +1,81 @@
-# Loop-result inline delivery (web/api) Implementation Plan
+# Loop-result Inline Delivery Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Surface each web/api-originated loop run's final answer inline in the originating conversation by emitting a new `loop.result` event on the parent session, and stop creating the redundant expiring inbox card for those runs.
+**Goal:** Surface each web/api-originated loop run's final answer inline in the originating conversation with a parent-session `loop.result` event, without waking the parent agent or adding the result to replay context.
 
-**Architecture:** At loop-run completion the harness emits a new `loop.result` event onto the *parent* web/api session's event log (never the outbox, never a parent wake). `emit_event` already publishes to `surogates:session:{id}`, so the parent's SSE/poll stream delivers it. Because `loop.result` is a new event type, the context-replay whitelist ignores it, keeping the parent agent's context untouched. Frontends render it as an assistant-style message.
+**Architecture:** The harness adds a new `loop.result` event type and emits it on a scheduled run's web/api parent during `_complete_session`. The child run still records its own `session.complete`, but web/api scheduled runs skip the redundant `inbox.task_complete` card and advance the child cursor to the child terminal event. The shared React SDK listens for `loop.result` and renders it as assistant output; ops includes the event in `v_session_messages` and both session-thread renderers.
 
-**Tech Stack:** Python 3.12 async (surogates harness), pytest + testcontainers Postgres, TypeScript/React (`sdk/agent-chat-react`, `web`, `surogate-ops/frontend`), SQL view (`surogates/db/observability.sql`).
-
-## Global Constraints
-
-- Spec: `docs/superpowers/specs/2026-07-03-loop-result-inline-delivery-design.md` — authoritative.
-- Run backend tests with the repo venv: `/work/surogates/.venv/bin/pytest`. Never `uv run` (it reinstalls pinned wheels).
-- Conventional Commits for every commit (`type(scope): subject`). No `Co-Authored-By` trailer. Never reference plan/task/phase/step numbers in code comments or commit messages.
-- Gating is by parent **channel** (`web` or `api`), not by loop kind — cron and dynamic loops both qualify.
-- `loop.result` must NOT be added to `SessionStore._DELIVERABLE_EVENTS` and must NOT be consumed by `_rebuild_messages`.
-- Emission is best-effort: a failure must never abort run completion, status update, cursor advancement, or dynamic-loop finalization.
-- Two repos are touched: `/work/surogates` (backend, SDK, web host, SQL view) and `/work/surogate-ops` (ops frontend). Commit within each repo separately.
+**Tech Stack:** Python 3.12 async harness, SQLAlchemy-backed session store, pytest, PostgreSQL SQL view, TypeScript/React, Vitest, Vite/tsc.
 
 ---
+
+## Scope And Repos
+
+- Spec: `/work/surogates/docs/superpowers/specs/2026-07-03-loop-result-inline-delivery-design.md`.
+- Main repo: `/work/surogates`.
+- Ops repo: `/work/surogate-ops`.
+- Backend tests run with `/work/surogates/.venv/bin/pytest`.
+- Frontend commands: use `pnpm` for `/work/surogates/sdk/agent-chat-react` (root `/work/surogates/pnpm-lock.yaml`), and use `npm` for `/work/surogates/web` and `/work/surogate-ops/frontend` (both have `package-lock.json`).
+- Do not add `loop.result` to `SessionStore._DELIVERABLE_EVENTS`.
+- Do not add `loop.result` to `ContextReplayMixin._rebuild_messages`.
+- Do not enqueue or otherwise wake the parent session.
+- Commit `/work/surogates` and `/work/surogate-ops` changes separately.
 
 ## File Structure
 
-Backend (`/work/surogates`):
-- `surogates/session/events.py` — add `EventType.LOOP_RESULT`.
-- `surogates/harness/loop_messages.py` — add `_resolve_loop_result_parent` helper.
-- `surogates/harness/loop_artifact_completion.py` — emit `loop.result`, suppress inbox card, fix cursor fallback.
-- `tests/test_loop_result_delivery.py` — new unit tests (gating + emission + suppression + cursor + no-wake).
-- `tests/test_loop_result_replay_safety.py` — replay + `_DELIVERABLE_EVENTS` guards.
+Backend in `/work/surogates`:
 
-Frontend SDK (`/work/surogates/sdk/agent-chat-react`):
-- `src/types.ts` — add `"loop.result"` to `AgentChatEventType`; add `loopResult?` to `AgentChatMessage`.
-- `src/runtime/events.ts` — add `"loop.result"` to `AGENT_CHAT_LISTENED_EVENTS`.
-- `src/runtime/reducer.ts` — add `case "loop.result"`.
-- `src/components/chat/chat-thread.tsx` — render the loop affordance.
-- `src/runtime/reducer.test.ts` (or existing reducer test file) — reducer test.
+- Modify `surogates/session/events.py`: add `EventType.LOOP_RESULT`.
+- Modify `surogates/harness/loop_artifact_completion.py`: add helper and completion-path surfacing.
+- Test `tests/test_loop_result_inline_delivery.py`: backend event type, gating, emission, suppression, cursor fallback, best-effort behavior.
+- Test `tests/test_loop_result_replay_safety.py`: replay/outbox guard.
 
-Web host (`/work/surogates/web`):
-- `src/types/session.ts` — add `"loop.result"` to the raw session event type.
+SDK and web host in `/work/surogates`:
 
-Ops (`/work/surogates/surogates/db` + `/work/surogate-ops/frontend`):
-- `surogates/db/observability.sql` — add `'loop.result'` to `v_session_messages`.
-- `frontend/src/types/session.ts` — add `EventType.LOOP_RESULT`.
-- `frontend/src/components/sessions/session-thread.tsx` — render loop.result as an agent turn.
+- Modify `sdk/agent-chat-react/src/types.ts`: add `"loop.result"` and `AgentChatMessage.loopResult`.
+- Modify `sdk/agent-chat-react/src/runtime/events.ts`: listen for `"loop.result"`.
+- Modify `sdk/agent-chat-react/src/runtime/reducer.ts`: append completed assistant message for `loop.result`.
+- Modify `sdk/agent-chat-react/src/components/chat/chat-thread.tsx`: show a compact "From loop" affordance.
+- Test `sdk/agent-chat-react/tests/listened-events.test.ts`: listened-event registration.
+- Test `sdk/agent-chat-react/tests/reducer.test.ts`: reducer behavior.
+- Modify `web/src/types/session.ts`: accept raw `"loop.result"` session events.
+
+Ops/admin:
+
+- Modify `/work/surogates/surogates/db/observability.sql`: include `loop.result` in `v_session_messages`.
+- Modify `/work/surogate-ops/frontend/src/types/session.ts`: add `EventType.LOOP_RESULT`.
+- Modify `/work/surogate-ops/frontend/src/components/sessions/session-thread.tsx`: render loop result in the compact thread.
+- Modify `/work/surogate-ops/frontend/src/components/sessions/thread-tab.tsx`: render loop result in the detailed thread.
 
 ---
 
-## Task 1: Add the `loop.result` event type (backend)
+## Task 1: Backend Event Type And Replay Guards
 
 **Files:**
-- Modify: `surogates/session/events.py` (near `INBOX_TASK_COMPLETE`, ~line 217)
-- Test: `tests/test_loop_result_replay_safety.py`
+- Modify: `/work/surogates/surogates/session/events.py`
+- Create: `/work/surogates/tests/test_loop_result_replay_safety.py`
 
-**Interfaces:**
-- Produces: `EventType.LOOP_RESULT` with value `"loop.result"`.
+- [ ] **Step 1: Write the failing guard tests**
 
-- [ ] **Step 1: Write the failing test**
-
-Create `tests/test_loop_result_replay_safety.py`:
+Create `/work/surogates/tests/test_loop_result_replay_safety.py`:
 
 ```python
+from types import SimpleNamespace
+from uuid import uuid4
+
+from surogates.harness.loop_context_replay import ContextReplayMixin
 from surogates.session.events import EventType
 from surogates.session.store import _DELIVERABLE_EVENTS
+
+
+def _event(event_type: EventType, data: dict, event_id: int = 1):
+    return SimpleNamespace(
+        id=event_id,
+        session_id=uuid4(),
+        type=event_type.value,
+        data=data,
+    )
 
 
 def test_loop_result_event_type_exists():
@@ -69,28 +83,55 @@ def test_loop_result_event_type_exists():
 
 
 def test_loop_result_is_not_a_deliverable_event():
-    # loop.result is surfaced on web/api parents via SSE, never the outbox.
     assert EventType.LOOP_RESULT not in _DELIVERABLE_EVENTS
+
+
+def test_rebuild_messages_ignores_loop_result():
+    host = type("_ReplayHost", (ContextReplayMixin,), {})()
+    rebuilt = host._rebuild_messages([
+        _event(
+            EventType.LLM_RESPONSE,
+            {"message": {"role": "assistant", "content": "normal reply"}},
+            1,
+        ),
+        _event(EventType.LOOP_RESULT, {"content": "scheduled output"}, 2),
+    ])
+
+    joined = "\n".join(str(m.get("content", "")) for m in rebuilt)
+    assert "normal reply" in joined
+    assert "scheduled output" not in joined
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Run the failing tests**
 
-Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_replay_safety.py -q`
-Expected: FAIL with `AttributeError: LOOP_RESULT`.
+Run:
 
-- [ ] **Step 3: Add the enum member**
+```bash
+cd /work/surogates
+/work/surogates/.venv/bin/pytest tests/test_loop_result_replay_safety.py -q
+```
 
-In `surogates/session/events.py`, immediately after the `INBOX_*` block:
+Expected: fails with `AttributeError: LOOP_RESULT`.
+
+- [ ] **Step 3: Add the event type**
+
+In `/work/surogates/surogates/session/events.py`, add this immediately after the inbox event block:
 
 ```python
-    # Loop-run result surfaced inline on a web/api parent conversation.
+    # Scheduled loop run result surfaced inline on a web/api parent session.
     LOOP_RESULT = "loop.result"
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 4: Run the passing guard tests**
 
-Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_replay_safety.py -q`
-Expected: PASS (2 passed).
+Run:
+
+```bash
+cd /work/surogates
+/work/surogates/.venv/bin/pytest tests/test_loop_result_replay_safety.py -q
+```
+
+Expected: all tests pass.
 
 - [ ] **Step 5: Commit**
 
@@ -102,253 +143,391 @@ git commit -m "feat(events): add loop.result event type"
 
 ---
 
-## Task 2: `_resolve_loop_result_parent` gating helper (backend)
+## Task 2: Backend Parent Resolution Helper
 
 **Files:**
-- Modify: `surogates/harness/loop_messages.py` (add helper next to `_should_notify_parent_on_completion`, ~line 239)
-- Test: `tests/test_loop_result_delivery.py`
+- Modify: `/work/surogates/surogates/harness/loop_artifact_completion.py`
+- Create/modify: `/work/surogates/tests/test_loop_result_inline_delivery.py`
 
-**Interfaces:**
-- Consumes: a `session` with `.channel`, `.parent_id`; an async `store.get_session(uuid) -> Session` (raises `SessionNotFoundError` when missing).
-- Produces: `async def resolve_loop_result_parent(session, store) -> Session | None` — returns the parent `Session` only for a scheduled child (`channel == "scheduled"`) with a `parent_id` whose parent channel is `web` or `api`; otherwise `None` (including lookup failure).
+- [ ] **Step 1: Write failing gating tests**
 
-- [ ] **Step 1: Write the failing test**
-
-Create `tests/test_loop_result_delivery.py`:
+Create `/work/surogates/tests/test_loop_result_inline_delivery.py`:
 
 ```python
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
 
-from surogates.harness.loop_messages import resolve_loop_result_parent
+from surogates.harness.loop_artifact_completion import ArtifactCompletionMixin
 from surogates.session.store import SessionNotFoundError
 
 
-class _FakeStore:
-    def __init__(self, parent):
-        self._parent = parent
+def _session(*, channel: str, parent_id=None, config=None):
+    now = datetime.now(timezone.utc)
+    return SimpleNamespace(
+        id=uuid4(),
+        user_id=uuid4(),
+        org_id=uuid4(),
+        agent_id="agent-a",
+        channel=channel,
+        status="active",
+        parent_id=parent_id,
+        title="Loop run",
+        config=config or {},
+        created_at=now,
+        updated_at=now,
+        task_id=None,
+    )
 
-    async def get_session(self, sid):
-        if self._parent is None or self._parent.id != sid:
-            raise SessionNotFoundError(str(sid))
-        return self._parent
+
+class _ParentStore:
+    def __init__(self, parent=None):
+        self.parent = parent
+
+    async def get_session(self, session_id):
+        if self.parent is not None and session_id == self.parent.id:
+            return self.parent
+        raise SessionNotFoundError(str(session_id))
 
 
-def _child(channel="scheduled", parent_id=None):
-    return SimpleNamespace(id=uuid4(), channel=channel, parent_id=parent_id)
-
-
-def _parent(channel):
-    return SimpleNamespace(id=uuid4(), channel=channel, parent_id=None)
+def _harness(store):
+    host = type("_Harness", (ArtifactCompletionMixin,), {})()
+    host._store = store
+    return host
 
 
 @pytest.mark.parametrize("parent_channel", ["web", "api"])
-async def test_resolves_parent_for_web_and_api(parent_channel):
-    parent = _parent(parent_channel)
-    child = _child(parent_id=parent.id)
-    got = await resolve_loop_result_parent(child, _FakeStore(parent))
-    assert got is parent
+async def test_resolves_web_and_api_loop_parent(parent_channel):
+    parent = _session(channel=parent_channel)
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+
+    assert await _harness(_ParentStore(parent))._resolve_loop_result_parent(child) is parent
 
 
-@pytest.mark.parametrize("parent_channel", ["slack", "telegram", "teams"])
-async def test_skips_channel_parents(parent_channel):
-    parent = _parent(parent_channel)
-    child = _child(parent_id=parent.id)
-    assert await resolve_loop_result_parent(child, _FakeStore(parent)) is None
+@pytest.mark.parametrize("parent_channel", ["slack", "telegram", "teams", "ambient"])
+async def test_skips_channel_and_private_parents(parent_channel):
+    parent = _session(channel=parent_channel)
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+
+    assert await _harness(_ParentStore(parent))._resolve_loop_result_parent(child) is None
 
 
-async def test_skips_non_scheduled_child():
-    parent = _parent("web")
-    child = _child(channel="worker", parent_id=parent.id)
-    assert await resolve_loop_result_parent(child, _FakeStore(parent)) is None
+async def test_skips_detached_scheduled_run():
+    child = _session(
+        channel="scheduled",
+        parent_id=None,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+
+    assert await _harness(_ParentStore())._resolve_loop_result_parent(child) is None
 
 
-async def test_skips_when_no_parent_id():
-    child = _child(parent_id=None)
-    assert await resolve_loop_result_parent(child, _FakeStore(None)) is None
+async def test_skips_missing_parent():
+    child = _session(
+        channel="scheduled",
+        parent_id=uuid4(),
+        config={"scheduled_session_id": str(uuid4())},
+    )
+
+    assert await _harness(_ParentStore())._resolve_loop_result_parent(child) is None
 
 
-async def test_skips_when_parent_missing():
-    child = _child(parent_id=uuid4())
-    assert await resolve_loop_result_parent(child, _FakeStore(None)) is None
+async def test_accepts_legacy_scheduled_run_marker_even_if_channel_drifted():
+    parent = _session(channel="web")
+    child = _session(
+        channel="api",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+
+    assert await _harness(_ParentStore(parent))._resolve_loop_result_parent(child) is parent
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Run the failing tests**
 
-Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_delivery.py -q`
-Expected: FAIL with `ImportError: cannot import name 'resolve_loop_result_parent'`.
+Run:
+
+```bash
+cd /work/surogates
+/work/surogates/.venv/bin/pytest tests/test_loop_result_inline_delivery.py -q
+```
+
+Expected: fails with `AttributeError: '_Harness' object has no attribute '_resolve_loop_result_parent'`.
 
 - [ ] **Step 3: Implement the helper**
 
-In `surogates/harness/loop_messages.py`, add (imports `SessionNotFoundError` lazily to avoid a cycle):
+In `/work/surogates/surogates/harness/loop_artifact_completion.py`, add this method inside `ArtifactCompletionMixin`, before `_complete_session`:
 
 ```python
-async def resolve_loop_result_parent(session: Any, store: Any) -> Any | None:
-    """Return the parent session a loop run should surface its result into.
+    async def _resolve_loop_result_parent(self, session: Session) -> Session | None:
+        """Return the web/api parent that should receive this loop run result."""
+        config = session.config or {}
+        is_scheduled_run = (
+            session.channel == "scheduled"
+            or bool(config.get("scheduled_session_id"))
+        )
+        if not is_scheduled_run or session.parent_id is None:
+            return None
 
-    A scheduled run (``channel == "scheduled"``) whose parent conversation
-    is a pull-based surface (``web`` or ``api``) has no outbox path, so its
-    per-run answer is delivered by emitting a ``loop.result`` event on the
-    parent.  Channel parents (slack/telegram/teams) already receive each run
-    through the outbox and are skipped; detached runs (no parent) and missing
-    parents return ``None``.
-    """
-    if session.channel != "scheduled" or session.parent_id is None:
-        return None
-    from surogates.session.store import SessionNotFoundError
+        from surogates.session.store import SessionNotFoundError
 
-    try:
-        parent = await store.get_session(session.parent_id)
-    except SessionNotFoundError:
-        return None
-    if parent is None or parent.channel not in ("web", "api"):
-        return None
-    return parent
+        try:
+            parent = await self._store.get_session(session.parent_id)
+        except SessionNotFoundError:
+            return None
+
+        if parent.channel not in {"web", "api"}:
+            return None
+        return parent
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 4: Run the passing tests**
 
-Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_delivery.py -q`
-Expected: PASS (9 passed).
+Run:
+
+```bash
+cd /work/surogates
+/work/surogates/.venv/bin/pytest tests/test_loop_result_inline_delivery.py -q
+```
+
+Expected: all tests pass.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 cd /work/surogates
-git add surogates/harness/loop_messages.py tests/test_loop_result_delivery.py
-git commit -m "feat(harness): add loop-result parent resolution helper"
+git add surogates/harness/loop_artifact_completion.py tests/test_loop_result_inline_delivery.py
+git commit -m "feat(harness): resolve loop-result parent sessions"
 ```
 
 ---
 
-## Task 3: Emit `loop.result`, suppress inbox card, fix cursor fallback (backend)
+## Task 3: Backend Inline Emission And Inbox Suppression
 
 **Files:**
-- Modify: `surogates/harness/loop_artifact_completion.py` (`_complete_session`, lines ~596–662)
-- Test: `tests/test_loop_result_delivery.py` (append)
+- Modify: `/work/surogates/surogates/harness/loop_artifact_completion.py`
+- Modify: `/work/surogates/tests/test_loop_result_inline_delivery.py`
 
-**Interfaces:**
-- Consumes: `resolve_loop_result_parent` (Task 2); `EventType.LOOP_RESULT` (Task 1); `self._store.get_events(session_id) -> list[Event]`; `extract_final_response(events, fallback="") -> str`; `self._store.emit_event(session_id, type, data) -> int`.
-- Produces: a `loop.result` event on the parent for web/api scheduled runs; no `inbox.task_complete` for those runs; correct cursor advancement.
+- [ ] **Step 1: Add failing completion-path tests**
 
-- [ ] **Step 1: Write the failing test (append to `tests/test_loop_result_delivery.py`)**
+Append to `/work/surogates/tests/test_loop_result_inline_delivery.py`:
 
 ```python
 from surogates.session.events import EventType
 
 
-class _RecordingStore:
-    """Captures emit_event calls and serves child events for extraction."""
-
-    def __init__(self, parent, child_events):
-        self._parent = parent
-        self._child_events = child_events
-        self.emitted = []          # (session_id, type, data)
-        self.enqueued = []         # parent re-enqueue attempts
-        self.next_id = 1000
-
-    async def get_session(self, sid):
-        if self._parent is not None and self._parent.id == sid:
-            return self._parent
-        from surogates.session.store import SessionNotFoundError
-        raise SessionNotFoundError(str(sid))
-
-    async def get_events(self, sid):
-        return self._child_events
-
-    async def emit_event(self, sid, etype, data):
-        self.next_id += 1
-        self.emitted.append((sid, etype, data))
-        return self.next_id
-
-    async def update_session_status(self, *a, **k):
-        pass
-
-    async def advance_harness_cursor(self, *a, **k):
-        pass
+def _llm_response(content: str):
+    return SimpleNamespace(
+        type=EventType.LLM_RESPONSE.value,
+        data={"message": {"role": "assistant", "content": content}},
+    )
 
 
-def _evt(etype, content):
-    return SimpleNamespace(type=etype.value if hasattr(etype, "value") else etype,
-                           data={"message": {"content": content}})
+class _RecordingStore(_ParentStore):
+    def __init__(self, parent=None, child_events=None, fail_loop_result=False):
+        super().__init__(parent)
+        self.child_events = list(child_events or [])
+        self.fail_loop_result = fail_loop_result
+        self.emitted = []
+        self.status_updates = []
+        self.cursor_advancements = []
+        self.next_event_id = 100
+
+    async def get_events(self, session_id):
+        return list(self.child_events)
+
+    async def emit_event(self, session_id, event_type, data):
+        if event_type == EventType.LOOP_RESULT and self.fail_loop_result:
+            raise RuntimeError("boom")
+        self.next_event_id += 1
+        self.emitted.append((self.next_event_id, session_id, event_type, data))
+        return self.next_event_id
+
+    async def update_session_status(self, session_id, status):
+        self.status_updates.append((session_id, status))
+
+    async def advance_harness_cursor(self, session_id, cursor, lease_token):
+        self.cursor_advancements.append((session_id, cursor, lease_token))
 
 
-def _bare_harness(store):
-    # _complete_session lives on ArtifactCompletionMixin. Build a bare host and
-    # set only the attributes the method touches.
-    from surogates.harness.loop_artifact_completion import ArtifactCompletionMixin
+def _completion_harness(store):
+    host = _harness(store)
+    host._worker_id = "worker-1"
+    host._sandbox_pool = None
+    host._memory_manager = None
+    host._turn_summarizer = None
+    host._redis = None
+    host._session_factory = None
+    return host
 
-    h = type("_H", (ArtifactCompletionMixin,), {})()
-    h._store = store
-    h._worker_id = "w"
-    h._sandbox_pool = None
-    h._memory_manager = None
-    h._turn_summarizer = None
-    h._redis = None
-    h._session_factory = None
-    h._tenant = SimpleNamespace(user_id=uuid4(), service_account_id=None)
-    return h
+
+async def _complete(host, child, *, messages=None, reason="stop", through_event_id=None):
+    await host._complete_session(
+        child,
+        messages=messages if messages is not None else [{"role": "assistant", "content": "done"}],
+        lease=SimpleNamespace(lease_token="lease-1"),
+        reason=reason,
+        through_event_id=through_event_id,
+    )
+
+
+def _types(store):
+    return [event_type for _, _, event_type, _ in store.emitted]
+
+
+async def test_web_parent_gets_loop_result_and_inbox_is_suppressed():
+    schedule_id = uuid4()
+    parent = _session(channel="web")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(schedule_id)},
+    )
+    store = _RecordingStore(parent, [_llm_response("Full final answer")])
+
+    await _complete(_completion_harness(store), child)
+
+    loop_rows = [row for row in store.emitted if row[2] == EventType.LOOP_RESULT]
+    assert len(loop_rows) == 1
+    _, emitted_session_id, _, payload = loop_rows[0]
+    assert emitted_session_id == parent.id
+    assert payload["run_session_id"] == str(child.id)
+    assert payload["scheduled_session_id"] == str(schedule_id)
+    assert payload["content"] == "Full final answer"
+    assert payload["outcome"] == "success"
+    assert isinstance(payload["duration_seconds"], int)
+    assert payload["run_completed_at"]
+    assert EventType.INBOX_TASK_COMPLETE not in _types(store)
+
+
+async def test_api_parent_gets_loop_result_and_inbox_is_suppressed():
+    parent = _session(channel="api")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+    store = _RecordingStore(parent, [_llm_response("API final answer")])
+
+    await _complete(_completion_harness(store), child)
+
+    assert EventType.LOOP_RESULT in _types(store)
+    assert EventType.INBOX_TASK_COMPLETE not in _types(store)
+
+
+async def test_channel_parent_keeps_existing_inbox_completion_and_no_loop_result():
+    parent = _session(channel="slack")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+    store = _RecordingStore(parent, [_llm_response("Channel final answer")])
+
+    await _complete(_completion_harness(store), child)
+
+    assert EventType.LOOP_RESULT not in _types(store)
+    assert EventType.INBOX_TASK_COMPLETE in _types(store)
+
+
+async def test_empty_final_response_suppresses_inbox_but_emits_no_loop_result():
+    parent = _session(channel="web")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+    store = _RecordingStore(parent, child_events=[])
+
+    await _complete(_completion_harness(store), child, messages=[])
+
+    assert EventType.LOOP_RESULT not in _types(store)
+    assert EventType.INBOX_TASK_COMPLETE not in _types(store)
+    assert store.status_updates == [(child.id, "completed")]
+
+
+async def test_loop_result_failure_does_not_abort_completion_and_still_suppresses_inbox():
+    parent = _session(channel="web")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+    store = _RecordingStore(parent, [_llm_response("Final")], fail_loop_result=True)
+
+    await _complete(_completion_harness(store), child)
+
+    assert EventType.INBOX_TASK_COMPLETE not in _types(store)
+    assert store.status_updates == [(child.id, "completed")]
+    assert store.cursor_advancements
+
+
+async def test_cursor_uses_child_session_complete_when_inbox_is_suppressed():
+    parent = _session(channel="web")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+    store = _RecordingStore(parent, [_llm_response("Final")])
+
+    await _complete(_completion_harness(store), child)
+
+    session_complete_id = next(
+        event_id for event_id, _, event_type, _ in store.emitted
+        if event_type == EventType.SESSION_COMPLETE
+    )
+    assert store.cursor_advancements == [(child.id, session_complete_id, "lease-1")]
+
+
+async def test_explicit_through_event_id_still_wins_for_cursor():
+    parent = _session(channel="web")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+    store = _RecordingStore(parent, [_llm_response("Final")])
+
+    await _complete(_completion_harness(store), child, through_event_id=77)
+
+    assert store.cursor_advancements == [(child.id, 77, "lease-1")]
 ```
 
-Concrete tests (append to the same file):
+- [ ] **Step 2: Run the failing tests**
+
+Run:
+
+```bash
+cd /work/surogates
+/work/surogates/.venv/bin/pytest tests/test_loop_result_inline_delivery.py -q
+```
+
+Expected: failures showing `loop.result` is not emitted and web/api inbox cards are still emitted.
+
+- [ ] **Step 3: Import final-response extraction**
+
+In `/work/surogates/surogates/harness/loop_artifact_completion.py`, add:
 
 ```python
-    parent = _parent("web")
-    child = SimpleNamespace(
-        id=uuid4(), channel="scheduled", parent_id=parent.id,
-        org_id=uuid4(), agent_id="a", title="t",
-        created_at=__import__("datetime").datetime.now(__import__("datetime").timezone.utc),
-        config={"scheduled_session_id": str(uuid4())},
-        task_id=None,
-    )
-    store = _RecordingStore(parent, child_events=[_evt(EventType.LLM_RESPONSE, "Weather: 22C")])
-    h = _bare_harness(store)
-
-    await h._complete_session(
-        child,
-        messages=[{"role": "assistant", "content": "Weather: 22C"}],
-        lease=SimpleNamespace(lease_token="t"),
-        reason="stop",
-    )
-
-    loop_results = [e for e in store.emitted if e[1] == EventType.LOOP_RESULT]
-    assert len(loop_results) == 1
-    sid, _, data = loop_results[0]
-    assert sid == parent.id                       # emitted on the PARENT
-    assert data["content"] == "Weather: 22C"      # full final response
-    assert data["run_session_id"] == str(child.id)
-    # inbox card suppressed for this run
-    assert not any(e[1] == EventType.INBOX_TASK_COMPLETE for e in store.emitted)
-
-
-async def test_slack_parent_scheduled_run_keeps_inbox_and_no_loop_result():
-    parent = _parent("slack")
-    child = SimpleNamespace(
-        id=uuid4(), channel="scheduled", parent_id=parent.id,
-        org_id=uuid4(), agent_id="a", title="t",
-        created_at=__import__("datetime").datetime.now(__import__("datetime").timezone.utc),
-        config={"scheduled_session_id": str(uuid4())}, task_id=None,
-    )
-    store = _RecordingStore(parent, child_events=[_evt(EventType.LLM_RESPONSE, "hi")])
-    h = _bare_harness(store)
-    await h._complete_session(child, messages=[{"role": "assistant", "content": "hi"}],
-                              lease=SimpleNamespace(lease_token="t"), reason="stop")
-    assert not any(e[1] == EventType.LOOP_RESULT for e in store.emitted)
-    assert any(e[1] == EventType.INBOX_TASK_COMPLETE for e in store.emitted)
+from surogates.harness.message_utils import extract_final_response
 ```
 
-Add a `_bare_harness(store)` helper in the test file per the fixture note.
+The file already imports `datetime`, `timezone`, `_seconds_since`, and `_last_assistant_message_excerpt`.
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 4: Replace the completion event block**
 
-Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_delivery.py -q`
-Expected: FAIL — `loop.result` never emitted / inbox still present.
-
-- [ ] **Step 3: Implement in `_complete_session`**
-
-Replace the SESSION_COMPLETE + INBOX_TASK_COMPLETE block (lines ~596–615) and the cursor block (lines ~650–653):
+In `_complete_session`, replace the current `SESSION_COMPLETE` plus unconditional `INBOX_TASK_COMPLETE` block with:
 
 ```python
         session_complete_event_id = await self._store.emit_event(
@@ -356,21 +535,22 @@ Replace the SESSION_COMPLETE + INBOX_TASK_COMPLETE block (lines ~596–615) and 
             EventType.SESSION_COMPLETE,
             complete_data,
         )
-
         outcome = (
             "success"
             if reason in {"stop", "done", "complete", "completed"}
             else reason
         )
 
-        # Surface web/api loop runs inline on the origin conversation instead
-        # of an expiring inbox card. Best-effort; never abort completion.
         loop_result_parent = None
         try:
-            loop_result_parent = await resolve_loop_result_parent(session, self._store)
+            loop_result_parent = await self._resolve_loop_result_parent(session)
         except Exception:
-            logger.debug("loop.result parent resolution failed for %s", session.id,
-                         exc_info=True)
+            logger.debug(
+                "Failed to resolve loop.result parent for %s",
+                session.id,
+                exc_info=True,
+            )
+
         if loop_result_parent is not None:
             try:
                 child_events = await self._store.get_events(session.id)
@@ -382,7 +562,7 @@ Replace the SESSION_COMPLETE + INBOX_TASK_COMPLETE block (lines ~596–615) and 
                         {
                             "run_session_id": str(session.id),
                             "scheduled_session_id": str(
-                                session.config.get("scheduled_session_id") or ""
+                                (session.config or {}).get("scheduled_session_id") or ""
                             ),
                             "content": content,
                             "outcome": outcome,
@@ -391,10 +571,13 @@ Replace the SESSION_COMPLETE + INBOX_TASK_COMPLETE block (lines ~596–615) and 
                         },
                     )
             except Exception:
-                logger.warning("Failed to emit loop.result on parent %s for run %s",
-                               loop_result_parent.id, session.id, exc_info=True)
+                logger.warning(
+                    "Failed to emit loop.result on parent %s for run %s",
+                    loop_result_parent.id,
+                    session.id,
+                    exc_info=True,
+                )
 
-        # Inbox card: skip for web/api loop runs (delivered inline above).
         inbox_event_id: int | None = None
         if loop_result_parent is None:
             inbox_event_id = await self._store.emit_event(
@@ -410,164 +593,115 @@ Replace the SESSION_COMPLETE + INBOX_TASK_COMPLETE block (lines ~596–615) and 
             )
 ```
 
-And the cursor fallback (lines ~650–653):
+- [ ] **Step 5: Replace the cursor fallback**
+
+In `_complete_session`, replace the existing `cursor_target` assignment with:
 
 ```python
-        # Advance cursor to the latest child event. When the inbox card is
-        # suppressed, fall back to the child's SESSION_COMPLETE event id.
         cursor_target = (
             through_event_id
             if through_event_id is not None
-            else (inbox_event_id if inbox_event_id is not None
-                  else session_complete_event_id)
+            else (
+                inbox_event_id
+                if inbox_event_id is not None
+                else session_complete_event_id
+            )
         )
 ```
 
-Add imports at the top of `loop_artifact_completion.py` if absent:
+- [ ] **Step 6: Run the passing backend tests**
 
-```python
-from datetime import datetime, timezone
-
-from surogates.harness.loop_messages import resolve_loop_result_parent
-from surogates.harness.message_utils import extract_final_response
-```
-
-(`_seconds_since` and `_last_assistant_message_excerpt` already exist in this module — reuse them. There is no `_utcnow` here, so use `datetime.now(timezone.utc)` for `run_completed_at`.)
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_delivery.py -q`
-Expected: PASS.
-
-- [ ] **Step 5: Add cursor + no-wake tests (append) and run**
-
-```python
-async def test_parent_not_re_enqueued_by_surfacing():
-    parent = _parent("web")
-    child = SimpleNamespace(id=uuid4(), channel="scheduled", parent_id=parent.id,
-                            org_id=uuid4(), agent_id="a", title="t",
-                            created_at=__import__("datetime").datetime.now(
-                                __import__("datetime").timezone.utc),
-                            config={"scheduled_session_id": str(uuid4())}, task_id=None)
-    store = _RecordingStore(parent, [_evt(EventType.LLM_RESPONSE, "x")])
-    h = _bare_harness(store)
-    await h._complete_session(child, messages=[{"role": "assistant", "content": "x"}],
-                              lease=SimpleNamespace(lease_token="t"), reason="stop")
-    assert store.enqueued == []   # no parent wake
-
-
-async def test_empty_final_response_emits_no_loop_result_but_completes():
-    parent = _parent("web")
-    child = SimpleNamespace(id=uuid4(), channel="scheduled", parent_id=parent.id,
-                            org_id=uuid4(), agent_id="a", title="t",
-                            created_at=__import__("datetime").datetime.now(
-                                __import__("datetime").timezone.utc),
-                            config={"scheduled_session_id": str(uuid4())}, task_id=None)
-    store = _RecordingStore(parent, child_events=[])   # no llm.response
-    h = _bare_harness(store)
-    await h._complete_session(child, messages=[], lease=SimpleNamespace(lease_token="t"),
-                              reason="stop")
-    assert not any(e[1] == EventType.LOOP_RESULT for e in store.emitted)
-```
-
-Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_delivery.py -q`
-Expected: PASS.
-
-- [ ] **Step 6: Commit**
+Run:
 
 ```bash
 cd /work/surogates
-git add surogates/harness/loop_artifact_completion.py tests/test_loop_result_delivery.py
-git commit -m "feat(harness): deliver web/api loop results inline on the parent conversation"
+/work/surogates/.venv/bin/pytest tests/test_loop_result_inline_delivery.py tests/test_loop_result_replay_safety.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /work/surogates
+git add surogates/harness/loop_artifact_completion.py tests/test_loop_result_inline_delivery.py
+git commit -m "feat(harness): surface web api loop results inline"
 ```
 
 ---
 
-## Task 4: Replay-safety guard (backend)
+## Task 4: SDK Event Registration And Reducer
 
 **Files:**
-- Test: `tests/test_loop_result_replay_safety.py` (append)
+- Modify: `/work/surogates/sdk/agent-chat-react/src/types.ts`
+- Modify: `/work/surogates/sdk/agent-chat-react/src/runtime/events.ts`
+- Modify: `/work/surogates/sdk/agent-chat-react/src/runtime/reducer.ts`
+- Modify: `/work/surogates/sdk/agent-chat-react/tests/listened-events.test.ts`
+- Modify: `/work/surogates/sdk/agent-chat-react/tests/reducer.test.ts`
 
-**Interfaces:**
-- Consumes: `LoopContextReplay._rebuild_messages` (in `surogates/harness/loop_context_replay.py`) or the class that owns it.
+- [ ] **Step 1: Add failing SDK tests**
 
-This is a guard test that locks in existing whitelist behavior: `_rebuild_messages`
-(on `ContextReplayMixin`) branches on known event types via an if/elif chain, so
-`loop.result` — a new type — is never appended to the agent's message history. It
-requires no production change and should pass immediately once wired to the real
-class.
+Add this test inside the existing `describe("AGENT_CHAT_LISTENED_EVENTS", ...)` block in `/work/surogates/sdk/agent-chat-react/tests/listened-events.test.ts`:
 
-- [ ] **Step 1: Write the test (append to `tests/test_loop_result_replay_safety.py`)**
-
-```python
-from types import SimpleNamespace
-
-from surogates.session.events import EventType
-
-
-def _event(etype, data, eid):
-    return SimpleNamespace(type=etype.value, data=data, id=eid)
-
-
-def _rebuild(events):
-    from surogates.harness.loop_context_replay import ContextReplayMixin
-
-    host = type("_H", (ContextReplayMixin,), {})()
-    return host._rebuild_messages(events)
-
-
-def test_rebuild_messages_ignores_loop_result():
-    events = [
-        _event(EventType.LLM_RESPONSE,
-               {"message": {"role": "assistant", "content": "real"}}, 1),
-        _event(EventType.LOOP_RESULT, {"content": "loop output"}, 2),
-    ]
-    rebuilt = _rebuild(events)
-    joined = " ".join(str(m.get("content", "")) for m in rebuilt)
-    assert "real" in joined
-    assert "loop output" not in joined
+```typescript
+  it("includes loop.result so scheduled results reach the reducer", () => {
+    expect(AGENT_CHAT_LISTENED_EVENTS).toContain("loop.result");
+  });
 ```
 
-- [ ] **Step 2: Run the test**
+Append inside the existing `describe("applyAgentChatEvent", ...)` block in `/work/surogates/sdk/agent-chat-react/tests/reducer.test.ts`:
 
-Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_replay_safety.py -q`
-Expected: PASS (guard test — `loop.result` is not a handled branch, so it is ignored).
+```typescript
+  it("appends loop.result as completed assistant output", () => {
+    const running = {
+      ...createInitialAgentChatState(),
+      isRunning: false,
+    };
 
-- [ ] **Step 3: Commit**
+    const next = applyAgentChatEvent(running, {
+      type: "loop.result",
+      eventId: 42,
+      data: {
+        content: "Loop says: done.",
+        run_session_id: "run-1",
+        scheduled_session_id: "schedule-1",
+        run_completed_at: "2026-07-03T12:00:00Z",
+      },
+    });
+
+    expect(next.isRunning).toBe(false);
+    expect(next.lastEventId).toBe(42);
+    expect(next.messages).toHaveLength(1);
+    expect(next.messages[0]).toMatchObject({
+      id: "evt-42",
+      role: "assistant",
+      content: "Loop says: done.",
+      status: "complete",
+      loopResult: {
+        runSessionId: "run-1",
+        scheduledSessionId: "schedule-1",
+        runCompletedAt: "2026-07-03T12:00:00Z",
+      },
+    });
+  });
+```
+
+- [ ] **Step 2: Run the failing SDK tests**
+
+Run:
 
 ```bash
-cd /work/surogates
-git add tests/test_loop_result_replay_safety.py
-git commit -m "test(harness): guard that loop.result stays out of replay + outbox"
+cd /work/surogates/sdk/agent-chat-react
+pnpm test tests/listened-events.test.ts tests/reducer.test.ts
 ```
 
----
+Expected: type/test failure because `"loop.result"` is not in `AgentChatEventType` and reducer has no case.
 
-## Task 5: SDK type + listened-events registration
+- [ ] **Step 3: Add SDK types**
 
-**Files:**
-- Modify: `sdk/agent-chat-react/src/types.ts` (`AgentChatEventType` ~line 478; `AgentChatMessage` ~line 61)
-- Modify: `sdk/agent-chat-react/src/runtime/events.ts` (`AGENT_CHAT_LISTENED_EVENTS` ~line 11)
-
-**Interfaces:**
-- Produces: `"loop.result"` is a valid `AgentChatEventType` and a listened event; `AgentChatMessage.loopResult?` metadata field.
-
-- [ ] **Step 1: Add to the type union**
-
-In `src/types.ts`, append to `AgentChatEventType` (before the terminating `;`):
+In `/work/surogates/sdk/agent-chat-react/src/types.ts`, add the metadata field to `AgentChatMessage` after `turnSummary?: AgentChatTurnSummary;`:
 
 ```typescript
-  | "turn.summary"
-  | "loop.result";
-```
-
-- [ ] **Step 2: Add the message metadata field**
-
-In `AgentChatMessage`, add after `turnSummary?`:
-
-```typescript
-  /** Present when this message was produced by a scheduled loop run
-   * surfaced inline on the parent conversation. */
   loopResult?: {
     runSessionId?: string;
     scheduledSessionId?: string;
@@ -575,79 +709,25 @@ In `AgentChatMessage`, add after `turnSummary?`:
   };
 ```
 
-- [ ] **Step 3: Register the listened event**
+In the `AgentChatEventType` union, add:
 
-In `src/runtime/events.ts`, add `"loop.result"` to `AGENT_CHAT_LISTENED_EVENTS` (after `"turn.summary"`):
+```typescript
+  | "turn.summary"
+  | "loop.result";
+```
+
+- [ ] **Step 4: Listen for the event**
+
+In `/work/surogates/sdk/agent-chat-react/src/runtime/events.ts`, add `"loop.result"` after `"turn.summary"`:
 
 ```typescript
   "turn.summary",
   "loop.result",
 ```
 
-- [ ] **Step 4: Typecheck**
+- [ ] **Step 5: Add the reducer case**
 
-Run: `cd /work/surogates/sdk/agent-chat-react && npm run typecheck` (or the SDK's `tsc --noEmit`).
-Expected: no new type errors.
-
-- [ ] **Step 5: Commit**
-
-```bash
-cd /work/surogates
-git add sdk/agent-chat-react/src/types.ts sdk/agent-chat-react/src/runtime/events.ts
-git commit -m "feat(agent-chat): register loop.result event type"
-```
-
----
-
-## Task 6: SDK reducer case for `loop.result`
-
-**Files:**
-- Modify: `sdk/agent-chat-react/src/runtime/reducer.ts` (add case near `case "skill.invoked":`)
-- Test: `sdk/agent-chat-react/src/runtime/reducer.test.ts` (create if absent, else append)
-
-**Interfaces:**
-- Consumes: reducer `(state, event) -> state`, `withMessages`, `AgentChatMessage` (with `loopResult`).
-- Produces: a completed assistant-role message appended for a `loop.result` event, `isRunning` untouched.
-
-- [ ] **Step 1: Write the failing test**
-
-In the reducer test file:
-
-```typescript
-import { describe, it, expect } from "vitest";
-import { agentChatReducer, initialAgentChatState } from "./reducer";
-
-describe("loop.result", () => {
-  it("appends a completed assistant message and does not set isRunning", () => {
-    const state = { ...initialAgentChatState(), isRunning: false };
-    const next = agentChatReducer(state, {
-      type: "loop.result",
-      eventId: 42,
-      data: {
-        content: "Weather in Bucharest: 22C",
-        run_session_id: "r1",
-        scheduled_session_id: "s1",
-        run_completed_at: "2026-07-03T05:01:00Z",
-      },
-    });
-    const msg = next.messages[next.messages.length - 1];
-    expect(msg.role).toBe("assistant");
-    expect(msg.content).toBe("Weather in Bucharest: 22C");
-    expect(msg.status).toBe("complete");
-    expect(msg.loopResult?.runSessionId).toBe("r1");
-    expect(next.isRunning).toBe(false);
-  });
-});
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `cd /work/surogates/sdk/agent-chat-react && npx vitest run src/runtime/reducer.test.ts`
-Expected: FAIL — no assistant message appended (unhandled type returns state unchanged).
-
-- [ ] **Step 3: Implement the case**
-
-In `reducer.ts`, add before `case "artifact.created":`:
+In `/work/surogates/sdk/agent-chat-react/src/runtime/reducer.ts`, add this `switch` case after `case "skill.invoked":` and before artifact cases:
 
 ```typescript
     case "loop.result":
@@ -669,234 +749,353 @@ In `reducer.ts`, add before `case "artifact.created":`:
       ]);
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+Do not change token usage and do not set `isRunning`.
 
-Run: `cd /work/surogates/sdk/agent-chat-react && npx vitest run src/runtime/reducer.test.ts`
-Expected: PASS.
+- [ ] **Step 6: Run the passing SDK tests**
+
+Run:
+
+```bash
+cd /work/surogates/sdk/agent-chat-react
+pnpm test tests/listened-events.test.ts tests/reducer.test.ts
+pnpm run typecheck
+```
+
+Expected: tests and typecheck pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /work/surogates
+git add sdk/agent-chat-react/src/types.ts \
+  sdk/agent-chat-react/src/runtime/events.ts \
+  sdk/agent-chat-react/src/runtime/reducer.ts \
+  sdk/agent-chat-react/tests/listened-events.test.ts \
+  sdk/agent-chat-react/tests/reducer.test.ts
+git commit -m "feat(agent-chat): handle loop.result messages"
+```
+
+---
+
+## Task 5: SDK Chat Thread Affordance
+
+**Files:**
+- Modify: `/work/surogates/sdk/agent-chat-react/src/components/chat/chat-thread.tsx`
+
+- [ ] **Step 1: Add a loop affordance helper**
+
+In `/work/surogates/sdk/agent-chat-react/src/components/chat/chat-thread.tsx`, add this helper near the small render helpers before `SimpleAssistantGroup`:
+
+```tsx
+function LoopResultAffordance({ message }: { message?: ChatMessageType }) {
+  if (!message?.loopResult) return null;
+  const completedAt = message.loopResult.runCompletedAt
+    ? new Date(message.loopResult.runCompletedAt)
+    : null;
+  const time =
+    completedAt && !Number.isNaN(completedAt.getTime())
+      ? completedAt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+      : "";
+  return (
+    <div className="text-xs text-muted-foreground/70">
+      From loop{time ? ` · ${time}` : ""}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Render it in Simple mode**
+
+In `SimpleAssistantGroup`, inside the `finalText && (...)` block, replace:
+
+```tsx
+        {finalText && (
+          <SimpleFinalAnswer
+            text={finalText}
+            isStreaming={tail?.status === "streaming"}
+            tail={tail}
+          />
+        )}
+```
+
+with:
+
+```tsx
+        {finalText && (
+          <div className="space-y-1">
+            <LoopResultAffordance message={tail} />
+            <SimpleFinalAnswer
+              text={finalText}
+              isStreaming={tail?.status === "streaming"}
+              tail={tail}
+            />
+          </div>
+        )}
+```
+
+- [ ] **Step 3: Render it in Expert mode**
+
+In `TextEntry` (the function that renders `Extract<TimelineEntry, { kind: "text" }>`), render the same helper immediately before the `MessageResponse` that displays `entry.content`:
+
+```tsx
+      <LoopResultAffordance message={entry.msg} />
+```
+
+Keep the existing `MessageResponse` and `TurnFeedback` logic intact.
+
+- [ ] **Step 4: Typecheck and build**
+
+Run:
+
+```bash
+cd /work/surogates/sdk/agent-chat-react
+pnpm run typecheck
+pnpm run build
+```
+
+Expected: typecheck and build pass.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 cd /work/surogates
-git add sdk/agent-chat-react/src/runtime/reducer.ts sdk/agent-chat-react/src/runtime/reducer.test.ts
-git commit -m "feat(agent-chat): reduce loop.result into an assistant message"
-```
-
----
-
-## Task 7: SDK thread affordance
-
-**Files:**
-- Modify: `sdk/agent-chat-react/src/components/chat/chat-thread.tsx`
-
-**Interfaces:**
-- Consumes: `AgentChatMessage.loopResult`.
-
-- [ ] **Step 1: Render the affordance**
-
-Find where an assistant message bubble is rendered in `chat-thread.tsx`. Add a
-small metadata line, shown only when `message.loopResult` is set. Example
-(adapt to the file's existing JSX/classnames):
-
-```tsx
-{message.loopResult && (
-  <div className="text-xs text-muted-foreground/70 mb-1">
-    From loop
-    {message.loopResult.runCompletedAt
-      ? ` · ${new Date(message.loopResult.runCompletedAt).toLocaleTimeString()}`
-      : ""}
-  </div>
-)}
-```
-
-- [ ] **Step 2: Typecheck + build**
-
-Run: `cd /work/surogates/sdk/agent-chat-react && npm run typecheck && npm run build`
-Expected: clean.
-
-- [ ] **Step 3: Manual verification note**
-
-The affordance is visual; verify in a host app after Task 8/10 wiring. No unit
-test required for the JSX label.
-
-- [ ] **Step 4: Commit**
-
-```bash
-cd /work/surogates
 git add sdk/agent-chat-react/src/components/chat/chat-thread.tsx
-git commit -m "feat(agent-chat): show 'From loop' affordance on loop.result messages"
+git commit -m "feat(agent-chat): label loop result messages"
 ```
 
 ---
 
-## Task 8: Web host raw event type
+## Task 6: Surogates Web Raw Event Type
 
 **Files:**
-- Modify: `web/src/types/session.ts`
-
-**Interfaces:**
-- Consumes: raw session event type union. The chat adapter opens the raw SSE
-  stream and delegates filtering to the SDK runtime (no adapter change needed).
+- Modify: `/work/surogates/web/src/types/session.ts`
 
 - [ ] **Step 1: Add the type**
 
-In `web/src/types/session.ts`, add `"loop.result"` wherever the raw session
-event `type` union / enum is declared (mirror how `"llm.response"` /
-`"inbox.task_complete"` appear).
+In `/work/surogates/web/src/types/session.ts`, add `"loop.result"` to the `EventType` union after `"llm.response"`:
 
-- [ ] **Step 2: Typecheck**
+```typescript
+  | "llm.response"
+  | "loop.result"
+```
 
-Run: `cd /work/surogates/web && npm run typecheck`
-Expected: clean.
+- [ ] **Step 2: Typecheck web**
+
+Run:
+
+```bash
+cd /work/surogates/web
+npm run typecheck
+```
+
+Expected: typecheck passes.
 
 - [ ] **Step 3: Commit**
 
 ```bash
 cd /work/surogates
 git add web/src/types/session.ts
-git commit -m "feat(web): accept loop.result raw session event"
+git commit -m "feat(web): accept loop.result session events"
 ```
 
 ---
 
-## Task 9: Ops observability view
+## Task 7: Ops Observability View
 
 **Files:**
-- Modify: `surogates/db/observability.sql` (`v_session_messages`, ~line 660)
+- Modify: `/work/surogates/surogates/db/observability.sql`
 
-**Interfaces:**
-- Produces: `loop.result` rows appear in `v_session_messages`.
+- [ ] **Step 1: Add `loop.result` to the SQL view**
 
-- [ ] **Step 1: Add the type to the view whitelist**
-
-In the `WHERE e.type IN (...)` list of `v_session_messages`, add `'loop.result'`:
+In `/work/surogates/surogates/db/observability.sql`, update the `v_session_messages` `WHERE e.type IN (...)` list:
 
 ```sql
+    'expert.override',
     'user.feedback',
     'loop.result'
 );
 ```
 
-- [ ] **Step 2: Verify the SQL is well-formed**
-
-Run (against the PROD-style test DB or a local psql): apply the `CREATE OR
-REPLACE VIEW v_session_messages` statement and confirm no syntax error, e.g.:
-
-```bash
-# local dev DB only
-psql "$SUROGATES_DATABASE_URL" -c "$(sed -n '/CREATE OR REPLACE VIEW v_session_messages/,/);/p' surogates/db/observability.sql)"
-psql "$SUROGATES_DATABASE_URL" -c "SELECT 1 FROM v_session_messages LIMIT 1;"
-```
-
-Expected: `CREATE VIEW` then a clean select (0+ rows).
-
-- [ ] **Step 3: Commit**
+- [ ] **Step 2: Commit the SQL in `/work/surogates`**
 
 ```bash
 cd /work/surogates
 git add surogates/db/observability.sql
-git commit -m "feat(observability): surface loop.result in v_session_messages"
+git commit -m "feat(observability): include loop.result in session messages"
 ```
+
+Do not include `/work/surogate-ops` files in this commit.
 
 ---
 
-## Task 10: Ops frontend thread rendering
+## Task 8: Ops Frontend Thread Rendering
 
 **Files:**
-- Modify: `/work/surogate-ops/frontend/src/types/session.ts` (`EventType` object, ~line 28)
-- Modify: `/work/surogate-ops/frontend/src/components/sessions/session-thread.tsx` (~line 200)
+- Modify: `/work/surogate-ops/frontend/src/components/sessions/session-thread.tsx`
+- Modify: `/work/surogate-ops/frontend/src/components/sessions/thread-tab.tsx`
+- Modify: `/work/surogate-ops/frontend/src/types/session.ts`
 
-**Interfaces:**
-- Consumes: `EventType.LOOP_RESULT`; the `AgentTurn` component (reads message content).
+- [ ] **Step 1: Add the ops event constant**
 
-- [ ] **Step 1: Add the enum entry**
-
-In `frontend/src/types/session.ts`, add to the `EventType` object:
+In `/work/surogate-ops/frontend/src/types/session.ts`, add to the `EventType` object after `LLM_RESPONSE`:
 
 ```typescript
   LOOP_RESULT: "loop.result",
 ```
 
-- [ ] **Step 2: Include loop.result in the turn filter and render as an agent turn**
+- [ ] **Step 2: Update compact `SessionThread` content extraction**
 
-In `session-thread.tsx`, extend the `turns` filter and render:
+In `/work/surogate-ops/frontend/src/components/sessions/session-thread.tsx`, replace the `content` line in `AgentTurn`:
 
 ```tsx
-  const turns = useMemo(
-    () =>
-      messages.filter(
-        (m) =>
+  const content = message?.content ?? "";
+```
+
+with:
+
+```tsx
+  const content = message?.content ?? asStr(d?.content) ?? "";
+```
+
+- [ ] **Step 3: Include `loop.result` in the compact turn filter**
+
+In the same file, update the `turns` filter:
+
+```tsx
           m.type === EventType.USER_MESSAGE ||
           m.type === EventType.LLM_RESPONSE ||
           m.type === EventType.LOOP_RESULT,
-      ),
-    [messages],
+```
+
+The existing map already sends all non-user turns through `AgentTurn`, so no additional branch is needed.
+
+- [ ] **Step 4: Add a detailed-thread bubble**
+
+In `/work/surogate-ops/frontend/src/components/sessions/thread-tab.tsx`, add this function after `AssistantBubble`:
+
+```tsx
+function LoopResultBubble({ msg }: { msg: SessionMessage }) {
+  const d = asObj(msg.data);
+  const content = asStr(d?.content) ?? "";
+  const completedAt = asStr(d?.run_completed_at);
+  return (
+    <div className="flex gap-2.5">
+      <Avatar letter="L" color="#3B82F6" />
+      <Bubble side="left">
+        <div className="mb-1 text-[9px] font-semibold uppercase text-muted-foreground/60">
+          From loop{completedAt ? ` · ${formatTimestamp(completedAt)}` : ""}
+        </div>
+        <div className="text-[12px] text-foreground leading-relaxed whitespace-pre-wrap wrap-break-word">
+          {content || (
+            <span className="text-muted-foreground/30 italic">empty</span>
+          )}
+        </div>
+        <TimestampFooter createdAt={msg.createdAt} />
+      </Bubble>
+    </div>
   );
+}
 ```
 
-and in the map, route `LOOP_RESULT` through `AgentTurn`:
+- [ ] **Step 5: Render `loop.result` in detailed `ThreadTab`**
+
+In the `switch (m.type)` in `ThreadTab`, add:
 
 ```tsx
-      {turns.map((m) =>
-        m.type === EventType.USER_MESSAGE ? (
-          <UserTurn key={m.eventId} msg={m} />
-        ) : (
-          <AgentTurn
-            key={m.eventId}
-            msg={m}
-            agentLabel={agentLabel}
-            feedback={feedbackMap.get(m.eventId)}
-          />
-        ),
-      )}
+          case EventType.LOOP_RESULT:
+            return <LoopResultBubble key={m.eventId} msg={m} />;
 ```
 
-- [ ] **Step 3: Ensure AgentTurn reads loop.result content**
+Place it next to `EventType.LLM_RESPONSE`.
 
-Inspect `AgentTurn`: if it extracts content from `data.message.content`
-(llm.response shape), add a fallback to `data.content` so a `loop.result`
-event renders its text. Keep it minimal:
+- [ ] **Step 6: Typecheck ops**
 
-```tsx
-  const text =
-    msg.data?.message?.content ?? msg.data?.content ?? "";
+Run:
+
+```bash
+cd /work/surogate-ops/frontend
+npm run typecheck
 ```
 
-- [ ] **Step 4: Typecheck**
+Expected: typecheck passes.
 
-Run: `cd /work/surogate-ops/frontend && npm run typecheck`
-Expected: clean.
-
-- [ ] **Step 5: Commit**
+- [ ] **Step 7: Commit ops changes**
 
 ```bash
 cd /work/surogate-ops
-git add frontend/src/types/session.ts frontend/src/components/sessions/session-thread.tsx
-git commit -m "feat(sessions): render loop.result as an agent turn in the thread"
+git add frontend/src/types/session.ts \
+  frontend/src/components/sessions/session-thread.tsx \
+  frontend/src/components/sessions/thread-tab.tsx
+git commit -m "feat(sessions): render loop results in session threads"
 ```
 
 ---
 
-## Final verification
+## Task 9: Final Verification
 
-- [ ] **Backend suite**
+**Files:**
+- No code edits unless verification exposes a defect.
 
-Run: `/work/surogates/.venv/bin/pytest tests/test_loop_result_delivery.py tests/test_loop_result_replay_safety.py tests/test_channel_delivery.py -q`
-Expected: all pass.
+- [ ] **Step 1: Run focused backend tests**
 
-- [ ] **SDK suite + build**
+Run:
 
-Run: `cd /work/surogates/sdk/agent-chat-react && npx vitest run && npm run build`
-Expected: pass + clean build.
+```bash
+cd /work/surogates
+/work/surogates/.venv/bin/pytest \
+  tests/test_loop_result_inline_delivery.py \
+  tests/test_loop_result_replay_safety.py \
+  tests/test_channel_delivery.py \
+  -q
+```
 
-- [ ] **Hosts typecheck**
+Expected: all pass. `tests/test_channel_delivery.py` confirms existing channel-loop outbox behavior remains intact.
 
-Run: `cd /work/surogates/web && npm run typecheck` and `cd /work/surogate-ops/frontend && npm run typecheck`
-Expected: clean.
+- [ ] **Step 2: Run SDK tests and build**
 
-- [ ] **End-to-end (staging/local)**
+Run:
 
-Create a `/loop … every 1 minute` from a web session; after the next tick,
-confirm the run's answer appears inline in that conversation and that no
-`inbox.task_complete` card is created for the run (query `inbox_items` for the
-run session id → 0 rows).
+```bash
+cd /work/surogates/sdk/agent-chat-react
+pnpm test tests/listened-events.test.ts tests/reducer.test.ts
+pnpm run typecheck
+pnpm run build
+```
+
+Expected: tests, typecheck, and build pass.
+
+- [ ] **Step 3: Run host typechecks**
+
+Run:
+
+```bash
+cd /work/surogates/web
+npm run typecheck
+
+cd /work/surogate-ops/frontend
+npm run typecheck
+```
+
+Expected: both pass.
+
+- [ ] **Step 4: Inspect git state**
+
+Run:
+
+```bash
+git -C /work/surogates status --short
+git -C /work/surogate-ops status --short
+```
+
+Expected: only intended files are modified, or no changes if every task was committed. Do not revert unrelated pre-existing files.
+
+- [ ] **Step 5: Manual staging check**
+
+In a local or staging web session:
+
+1. Create a `/loop` that runs quickly.
+2. Wait for the next scheduled run to complete.
+3. Confirm the parent conversation displays the run's final answer inline with the "From loop" affordance.
+4. Query `events` for the parent session and confirm one `loop.result` row with `run_session_id`, `scheduled_session_id`, and full `content`.
+5. Query `inbox_items` for the child run's `inbox.task_complete` source event and confirm no new web/api scheduled-run completion card was created.
+6. Create or inspect a Slack/Telegram scheduled run and confirm channel delivery still uses the existing outbox path, with no parent `loop.result`.

--- a/docs/superpowers/specs/2026-07-03-loop-result-inline-delivery-design.md
+++ b/docs/superpowers/specs/2026-07-03-loop-result-inline-delivery-design.md
@@ -1,0 +1,175 @@
+# Loop-result inline delivery (web/api) — design
+
+**Date:** 2026-07-03
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+A `/loop` (recurring scheduled prompt) fires on an interval. Each firing runs
+on a **separate child session** (`channel="scheduled"`) that executes the loop's
+prompt and produces a final assistant message. That per-run answer never reaches
+the originating conversation:
+
+- Each run's output is mirrored to a `task_complete` **inbox card**, which the
+  background inbox-expiry job removes unread. In production, web loop inbox
+  cards are **8/8 expired**, service-account **6/6 expired** — users never see
+  the results.
+- The run's events live on the child session; the parent conversation's live
+  stream (web SSE reads the *parent* session's events) never includes them.
+
+For **channel** parents (Slack/Telegram/Teams) this is already solved: the
+channel-delivery fix resolves a scheduled run's deliverable events to the
+parent's channel and pushes each run into the channel conversation via the
+outbox. The gap remains for **web** and **api** parents, which have no outbox
+path — they consume results by streaming/polling `GET /sessions/{id}/events`,
+and that endpoint is per-session.
+
+## Goal
+
+When a loop run whose origin is a **web** or **api** session completes, surface
+that run's final answer **inline in the originating conversation**, matching the
+Slack behavior (every run is surfaced). Do not wake the parent agent, do not
+pollute its LLM context, and remove the now-redundant expiring inbox card for
+these runs.
+
+Non-goals: changing channel (Slack/Telegram/Teams) delivery; per-run
+diffing/filtering (every run is surfaced); a separate loop-runs UI panel.
+
+## Approach
+
+Emit a new **`loop.result`** event into the **parent** session's event log at
+run completion. Web SSE streams it so it renders inline; api clients see it by
+polling the parent session's events. Because it is a new event type, the
+harness's history reconstruction ignores it — the parent agent's context is
+untouched and the parent is never re-enqueued.
+
+Considered and rejected:
+
+- **Reuse `LLM_RESPONSE` on the parent (tagged).** No frontend change, but
+  `_rebuild_messages` consumes `LLM_RESPONSE`, so every loop output would flood
+  the parent agent's context. Avoiding that requires a skip-filter inside the
+  byte-stable, prefix-cache-stable replay path — a riskier change to a sensitive
+  code path. Rejected.
+- **Reuse `notify_parent_on_completion` minus the wake.** Emits
+  `WORKER_COMPLETE`, which is sub-agent coordinator plumbing, not a user-facing
+  message; the thread renderer would not show it as a reply. Rejected.
+
+## Backend design
+
+### New event type
+
+`EventType.LOOP_RESULT = "loop.result"`, emitted on the **parent** session.
+
+Payload:
+
+```json
+{
+  "run_session_id": "<child run session uuid>",
+  "scheduled_session_id": "<schedule uuid>",
+  "content": "<full final assistant message of this run>",
+  "outcome": "success | <reason>",
+  "created_at": "<run completion time, ISO8601>"
+}
+```
+
+`content` is the run's full final assistant response (via `extract_final_response`,
+generously capped), not the short inbox excerpt.
+
+### Integration point
+
+In the loop-run completion path (`surogates/harness/loop_artifact_completion.py`,
+adjacent to the `INBOX_TASK_COMPLETE` emission):
+
+1. Determine whether this run should surface inline (gating helper below).
+2. If yes, emit `LOOP_RESULT` on the parent session with the run's final
+   response.
+3. Suppress the `INBOX_TASK_COMPLETE` inbox card for these runs (see below).
+
+The emission is **best-effort**: any failure is logged and must never abort run
+completion or the schedule's `mark_run_created`. An empty/missing final response
+emits nothing.
+
+### Gating
+
+Emit `loop.result` only when **all** hold:
+
+- the run is a scheduled run (`session.channel == "scheduled"`), and
+- it has a `parent_id`, and
+- the parent session's channel is **`web` or `api`**.
+
+Slack/Telegram/Teams parents are skipped — they already receive each run through
+the outbox (channel-delivery fix). Detached runs (no parent) are skipped.
+
+A small helper resolves the parent's channel (one session lookup by
+`parent_id`) and returns the surfacing decision.
+
+### Inbox card suppression
+
+Today every completion emits `INBOX_TASK_COMPLETE`, which for these runs becomes
+the expiring card. For **scheduled runs with a web/api parent**, suppress that
+emission — the result is now surfaced inline, so the card is redundant. Other
+sessions (regular tasks, sub-agent work, channel runs) are unaffected.
+
+### Context and wake safety
+
+`loop.result` is a new type, so `_rebuild_messages`
+(`surogates/harness/loop_context_replay.py`), which whitelists the event types
+that feed the agent context, ignores it automatically — no bloat, no replay
+change. The completion step does **not** re-enqueue the parent, so the parent
+agent is never woken.
+
+## Frontend design
+
+Add `loop.result` to the `EventType` enum in each web app and render it in the
+conversation thread as an **assistant-style message** with a small affordance
+(e.g. `🔁 from your loop · <time>`) and a click-through to the run session.
+
+- ops frontend: `frontend/src/types/session.ts` +
+  `frontend/src/components/sessions/session-thread.tsx`
+- surogates web: `web/src/types/session.ts` + its chat thread renderer
+
+Both apps consume the same session events; an unknown event type must never
+break the thread. The implementation plan will confirm which app hosts the
+web loop conversations and prioritize accordingly.
+
+## Data flow (web/api loop, per run)
+
+```
+ticker fires → run child session executes prompt → final assistant message
+  → completion hook:
+       emit loop.result on PARENT session  (content = run's final response)
+       suppress task_complete inbox item for web/api scheduled runs
+  → parent SSE (GET /sessions/{parent}/events) streams loop.result
+  → web thread renders it inline as an assistant message
+  → api client sees it by polling the parent session's events
+_rebuild_messages ignores loop.result → parent agent context unchanged, parent not woken
+```
+
+## Testing
+
+Backend (unit):
+
+- Gating: web parent → emit; api parent → emit; slack/telegram/teams parent →
+  skip; no parent → skip.
+- Emission writes a `loop.result` on the **parent** with the full final content
+  and correct metadata.
+- Inbox `task_complete` is suppressed for web/api scheduled runs and still
+  emitted for other sessions.
+- The parent is **not** re-enqueued by the surfacing step.
+- Best-effort: a failure in the emission does not abort completion.
+
+Replay:
+
+- `_rebuild_messages` ignores `loop.result` (parent context byte-stable).
+
+Frontend:
+
+- Thread renders `loop.result` as an assistant message with the loop affordance.
+- Unknown event type does not crash the thread.
+
+## Consistency note (accepted)
+
+Channel loops post each run via the outbox (including intermediate narration);
+web/api loops post one clean final result per run at completion. This asymmetry
+is accepted — the web/api surface shows the run's final answer, which is the
+useful unit.

--- a/docs/superpowers/specs/2026-07-03-loop-result-inline-delivery-design.md
+++ b/docs/superpowers/specs/2026-07-03-loop-result-inline-delivery-design.md
@@ -1,7 +1,7 @@
 # Loop-result inline delivery (web/api) — design
 
 **Date:** 2026-07-03
-**Status:** Approved design, pending implementation plan
+**Status:** Reviewed design, pending implementation plan
 
 ## Problem
 
@@ -24,6 +24,17 @@ outbox. The gap remains for **web** and **api** parents, which have no outbox
 path — they consume results by streaming/polling `GET /sessions/{id}/events`,
 and that endpoint is per-session.
 
+Current code confirms the two relevant mechanics:
+
+- `SessionStore.emit_event()` publishes every committed event to
+  `surogates:session:{session_id}`, so an event emitted on the parent session is
+  immediately visible to the parent's SSE stream without adding it to the
+  channel-delivery outbox.
+- `_enqueue_channel_delivery()` already resolves `channel="scheduled"` runs to
+  their parent channel and skips `web`; therefore channel parents keep their
+  existing outbox behavior, and this design only adds a parent-event path for
+  non-outbox parents.
+
 ## Goal
 
 When a loop run whose origin is a **web** or **api** session completes, surface
@@ -42,6 +53,10 @@ run completion. Web SSE streams it so it renders inline; api clients see it by
 polling the parent session's events. Because it is a new event type, the
 harness's history reconstruction ignores it — the parent agent's context is
 untouched and the parent is never re-enqueued.
+
+The new event is intentionally **message-shaped for UI only**: renderers treat
+it like an assistant reply, but the replay layer does not treat it as
+`llm.response`.
 
 Considered and rejected:
 
@@ -68,47 +83,83 @@ Payload:
   "scheduled_session_id": "<schedule uuid>",
   "content": "<full final assistant message of this run>",
   "outcome": "success | <reason>",
-  "created_at": "<run completion time, ISO8601>"
+  "duration_seconds": 123,
+  "run_completed_at": "<run completion time, ISO8601>"
 }
 ```
 
-`content` is the run's full final assistant response (via `extract_final_response`,
-generously capped), not the short inbox excerpt.
+`content` is the run's full final assistant response, not the short inbox
+excerpt. Use `extract_final_response(events, fallback="")` against the child
+run's events, then emit only when the resulting content is non-empty after
+trimming. The implementation may cap the stored string defensively, but the cap
+must be substantially larger than the inbox excerpt because this event is the
+primary delivery surface.
+
+`scheduled_session_id` comes from `session.config["scheduled_session_id"]`.
+`outcome` matches the current completion mapping: `"success"` for
+`stop`/`done`/`complete`/`completed`, otherwise the raw completion `reason`.
 
 ### Integration point
 
-In the loop-run completion path (`surogates/harness/loop_artifact_completion.py`,
-adjacent to the `INBOX_TASK_COMPLETE` emission):
+In the loop-run completion path
+(`surogates/harness/loop_artifact_completion.py::_complete_session`, adjacent
+to the `INBOX_TASK_COMPLETE` emission):
 
 1. Determine whether this run should surface inline (gating helper below).
-2. If yes, emit `LOOP_RESULT` on the parent session with the run's final
-   response.
-3. Suppress the `INBOX_TASK_COMPLETE` inbox card for these runs (see below).
+2. If yes, read the child run's events and extract the final response.
+3. If the final response is non-empty, emit `LOOP_RESULT` on the parent session.
+4. Suppress the `INBOX_TASK_COMPLETE` inbox card for these runs (see below).
 
 The emission is **best-effort**: any failure is logged and must never abort run
-completion or the schedule's `mark_run_created`. An empty/missing final response
-emits nothing.
+completion, status update, cursor advancement, or dynamic-loop finalization. An
+empty/missing final response emits nothing.
+
+Emit `loop.result` after `session.complete` for the child has been written and
+before the optional inbox-card emission/status update. This ordering keeps the
+child run's own terminal event durable first while still making the parent
+inline result available as soon as completion is processed. The parent event id
+is not used as the child's harness cursor; cursor advancement remains scoped to
+the child session's events.
 
 ### Gating
 
 Emit `loop.result` only when **all** hold:
 
-- the run is a scheduled run (`session.channel == "scheduled"`), and
+- the run is a scheduled run (`session.channel == "scheduled"` and/or
+  `session.config["scheduled_session_id"]` is present), and
 - it has a `parent_id`, and
 - the parent session's channel is **`web` or `api`**.
 
 Slack/Telegram/Teams parents are skipped — they already receive each run through
-the outbox (channel-delivery fix). Detached runs (no parent) are skipped.
+the outbox (channel-delivery fix). Detached schedules/runs (no parent) are
+skipped because there is no originating conversation to append to.
 
 A small helper resolves the parent's channel (one session lookup by
-`parent_id`) and returns the surfacing decision.
+`parent_id`) and returns the surfacing decision plus the parent session. Lookup
+failure is a skip, not a hard error.
+
+Recommended helper boundary:
+`_resolve_loop_result_parent(self, session: Session) -> Session | None`.
+
+Return a parent session only for web/api scheduled children; callers use the
+returned parent both for `emit_event(parent.id, EventType.LOOP_RESULT, ...)` and
+for deciding whether to suppress the inbox card.
 
 ### Inbox card suppression
 
 Today every completion emits `INBOX_TASK_COMPLETE`, which for these runs becomes
 the expiring card. For **scheduled runs with a web/api parent**, suppress that
-emission — the result is now surfaced inline, so the card is redundant. Other
-sessions (regular tasks, sub-agent work, channel runs) are unaffected.
+emission even if `loop.result` extraction/emission fails — the inbox card is not
+a reliable delivery path and creates noisy, expiring duplicates. Other sessions
+(regular tasks, sub-agent work, channel runs, detached scheduled runs) are
+unaffected.
+
+Because `_complete_session` currently uses the inbox event id as the fallback
+cursor target, suppression must also adjust cursor advancement:
+
+- If `through_event_id` was supplied, keep using it.
+- Else if the inbox card was emitted, use that inbox event id.
+- Else use the child `SESSION_COMPLETE` event id.
 
 ### Context and wake safety
 
@@ -118,25 +169,69 @@ that feed the agent context, ignores it automatically — no bloat, no replay
 change. The completion step does **not** re-enqueue the parent, so the parent
 agent is never woken.
 
+Do not add `loop.result` to `SessionStore._DELIVERABLE_EVENTS`. It is emitted on
+web/api parents specifically so SSE/polling can see it; channel parents must
+continue to use their existing `llm.response` outbox delivery from the child
+run.
+
 ## Frontend design
 
-Add `loop.result` to the `EventType` enum in each web app and render it in the
-conversation thread as an **assistant-style message** with a small affordance
-(e.g. `🔁 from your loop · <time>`) and a click-through to the run session.
+Add `loop.result` to the live chat event types and render it in the conversation
+thread as an **assistant-style message** with a small text affordance (for
+example, `From loop · <time>`) and a click-through to the run session when the
+host app has a route for session drill-in.
 
-- ops frontend: `frontend/src/types/session.ts` +
-  `frontend/src/components/sessions/session-thread.tsx`
-- surogates web: `web/src/types/session.ts` + its chat thread renderer
+Primary live-chat surface:
 
-Both apps consume the same session events; an unknown event type must never
-break the thread. The implementation plan will confirm which app hosts the
-web loop conversations and prioritize accordingly.
+- `sdk/agent-chat-react/src/types.ts`: add `"loop.result"` to
+  `AgentChatEventType`.
+- `sdk/agent-chat-react/src/runtime/events.ts`: add it to
+  `AGENT_CHAT_LISTENED_EVENTS` so SSE and reconciliation polling both pass the
+  event into the reducer.
+- `sdk/agent-chat-react/src/runtime/reducer.ts`: add a `loop.result` case that
+  appends a completed assistant message from `data.content`. The message should
+  carry metadata such as `run_session_id`, `scheduled_session_id`, and
+  `run_completed_at` without disturbing normal `llm.response` bookkeeping
+  (`llmResponseEventId`, token usage, `isRunning`, turn summaries).
+- `sdk/agent-chat-react/src/components/chat/chat-thread.tsx`: render the
+  affordance on loop-result messages. Prefer a small metadata line inside the
+  assistant bubble over a separate card.
+
+Surogates web host:
+
+- `web/src/types/session.ts`: add `"loop.result"` so raw session event typing
+  does not reject it.
+- `web/src/features/chat/surogates-web-chat-adapter.ts`: no special handling is
+  needed; it opens the raw session SSE stream and polls raw events, while the
+  shared SDK runtime owns event-type filtering.
+
+Ops/admin session drill-in:
+
+- `surogates/db/observability.sql`: add `'loop.result'` to `v_session_messages`
+  so ops shows parent-loop outputs in the Thread tab.
+- `surogate-ops/frontend/src/types/session.ts`: add
+  `EventType.LOOP_RESULT = "loop.result"`.
+- `surogate-ops/frontend/src/components/sessions/thread-tab.tsx` and
+  `session-thread.tsx`: render `loop.result` as an assistant-like bubble that
+  reads `data.content` directly.
+
+Unknown event types already arrive through polling in some clients; reducers
+and renderers must continue to ignore unhandled events rather than crash.
+
+Website widget SDK:
+
+- No first-pass change is required for `sdk/website-widget`. Its translator
+  maps unknown Surogates events to AG-UI `CUSTOM`, and widget loops are not the
+  target surface for parent conversation inline loop delivery. Add first-class
+  handling later only if website-channel loops need user-visible inline
+  scheduled results.
 
 ## Data flow (web/api loop, per run)
 
 ```
 ticker fires → run child session executes prompt → final assistant message
   → completion hook:
+       child session.complete is emitted
        emit loop.result on PARENT session  (content = run's final response)
        suppress task_complete inbox item for web/api scheduled runs
   → parent SSE (GET /sessions/{parent}/events) streams loop.result
@@ -150,22 +245,32 @@ _rebuild_messages ignores loop.result → parent agent context unchanged, parent
 Backend (unit):
 
 - Gating: web parent → emit; api parent → emit; slack/telegram/teams parent →
-  skip; no parent → skip.
+  skip; no parent → skip; missing/deleted parent → skip.
 - Emission writes a `loop.result` on the **parent** with the full final content
   and correct metadata.
+- Empty final response suppresses `loop.result` but does not fail completion.
 - Inbox `task_complete` is suppressed for web/api scheduled runs and still
-  emitted for other sessions.
+  emitted for other sessions, including detached scheduled runs.
+- Cursor advancement uses `SESSION_COMPLETE` when the inbox event is suppressed
+  and no explicit `through_event_id` was supplied.
 - The parent is **not** re-enqueued by the surfacing step.
 - Best-effort: a failure in the emission does not abort completion.
 
 Replay:
 
 - `_rebuild_messages` ignores `loop.result` (parent context byte-stable).
+- `loop.result` is not included in `_DELIVERABLE_EVENTS`.
 
 Frontend:
 
+- `AGENT_CHAT_LISTENED_EVENTS` includes `loop.result`; SSE and polling both
+  deliver it to the reducer.
+- Reducer appends a completed assistant-style message with loop metadata and
+  does not set `isRunning`.
 - Thread renders `loop.result` as an assistant message with the loop affordance.
-- Unknown event type does not crash the thread.
+- Ops `v_session_messages` includes `loop.result` and both ops thread renderers
+  show it as assistant-like output.
+- Unknown event type does not crash the thread/reducer.
 
 ## Consistency note (accepted)
 

--- a/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
@@ -959,6 +959,7 @@ function TextEntry({
         <TimelineIndicator className="size-2 border-none bg-foreground/40" />
       </TimelineHeader>
       <TimelineContent>
+        <LoopResultAffordance message={entry.msg} />
         <MessageResponse>{cleaned}</MessageResponse>
         {entry.isFinalTurnText && entry.msg.status === "complete" && (
           <TurnFeedback msg={entry.msg} />
@@ -1765,6 +1766,22 @@ function deriveFileArtifactsFromMessages(
 // keep their existing markers so we don't lose their visibility in
 // Simple mode.
 
+function LoopResultAffordance({ message }: { message?: ChatMessageType }) {
+  if (!message?.loopResult) return null;
+  const completedAt = message.loopResult.runCompletedAt
+    ? new Date(message.loopResult.runCompletedAt)
+    : null;
+  const time =
+    completedAt && !Number.isNaN(completedAt.getTime())
+      ? completedAt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+      : "";
+  return (
+    <div className="text-xs text-muted-foreground/70">
+      From loop{time ? ` · ${time}` : ""}
+    </div>
+  );
+}
+
 function SimpleAssistantGroup({
   messages,
   isRunning,
@@ -1916,11 +1933,14 @@ function SimpleAssistantGroup({
           })}
         </div>
         {finalText && (
-          <SimpleFinalAnswer
-            text={finalText}
-            isStreaming={tail?.status === "streaming"}
-            tail={tail}
-          />
+          <div className="space-y-1">
+            <LoopResultAffordance message={tail} />
+            <SimpleFinalAnswer
+              text={finalText}
+              isStreaming={tail?.status === "streaming"}
+              tail={tail}
+            />
+          </div>
         )}
         {effectiveTurnSummary && !hideTurnSummary && (
           <TurnSummaryCard

--- a/sdk/agent-chat-react/src/runtime/events.ts
+++ b/sdk/agent-chat-react/src/runtime/events.ts
@@ -46,6 +46,7 @@ export const AGENT_CHAT_LISTENED_EVENTS = [
   "ask_user_question.response",
   "iteration.summary",
   "turn.summary",
+  "loop.result",
 ] as const satisfies readonly AgentChatEventType[];
 
 /** Membership set for the listened events above.  The reconciliation poll

--- a/sdk/agent-chat-react/src/runtime/reducer.ts
+++ b/sdk/agent-chat-react/src/runtime/reducer.ts
@@ -99,6 +99,24 @@ export function applyAgentChatEvent(
         },
       ]);
 
+    case "loop.result":
+      return withMessages(nextState, [
+        ...nextState.messages,
+        {
+          id: `evt-${event.eventId}`,
+          role: "assistant",
+          content: stringValue(event.data.content),
+          createdAt: new Date(),
+          status: "complete",
+          loopResult: {
+            runSessionId: stringValue(event.data.run_session_id) || undefined,
+            scheduledSessionId:
+              stringValue(event.data.scheduled_session_id) || undefined,
+            runCompletedAt: stringValue(event.data.run_completed_at) || undefined,
+          },
+        },
+      ]);
+
     case "artifact.created":
     case "artifact.updated":
       return withMessages(nextState, [

--- a/sdk/agent-chat-react/src/types.ts
+++ b/sdk/agent-chat-react/src/types.ts
@@ -81,6 +81,11 @@ export interface AgentChatMessage {
   iterationIndex?: number;
   iterationSummary?: AgentChatIterationSummary;
   turnSummary?: AgentChatTurnSummary;
+  loopResult?: {
+    runSessionId?: string;
+    scheduledSessionId?: string;
+    runCompletedAt?: string;
+  };
 }
 
 export interface AgentChatIterationSummary {
@@ -512,7 +517,8 @@ export type AgentChatEventType =
   | "browser.control_returned"
   | "ask_user_question.response"
   | "iteration.summary"
-  | "turn.summary";
+  | "turn.summary"
+  | "loop.result";
 
 export interface AgentChatRuntimeEvent {
   type: AgentChatEventType;

--- a/sdk/agent-chat-react/tests/listened-events.test.ts
+++ b/sdk/agent-chat-react/tests/listened-events.test.ts
@@ -10,4 +10,8 @@ describe("AGENT_CHAT_LISTENED_EVENTS", () => {
   it("includes turn.summary so the SSE stream is subscribed", () => {
     expect(AGENT_CHAT_LISTENED_EVENTS).toContain("turn.summary");
   });
+
+  it("includes loop.result so scheduled results reach the reducer", () => {
+    expect(AGENT_CHAT_LISTENED_EVENTS).toContain("loop.result");
+  });
 });

--- a/sdk/agent-chat-react/tests/reducer.test.ts
+++ b/sdk/agent-chat-react/tests/reducer.test.ts
@@ -671,4 +671,37 @@ describe("insufficient credits (402 token-credit gate)", () => {
     expect(errMsg?.errorInfo?.insufficientCredits).toBeFalsy();
     expect(errMsg?.errorInfo?.retryable).toBe(true);
   });
+
+  it("appends loop.result as completed assistant output", () => {
+    const running = {
+      ...createInitialAgentChatState(),
+      isRunning: false,
+    };
+
+    const next = applyAgentChatEvent(running, {
+      type: "loop.result",
+      eventId: 42,
+      data: {
+        content: "Loop says: done.",
+        run_session_id: "run-1",
+        scheduled_session_id: "schedule-1",
+        run_completed_at: "2026-07-03T12:00:00Z",
+      },
+    });
+
+    expect(next.isRunning).toBe(false);
+    expect(next.lastEventId).toBe(42);
+    expect(next.messages).toHaveLength(1);
+    expect(next.messages[0]).toMatchObject({
+      id: "evt-42",
+      role: "assistant",
+      content: "Loop says: done.",
+      status: "complete",
+      loopResult: {
+        runSessionId: "run-1",
+        scheduledSessionId: "schedule-1",
+        runCompletedAt: "2026-07-03T12:00:00Z",
+      },
+    });
+  });
 });

--- a/surogates/db/observability.sql
+++ b/surogates/db/observability.sql
@@ -681,7 +681,8 @@ WHERE e.type IN (
     'expert.failure',
     'expert.endorse',
     'expert.override',
-    'user.feedback'
+    'user.feedback',
+    'loop.result'
 );
 
 

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -23,6 +23,7 @@ from surogates.harness.loop_messages import (
     _seconds_since,
     _should_notify_parent_on_completion,
 )
+from surogates.harness.message_utils import extract_final_response
 from surogates.session.events import EventType
 
 logger = logging.getLogger(__name__)
@@ -614,26 +615,67 @@ class ArtifactCompletionMixin:
         if cost_tracker is not None:
             complete_data["cost_summary"] = cost_tracker.summary()
 
-        await self._store.emit_event(
+        session_complete_event_id = await self._store.emit_event(
             session.id,
             EventType.SESSION_COMPLETE,
             complete_data,
         )
-        inbox_event_id = await self._store.emit_event(
-            session.id,
-            EventType.INBOX_TASK_COMPLETE,
-            {
-                "outcome": (
-                    "success"
-                    if reason in {"stop", "done", "complete", "completed"}
-                    else reason
-                ),
-                "summary": _last_assistant_message_excerpt(messages),
-                "duration_seconds": _seconds_since(session.created_at),
-                "session_title": session.title or "Task complete",
-                "error": None,
-            },
+        outcome = (
+            "success"
+            if reason in {"stop", "done", "complete", "completed"}
+            else reason
         )
+
+        loop_result_parent = None
+        try:
+            loop_result_parent = await self._resolve_loop_result_parent(session)
+        except Exception:
+            logger.debug(
+                "Failed to resolve loop.result parent for %s",
+                session.id,
+                exc_info=True,
+            )
+
+        if loop_result_parent is not None:
+            try:
+                child_events = await self._store.get_events(session.id)
+                content = extract_final_response(child_events, fallback="").strip()
+                if content:
+                    await self._store.emit_event(
+                        loop_result_parent.id,
+                        EventType.LOOP_RESULT,
+                        {
+                            "run_session_id": str(session.id),
+                            "scheduled_session_id": str(
+                                (session.config or {}).get("scheduled_session_id") or ""
+                            ),
+                            "content": content,
+                            "outcome": outcome,
+                            "duration_seconds": _seconds_since(session.created_at),
+                            "run_completed_at": datetime.now(timezone.utc).isoformat(),
+                        },
+                    )
+            except Exception:
+                logger.warning(
+                    "Failed to emit loop.result on parent %s for run %s",
+                    loop_result_parent.id,
+                    session.id,
+                    exc_info=True,
+                )
+
+        inbox_event_id: int | None = None
+        if loop_result_parent is None:
+            inbox_event_id = await self._store.emit_event(
+                session.id,
+                EventType.INBOX_TASK_COMPLETE,
+                {
+                    "outcome": outcome,
+                    "summary": _last_assistant_message_excerpt(messages),
+                    "duration_seconds": _seconds_since(session.created_at),
+                    "session_title": session.title or "Task complete",
+                    "error": None,
+                },
+            )
         try:
             await self._store.update_session_status(session.id, "completed")
         except Exception:
@@ -670,7 +712,13 @@ class ArtifactCompletionMixin:
 
         # Advance cursor to the latest event.
         cursor_target = (
-            through_event_id if through_event_id is not None else inbox_event_id
+            through_event_id
+            if through_event_id is not None
+            else (
+                inbox_event_id
+                if inbox_event_id is not None
+                else session_complete_event_id
+            )
         )
         try:
             await self._store.advance_harness_cursor(

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -18,6 +18,7 @@ from surogates.harness.loop_artifacts import (
 from surogates.harness.loop_constants import _BACKGROUND_DRAIN_TIMEOUT_SECONDS
 from surogates.harness.loop_messages import (
     _as_aware_utc,
+    _is_scheduled_run,
     _last_assistant_message_excerpt,
     _latest_user_message_text,
     _seconds_since,
@@ -513,12 +514,7 @@ class ArtifactCompletionMixin:
 
     async def _resolve_loop_result_parent(self, session: Session) -> Session | None:
         """Return the web/api parent that should receive this loop run result."""
-        config = session.config or {}
-        is_scheduled_run = (
-            session.channel == "scheduled"
-            or bool(config.get("scheduled_session_id"))
-        )
-        if not is_scheduled_run or session.parent_id is None:
+        if not _is_scheduled_run(session) or session.parent_id is None:
             return None
 
         from surogates.session.store import SessionNotFoundError

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -510,6 +510,27 @@ class ArtifactCompletionMixin:
             )
         return out
 
+    async def _resolve_loop_result_parent(self, session: Session) -> Session | None:
+        """Return the web/api parent that should receive this loop run result."""
+        config = session.config or {}
+        is_scheduled_run = (
+            session.channel == "scheduled"
+            or bool(config.get("scheduled_session_id"))
+        )
+        if not is_scheduled_run or session.parent_id is None:
+            return None
+
+        from surogates.session.store import SessionNotFoundError
+
+        try:
+            parent = await self._store.get_session(session.parent_id)
+        except SessionNotFoundError:
+            return None
+
+        if parent.channel not in {"web", "api"}:
+            return None
+        return parent
+
     async def _complete_session(
         self,
         session: Session,

--- a/surogates/harness/loop_messages.py
+++ b/surogates/harness/loop_messages.py
@@ -236,5 +236,19 @@ def _as_aware_utc(value: datetime) -> datetime:
     return value.astimezone(timezone.utc)
 
 
+def _is_scheduled_run(session: Any) -> bool:
+    """True when *session* is a scheduled/loop run.
+
+    A run is identified by ``channel == "scheduled"`` or a
+    ``scheduled_session_id`` config marker (the latter guards the case where a
+    run's channel drifts from ``"scheduled"``). Both the loop-result surfacing
+    and the parent-notify suppression key off this single predicate so they can
+    never disagree.
+    """
+    if session.channel == "scheduled":
+        return True
+    return bool((getattr(session, "config", None) or {}).get("scheduled_session_id"))
+
+
 def _should_notify_parent_on_completion(session: Any) -> bool:
-    return session.parent_id is not None and session.channel != "scheduled"
+    return session.parent_id is not None and not _is_scheduled_run(session)

--- a/surogates/session/events.py
+++ b/surogates/session/events.py
@@ -217,3 +217,6 @@ class EventType(str, Enum):
     INBOX_TASK_COMPLETE = "inbox.task_complete"
     INBOX_GOVERNANCE_GATE = "inbox.governance_gate"
     INBOX_PROGRESS_CHECKIN = "inbox.progress_checkin"
+
+    # Scheduled loop run result surfaced inline on a web/api parent session.
+    LOOP_RESULT = "loop.result"

--- a/tests/test_loop_result_inline_delivery.py
+++ b/tests/test_loop_result_inline_delivery.py
@@ -95,3 +95,184 @@ async def test_accepts_legacy_scheduled_run_marker_even_if_channel_drifted():
     )
 
     assert await _harness(_ParentStore(parent))._resolve_loop_result_parent(child) is parent
+
+
+from surogates.session.events import EventType
+
+
+def _llm_response(content: str):
+    return SimpleNamespace(
+        type=EventType.LLM_RESPONSE.value,
+        data={"message": {"role": "assistant", "content": content}},
+    )
+
+
+class _RecordingStore(_ParentStore):
+    def __init__(self, parent=None, child_events=None, fail_loop_result=False):
+        super().__init__(parent)
+        self.child_events = list(child_events or [])
+        self.fail_loop_result = fail_loop_result
+        self.emitted = []
+        self.status_updates = []
+        self.cursor_advancements = []
+        self.next_event_id = 100
+
+    async def get_events(self, session_id):
+        return list(self.child_events)
+
+    async def emit_event(self, session_id, event_type, data):
+        if event_type == EventType.LOOP_RESULT and self.fail_loop_result:
+            raise RuntimeError("boom")
+        self.next_event_id += 1
+        self.emitted.append((self.next_event_id, session_id, event_type, data))
+        return self.next_event_id
+
+    async def update_session_status(self, session_id, status):
+        self.status_updates.append((session_id, status))
+
+    async def advance_harness_cursor(self, session_id, cursor, lease_token):
+        self.cursor_advancements.append((session_id, cursor, lease_token))
+
+
+def _completion_harness(store):
+    host = _harness(store)
+    host._worker_id = "worker-1"
+    host._sandbox_pool = None
+    host._memory_manager = None
+    host._turn_summarizer = None
+    host._redis = None
+    host._session_factory = None
+    return host
+
+
+async def _complete(host, child, *, messages=None, reason="stop", through_event_id=None):
+    await host._complete_session(
+        child,
+        messages=messages if messages is not None else [{"role": "assistant", "content": "done"}],
+        lease=SimpleNamespace(lease_token="lease-1"),
+        reason=reason,
+        through_event_id=through_event_id,
+    )
+
+
+def _types(store):
+    return [event_type for _, _, event_type, _ in store.emitted]
+
+
+async def test_web_parent_gets_loop_result_and_inbox_is_suppressed():
+    schedule_id = uuid4()
+    parent = _session(channel="web")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(schedule_id)},
+    )
+    store = _RecordingStore(parent, [_llm_response("Full final answer")])
+
+    await _complete(_completion_harness(store), child)
+
+    loop_rows = [row for row in store.emitted if row[2] == EventType.LOOP_RESULT]
+    assert len(loop_rows) == 1
+    _, emitted_session_id, _, payload = loop_rows[0]
+    assert emitted_session_id == parent.id
+    assert payload["run_session_id"] == str(child.id)
+    assert payload["scheduled_session_id"] == str(schedule_id)
+    assert payload["content"] == "Full final answer"
+    assert payload["outcome"] == "success"
+    assert isinstance(payload["duration_seconds"], int)
+    assert payload["run_completed_at"]
+    assert EventType.INBOX_TASK_COMPLETE not in _types(store)
+
+
+async def test_api_parent_gets_loop_result_and_inbox_is_suppressed():
+    parent = _session(channel="api")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+    store = _RecordingStore(parent, [_llm_response("API final answer")])
+
+    await _complete(_completion_harness(store), child)
+
+    assert EventType.LOOP_RESULT in _types(store)
+    assert EventType.INBOX_TASK_COMPLETE not in _types(store)
+
+
+async def test_channel_parent_keeps_existing_inbox_completion_and_no_loop_result():
+    parent = _session(channel="slack")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+    store = _RecordingStore(parent, [_llm_response("Channel final answer")])
+
+    await _complete(_completion_harness(store), child)
+
+    assert EventType.LOOP_RESULT not in _types(store)
+    assert EventType.INBOX_TASK_COMPLETE in _types(store)
+
+
+async def test_empty_final_response_suppresses_inbox_but_emits_no_loop_result():
+    parent = _session(channel="web")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+    store = _RecordingStore(parent, child_events=[])
+
+    await _complete(_completion_harness(store), child, messages=[])
+
+    assert EventType.LOOP_RESULT not in _types(store)
+    assert EventType.INBOX_TASK_COMPLETE not in _types(store)
+    assert store.status_updates == [(child.id, "completed")]
+
+
+async def test_loop_result_failure_does_not_abort_completion_and_still_suppresses_inbox():
+    parent = _session(channel="web")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+    store = _RecordingStore(parent, [_llm_response("Final")], fail_loop_result=True)
+
+    await _complete(_completion_harness(store), child)
+
+    assert EventType.INBOX_TASK_COMPLETE not in _types(store)
+    assert store.status_updates == [(child.id, "completed")]
+    assert store.cursor_advancements
+
+
+async def test_cursor_uses_child_session_complete_when_inbox_is_suppressed():
+    parent = _session(channel="web")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+    store = _RecordingStore(parent, [_llm_response("Final")])
+
+    await _complete(_completion_harness(store), child)
+
+    session_complete_id = next(
+        event_id for event_id, _, event_type, _ in store.emitted
+        if event_type == EventType.SESSION_COMPLETE
+    )
+    assert store.cursor_advancements == [(child.id, session_complete_id, "lease-1")]
+
+
+async def test_explicit_through_event_id_still_wins_for_cursor():
+    parent = _session(channel="web")
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+    store = _RecordingStore(parent, [_llm_response("Final")])
+
+    await _complete(_completion_harness(store), child, through_event_id=77)
+
+    assert store.cursor_advancements == [(child.id, 77, "lease-1")]

--- a/tests/test_loop_result_inline_delivery.py
+++ b/tests/test_loop_result_inline_delivery.py
@@ -1,0 +1,97 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from surogates.harness.loop_artifact_completion import ArtifactCompletionMixin
+from surogates.session.store import SessionNotFoundError
+
+
+def _session(*, channel: str, parent_id=None, config=None):
+    now = datetime.now(timezone.utc)
+    return SimpleNamespace(
+        id=uuid4(),
+        user_id=uuid4(),
+        org_id=uuid4(),
+        agent_id="agent-a",
+        channel=channel,
+        status="active",
+        parent_id=parent_id,
+        title="Loop run",
+        config=config or {},
+        created_at=now,
+        updated_at=now,
+        task_id=None,
+    )
+
+
+class _ParentStore:
+    def __init__(self, parent=None):
+        self.parent = parent
+
+    async def get_session(self, session_id):
+        if self.parent is not None and session_id == self.parent.id:
+            return self.parent
+        raise SessionNotFoundError(str(session_id))
+
+
+def _harness(store):
+    host = type("_Harness", (ArtifactCompletionMixin,), {})()
+    host._store = store
+    return host
+
+
+@pytest.mark.parametrize("parent_channel", ["web", "api"])
+async def test_resolves_web_and_api_loop_parent(parent_channel):
+    parent = _session(channel=parent_channel)
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+
+    assert await _harness(_ParentStore(parent))._resolve_loop_result_parent(child) is parent
+
+
+@pytest.mark.parametrize("parent_channel", ["slack", "telegram", "teams", "ambient"])
+async def test_skips_channel_and_private_parents(parent_channel):
+    parent = _session(channel=parent_channel)
+    child = _session(
+        channel="scheduled",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+
+    assert await _harness(_ParentStore(parent))._resolve_loop_result_parent(child) is None
+
+
+async def test_skips_detached_scheduled_run():
+    child = _session(
+        channel="scheduled",
+        parent_id=None,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+
+    assert await _harness(_ParentStore())._resolve_loop_result_parent(child) is None
+
+
+async def test_skips_missing_parent():
+    child = _session(
+        channel="scheduled",
+        parent_id=uuid4(),
+        config={"scheduled_session_id": str(uuid4())},
+    )
+
+    assert await _harness(_ParentStore())._resolve_loop_result_parent(child) is None
+
+
+async def test_accepts_legacy_scheduled_run_marker_even_if_channel_drifted():
+    parent = _session(channel="web")
+    child = _session(
+        channel="api",
+        parent_id=parent.id,
+        config={"scheduled_session_id": str(uuid4())},
+    )
+
+    assert await _harness(_ParentStore(parent))._resolve_loop_result_parent(child) is parent

--- a/tests/test_loop_result_replay_safety.py
+++ b/tests/test_loop_result_replay_safety.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+from surogates.harness.loop_context_replay import ContextReplayMixin
+from surogates.session.events import EventType
+from surogates.session.store import _DELIVERABLE_EVENTS
+
+
+def _event(event_type: EventType, data: dict, event_id: int = 1):
+    return SimpleNamespace(
+        id=event_id,
+        session_id=uuid4(),
+        type=event_type.value,
+        data=data,
+    )
+
+
+def test_loop_result_event_type_exists():
+    assert EventType.LOOP_RESULT.value == "loop.result"
+
+
+def test_loop_result_is_not_a_deliverable_event():
+    assert EventType.LOOP_RESULT not in _DELIVERABLE_EVENTS
+
+
+def test_rebuild_messages_ignores_loop_result():
+    host = type("_ReplayHost", (ContextReplayMixin,), {})()
+    rebuilt = host._rebuild_messages([
+        _event(
+            EventType.LLM_RESPONSE,
+            {"message": {"role": "assistant", "content": "normal reply"}},
+            1,
+        ),
+        _event(EventType.LOOP_RESULT, {"content": "scheduled output"}, 2),
+    ])
+
+    joined = "\n".join(str(m.get("content", "")) for m in rebuilt)
+    assert "normal reply" in joined
+    assert "scheduled output" not in joined

--- a/tests/test_scheduled_parenting.py
+++ b/tests/test_scheduled_parenting.py
@@ -14,3 +14,18 @@ def test_worker_child_sessions_notify_parent_on_completion() -> None:
     session = SimpleNamespace(parent_id=uuid4(), channel="worker")
 
     assert _should_notify_parent_on_completion(session) is True
+
+
+def test_scheduled_run_marker_does_not_notify_parent_even_if_channel_drifted() -> None:
+    # A scheduled run is identified by channel=="scheduled" OR a
+    # scheduled_session_id config marker. Whichever way it is recognised, it
+    # must never wake the parent as sub-agent work — otherwise a loop run whose
+    # channel drifted would both surface a loop.result and re-enqueue the
+    # parent.
+    session = SimpleNamespace(
+        parent_id=uuid4(),
+        channel="api",
+        config={"scheduled_session_id": str(uuid4())},
+    )
+
+    assert _should_notify_parent_on_completion(session) is False

--- a/web/src/types/session.ts
+++ b/web/src/types/session.ts
@@ -39,6 +39,7 @@ export type EventType =
   | "user.message"
   | "llm.request"
   | "llm.response"
+  | "loop.result"
   | "llm.thinking"
   | "llm.delta"
   | "tool.call"


### PR DESCRIPTION
## What

Web/api-originated `/loop` runs now surface each run's final answer **inline in the originating conversation** instead of an expiring inbox card. (Channel-origin loops post to their channel via #135.)

Design + plan: `docs/superpowers/specs/2026-07-03-loop-result-inline-delivery-design.md`, `docs/superpowers/plans/2026-07-03-loop-result-inline-delivery.md`.

## How

A new `loop.result` event is emitted on the **parent** web/api session at run completion, carrying the run's final response. `emit_event` publishes to `surogates:session:{id}`, so the parent's SSE / poll stream delivers it; API clients read it via `GET /sessions/{id}/events`. Because it is a new event type, the replay whitelist ignores it — the parent agent's context is untouched and the parent is never re-enqueued. The redundant `inbox.task_complete` card is suppressed for these runs.

- **Backend**: `EventType.LOOP_RESULT`; `_resolve_loop_result_parent` gating (web/api parent only); `_complete_session` emits + suppresses inbox + falls the cursor back to the child `SESSION_COMPLETE`; guarded out of `_DELIVERABLE_EVENTS` and `_rebuild_messages`.
- **Chat SDK** (`agent-chat-react`): event registration, reducer case (assistant message, no `isRunning`/context bleed), "From loop" thread affordance.
- **Web host**: raw `loop.result` session-event type.
- **Ops view**: `loop.result` in `v_session_messages`. (Ops frontend rendering is a separate PR in `surogate-ops`.)

## Review fix included

Unified the "is this a scheduled run?" predicate (`_is_scheduled_run`) so `_should_notify_parent_on_completion` and `_resolve_loop_result_parent` can never disagree — closes a latent double-surface + parent-wake on a channel-drifted run.

## Tests

`test_loop_result_inline_delivery.py`, `test_loop_result_replay_safety.py`, `test_scheduled_parenting.py` (+19 tests), SDK 393 passed, web + ops typecheck clean. Zero regressions vs master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)