### PR TITLE
feat(ssh): agent SSH remote access via isolated ssh-agent sidecar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
             name: surogates-s3fs
           - dir: browser
             name: surogates-agent-browser
+          - dir: ssh-agent
+            name: surogates-ssh-agent
     steps:
       - uses: actions/checkout@v4
 

--- a/images/build.sh
+++ b/images/build.sh
@@ -21,6 +21,7 @@ declare -A IMAGES=(
   [sandbox]="surogates-agent-sandbox"
   [s3fs]="surogates-s3fs"
   [browser]="surogates-agent-browser"
+  [ssh-agent]="surogates-ssh-agent"
 )
 PUSH="${PUSH:-1}"
 

--- a/images/ssh-agent/Dockerfile
+++ b/images/ssh-agent/Dockerfile
@@ -1,0 +1,29 @@
+# Isolated ssh-agent sidecar for Surogates sandbox pods.
+#
+# Holds an agent's SSH private key(s) in a separate container the untrusted
+# sandbox cannot read or ptrace. The main sandbox container is handed ONLY the
+# auth socket (a shared in-memory volume), so it can authenticate to the
+# configured remote hosts but can never read or exfiltrate the key material.
+#
+# The sidecar is launched with an inline `/bin/sh -c` script (see
+# surogates/sandbox/kubernetes.py::_build_ssh_sidecar) that runs `ssh-agent`,
+# loads each key with `ssh-add`, then idles holding the socket. It runs as a
+# non-root uid with a read-only root filesystem and all Linux capabilities
+# dropped; the key Secret and socket arrive via mounted volumes, so the image
+# only needs the OpenSSH client tooling and a POSIX shell.
+#
+# Image name (surogates-ssh-agent) matches the surogates config default
+# `sandbox.k8s_ssh_agent_image`.
+#
+# Build:
+#   docker build -t ghcr.io/invergent-ai/surogates-ssh-agent:latest -f images/ssh-agent/Dockerfile .
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# The pod securityContext pins runAsUser=65532 (nonroot) with a read-only root
+# filesystem; declaring it here keeps the image safe to run standalone too.
+USER 65532:65532

--- a/surogates/api/app.py
+++ b/surogates/api/app.py
@@ -707,6 +707,7 @@ def create_app() -> FastAPI:
         scheduled_work,
         sessions,
         skills,
+        ssh_credentials,
         tools,
         transparency,
         website,
@@ -750,6 +751,12 @@ def create_app() -> FastAPI:
     # agent SA's bare ``surg_sk_`` token (auth middleware only accepts /v1/api/*).
     app.include_router(
         git_credentials.router, prefix="/v1/api", tags=["git-credentials"],
+    )
+    app.include_router(ssh_credentials.router, prefix="/v1", tags=["ssh-credentials"])
+    # Also at /v1/api so ops can forward SSH-key store/list/delete under the
+    # agent SA's bare ``surg_sk_`` token (auth middleware only accepts /v1/api/*).
+    app.include_router(
+        ssh_credentials.router, prefix="/v1/api", tags=["ssh-credentials"],
     )
     app.include_router(memory.router, prefix="/v1", tags=["memory"])
     app.include_router(prompts.router, prefix="/v1", tags=["prompts"])

--- a/surogates/api/routes/ssh_credentials.py
+++ b/surogates/api/routes/ssh_credentials.py
@@ -1,0 +1,80 @@
+"""Store/list/delete a managed agent's named SSH private keys in the vault.
+
+Keyed on the caller's principal (end user, or a service account — the agent's
+own SA when ops forwards as it), stored under ``ssh_key:<name>`` so a session
+resolves it under the same principal.  Plaintext never returned.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from pydantic import BaseModel, Field
+
+from surogates.api.routes.coding_agents import _require_principal, _vault
+from surogates.runtime import AgentRuntimeContext, agent_runtime_context_dep
+from surogates.ssh_access.bundle import SSHKeyBundle, validate_private_key
+from surogates.ssh_access.resolve import SSH_KEY_PREFIX
+from surogates.tenant.auth.middleware import get_current_tenant
+from surogates.tenant.context import TenantContext
+
+router = APIRouter()
+
+
+class SSHKeySubmit(BaseModel):
+    name: str = Field(..., min_length=1, max_length=64)
+    private_key: str = Field(..., repr=False)
+    passphrase: str | None = Field(default=None, repr=False)
+
+
+def _vault_name(name: str) -> str:
+    n = (name or "").strip()
+    if not n or "/" in n or ":" in n:
+        raise HTTPException(status_code=422, detail="invalid key name")
+    return f"{SSH_KEY_PREFIX}{n}"
+
+
+@router.post("/ssh-credentials/credential")
+async def submit_ssh_key(
+    body: SSHKeySubmit,
+    request: Request,
+    tenant: TenantContext = Depends(get_current_tenant),
+    ctx: AgentRuntimeContext = Depends(agent_runtime_context_dep),
+) -> dict:
+    principal = _require_principal(tenant, ctx)
+    vault_name = _vault_name(body.name)
+    try:
+        key = validate_private_key(body.private_key)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    bundle = SSHKeyBundle(private_key=key, passphrase=body.passphrase or None)
+    await _vault(request).store(tenant.org_id, vault_name, bundle.to_json(), **principal)
+    return {"connected": True, "name": body.name.strip()}
+
+
+@router.get("/ssh-credentials/credentials")
+async def list_ssh_keys(
+    request: Request,
+    tenant: TenantContext = Depends(get_current_tenant),
+    ctx: AgentRuntimeContext = Depends(agent_runtime_context_dep),
+) -> dict:
+    principal = _require_principal(tenant, ctx)
+    names = await _vault(request).list_names(tenant.org_id, **principal)
+    creds = [
+        {"name": n[len(SSH_KEY_PREFIX):]}
+        for n in names
+        if n.startswith(SSH_KEY_PREFIX)
+    ]
+    return {"credentials": creds}
+
+
+@router.delete(
+    "/ssh-credentials/credential", status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_ssh_key(
+    request: Request,
+    name: str = Query(..., min_length=1),
+    tenant: TenantContext = Depends(get_current_tenant),
+    ctx: AgentRuntimeContext = Depends(agent_runtime_context_dep),
+) -> Response:
+    principal = _require_principal(tenant, ctx)
+    await _vault(request).delete(tenant.org_id, _vault_name(name), **principal)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/surogates/api/routes/ssh_credentials.py
+++ b/surogates/api/routes/ssh_credentials.py
@@ -6,6 +6,8 @@ resolves it under the same principal.  Plaintext never returned.
 """
 from __future__ import annotations
 
+import re
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from pydantic import BaseModel, Field
 
@@ -25,9 +27,15 @@ class SSHKeySubmit(BaseModel):
     passphrase: str | None = Field(default=None, repr=False)
 
 
+# A key name becomes part of a vault ref and of the sidecar shell script
+# (``id_<name>``/``pass_<name>``); restrict it to a conservative charset so a
+# metacharacter cannot inject into either.
+_VALID_KEY_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
 def _vault_name(name: str) -> str:
     n = (name or "").strip()
-    if not n or "/" in n or ":" in n:
+    if not _VALID_KEY_NAME.match(n):
         raise HTTPException(status_code=422, detail="invalid key name")
     return f"{SSH_KEY_PREFIX}{n}"
 

--- a/surogates/config.py
+++ b/surogates/config.py
@@ -368,6 +368,15 @@ class SandboxSettings(BaseSettings):
     # In-cluster S3 endpoint for sandbox pods (they can't use the host NodePort).
     # If empty, falls back to storage.endpoint.
     k8s_s3_endpoint: str = ""
+    # Isolated ssh-agent sidecar image for SSH remote-access sessions.
+    k8s_ssh_agent_image: str = "ghcr.io/invergent-ai/surogates-ssh-agent:latest"
+    # SSH host scoping is enforced by NetworkPolicy egress.  Must be True for
+    # the cluster's CNI to actually enforce it; when False, SSH-enabled
+    # sessions fail closed rather than run without a network boundary.
+    ssh_egress_enforced: bool = False
+    # CIDRs the sandbox always needs egress to (DNS, S3/workspace, MCP proxy,
+    # runtime APIs) in addition to the resolved SSH target IPs.
+    ssh_egress_baseline_cidrs: list[str] = Field(default_factory=list)
 
 
 class BrowserSettings(BaseSettings):

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -387,6 +387,7 @@ class AgentHarness(
         slash_commands: SlashCommandConfig | None = None,
         coding_repos: tuple[dict[str, str], ...] = (),
         ssh_targets: tuple[dict[str, Any], ...] = (),
+        agent_service_account_id: str | None = None,
         acting_principal: Any | None = None,
     ) -> None:
         self._store = session_store
@@ -413,6 +414,9 @@ class AgentHarness(
         # ssh-agent.  Overlaid onto the wake-local session config alongside
         # repos (see ``_overlay_repos``).
         self._ssh_targets: tuple[dict[str, Any], ...] = tuple(ssh_targets or ())
+        # The agent's service account id — SSH keys are agent-owned and resolved
+        # under it regardless of the session's channel-gated credential principal.
+        self._agent_service_account_id: str | None = agent_service_account_id
         self._llm = llm_client
         self._tenant = tenant
         # Who actually SENT this turn — the owner of any automation they create
@@ -803,6 +807,10 @@ class AgentHarness(
             config["repos"] = [dict(repo) for repo in self._coding_repos]
         if self._ssh_targets:
             config["ssh_targets"] = [dict(t) for t in self._ssh_targets]
+            # Carry the agent SA id so the spec builder resolves the agent-owned
+            # SSH keys under it (not the session's credential principal).
+            if self._agent_service_account_id:
+                config["agent_service_account_id"] = self._agent_service_account_id
         return session.model_copy(update={"config": config})
 
     def _slash_command_block_reason(self, content: str | None) -> str | None:

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -2737,8 +2737,9 @@ class AgentHarness(
                     try:
                         from surogates.harness.tool_exec import _build_session_sandbox_spec
                         sandbox_owner = sandbox_session_key(session)
-                        sandbox_spec = _build_session_sandbox_spec(
+                        sandbox_spec = await _build_session_sandbox_spec(
                             session, self._tenant, sandbox_owner,
+                            credential_vault=self._credential_vault,
                         )
                         await self._sandbox_pool.ensure(sandbox_owner, sandbox_spec)
                     except Exception:

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -386,6 +386,7 @@ class AgentHarness(
         composio_tool_names: frozenset[str] | None = None,
         slash_commands: SlashCommandConfig | None = None,
         coding_repos: tuple[dict[str, str], ...] = (),
+        ssh_targets: tuple[dict[str, Any], ...] = (),
         acting_principal: Any | None = None,
     ) -> None:
         self._store = session_store
@@ -408,6 +409,10 @@ class AgentHarness(
         # onto the wake-local session config (see ``_overlay_repos``) rather
         # than in the worker's harness factory.
         self._coding_repos: tuple[dict[str, str], ...] = tuple(coding_repos or ())
+        # Per-agent SSH targets the terminal may connect to via the isolated
+        # ssh-agent.  Overlaid onto the wake-local session config alongside
+        # repos (see ``_overlay_repos``).
+        self._ssh_targets: tuple[dict[str, Any], ...] = tuple(ssh_targets or ())
         self._llm = llm_client
         self._tenant = tenant
         # Who actually SENT this turn — the owner of any automation they create
@@ -783,17 +788,21 @@ class AgentHarness(
         return name in self._slash_commands.commands
 
     def _overlay_repos(self, session: Session) -> Session:
-        """Overlay the agent's configured repos onto a wake-local session.
+        """Overlay the agent's configured repos + ssh targets onto a wake-local session.
 
         ``wake`` re-fetches the session from the store, so the runtime-projected
-        repos are applied here so ``/code`` and the coding tool can read
-        ``session.config['repos']``.  Never written back to the persisted row;
-        with no repos configured the session is returned unchanged.
+        repos/ssh_targets are applied here so ``/code``, the coding tool, and the
+        sandbox spec builder can read ``session.config['repos']`` /
+        ``session.config['ssh_targets']``.  Never written back to the persisted
+        row; with nothing configured the session is returned unchanged.
         """
-        if not self._coding_repos:
+        if not self._coding_repos and not self._ssh_targets:
             return session
         config = dict(session.config or {})
-        config["repos"] = [dict(repo) for repo in self._coding_repos]
+        if self._coding_repos:
+            config["repos"] = [dict(repo) for repo in self._coding_repos]
+        if self._ssh_targets:
+            config["ssh_targets"] = [dict(t) for t in self._ssh_targets]
         return session.model_copy(update={"config": config})
 
     def _slash_command_block_reason(self, content: str | None) -> str | None:

--- a/surogates/harness/loop_code_commands.py
+++ b/surogates/harness/loop_code_commands.py
@@ -242,7 +242,10 @@ class CodeCommandMixin:
     async def _ensure_code_sandbox(self, session, sandbox_owner: str) -> None:
         from surogates.harness.tool_exec import _build_session_sandbox_spec
 
-        spec = _build_session_sandbox_spec(session, self._tenant, sandbox_owner)
+        spec = await _build_session_sandbox_spec(
+            session, self._tenant, sandbox_owner,
+            credential_vault=self._credential_vault,
+        )
         await self._sandbox_pool.ensure(sandbox_owner, spec)
 
 

--- a/surogates/harness/loop_context_replay.py
+++ b/surogates/harness/loop_context_replay.py
@@ -402,5 +402,11 @@ class ContextReplayMixin:
         repos_section = render_repos_prompt(self._coding_repos)
         if repos_section:
             prompt = f"{prompt}\n\n{repos_section}"
+        # Tell the agent which SSH hosts its terminal is authenticated for.
+        from surogates.ssh_access.resolve import render_ssh_targets_prompt
+
+        ssh_section = render_ssh_targets_prompt(self._ssh_targets)
+        if ssh_section:
+            prompt = f"{prompt}\n\n{ssh_section}"
         self._system_prompt_cache.set(session.id, prompt)
         return prompt

--- a/surogates/harness/prompt.py
+++ b/surogates/harness/prompt.py
@@ -54,6 +54,17 @@ MODELS_REQUIRING_DISCIPLINE: tuple[str, ...] = (
     "surogate",
 )
 
+# Channels that render agent output as chat messages with native media
+# attachments but have NO artifact panel -- the create_artifact surface
+# only exists in the Surogate Studio web app.  When create_artifact is
+# loaded on one of these channels the agent is told to deliver visual
+# output as an image via MEDIA: instead (guidance/artifact_in_channel).
+# SMS and CLI are excluded because they can't carry image attachments;
+# cron is excluded because its delivery destination varies.
+CHANNELS_WITHOUT_ARTIFACT_PANEL: frozenset[str] = frozenset({
+    "slack", "discord", "telegram", "whatsapp", "signal", "email",
+})
+
 # Maximum bytes to read from any single memory/skill file.
 _MAX_FILE_BYTES: int = 32_768
 
@@ -777,6 +788,19 @@ class PromptBuilder:
             hint = self._prompts.platform_hint(channel)
             if hint:
                 parts.append(f"\n## Platform\n{hint}")
+            # create_artifact renders into the Studio web panel, which these
+            # channels don't have -- tell the agent to deliver visual output
+            # as an image via MEDIA: instead.  Appended after the platform
+            # hint so it lands late in the prompt (overriding the earlier
+            # guidance/artifact block) and can reference the MEDIA: mechanism
+            # the hint just described.
+            if (
+                "create_artifact" in self._available_tools
+                and channel in CHANNELS_WITHOUT_ARTIFACT_PANEL
+            ):
+                parts.append(
+                    "\n" + self._prompts.get("guidance/artifact_in_channel")
+                )
 
         return "\n".join(parts)
 

--- a/surogates/harness/prompt_library.py
+++ b/surogates/harness/prompt_library.py
@@ -49,6 +49,7 @@ REQUIRED_KEYS: tuple[str, ...] = (
     "guidance/brainstorming_gate",
     "guidance/ask_user_question",
     "guidance/artifact",
+    "guidance/artifact_in_channel",
     "guidance/browser",
     "guidance/web_search",
     "guidance/loop_wait",

--- a/surogates/harness/prompts/guidance/artifact_in_channel.md
+++ b/surogates/harness/prompts/guidance/artifact_in_channel.md
@@ -1,0 +1,9 @@
+---
+name: artifact_in_channel
+description: Injected when create_artifact is loaded on a messaging channel (Slack, Discord, Telegram, WhatsApp, Signal, email) — the artifact panel only exists in the Surogate Studio web app, so visual output must be delivered as an image attachment instead.
+applies_when: create_artifact tool loaded AND session channel is a messaging channel
+---
+## Artifacts here
+The `create_artifact` panel only renders in the Surogate Studio web app. This is a messaging channel — it has **no artifact panel**, so anything you send with `create_artifact` is invisible to the user here. Don't use `create_artifact` to deliver a result in this channel.
+
+Deliver visual output as an image instead: render it to an image file (`.png` / `.jpg`) in your workspace and send it with `MEDIA:<path>`, exactly as described above. Charts, diagrams, tables, and rendered documents all go out as images. Plain text — code, snippets, short data — still goes inline as usual.

--- a/surogates/harness/tool_exec.py
+++ b/surogates/harness/tool_exec.py
@@ -56,10 +56,12 @@ def build_workspace_source_ref(
     return f"s3://{storage_bucket}/{workspace_prefix}"
 
 
-def _build_session_sandbox_spec(
+async def _build_session_sandbox_spec(
     session: Any,
     tenant: Any,
     sandbox_owner: str,
+    *,
+    credential_vault: Any = None,
 ) -> Any:
     """Build the SandboxSpec used to provision *session*'s sandbox.
 
@@ -144,7 +146,74 @@ def _build_session_sandbox_spec(
     sandbox_spec.env["SUROGATES_IS_SERVICE_ACCOUNT"] = (
         "1" if is_service_account else "0"
     )
+    await _apply_ssh_access(session, tenant, sandbox_spec, credential_vault)
     return sandbox_spec
+
+
+async def _apply_ssh_access(
+    session: Any, tenant: Any, sandbox_spec: Any, credential_vault: Any,
+) -> None:
+    """Resolve SSH key material worker-side and populate the spec.
+
+    Non-secret target data + ``known_hosts`` go into ``env`` (they reach the
+    main container so the executor can write ``~/.ssh``); private keys go into
+    ``ssh_key_material`` (delivered only to the isolated ssh-agent, never to the
+    main container's env or the workspace).  Targets whose key does not resolve,
+    or which have no pinned ``host_key``, are dropped (fail closed).
+    """
+    import json as _json
+
+    from surogates.ssh_access.resolve import (
+        build_known_hosts,
+        resolve_ssh_key,
+        ssh_key_names,
+        validate_targets,
+    )
+
+    raw = (getattr(session, "config", None) or {}).get("ssh_targets") or []
+    if not raw or credential_vault is None:
+        return
+    try:
+        targets = validate_targets(raw)
+    except ValueError:
+        logger.warning("Invalid ssh_targets for session; skipping SSH access")
+        return
+    # Unpinned targets fail closed — StrictHostKeyChecking would reject them and
+    # we never blind-accept a host key inside the sandbox.
+    targets = [t for t in targets if t.get("host_key")]
+    if not targets:
+        return
+
+    org_id = getattr(tenant, "org_id", None)
+    user_id = getattr(tenant, "user_id", None)
+    service_account_id = getattr(tenant, "service_account_id", None)
+    material: dict[str, dict[str, str]] = {}
+    for name in ssh_key_names(targets):
+        bundle = await resolve_ssh_key(
+            credential_vault, org_id=org_id, name=name,
+            user_id=user_id, service_account_id=service_account_id,
+        )
+        if bundle is None:
+            continue
+        material[name] = {
+            "private_key": bundle.private_key,
+            "passphrase": bundle.passphrase or "",
+        }
+    # Only keep targets whose key actually resolved.
+    targets = [t for t in targets if t["key_name"] in material]
+    if not targets:
+        return
+
+    sandbox_spec.ssh_targets = targets
+    sandbox_spec.ssh_key_material = material
+    # Non-secret transport into the main container (host_key travels via
+    # known_hosts, not the targets JSON, so the config file stays minimal).
+    public_targets = [
+        {k: v for k, v in t.items() if k != "host_key"} for t in targets
+    ]
+    sandbox_spec.env["SUROGATES_SSH_TARGETS"] = _json.dumps(public_targets)
+    sandbox_spec.env["SUROGATES_SSH_KNOWN_HOSTS"] = build_known_hosts(targets)
+    sandbox_spec.env["SSH_AUTH_SOCK"] = "/ssh-agent/auth.sock"
 
 
 def _sanitize_paths(data: Any, workspace_path: str | None) -> Any:
@@ -1337,7 +1406,9 @@ async def execute_single_tool(
         elif location == ToolLocation.SANDBOX and sandbox_pool is not None:
             from surogates.sandbox.pool import sandbox_session_key
             sandbox_owner = sandbox_session_key(session)
-            sandbox_spec = _build_session_sandbox_spec(session, tenant, sandbox_owner)
+            sandbox_spec = await _build_session_sandbox_spec(
+                session, tenant, sandbox_owner, credential_vault=credential_vault,
+            )
             await sandbox_pool.ensure(sandbox_owner, sandbox_spec)
             # Dispatch to the sandbox pod — runs the real Python tool handler
             # inside the sandbox via tool-executor.

--- a/surogates/harness/tool_exec.py
+++ b/surogates/harness/tool_exec.py
@@ -184,14 +184,31 @@ async def _apply_ssh_access(
     if not targets:
         return
 
+    # SSH keys are agent-owned: the ops key-management route always stores them
+    # under the agent's service account.  Resolve under that SA regardless of
+    # the session's channel-gated credential principal, so web/api/Studio
+    # sessions (whose principal is the acting user, not the agent SA) find the
+    # key too — not only managed Slack/Telegram sessions.  Without a resolved
+    # agent SA there are no agent-owned keys to load, so fail closed.
+    from uuid import UUID
+
+    agent_sa_id = (getattr(session, "config", None) or {}).get(
+        "agent_service_account_id",
+    )
+    if not agent_sa_id:
+        return
+    try:
+        agent_sa_uuid = UUID(str(agent_sa_id))
+    except (ValueError, TypeError):
+        logger.warning("Invalid agent_service_account_id for session; skipping SSH")
+        return
+
     org_id = getattr(tenant, "org_id", None)
-    user_id = getattr(tenant, "user_id", None)
-    service_account_id = getattr(tenant, "service_account_id", None)
     material: dict[str, dict[str, str]] = {}
     for name in ssh_key_names(targets):
         bundle = await resolve_ssh_key(
             credential_vault, org_id=org_id, name=name,
-            user_id=user_id, service_account_id=service_account_id,
+            service_account_id=agent_sa_uuid,
         )
         if bundle is None:
             continue

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -783,6 +783,9 @@ async def run_worker(settings: Settings) -> None:
             s3fs_image=settings.sandbox.k8s_s3fs_image,
             s3_endpoint=settings.sandbox.k8s_s3_endpoint,
             mcp_proxy_url=settings.mcp_proxy_url,
+            ssh_agent_image=settings.sandbox.k8s_ssh_agent_image,
+            ssh_egress_enforced=settings.sandbox.ssh_egress_enforced,
+            ssh_egress_baseline_cidrs=settings.sandbox.ssh_egress_baseline_cidrs,
         )
     elif settings.sandbox.backend == "docker":
         from surogates.sandbox.docker import DockerSandbox

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -1534,6 +1534,9 @@ async def run_worker(settings: Settings) -> None:
             # Per-agent git repos the coding tool / /code check out; overlaid
             # onto the wake-local session inside AgentHarness.wake.
             coding_repos=ctx.repos,
+            # Per-agent SSH targets the terminal connects to via the isolated
+            # ssh-agent; overlaid onto the wake-local session alongside repos.
+            ssh_targets=ctx.ssh_targets,
             # The sending human/service account — owns automation they create
             # (/loop, /mission, /auto-research), distinct from the agent
             # credential principal the tenant carries on managed channels.

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -1540,6 +1540,11 @@ async def run_worker(settings: Settings) -> None:
             # Per-agent SSH targets the terminal connects to via the isolated
             # ssh-agent; overlaid onto the wake-local session alongside repos.
             ssh_targets=ctx.ssh_targets,
+            # SSH keys are agent-owned; resolve them under the agent SA on every
+            # channel (not just managed ones), so web/api sessions find them.
+            agent_service_account_id=(
+                str(agent_principal.id) if agent_principal is not None else None
+            ),
             # The sending human/service account — owns automation they create
             # (/loop, /mission, /auto-research), distinct from the agent
             # credential principal the tenant carries on managed channels.

--- a/surogates/runtime/context.py
+++ b/surogates/runtime/context.py
@@ -28,6 +28,7 @@ mutation would let one session's edits leak into another's.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 __all__ = [
     "AgentRuntimeContext",
@@ -146,6 +147,12 @@ class AgentRuntimeContext:
     # default so a runtime-config payload that predates this field keeps the
     # no-repo coding behavior.
     repos: tuple[dict[str, str], ...] = ()
+
+    # Per-agent SSH targets the terminal may connect to via the isolated
+    # ssh-agent.  Each entry: ``{"alias","host","port","user","key_name",
+    # "host_key"}``.  Empty by default so a payload predating this field keeps
+    # the no-SSH behavior.
+    ssh_targets: tuple[dict[str, Any], ...] = ()
 
     # Per-agent slash-command gating.  Defaults to fully permissive so a
     # runtime-config payload that predates this field keeps every command.

--- a/surogates/runtime/resolver.py
+++ b/surogates/runtime/resolver.py
@@ -99,6 +99,7 @@ def build_agent_runtime_context(payload: dict) -> AgentRuntimeContext:
         llm_video=_opt_llm(payload.get("llm_video")),
         mcp_server_ids=tuple(payload.get("mcp_server_ids") or ()),
         repos=tuple(dict(repo) for repo in (payload.get("repos") or ())),
+        ssh_targets=tuple(dict(t) for t in (payload.get("ssh_targets") or ())),
         governance=dict(payload.get("governance") or {}),
         slash_commands=_slash_commands(payload.get("slash_commands")),
         brainstorming_gate=bool(payload.get("brainstorming_gate", True)),

--- a/surogates/sandbox/base.py
+++ b/surogates/sandbox/base.py
@@ -102,6 +102,14 @@ class SandboxSpec:
     # Host-bindable workspace path when one exists. Docker bind-mounts it;
     # K8sSandbox ignores it (its workspace is mounted by the s3fs sidecar).
     workspace_path: str | None = None
+    # SSH remote-access (non-secret): targets whose ssh_config/known_hosts the
+    # main container may read. Populated by the spec builder only when the
+    # agent has ssh_targets and their keys resolve.
+    ssh_targets: list[dict] = field(default_factory=list)
+    # SSH key material (SECRET): ``{key_name: {"private_key", "passphrase"}}``.
+    # Consumed only by the k8s backend (in-memory Secret into the isolated
+    # sidecar) and the dev-only local agent. NEVER placed in ``env`` or logged.
+    ssh_key_material: dict[str, dict[str, str]] = field(default_factory=dict)
 
 
 def default_sandbox_spec() -> SandboxSpec:

--- a/surogates/sandbox/docker.py
+++ b/surogates/sandbox/docker.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import re
 import secrets
 import uuid
@@ -115,6 +116,15 @@ class DockerSandbox:
 
         mode, detail = self._workspace_mode(spec)
         env = self._build_env(spec, sandbox_id, token, mode, detail)
+
+        # SSH remote-access (dev-only, non-production isolation): start a local
+        # ssh-agent on the host and bind-mount its socket into the container.
+        ssh_mount_args: list[str] = []
+        if spec.ssh_key_material:
+            from surogates.sandbox.ssh_agent_local import start_local_ssh_agent
+
+            sock = await start_local_ssh_agent(sandbox_id, spec.ssh_key_material)
+            ssh_mount_args = ["-v", f"{os.path.dirname(sock)}:/ssh-agent"]
         # Docker is the local-dev backend: the configured image (docker_image)
         # is authoritative, so a developer's locally-built image is used rather
         # than the production ghcr reference that SandboxSpec.image defaults to.
@@ -145,6 +155,7 @@ class DockerSandbox:
                 ]
             elif mode == "bind":
                 args += ["-v", f"{detail}:/workspace"]
+            args += ssh_mount_args
             for key, value in env.items():
                 args += ["-e", f"{key}={value}"]
             args.append(image)
@@ -230,6 +241,9 @@ class DockerSandbox:
             return
         await self._docker.run(["stop", entry.container_id])
         await self._docker.run(["rm", entry.container_id])
+        from surogates.sandbox.ssh_agent_local import stop_local_ssh_agent
+
+        await stop_local_ssh_agent(sandbox_id)
         logger.info("Destroyed docker sandbox %s", sandbox_id)
 
     async def destroy_for_session(self, session_id: str) -> None:

--- a/surogates/sandbox/kubernetes.py
+++ b/surogates/sandbox/kubernetes.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import secrets
+import socket
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -202,6 +203,20 @@ class K8sSandbox:
             ssh_secret_name=ssh_secret_name,
         )
         self._pods[sandbox_id] = entry
+
+        # 2b. Apply the SSH egress NetworkPolicy before the pod can make
+        # outbound connections (the agent only runs ssh well after provision
+        # returns).  Failure here must not leave a half-provisioned SSH pod.
+        try:
+            entry.ssh_netpol_name = await self._apply_ssh_network_policy(
+                spec, sandbox_id, pod_name,
+            )
+        except ApiException as exc:
+            logger.error("Failed to apply SSH network policy for %s: %s", pod_name, exc)
+            await self._destroy_entry(api, entry)
+            raise SandboxUnavailableError(
+                f"Could not enforce SSH egress for {pod_name}: {exc}",
+            ) from exc
 
         # 3. Wait for the pod to become ready (the readinessProbe gates
         # on the executor daemon being up AND /workspace being FUSE-
@@ -654,6 +669,99 @@ class K8sSandbox:
                 "SSH targets require enforced egress (ssh_egress_enforced); "
                 "refusing to provision an SSH-enabled sandbox.",
             )
+
+    async def _resolve_target_ips(self, spec: SandboxSpec) -> list[tuple[str, int]]:
+        """Resolve each SSH target host to ``(ip, port)`` pairs.
+
+        Kubernetes-native NetworkPolicy has no FQDN selector, so we pin the
+        resolved IPs at provision time.  IP churn within the pod's ≤1h lifetime
+        is an accepted limitation.  Unresolvable hosts contribute no egress rule
+        (the connection then simply fails — still fail-closed).
+        """
+        loop = asyncio.get_running_loop()
+        out: list[tuple[str, int]] = []
+        for t in spec.ssh_targets:
+            port = int(t.get("port") or 22)
+            host = t.get("host")
+            if not host:
+                continue
+            try:
+                infos = await loop.getaddrinfo(
+                    host, port, type=socket.SOCK_STREAM,
+                )
+            except OSError:
+                logger.warning("Could not resolve SSH target host %s", host)
+                continue
+            for info in infos:
+                ip = info[4][0]
+                if (ip, port) not in out:
+                    out.append((ip, port))
+        return out
+
+    def _build_ssh_network_policy(
+        self, pod_name: str, sandbox_id: str, target_ips: list[tuple[str, int]],
+    ) -> client.V1NetworkPolicy:
+        """Build the pod-scoped egress NetworkPolicy for an SSH session.
+
+        Allows DNS, the operator-configured baseline CIDRs (S3/workspace, MCP
+        proxy, runtime APIs), and each resolved SSH target ``ip/32:port`` — and
+        nothing else.  This is the enforceable host-scoping boundary.
+        """
+        egress = [
+            client.V1NetworkPolicyEgressRule(
+                ports=[
+                    client.V1NetworkPolicyPort(protocol=proto, port=53)
+                    for proto in ("UDP", "TCP")
+                ],
+            ),
+        ]
+        for cidr in self._ssh_egress_baseline_cidrs:
+            egress.append(
+                client.V1NetworkPolicyEgressRule(
+                    to=[client.V1NetworkPolicyPeer(
+                        ip_block=client.V1IPBlock(cidr=cidr),
+                    )],
+                ),
+            )
+        for ip, port in target_ips:
+            egress.append(
+                client.V1NetworkPolicyEgressRule(
+                    to=[client.V1NetworkPolicyPeer(
+                        ip_block=client.V1IPBlock(cidr=f"{ip}/32"),
+                    )],
+                    ports=[client.V1NetworkPolicyPort(protocol="TCP", port=port)],
+                ),
+            )
+        return client.V1NetworkPolicy(
+            metadata=client.V1ObjectMeta(
+                name=f"ssh-{pod_name}",
+                namespace=self._namespace,
+                labels={"app": "surogates-sandbox"},
+            ),
+            spec=client.V1NetworkPolicySpec(
+                pod_selector=client.V1LabelSelector(
+                    match_labels={"surogates.ai/sandbox-id": sandbox_id},
+                ),
+                policy_types=["Egress"],
+                egress=egress,
+            ),
+        )
+
+    async def _apply_ssh_network_policy(
+        self, spec: SandboxSpec, sandbox_id: str, pod_name: str,
+    ) -> str | None:
+        """Create the SSH egress NetworkPolicy; return its name (or None)."""
+        if not spec.ssh_key_material:
+            return None
+        target_ips = await self._resolve_target_ips(spec)
+        np = self._build_ssh_network_policy(pod_name, sandbox_id, target_ips)
+        net_api = await self._get_net_api()
+        try:
+            await net_api.create_namespaced_network_policy(self._namespace, np)
+        except ApiException as exc:
+            if exc.status != 409:
+                raise
+        return np.metadata.name
 
     async def _delete_network_policy_safe(
         self, api: client.CoreV1Api, name: str,

--- a/surogates/sandbox/kubernetes.py
+++ b/surogates/sandbox/kubernetes.py
@@ -169,11 +169,35 @@ class K8sSandbox:
         # 1. Create K8s Secret with session-scoped S3 credentials.
         await self._create_s3_secret(api, secret_name)
 
-        # 1b. Create the in-memory SSH key Secret (sidecar-only) when needed.
+        # 1b. Create the SSH resources (in-memory key Secret + egress
+        # NetworkPolicy) BEFORE the pod, so the egress boundary exists before
+        # the workload can open any outbound connection.  Fail closed: if
+        # EITHER step raises (API error OR a plain connection error), tear down
+        # every resource created so far — the SSH secret, the netpol, and the
+        # S3 secret — so we never leave a half-provisioned SSH pod or an
+        # orphaned Secret behind.
         ssh_secret_name: str | None = None
+        ssh_netpol_name: str | None = None
         if spec.ssh_key_material:
             ssh_secret_name = f"sandbox-ssh-{sandbox_id[:12]}"
-            await self._create_ssh_secret(api, ssh_secret_name, spec.ssh_key_material)
+            try:
+                await self._create_ssh_secret(
+                    api, ssh_secret_name, spec.ssh_key_material,
+                )
+                ssh_netpol_name = await self._apply_ssh_network_policy(
+                    spec, sandbox_id, pod_name,
+                )
+            except Exception as exc:
+                logger.error(
+                    "Failed to provision SSH resources for %s: %s", pod_name, exc,
+                )
+                await self._delete_secret_safe(api, ssh_secret_name)
+                if ssh_netpol_name:
+                    await self._delete_network_policy_safe(api, ssh_netpol_name)
+                await self._delete_secret_safe(api, secret_name)
+                raise SandboxUnavailableError(
+                    f"Could not provision SSH resources for {pod_name}: {exc}",
+                ) from exc
 
         # 2. Build and create the pod.
         executor_token = secrets.token_urlsafe(32)
@@ -189,6 +213,8 @@ class K8sSandbox:
             await self._delete_secret_safe(api, secret_name)
             if ssh_secret_name:
                 await self._delete_secret_safe(api, ssh_secret_name)
+            if ssh_netpol_name:
+                await self._delete_network_policy_safe(api, ssh_netpol_name)
             raise SandboxUnavailableError(
                 self._classify_create_pod_failure(exc),
             ) from exc
@@ -201,22 +227,9 @@ class K8sSandbox:
             spec=spec,
             token=executor_token,
             ssh_secret_name=ssh_secret_name,
+            ssh_netpol_name=ssh_netpol_name,
         )
         self._pods[sandbox_id] = entry
-
-        # 2b. Apply the SSH egress NetworkPolicy before the pod can make
-        # outbound connections (the agent only runs ssh well after provision
-        # returns).  Failure here must not leave a half-provisioned SSH pod.
-        try:
-            entry.ssh_netpol_name = await self._apply_ssh_network_policy(
-                spec, sandbox_id, pod_name,
-            )
-        except ApiException as exc:
-            logger.error("Failed to apply SSH network policy for %s: %s", pod_name, exc)
-            await self._destroy_entry(api, entry)
-            raise SandboxUnavailableError(
-                f"Could not enforce SSH egress for {pod_name}: {exc}",
-            ) from exc
 
         # 3. Wait for the pod to become ready (the readinessProbe gates
         # on the executor daemon being up AND /workspace being FUSE-
@@ -231,6 +244,7 @@ class K8sSandbox:
         except Exception as exc:
             logger.error("Sandbox pod %s failed to become ready", pod_name, exc_info=True)
             await self._destroy_entry(api, entry)
+            self._pods.pop(sandbox_id, None)
             raise SandboxUnavailableError(
                 f"Sandbox pod {pod_name} failed to become ready: {exc}",
             ) from exc
@@ -485,6 +499,7 @@ class K8sSandbox:
             ),
         ]
         automount_sa_token = None
+        pod_security_context = None
 
         # Isolated ssh-agent sidecar: holds the private key(s) in a separate
         # container the untrusted sandbox cannot read or ptrace.  The main
@@ -504,7 +519,11 @@ class K8sSandbox:
                 client.V1Volume(
                     name="ssh-keys",
                     secret=client.V1SecretVolumeSource(
-                        secret_name=ssh_secret_name, default_mode=0o400,
+                        # 0o440 (group-readable): with the pod's fsGroup=65532
+                        # the sidecar's gid can read the key.  The volume is
+                        # mounted ONLY in the sidecar, so this is not a
+                        # cross-container exposure.
+                        secret_name=ssh_secret_name, default_mode=0o440,
                     ),
                 ),
                 client.V1Volume(
@@ -516,6 +535,11 @@ class K8sSandbox:
             # The sidecar (and the sandbox) need no K8s API access; withholding
             # the SA token shrinks the blast radius of the untrusted container.
             automount_sa_token = False
+            # fsGroup group-owns the mounted key + the shared socket dir under
+            # gid 65532 and adds it as a supplemental group to every container,
+            # so the sidecar can read the key and the main container (different
+            # uid) can connect to the agent socket over the shared group.
+            pod_security_context = client.V1PodSecurityContext(fs_group=65532)
 
         return client.V1Pod(
             metadata=client.V1ObjectMeta(
@@ -534,6 +558,7 @@ class K8sSandbox:
                 active_deadline_seconds=_DEFAULT_ACTIVE_DEADLINE,
                 restart_policy="Never",
                 automount_service_account_token=automount_sa_token,
+                security_context=pod_security_context,
                 volumes=volumes,
                 containers=containers,
             ),
@@ -627,6 +652,11 @@ class K8sSandbox:
             "cat > /tmp/askpass <<'EOF'\n#!/bin/sh\ncat /tmp/askpass_in\nEOF\n"
             "chmod 0700 /tmp/askpass\n"
             'eval "$(ssh-agent -a /ssh-agent/auth.sock)"\n'
+            # ssh-agent creates the socket 0600 owned by this sidecar's uid.
+            # The main sandbox container runs as a different uid but shares the
+            # pod fsGroup (65532) as a supplemental group, so widen the socket
+            # to 0660 to let it connect to the agent over the group.
+            "chmod 0660 /ssh-agent/auth.sock\n"
             f"{add_lines}\n"
             "rm -f /tmp/askpass_in\n"
             "while kill -0 \"$SSH_AGENT_PID\" 2>/dev/null; do sleep 5; done\n"
@@ -708,7 +738,21 @@ class K8sSandbox:
         nothing else.  This is the enforceable host-scoping boundary.
         """
         egress = [
+            # DNS only — scoped to the cluster's kube-dns pods (a single peer
+            # carrying both selectors ANDs them: kube-dns pods *within*
+            # kube-system).  An unscoped port-53 rule would match every
+            # destination, opening a DNS-tunnel / exfil path.
             client.V1NetworkPolicyEgressRule(
+                to=[
+                    client.V1NetworkPolicyPeer(
+                        namespace_selector=client.V1LabelSelector(
+                            match_labels={"kubernetes.io/metadata.name": "kube-system"},
+                        ),
+                        pod_selector=client.V1LabelSelector(
+                            match_labels={"k8s-app": "kube-dns"},
+                        ),
+                    ),
+                ],
                 ports=[
                     client.V1NetworkPolicyPort(protocol=proto, port=53)
                     for proto in ("UDP", "TCP")

--- a/surogates/sandbox/kubernetes.py
+++ b/surogates/sandbox/kubernetes.py
@@ -53,6 +53,9 @@ class _PodEntry:
     pod_ip: str = ""
     token: str = ""
     status: SandboxStatus = SandboxStatus.PENDING
+    # SSH remote-access resources reaped alongside the pod.
+    ssh_secret_name: str | None = None
+    ssh_netpol_name: str | None = None
 
 
 class K8sSandbox:
@@ -87,6 +90,9 @@ class K8sSandbox:
         s3fs_image: str = "ghcr.io/invergent-ai/s3fs-fuse:latest",
         s3_endpoint: str = "",
         mcp_proxy_url: str = "",
+        ssh_agent_image: str = "ghcr.io/invergent-ai/surogates-ssh-agent:latest",
+        ssh_egress_enforced: bool = False,
+        ssh_egress_baseline_cidrs: list[str] | None = None,
     ) -> None:
         self._namespace = namespace
         self._service_account = service_account
@@ -96,8 +102,14 @@ class K8sSandbox:
         self._s3fs_image = s3fs_image
         self._s3_endpoint = s3_endpoint
         self._mcp_proxy_url = mcp_proxy_url
+        # Isolated ssh-agent sidecar image + egress enforcement for the SSH
+        # remote-access feature (see ``_build_ssh_sidecar`` / NetworkPolicy).
+        self._ssh_agent_image = ssh_agent_image
+        self._ssh_egress_enforced = ssh_egress_enforced
+        self._ssh_egress_baseline_cidrs = list(ssh_egress_baseline_cidrs or ())
         self._pods: dict[str, _PodEntry] = {}
         self._api: client.CoreV1Api | None = None
+        self._net_api: client.NetworkingV1Api | None = None
         self._client = ExecutorHTTPClient()
 
     # ------------------------------------------------------------------
@@ -128,6 +140,16 @@ class K8sSandbox:
             self._api = client.CoreV1Api()
         return self._api
 
+    async def _get_net_api(self) -> client.NetworkingV1Api:
+        """Return a cached NetworkingV1Api client (SSH egress policies).
+
+        Reuses the same in-cluster/kubeconfig loading as ``_get_api``.
+        """
+        if self._net_api is None:
+            await self._get_api()
+            self._net_api = client.NetworkingV1Api()
+        return self._net_api
+
     # ------------------------------------------------------------------
     # Sandbox protocol
     # ------------------------------------------------------------------
@@ -139,20 +161,33 @@ class K8sSandbox:
         pod_name = f"sandbox-{sandbox_id[:12]}"
         secret_name = f"sandbox-s3-{sandbox_id[:12]}"
 
+        # SSH remote-access requires enforced egress; refuse rather than
+        # silently degrade to config-only host scoping.
+        self._require_ssh_egress_enforced(spec)
+
         # 1. Create K8s Secret with session-scoped S3 credentials.
         await self._create_s3_secret(api, secret_name)
+
+        # 1b. Create the in-memory SSH key Secret (sidecar-only) when needed.
+        ssh_secret_name: str | None = None
+        if spec.ssh_key_material:
+            ssh_secret_name = f"sandbox-ssh-{sandbox_id[:12]}"
+            await self._create_ssh_secret(api, ssh_secret_name, spec.ssh_key_material)
 
         # 2. Build and create the pod.
         executor_token = secrets.token_urlsafe(32)
         pod_manifest = self._build_pod_manifest(
             sandbox_id, pod_name, secret_name, spec,
             executor_token=executor_token,
+            ssh_secret_name=ssh_secret_name,
         )
         try:
             await api.create_namespaced_pod(self._namespace, pod_manifest)
         except ApiException as exc:
             logger.error("Failed to create sandbox pod %s: %s", pod_name, exc)
             await self._delete_secret_safe(api, secret_name)
+            if ssh_secret_name:
+                await self._delete_secret_safe(api, ssh_secret_name)
             raise SandboxUnavailableError(
                 self._classify_create_pod_failure(exc),
             ) from exc
@@ -164,6 +199,7 @@ class K8sSandbox:
             namespace=self._namespace,
             spec=spec,
             token=executor_token,
+            ssh_secret_name=ssh_secret_name,
         )
         self._pods[sandbox_id] = entry
 
@@ -272,6 +308,7 @@ class K8sSandbox:
         spec: SandboxSpec,
         *,
         executor_token: str,
+        ssh_secret_name: str | None = None,
     ) -> client.V1Pod:
         """Build the K8s pod manifest for a sandbox."""
         # Parse resources from spec for s3fs mount.  s3fs accepts
@@ -416,6 +453,55 @@ class K8sSandbox:
             ],
         )
 
+        containers = [sandbox_container, s3fs_container]
+        volumes = [
+            client.V1Volume(
+                name="workspace",
+                empty_dir=client.V1EmptyDirVolumeSource(),
+            ),
+            # On-disk cache for the geesefs sidecar. Sized to bound
+            # node ephemeral-storage pressure; if a session needs
+            # more, the cache evicts LRU rather than failing writes.
+            client.V1Volume(
+                name="geesefs-cache",
+                empty_dir=client.V1EmptyDirVolumeSource(
+                    size_limit="2Gi",
+                ),
+            ),
+        ]
+        automount_sa_token = None
+
+        # Isolated ssh-agent sidecar: holds the private key(s) in a separate
+        # container the untrusted sandbox cannot read or ptrace.  The main
+        # container gets ONLY the auth socket (a shared in-memory volume); the
+        # key Secret is mounted solely into the sidecar.
+        if spec.ssh_key_material and ssh_secret_name:
+            sandbox_container.volume_mounts.append(
+                client.V1VolumeMount(
+                    name="ssh-agent-sock", mount_path="/ssh-agent",
+                ),
+            )
+            volumes.extend([
+                client.V1Volume(
+                    name="ssh-agent-sock",
+                    empty_dir=client.V1EmptyDirVolumeSource(medium="Memory"),
+                ),
+                client.V1Volume(
+                    name="ssh-keys",
+                    secret=client.V1SecretVolumeSource(
+                        secret_name=ssh_secret_name, default_mode=0o400,
+                    ),
+                ),
+                client.V1Volume(
+                    name="ssh-tmp",
+                    empty_dir=client.V1EmptyDirVolumeSource(medium="Memory"),
+                ),
+            ])
+            containers.append(self._build_ssh_sidecar(spec, ssh_secret_name))
+            # The sidecar (and the sandbox) need no K8s API access; withholding
+            # the SA token shrinks the blast radius of the untrusted container.
+            automount_sa_token = False
+
         return client.V1Pod(
             metadata=client.V1ObjectMeta(
                 name=pod_name,
@@ -432,22 +518,9 @@ class K8sSandbox:
                 service_account_name=self._service_account,
                 active_deadline_seconds=_DEFAULT_ACTIVE_DEADLINE,
                 restart_policy="Never",
-                volumes=[
-                    client.V1Volume(
-                        name="workspace",
-                        empty_dir=client.V1EmptyDirVolumeSource(),
-                    ),
-                    # On-disk cache for the geesefs sidecar. Sized to bound
-                    # node ephemeral-storage pressure; if a session needs
-                    # more, the cache evicts LRU rather than failing writes.
-                    client.V1Volume(
-                        name="geesefs-cache",
-                        empty_dir=client.V1EmptyDirVolumeSource(
-                            size_limit="2Gi",
-                        ),
-                    ),
-                ],
-                containers=[sandbox_container, s3fs_container],
+                automount_service_account_token=automount_sa_token,
+                volumes=volumes,
+                containers=containers,
             ),
         )
 
@@ -479,6 +552,119 @@ class K8sSandbox:
         except ApiException as exc:
             if exc.status != 409:  # Already exists — OK
                 raise
+
+    # ------------------------------------------------------------------
+    # SSH remote-access: isolated ssh-agent sidecar
+    # ------------------------------------------------------------------
+
+    async def _create_ssh_secret(
+        self, api: client.CoreV1Api, secret_name: str,
+        ssh_key_material: dict[str, dict[str, str]],
+    ) -> None:
+        """Create the in-memory Secret holding the SSH private key(s).
+
+        Mounted solely into the ssh-agent sidecar (never the main container).
+        K8s Secret volumes are tmpfs-backed, and the Secret is reaped with the
+        pod so no key material outlives the session.
+        """
+        data: dict[str, str] = {}
+        for name, mat in ssh_key_material.items():
+            data[f"id_{name}"] = mat.get("private_key", "")
+            data[f"pass_{name}"] = mat.get("passphrase", "")
+        secret = client.V1Secret(
+            metadata=client.V1ObjectMeta(
+                name=secret_name,
+                namespace=self._namespace,
+                labels={"app": "surogates-sandbox"},
+            ),
+            string_data=data,
+        )
+        try:
+            await api.create_namespaced_secret(self._namespace, secret)
+        except ApiException as exc:
+            if exc.status != 409:
+                raise
+
+    def _build_ssh_sidecar(
+        self, spec: SandboxSpec, ssh_secret_name: str,
+    ) -> client.V1Container:
+        """Build the isolated ssh-agent sidecar container.
+
+        Runs as a distinct non-root uid with a read-only root filesystem and no
+        Linux capabilities.  Loads each key into the agent (passphrase fed via
+        ``SSH_ASKPASS`` non-interactively) then idles holding the socket.  The
+        untrusted sandbox container shares only the auth socket.
+        """
+        key_names = sorted(spec.ssh_key_material)
+        add_lines = "\n".join(
+            (
+                f'if [ -s /ssh-keys/pass_{n} ]; then '
+                f'cat /ssh-keys/pass_{n} > /tmp/askpass_in; '
+                f'SSH_ASKPASS=/tmp/askpass SSH_ASKPASS_REQUIRE=force DISPLAY=:0 '
+                f'ssh-add /ssh-keys/id_{n} < /dev/null; '
+                f'else ssh-add /ssh-keys/id_{n} < /dev/null; fi'
+            )
+            for n in key_names
+        )
+        script = (
+            "set -eu\n"
+            "umask 077\n"
+            "cat > /tmp/askpass <<'EOF'\n#!/bin/sh\ncat /tmp/askpass_in\nEOF\n"
+            "chmod 0700 /tmp/askpass\n"
+            'eval "$(ssh-agent -a /ssh-agent/auth.sock)"\n'
+            f"{add_lines}\n"
+            "rm -f /tmp/askpass_in\n"
+            "while kill -0 \"$SSH_AGENT_PID\" 2>/dev/null; do sleep 5; done\n"
+        )
+        return client.V1Container(
+            name="ssh-agent",
+            image=self._ssh_agent_image,
+            command=["/bin/sh", "-c", script],
+            security_context=client.V1SecurityContext(
+                run_as_non_root=True,
+                run_as_user=65532,
+                read_only_root_filesystem=True,
+                allow_privilege_escalation=False,
+                capabilities=client.V1Capabilities(drop=["ALL"]),
+            ),
+            resources=client.V1ResourceRequirements(
+                requests={"cpu": "10m", "memory": "32Mi"},
+                limits={"cpu": "100m", "memory": "64Mi"},
+            ),
+            volume_mounts=[
+                client.V1VolumeMount(
+                    name="ssh-agent-sock", mount_path="/ssh-agent",
+                ),
+                client.V1VolumeMount(
+                    name="ssh-keys", mount_path="/ssh-keys", read_only=True,
+                ),
+                client.V1VolumeMount(name="ssh-tmp", mount_path="/tmp"),
+            ],
+        )
+
+    def _require_ssh_egress_enforced(self, spec: SandboxSpec) -> None:
+        """Fail closed when SSH is requested but egress cannot be enforced.
+
+        Host scoping is enforced by NetworkPolicy egress, not by the in-sandbox
+        ssh config.  If the cluster is not configured to enforce it, refuse the
+        SSH session rather than silently degrade to config-only controls.
+        """
+        if spec.ssh_key_material and not self._ssh_egress_enforced:
+            raise SandboxUnavailableError(
+                "SSH targets require enforced egress (ssh_egress_enforced); "
+                "refusing to provision an SSH-enabled sandbox.",
+            )
+
+    async def _delete_network_policy_safe(
+        self, api: client.CoreV1Api, name: str,
+    ) -> None:
+        """Delete the SSH NetworkPolicy, ignoring 404."""
+        try:
+            net_api = await self._get_net_api()
+            await net_api.delete_namespaced_network_policy(name, self._namespace)
+        except ApiException as exc:
+            if exc.status != 404:
+                logger.warning("Failed to delete network policy %s: %s", name, exc)
 
     async def _delete_secret_safe(self, api: client.CoreV1Api, secret_name: str) -> None:
         """Delete a secret, ignoring 404."""
@@ -531,6 +717,10 @@ class K8sSandbox:
                 logger.warning("Failed to delete pod %s: %s", entry.pod_name, exc)
 
         await self._delete_secret_safe(api, entry.secret_name)
+        if entry.ssh_secret_name:
+            await self._delete_secret_safe(api, entry.ssh_secret_name)
+        if entry.ssh_netpol_name:
+            await self._delete_network_policy_safe(api, entry.ssh_netpol_name)
 
     # ------------------------------------------------------------------
     # Status mapping

--- a/surogates/sandbox/process.py
+++ b/surogates/sandbox/process.py
@@ -67,6 +67,14 @@ class ProcessSandbox:
         }
         restricted_env.update(spec.env)
 
+        # SSH remote-access (dev-only, non-production isolation): start a local
+        # ssh-agent on the worker host and point the sandbox at its socket.
+        if spec.ssh_key_material:
+            from surogates.sandbox.ssh_agent_local import start_local_ssh_agent
+
+            sock = await start_local_ssh_agent(sandbox_id, spec.ssh_key_material)
+            restricted_env["SSH_AUTH_SOCK"] = sock
+
         entry = _SandboxEntry(
             sandbox_id=sandbox_id,
             workdir=workdir,
@@ -241,6 +249,12 @@ class ProcessSandbox:
                 await entry.process.wait()
             except ProcessLookupError:
                 pass
+
+        # Tear down the dev-only local ssh-agent, if any.
+        if entry.spec.ssh_key_material:
+            from surogates.sandbox.ssh_agent_local import stop_local_ssh_agent
+
+            await stop_local_ssh_agent(sandbox_id)
 
         # Remove the temporary directory tree.
         try:

--- a/surogates/sandbox/ssh_agent_local.py
+++ b/surogates/sandbox/ssh_agent_local.py
@@ -1,0 +1,117 @@
+"""Dev-only local ssh-agent for the process/docker sandbox backends.
+
+**Non-production isolation.**  Unlike the k8s backend — which runs the ssh-agent
+in a separate hardened container the untrusted sandbox cannot read — this runs an
+``ssh-agent`` process on the worker host and exposes its socket to the local
+sandbox.  It exists solely so the SSH remote-access feature is testable on the
+``process``/``docker`` backends during development.  It MUST NOT be used in
+production; the k8s backend is the only isolated delivery path.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import stat
+import tempfile
+
+logger = logging.getLogger(__name__)
+
+# sandbox_id -> (agent_pid, agent_dir)
+_AGENTS: dict[str, tuple[int, str]] = {}
+
+
+async def _run(*args: str, env: dict[str, str] | None = None) -> tuple[int, str]:
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        env={**os.environ, **(env or {})},
+    )
+    out, _ = await proc.communicate()
+    return proc.returncode or 0, out.decode("utf-8", "replace")
+
+
+async def start_local_ssh_agent(
+    sandbox_id: str, ssh_key_material: dict[str, dict[str, str]],
+) -> str:
+    """Start a local ssh-agent, load the keys, and return the socket path.
+
+    Idempotent per ``sandbox_id`` — a second call returns the existing socket.
+    """
+    if sandbox_id in _AGENTS:
+        _pid, agent_dir = _AGENTS[sandbox_id]
+        return os.path.join(agent_dir, "auth.sock")
+
+    agent_dir = tempfile.mkdtemp(prefix=f"sshagent-{sandbox_id[:8]}-")
+    os.chmod(agent_dir, stat.S_IRWXU)
+    sock = os.path.join(agent_dir, "auth.sock")
+
+    rc, out = await _run("ssh-agent", "-a", sock)
+    if rc != 0:
+        shutil.rmtree(agent_dir, ignore_errors=True)
+        raise RuntimeError(f"ssh-agent failed to start: {out}")
+    pid = 0
+    for line in out.splitlines():
+        if line.startswith("SSH_AGENT_PID="):
+            pid = int(line.split("=", 1)[1].split(";", 1)[0])
+            break
+    _AGENTS[sandbox_id] = (pid, agent_dir)
+
+    for name, mat in ssh_key_material.items():
+        await _add_key(sock, agent_dir, name, mat)
+    return sock
+
+
+async def _add_key(
+    sock: str, agent_dir: str, name: str, mat: dict[str, str],
+) -> None:
+    key_path = os.path.join(agent_dir, f"id_{name}")
+    with open(key_path, "w", encoding="utf-8") as fh:
+        os.chmod(key_path, stat.S_IRUSR | stat.S_IWUSR)
+        fh.write(mat.get("private_key", ""))
+    try:
+        passphrase = mat.get("passphrase") or ""
+        if passphrase:
+            askpass = os.path.join(agent_dir, f"askpass_{name}")
+            pass_file = os.path.join(agent_dir, f"pass_{name}")
+            with open(pass_file, "w", encoding="utf-8") as fh:
+                os.chmod(pass_file, stat.S_IRUSR | stat.S_IWUSR)
+                fh.write(passphrase)
+            with open(askpass, "w", encoding="utf-8") as fh:
+                fh.write(f'#!/bin/sh\ncat {pass_file}\n')
+            os.chmod(askpass, stat.S_IRWXU)
+            rc, out = await _run(
+                "ssh-add", key_path,
+                env={
+                    "SSH_AUTH_SOCK": sock,
+                    "SSH_ASKPASS": askpass,
+                    "SSH_ASKPASS_REQUIRE": "force",
+                    "DISPLAY": ":0",
+                },
+            )
+            os.unlink(pass_file)
+            os.unlink(askpass)
+        else:
+            rc, out = await _run("ssh-add", key_path, env={"SSH_AUTH_SOCK": sock})
+        if rc != 0:
+            logger.warning("ssh-add failed for key %s: %s", name, out.strip())
+    finally:
+        # The key must never linger on disk beyond the load.
+        if os.path.exists(key_path):
+            os.unlink(key_path)
+
+
+async def stop_local_ssh_agent(sandbox_id: str) -> None:
+    """Kill the local ssh-agent and remove its socket dir."""
+    entry = _AGENTS.pop(sandbox_id, None)
+    if entry is None:
+        return
+    pid, agent_dir = entry
+    if pid:
+        try:
+            os.kill(pid, 15)
+        except ProcessLookupError:
+            pass
+    shutil.rmtree(agent_dir, ignore_errors=True)

--- a/surogates/ssh_access/__init__.py
+++ b/surogates/ssh_access/__init__.py
@@ -1,0 +1,7 @@
+"""SSH remote-access: vaulted private keys + per-agent targets.
+
+An agent's terminal can open authenticated SSH sessions into user-configured
+remote hosts.  The private key is held by an isolated ``ssh-agent`` (a separate
+container in the k8s backend); the untrusted sandbox receives only the auth
+socket and can authenticate but never read the key material.
+"""

--- a/surogates/ssh_access/bundle.py
+++ b/surogates/ssh_access/bundle.py
@@ -22,7 +22,8 @@ def validate_private_key(value: str) -> str:
         raise ValueError(
             "Expected a PEM/OpenSSH private key (-----BEGIN … PRIVATE KEY-----).",
         )
-    return v
+    # OpenSSH/ssh-add rejects a key without a trailing newline; guarantee one.
+    return v + "\n"
 
 
 @dataclass

--- a/surogates/ssh_access/bundle.py
+++ b/surogates/ssh_access/bundle.py
@@ -1,0 +1,50 @@
+"""The opaque bundle stored (encrypted) in the credentials vault for an SSH key.
+
+Mirrors :class:`surogates.coding_agents.credentials.CredentialBundle`: a stdlib
+dataclass with JSON (de)serialization.  Holds only the private key + optional
+passphrase — host keys are per-target (``ssh_targets[].host_key``), not per-key.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+
+
+def validate_private_key(value: str) -> str:
+    """Return the stripped key if it looks like a PEM/OpenSSH private key.
+
+    Raises ``ValueError`` otherwise.  Deliberately format-agnostic (RSA, EC,
+    OpenSSH, PKCS#8 all carry the ``PRIVATE KEY-----`` marker) — the ssh-agent
+    is the real parser; this only rejects obvious non-keys before we vault them.
+    """
+    v = (value or "").strip()
+    if not (v.startswith("-----BEGIN") and "PRIVATE KEY-----" in v):
+        raise ValueError(
+            "Expected a PEM/OpenSSH private key (-----BEGIN … PRIVATE KEY-----).",
+        )
+    return v
+
+
+@dataclass
+class SSHKeyBundle:
+    """The vault value for a named SSH key."""
+
+    private_key: str
+    passphrase: str | None = None
+    version: int = 1
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), separators=(",", ":"), sort_keys=True)
+
+    @classmethod
+    def from_json(cls, raw: str) -> "SSHKeyBundle":
+        data = json.loads(raw)
+        return cls(
+            private_key=data["private_key"],
+            passphrase=data.get("passphrase"),
+            version=data.get("version", 1),
+        )
+
+    def status(self) -> dict:
+        """Connection metadata for the UI — never includes the secret."""
+        return {"connected": True, "has_passphrase": self.passphrase is not None}

--- a/surogates/ssh_access/resolve.py
+++ b/surogates/ssh_access/resolve.py
@@ -1,0 +1,141 @@
+"""Resolve vaulted SSH keys and render per-agent SSH target config.
+
+Mirrors :mod:`surogates.coding_agents.repo_resolve`: principal-scoped vault
+resolution plus a system-prompt section.  The private key is resolved
+worker-side; only the generated ``ssh_config``/``known_hosts`` (non-secret) ever
+reach the sandbox.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from surogates.ssh_access.bundle import SSHKeyBundle
+
+SSH_KEY_PREFIX = "ssh_key:"
+
+
+def ssh_key_ref(name: str) -> str:
+    """The ``vault://`` reference for a named SSH key."""
+    return f"vault://{SSH_KEY_PREFIX}{name}"
+
+
+def _principal_kwargs(*, user_id=None, service_account_id=None) -> dict[str, Any]:
+    """Credential-principal kwargs: the agent SA wins, else the acting user."""
+    if service_account_id is not None:
+        return {"user_id": None, "service_account_id": service_account_id}
+    return {"user_id": user_id, "service_account_id": None}
+
+
+async def resolve_ssh_key(
+    vault: Any, *, org_id, name: str, user_id=None, service_account_id=None,
+) -> SSHKeyBundle | None:
+    """Resolve ``ssh_key:<name>`` under the caller's principal, or ``None``."""
+    raw = await vault.resolve_ref(
+        ssh_key_ref(name),
+        org_id=org_id,
+        **_principal_kwargs(user_id=user_id, service_account_id=service_account_id),
+    )
+    return SSHKeyBundle.from_json(raw) if raw else None
+
+
+def validate_targets(raw: Sequence[Mapping[str, Any]] | None) -> list[dict]:
+    """Normalize + validate ssh targets; raise ``ValueError`` on bad input.
+
+    Each output entry is ``{alias, host, port, user, key_name, host_key}`` with
+    ``user``/``host_key`` possibly ``None``.  Aliases must be unique.
+    """
+    out: list[dict] = []
+    seen: set[str] = set()
+    for t in raw or ():
+        alias = str(t.get("alias", "")).strip()
+        host = str(t.get("host", "")).strip()
+        key_name = str(t.get("key_name", "")).strip()
+        if not alias or not host or not key_name:
+            raise ValueError("each ssh target needs alias, host, and key_name")
+        if alias in seen:
+            raise ValueError(f"duplicate ssh target alias: {alias}")
+        seen.add(alias)
+        raw_port = t.get("port")
+        port = 22 if raw_port is None else int(raw_port)
+        if not (1 <= port <= 65535):
+            raise ValueError(f"invalid port for {alias}: {port}")
+        out.append({
+            "alias": alias,
+            "host": host,
+            "port": port,
+            "user": str(t.get("user", "")).strip() or None,
+            "key_name": key_name,
+            "host_key": (str(t.get("host_key")).strip() if t.get("host_key") else None),
+        })
+    return out
+
+
+def build_ssh_config(targets: Sequence[Mapping[str, Any]]) -> str:
+    """Render ``~/.ssh/config`` from targets (no secret; safe for the sandbox).
+
+    Every host authenticates only through the agent socket (``IdentityAgent``
+    + ``IdentitiesOnly``) and verifies against the pinned ``known_hosts``
+    (``StrictHostKeyChecking yes``).
+    """
+    blocks: list[str] = []
+    for t in targets or ():
+        lines = [
+            f"Host {t['alias']}",
+            f"    HostName {t['host']}",
+            f"    Port {int(t.get('port') or 22)}",
+        ]
+        if t.get("user"):
+            lines.append(f"    User {t['user']}")
+        lines.extend([
+            "    IdentityAgent ${SSH_AUTH_SOCK}",
+            "    IdentitiesOnly yes",
+            "    StrictHostKeyChecking yes",
+            "    UserKnownHostsFile ~/.ssh/known_hosts",
+        ])
+        blocks.append("\n".join(lines))
+    return "\n\n".join(blocks) + ("\n" if blocks else "")
+
+
+def build_known_hosts(targets: Sequence[Mapping[str, Any]]) -> str:
+    """Render ``~/.ssh/known_hosts`` from pinned ``host_key`` lines only."""
+    lines = [str(t["host_key"]).strip() for t in (targets or ()) if t.get("host_key")]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def ssh_key_names(targets: Sequence[Mapping[str, Any]]) -> list[str]:
+    """Distinct ``key_name``s referenced by the targets, in first-seen order."""
+    out: list[str] = []
+    for t in targets or ():
+        name = str(t.get("key_name", "")).strip()
+        if name and name not in out:
+            out.append(name)
+    return out
+
+
+def render_ssh_targets_prompt(targets: Sequence[Mapping[str, Any]] | None) -> str:
+    """A system-prompt section naming the agent's SSH targets.
+
+    Empty when no valid target is configured, so the section only appears for
+    agents that actually have SSH access.  The inverse of the git guardrail: it
+    tells the agent the terminal *is* authenticated for these hosts.
+    """
+    lines = []
+    for t in targets or ():
+        alias = str(t.get("alias", "")).strip()
+        host = str(t.get("host", "")).strip()
+        if not alias or not host:
+            continue
+        user = str(t.get("user", "")).strip()
+        target = f"{user}@{host}" if user else host
+        lines.append(f"- `{alias}` → {target}")
+    if not lines:
+        return ""
+    return (
+        "## SSH remote hosts\n"
+        "Your terminal is SSH-authenticated for these hosts via ssh-agent — "
+        "use `ssh <alias> …` (do NOT specify a key file):\n"
+        + "\n".join(lines)
+        + "\n\nThe private key is held by an isolated agent; you can authenticate "
+        "but cannot read or copy the key. Connections to hosts not listed here "
+        "are blocked by network policy."
+    )

--- a/surogates/ssh_access/resolve.py
+++ b/surogates/ssh_access/resolve.py
@@ -7,6 +7,8 @@ reach the sandbox.
 """
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from surogates.ssh_access.bundle import SSHKeyBundle
@@ -110,6 +112,31 @@ def ssh_key_names(targets: Sequence[Mapping[str, Any]]) -> list[str]:
         if name and name not in out:
             out.append(name)
     return out
+
+
+def write_ssh_home(
+    home: str, targets: Sequence[Mapping[str, Any]], known_hosts: str,
+) -> None:
+    """Write ``<home>/.ssh/config`` + ``known_hosts`` (no secrets) for the terminal.
+
+    Called just before an SSH-enabled command runs, under the child's ``HOME``.
+    Rewriting on every invocation re-pins ``known_hosts`` and restores the
+    strict config, so the agent cannot persistently weaken host-key checking by
+    editing the files between commands.  Both files are non-secret (the private
+    key lives in the isolated ssh-agent), so writing them into the workspace
+    home is safe.
+    """
+    if not targets:
+        return
+    ssh_dir = Path(home) / ".ssh"
+    ssh_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(ssh_dir, 0o700)
+    cfg = ssh_dir / "config"
+    cfg.write_text(build_ssh_config(targets), encoding="utf-8")
+    os.chmod(cfg, 0o600)
+    kh = ssh_dir / "known_hosts"
+    kh.write_text(known_hosts or "", encoding="utf-8")
+    os.chmod(kh, 0o600)
 
 
 def render_ssh_targets_prompt(targets: Sequence[Mapping[str, Any]] | None) -> str:

--- a/surogates/ssh_access/resolve.py
+++ b/surogates/ssh_access/resolve.py
@@ -8,12 +8,21 @@ reach the sandbox.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from surogates.ssh_access.bundle import SSHKeyBundle
 
 SSH_KEY_PREFIX = "ssh_key:"
+
+# Defense-in-depth against ``~/.ssh/config`` injection (a newline in
+# ``alias``/``host``/``user`` would forge extra config directives) and
+# sidecar-script injection (a metachar in ``key_name`` reaches a shell).
+# ``alias``/``user``/``key_name`` are conservative identifiers; ``host`` also
+# allows ``:`` for IPv6 literals — but neither permits whitespace/newlines.
+_IDENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_HOST_RE = re.compile(r"^[A-Za-z0-9._:-]+$")
 
 
 def ssh_key_ref(name: str) -> str:
@@ -54,6 +63,15 @@ def validate_targets(raw: Sequence[Mapping[str, Any]] | None) -> list[dict]:
         key_name = str(t.get("key_name", "")).strip()
         if not alias or not host or not key_name:
             raise ValueError("each ssh target needs alias, host, and key_name")
+        if not _IDENT_RE.match(alias):
+            raise ValueError(f"invalid ssh target alias: {alias!r}")
+        if not _HOST_RE.match(host):
+            raise ValueError(f"invalid ssh target host: {host!r}")
+        if not _IDENT_RE.match(key_name):
+            raise ValueError(f"invalid ssh target key_name: {key_name!r}")
+        user = str(t.get("user", "")).strip()
+        if user and not _IDENT_RE.match(user):
+            raise ValueError(f"invalid ssh target user: {user!r}")
         if alias in seen:
             raise ValueError(f"duplicate ssh target alias: {alias}")
         seen.add(alias)
@@ -65,7 +83,7 @@ def validate_targets(raw: Sequence[Mapping[str, Any]] | None) -> list[dict]:
             "alias": alias,
             "host": host,
             "port": port,
-            "user": str(t.get("user", "")).strip() or None,
+            "user": user or None,
             "key_name": key_name,
             "host_key": (str(t.get("host_key")).strip() if t.get("host_key") else None),
         })

--- a/surogates/tools/builtin/coding_agent.py
+++ b/surogates/tools/builtin/coding_agent.py
@@ -80,12 +80,14 @@ def register(registry: ToolRegistry) -> None:
 
 
 def _build_ensure(
-    sandbox_pool: Any, session: Any, tenant: Any, owner: str,
+    sandbox_pool: Any, session: Any, tenant: Any, owner: str, vault: Any,
 ) -> Callable[[], Awaitable[None]]:
     async def _ensure() -> None:
         from surogates.harness.tool_exec import _build_session_sandbox_spec
 
-        spec = _build_session_sandbox_spec(session, tenant, owner)
+        spec = await _build_session_sandbox_spec(
+            session, tenant, owner, credential_vault=vault,
+        )
         await sandbox_pool.ensure(owner, spec)
 
     return _ensure
@@ -165,7 +167,7 @@ async def _run_coding_agent_handler(arguments: dict[str, Any], **kwargs: Any) ->
         agent=agent, provider=provider, prompt=augmented,
         model=arguments.get("model"), effort=arguments.get("effort"),
         read_only=False,
-        ensure_sandbox=_build_ensure(sandbox_pool, session, tenant, owner),
+        ensure_sandbox=_build_ensure(sandbox_pool, session, tenant, owner, vault),
         execute=_execute,
         # Poll the global interrupt so a session/mission cancel stops the run
         # promptly (kills the pod-side CLI) instead of polling to completion.

--- a/surogates/tools/builtin/terminal.py
+++ b/surogates/tools/builtin/terminal.py
@@ -65,37 +65,105 @@ _DEFAULT_CWD = os.getenv("TERMINAL_CWD", os.getcwd())
 # ---------------------------------------------------------------------------
 
 
+def _ssh_hosts_from_env() -> list[str]:
+    """Sorted SSH target hosts from the sandbox env, or empty when SSH is off.
+
+    Presence of any host means the session is SSH-enabled: ``~/.ssh`` (which
+    then holds only the non-secret config/known_hosts — the private key is in
+    the isolated ssh-agent) becomes readable, and the hosts join the srt
+    network allowlist.
+    """
+    raw = os.environ.get("SUROGATES_SSH_TARGETS", "")
+    if not raw:
+        return []
+    try:
+        targets = json.loads(raw)
+    except ValueError:
+        return []
+    return sorted({str(t.get("host", "")) for t in targets if t.get("host")})
+
+
+def _setup_ssh_home(child_env: dict[str, str]) -> None:
+    """Write the pinned ssh config/known_hosts into the child's HOME.
+
+    No-op unless the session is SSH-enabled.  Rewrites on every command so the
+    strict host-key config is re-pinned and cannot be persistently weakened by
+    the agent editing the files between commands.  Files are non-secret.
+    """
+    raw = os.environ.get("SUROGATES_SSH_TARGETS", "")
+    if not raw:
+        return
+    home = child_env.get("HOME")
+    if not home:
+        return
+    try:
+        targets = json.loads(raw)
+    except ValueError:
+        return
+    from surogates.ssh_access.resolve import write_ssh_home
+
+    write_ssh_home(
+        home, targets, os.environ.get("SUROGATES_SSH_KNOWN_HOSTS", ""),
+    )
+
+
 def _get_srt_settings_path(workspace_path: str) -> str:
     """Return the path to the per-workspace srt settings file.
 
     Creates the file if it doesn't exist.  The settings restrict writes
-    to the workspace directory and block reads of secrets.
+    to the workspace directory and block reads of secrets.  For SSH-enabled
+    sessions the host allowlist and ``~/.ssh`` read policy differ, so the
+    SSH host set feeds the settings-file hash to force a regenerate.
     """
     import hashlib
-    ws_hash = hashlib.sha256(workspace_path.encode()).hexdigest()[:12]
+
+    ssh_hosts = _ssh_hosts_from_env()
+    ssh_enabled = bool(ssh_hosts)
+    seed = workspace_path + ("|ssh:" + ",".join(ssh_hosts) if ssh_enabled else "")
+    ws_hash = hashlib.sha256(seed.encode()).hexdigest()[:12]
     from surogates.config import load_settings
     settings_dir = Path(load_settings().sandbox.srt_settings_dir)
     settings_dir.mkdir(parents=True, exist_ok=True)
     settings_path = settings_dir / f"srt-{ws_hash}.json"
 
     if not settings_path.exists():
+        deny_read = [
+            "~/.aws",
+            "~/.gnupg",
+            "~/.kube",
+            "~/.docker",
+            # /code run credentials live pod-local under
+            # /tmp/.code-runs and in the vendor CLI config dirs.  Deny
+            # reads so code the agent runs via the terminal can't
+            # exfiltrate the user's coding-agent plan token.
+            "/tmp/.code-runs",
+            "auth.json",
+            "$CODEX_HOME",
+            "$CLAUDE_CONFIG_DIR",
+        ]
+        # Only deny ~/.ssh when SSH is NOT enabled.  With SSH enabled the dir
+        # holds only the non-secret config + known_hosts (the private key never
+        # touches the main container), and ssh must read them.
+        if not ssh_enabled:
+            deny_read.insert(0, "~/.ssh")
+        allowed_domains = [
+            "github.com",
+            "*.github.com",
+            "*.githubusercontent.com",
+            "pypi.org",
+            "*.pypi.org",
+            "files.pythonhosted.org",
+            "npmjs.org",
+            "*.npmjs.org",
+            "registry.npmjs.org",
+            # Coding-agent (/code) vendor API endpoints.
+            "api.anthropic.com",
+            "api.openai.com",
+            "chatgpt.com",
+        ] + ssh_hosts
         settings = {
             "filesystem": {
-                "denyRead": [
-                    "~/.ssh",
-                    "~/.aws",
-                    "~/.gnupg",
-                    "~/.kube",
-                    "~/.docker",
-                    # /code run credentials live pod-local under
-                    # /tmp/.code-runs and in the vendor CLI config dirs.  Deny
-                    # reads so code the agent runs via the terminal can't
-                    # exfiltrate the user's coding-agent plan token.
-                    "/tmp/.code-runs",
-                    "auth.json",
-                    "$CODEX_HOME",
-                    "$CLAUDE_CONFIG_DIR",
-                ],
+                "denyRead": deny_read,
                 "allowWrite": [workspace_path],
                 "denyWrite": [
                     ".env",
@@ -106,21 +174,7 @@ def _get_srt_settings_path(workspace_path: str) -> str:
                 ],
             },
             "network": {
-                "allowedDomains": [
-                    "github.com",
-                    "*.github.com",
-                    "*.githubusercontent.com",
-                    "pypi.org",
-                    "*.pypi.org",
-                    "files.pythonhosted.org",
-                    "npmjs.org",
-                    "*.npmjs.org",
-                    "registry.npmjs.org",
-                    # Coding-agent (/code) vendor API endpoints.
-                    "api.anthropic.com",
-                    "api.openai.com",
-                    "chatgpt.com",
-                ],
+                "allowedDomains": allowed_domains,
                 "deniedDomains": [],
             },
             "mandatoryDenySearchDepth": 3,
@@ -255,6 +309,9 @@ def _interpret_exit_code(command: str, exit_code: int) -> str | None:
 # and s3fs's locking/rename semantics deadlock uv mid-install.
 _ALWAYS_INHERIT = frozenset({
     "HOME",
+    # The isolated ssh-agent socket for SSH-enabled sessions; lets `ssh`
+    # authenticate without ever seeing the private key.
+    "SSH_AUTH_SOCK",
     "LANG",
     "LC_ALL",
     "LC_CTYPE",
@@ -541,6 +598,7 @@ async def _terminal_handler(
             if workspace_path:
                 bg_env["HOME"] = workspace_path
                 bg_env.pop("CDPATH", None)
+            _setup_ssh_home(bg_env)
             session = process_registry.spawn(
                 command=command,
                 cwd=workdir,
@@ -592,6 +650,11 @@ async def _terminal_handler(
             # XDG config dir — redirect to workspace to avoid srt denials
             # on $HOME/.config/ access attempts.
             child_env["XDG_CONFIG_HOME"] = os.path.join(workspace_path, ".config")
+
+        # Pin the ssh config/known_hosts into the child HOME for SSH-enabled
+        # sessions (no-op otherwise).  Must happen before srt-wrapping so the
+        # files exist when `ssh` reads them.
+        _setup_ssh_home(child_env)
 
         # Wrap command with Anthropic Sandbox Runtime (srt) for OS-level
         # filesystem and network isolation via bubblewrap + seccomp.

--- a/tests/api/test_ssh_credentials.py
+++ b/tests/api/test_ssh_credentials.py
@@ -1,0 +1,116 @@
+"""Tests for the agent/user SSH-key vault routes (surogates api)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from surogates.api.routes import ssh_credentials
+from surogates.runtime import agent_runtime_context_dep
+from surogates.ssh_access.bundle import SSHKeyBundle
+from surogates.tenant.auth.middleware import get_current_tenant
+
+pytestmark = pytest.mark.asyncio
+
+USER = UUID("11111111-1111-1111-1111-111111111111")
+ORG = UUID("22222222-2222-2222-2222-222222222222")
+
+_KEY = "-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----\n"
+
+
+class _FakeVault:
+    def __init__(self):
+        self.stored: dict[tuple, str] = {}
+
+    async def store(self, org_id, name, value, *, user_id=None, service_account_id=None):
+        self.stored[(org_id, name)] = value
+
+    async def list_names(self, org_id, user_id=None, *, service_account_id=None):
+        return [name for (o, name) in self.stored if o == org_id]
+
+    async def delete(self, org_id, name, *, user_id=None, service_account_id=None):
+        self.stored.pop((org_id, name), None)
+
+
+def _make_app(*, tenant, ctx, vault):
+    app = FastAPI()
+    app.state.credential_vault = vault
+    app.dependency_overrides[get_current_tenant] = lambda: tenant
+    app.dependency_overrides[agent_runtime_context_dep] = lambda: ctx
+    app.include_router(ssh_credentials.router, prefix="/v1/api")
+    return app
+
+
+def _client(app):
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _tenant(user_id=USER, org_id=ORG, service_account_id=None):
+    return SimpleNamespace(
+        user_id=user_id, org_id=org_id, service_account_id=service_account_id,
+    )
+
+
+def _ctx(org_id=str(ORG)):
+    return SimpleNamespace(agent_id="agent-1", org_id=org_id)
+
+
+async def test_store_and_list_ssh_key():
+    vault = _FakeVault()
+    app = _make_app(tenant=_tenant(), ctx=_ctx(), vault=vault)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/v1/api/ssh-credentials/credential",
+            json={"name": "prod", "private_key": _KEY, "passphrase": "pw"},
+        )
+        assert resp.status_code == 200, resp.text
+        listing = await client.get("/v1/api/ssh-credentials/credentials")
+    stored = vault.stored[(ORG, "ssh_key:prod")]
+    bundle = SSHKeyBundle.from_json(stored)
+    assert bundle.private_key == _KEY and bundle.passphrase == "pw"
+    assert "prod" in [c["name"] for c in listing.json()["credentials"]]
+
+
+async def test_reject_non_key():
+    app = _make_app(tenant=_tenant(), ctx=_ctx(), vault=_FakeVault())
+    async with _client(app) as client:
+        resp = await client.post(
+            "/v1/api/ssh-credentials/credential",
+            json={"name": "prod", "private_key": "nope"},
+        )
+    assert resp.status_code == 422
+
+
+async def test_reject_bad_name():
+    app = _make_app(tenant=_tenant(), ctx=_ctx(), vault=_FakeVault())
+    async with _client(app) as client:
+        resp = await client.post(
+            "/v1/api/ssh-credentials/credential",
+            json={"name": "a:b", "private_key": _KEY},
+        )
+    assert resp.status_code == 422
+
+
+async def test_delete_ssh_key():
+    vault = _FakeVault()
+    vault.stored[(ORG, "ssh_key:prod")] = SSHKeyBundle(private_key=_KEY).to_json()
+    app = _make_app(tenant=_tenant(), ctx=_ctx(), vault=vault)
+    async with _client(app) as client:
+        resp = await client.delete(
+            "/v1/api/ssh-credentials/credential", params={"name": "prod"},
+        )
+    assert resp.status_code == 204
+    assert (ORG, "ssh_key:prod") not in vault.stored
+
+
+async def test_requires_identity():
+    app = _make_app(
+        tenant=_tenant(user_id=None, service_account_id=None), ctx=_ctx(), vault=_FakeVault(),
+    )
+    async with _client(app) as client:
+        resp = await client.get("/v1/api/ssh-credentials/credentials")
+    assert resp.status_code == 401

--- a/tests/api/test_ssh_credentials.py
+++ b/tests/api/test_ssh_credentials.py
@@ -95,6 +95,19 @@ async def test_reject_bad_name():
     assert resp.status_code == 422
 
 
+async def test_reject_metachar_name():
+    # A shell metachar / space in the name must be rejected (it would flow
+    # into the vault ref and the sidecar's id_<name>/pass_<name> filenames).
+    app = _make_app(tenant=_tenant(), ctx=_ctx(), vault=_FakeVault())
+    async with _client(app) as client:
+        for bad in ("a;b", "a b"):
+            resp = await client.post(
+                "/v1/api/ssh-credentials/credential",
+                json={"name": bad, "private_key": _KEY},
+            )
+            assert resp.status_code == 422, bad
+
+
 async def test_delete_ssh_key():
     vault = _FakeVault()
     vault.stored[(ORG, "ssh_key:prod")] = SSHKeyBundle(private_key=_KEY).to_json()

--- a/tests/runtime/test_context_ssh_targets.py
+++ b/tests/runtime/test_context_ssh_targets.py
@@ -1,0 +1,38 @@
+"""ssh_targets projection onto AgentRuntimeContext."""
+
+from __future__ import annotations
+
+from surogates.runtime.resolver import build_agent_runtime_context
+
+_BASE = {
+    "agent_id": "a1",
+    "org_id": "o1",
+    "project_id": "o1",
+    "enabled": True,
+    "version": 1,
+    "storage_key_prefix": "o1/a1",
+}
+
+
+def test_ssh_targets_projected():
+    payload = {
+        **_BASE,
+        "ssh_targets": [
+            {"alias": "deploy", "host": "h", "port": 22, "key_name": "k"},
+        ],
+    }
+    ctx = build_agent_runtime_context(payload)
+    assert ctx.ssh_targets == (
+        {"alias": "deploy", "host": "h", "port": 22, "key_name": "k"},
+    )
+
+
+def test_ssh_targets_default_empty():
+    assert build_agent_runtime_context(dict(_BASE)).ssh_targets == ()
+
+
+def test_ssh_targets_are_copied():
+    src = [{"alias": "deploy", "host": "h", "port": 22, "key_name": "k"}]
+    ctx = build_agent_runtime_context({**_BASE, "ssh_targets": src})
+    src[0]["host"] = "mutated"
+    assert ctx.ssh_targets[0]["host"] == "h"

--- a/tests/test_coding_agent_tool.py
+++ b/tests/test_coding_agent_tool.py
@@ -108,7 +108,7 @@ async def test_handler_runs_repo_and_returns_pr_url(monkeypatch):
     sandbox = _sandbox(_result_poll("Opened https://github.com/acme/api/pull/42"))
 
     import surogates.tools.builtin.coding_agent as mod
-    monkeypatch.setattr(mod, "_build_ensure", lambda sp, s, t, owner: _aw_none)
+    monkeypatch.setattr(mod, "_build_ensure", lambda sp, s, t, owner, vault: _aw_none)
 
     out = await _run_coding_agent_handler(
         {"agent": "claude", "prompt": "implement the feature"},
@@ -133,7 +133,7 @@ async def test_handler_notes_when_no_pr_url(monkeypatch):
     sandbox = _sandbox(_result_poll("I made the change but could not push."))
 
     import surogates.tools.builtin.coding_agent as mod
-    monkeypatch.setattr(mod, "_build_ensure", lambda sp, s, t, owner: _aw_none)
+    monkeypatch.setattr(mod, "_build_ensure", lambda sp, s, t, owner, vault: _aw_none)
 
     out = await _run_coding_agent_handler(
         {"agent": "claude", "prompt": "do it"},
@@ -181,7 +181,7 @@ async def test_handler_selects_requested_repo(monkeypatch):
     sandbox = _sandbox(_result_poll("https://github.com/acme/web/pull/7"))
 
     import surogates.tools.builtin.coding_agent as mod
-    monkeypatch.setattr(mod, "_build_ensure", lambda sp, s, t, owner: _aw_none)
+    monkeypatch.setattr(mod, "_build_ensure", lambda sp, s, t, owner, vault: _aw_none)
 
     out = await _run_coding_agent_handler(
         {"agent": "claude", "prompt": "do it", "repo": "web"},
@@ -199,7 +199,7 @@ async def test_handler_not_connected_returns_error(monkeypatch):
     store = _FakeStore(session)
     vault = _FakeVault({"git_pat": "github_pat_abc"})
     import surogates.tools.builtin.coding_agent as mod
-    monkeypatch.setattr(mod, "_build_ensure", lambda sp, s, t, owner: _aw_none)
+    monkeypatch.setattr(mod, "_build_ensure", lambda sp, s, t, owner, vault: _aw_none)
     out = await _run_coding_agent_handler(
         {"agent": "codex", "prompt": "review"},
         tenant=_tenant(), session_id=str(session.id), session_store=store,
@@ -246,7 +246,7 @@ async def test_handler_cancels_on_interrupt(monkeypatch):
     async def ensure(owner, spec):
         return None
 
-    monkeypatch.setattr(mod, "_build_ensure", lambda sp, s, t, owner: _aw_none)
+    monkeypatch.setattr(mod, "_build_ensure", lambda sp, s, t, owner, vault: _aw_none)
 
     out = await _run_coding_agent_handler(
         {"agent": "claude", "prompt": "long task"},

--- a/tests/test_harness_repo_overlay.py
+++ b/tests/test_harness_repo_overlay.py
@@ -46,7 +46,7 @@ _SSH_TARGETS = (
 )
 
 
-def _harness(coding_repos=(), ssh_targets=()) -> AgentHarness:
+def _harness(coding_repos=(), ssh_targets=(), agent_service_account_id=None) -> AgentHarness:
     return AgentHarness(
         session_store=AsyncMock(),
         tool_registry=ToolRegistry(),
@@ -59,6 +59,7 @@ def _harness(coding_repos=(), ssh_targets=()) -> AgentHarness:
         sandbox_pool=MagicMock(spec=SandboxPool),
         coding_repos=coding_repos,
         ssh_targets=ssh_targets,
+        agent_service_account_id=agent_service_account_id,
     )
 
 
@@ -111,3 +112,18 @@ def test_overlay_noop_when_no_repos_or_targets():
 def test_overlay_sets_both_repos_and_ssh_targets():
     out = _harness(_REPOS, _SSH_TARGETS)._overlay_repos(_session())
     assert out.config["repos"] and out.config["ssh_targets"]
+
+
+def test_overlay_carries_agent_sa_with_ssh_targets():
+    out = _harness(
+        ssh_targets=_SSH_TARGETS, agent_service_account_id="sa-123",
+    )._overlay_repos(_session())
+    assert out.config["agent_service_account_id"] == "sa-123"
+
+
+def test_overlay_omits_agent_sa_without_ssh_targets():
+    # The agent SA id is only carried for SSH; a repos-only overlay omits it.
+    out = _harness(
+        _REPOS, agent_service_account_id="sa-123",
+    )._overlay_repos(_session())
+    assert "agent_service_account_id" not in out.config

--- a/tests/test_harness_repo_overlay.py
+++ b/tests/test_harness_repo_overlay.py
@@ -40,7 +40,13 @@ def _session(config=None) -> Session:
     )
 
 
-def _harness(coding_repos=()) -> AgentHarness:
+_SSH_TARGETS = (
+    {"alias": "deploy", "host": "deploy.example.com", "port": 22,
+     "user": "ubuntu", "key_name": "prod", "host_key": "deploy.example.com ssh-ed25519 AAAA"},
+)
+
+
+def _harness(coding_repos=(), ssh_targets=()) -> AgentHarness:
     return AgentHarness(
         session_store=AsyncMock(),
         tool_registry=ToolRegistry(),
@@ -52,6 +58,7 @@ def _harness(coding_repos=()) -> AgentHarness:
         prompt_builder=MagicMock(spec=PromptBuilder),
         sandbox_pool=MagicMock(spec=SandboxPool),
         coding_repos=coding_repos,
+        ssh_targets=ssh_targets,
     )
 
 
@@ -77,3 +84,30 @@ def test_overlay_noop_when_no_repos():
     original = _session({"multi_party": True})
     out = _harness(())._overlay_repos(original)
     assert out is original  # no repos → no needless copy
+
+
+def test_overlay_sets_ssh_targets_on_a_copy():
+    original = _session({"multi_party": True})
+    out = _harness(ssh_targets=_SSH_TARGETS)._overlay_repos(original)
+    assert out is not original
+    assert out.config["ssh_targets"] == [dict(_SSH_TARGETS[0])]
+    assert out.config["multi_party"] is True
+    assert "ssh_targets" not in original.config
+
+
+def test_overlay_deep_copies_ssh_target_dicts():
+    targets = [dict(_SSH_TARGETS[0])]
+    out = _harness(ssh_targets=tuple(targets))._overlay_repos(_session())
+    targets[0]["host"] = "mutated"
+    assert out.config["ssh_targets"][0]["host"] == "deploy.example.com"
+
+
+def test_overlay_noop_when_no_repos_or_targets():
+    original = _session({"multi_party": True})
+    out = _harness()._overlay_repos(original)
+    assert out is original
+
+
+def test_overlay_sets_both_repos_and_ssh_targets():
+    out = _harness(_REPOS, _SSH_TARGETS)._overlay_repos(_session())
+    assert out.config["repos"] and out.config["ssh_targets"]

--- a/tests/test_kubernetes_ssh_netpol.py
+++ b/tests/test_kubernetes_ssh_netpol.py
@@ -1,0 +1,82 @@
+"""SSH NetworkPolicy scopes egress to resolved target IPs (fail-closed)."""
+
+from __future__ import annotations
+
+from surogates.sandbox.base import SandboxSpec
+from surogates.sandbox.kubernetes import K8sSandbox
+
+
+def _backend(**kw):
+    return K8sSandbox(
+        namespace="ns", service_account="sa", pod_ready_timeout=1,
+        executor_port=8080, storage_settings=None, s3fs_image="i",
+        s3_endpoint="", mcp_proxy_url="", **kw,
+    )
+
+
+def _ssh_spec():
+    return SandboxSpec(
+        ssh_targets=[{"alias": "d", "host": "deploy.example.com", "port": 22,
+                      "key_name": "prod"}],
+        ssh_key_material={"prod": {"private_key": "x", "passphrase": ""}},
+    )
+
+
+def test_netpol_scopes_egress_to_targets_and_baseline():
+    b = _backend(ssh_egress_baseline_cidrs=["10.0.0.0/8"])
+    np = b._build_ssh_network_policy("sandbox-x", "sid1", [("1.2.3.4", 22)])
+    cidrs = [
+        peer.ip_block.cidr
+        for rule in np.spec.egress for peer in (rule.to or [])
+        if peer.ip_block
+    ]
+    assert "1.2.3.4/32" in cidrs
+    assert "10.0.0.0/8" in cidrs
+    assert np.spec.pod_selector.match_labels["surogates.ai/sandbox-id"] == "sid1"
+    assert np.spec.policy_types == ["Egress"]
+    assert np.metadata.name == "ssh-sandbox-x"
+    # DNS egress present (first rule, no `to`, ports 53)
+    dns_ports = {p.port for p in (np.spec.egress[0].ports or [])}
+    assert dns_ports == {53}
+
+
+def test_netpol_target_rule_restricts_to_port():
+    b = _backend()
+    np = b._build_ssh_network_policy("sandbox-x", "sid1", [("1.2.3.4", 2222)])
+    target_rule = next(
+        r for r in np.spec.egress
+        if r.to and any(p.ip_block and p.ip_block.cidr == "1.2.3.4/32" for p in r.to)
+    )
+    assert [p.port for p in target_rule.ports] == [2222]
+
+
+async def test_apply_returns_none_without_ssh():
+    b = _backend()
+    assert await b._apply_ssh_network_policy(SandboxSpec(), "sid", "sandbox-x") is None
+
+
+async def test_resolve_target_ips_uses_getaddrinfo(monkeypatch):
+    import asyncio
+
+    b = _backend()
+
+    async def fake_getaddrinfo(host, port, *, type=None):
+        return [(None, None, None, None, ("9.9.9.9", port))]
+
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "getaddrinfo", fake_getaddrinfo, raising=False)
+    ips = await b._resolve_target_ips(_ssh_spec())
+    assert ("9.9.9.9", 22) in ips
+
+
+async def test_resolve_target_ips_skips_unresolvable(monkeypatch):
+    import asyncio
+
+    b = _backend()
+
+    async def boom(host, port, *, type=None):
+        raise OSError("no such host")
+
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(loop, "getaddrinfo", boom, raising=False)
+    assert await b._resolve_target_ips(_ssh_spec()) == []

--- a/tests/test_kubernetes_ssh_netpol.py
+++ b/tests/test_kubernetes_ssh_netpol.py
@@ -35,9 +35,13 @@ def test_netpol_scopes_egress_to_targets_and_baseline():
     assert np.spec.pod_selector.match_labels["surogates.ai/sandbox-id"] == "sid1"
     assert np.spec.policy_types == ["Egress"]
     assert np.metadata.name == "ssh-sandbox-x"
-    # DNS egress present (first rule, no `to`, ports 53)
-    dns_ports = {p.port for p in (np.spec.egress[0].ports or [])}
+    # DNS egress present (first rule), ports 53 only, scoped to kube-dns
+    # rather than open to all destinations.
+    dns_rule = np.spec.egress[0]
+    dns_ports = {p.port for p in (dns_rule.ports or [])}
     assert dns_ports == {53}
+    assert dns_rule.to  # non-empty: not open to every destination
+    assert dns_rule.to[0].pod_selector.match_labels["k8s-app"] == "kube-dns"
 
 
 def test_netpol_target_rule_restricts_to_port():

--- a/tests/test_kubernetes_ssh_sidecar.py
+++ b/tests/test_kubernetes_ssh_sidecar.py
@@ -1,0 +1,93 @@
+"""The k8s sandbox adds an isolated ssh-agent sidecar for SSH sessions."""
+
+from __future__ import annotations
+
+import pytest
+
+from surogates.sandbox.base import SandboxSpec, SandboxUnavailableError
+from surogates.sandbox.kubernetes import K8sSandbox
+
+
+def _backend(**kw):
+    return K8sSandbox(
+        namespace="ns", service_account="sa", pod_ready_timeout=1,
+        executor_port=8080, storage_settings=None, s3fs_image="img",
+        s3_endpoint="", mcp_proxy_url="", **kw,
+    )
+
+
+def _ssh_spec():
+    return SandboxSpec(
+        env={"SSH_AUTH_SOCK": "/ssh-agent/auth.sock",
+             "SUROGATES_SSH_TARGETS": "[]", "ORG_ID": "0", "USER_ID": "0"},
+        ssh_key_material={"prod": {"private_key": "SECRET", "passphrase": ""}},
+    )
+
+
+def test_manifest_has_isolated_ssh_sidecar():
+    pod = _backend()._build_pod_manifest(
+        "sid123456789a", "sandbox-x", "sec", _ssh_spec(),
+        executor_token="t", ssh_secret_name="sandbox-ssh-x",
+    )
+    names = {c.name for c in pod.spec.containers}
+    assert "ssh-agent" in names
+    assert pod.spec.automount_service_account_token is False
+    assert not getattr(pod.spec, "share_process_namespace", None)
+
+
+def test_sidecar_is_hardened_and_key_only_in_sidecar():
+    pod = _backend()._build_pod_manifest(
+        "sid1", "sandbox-x", "sec", _ssh_spec(),
+        executor_token="t", ssh_secret_name="sandbox-ssh-x",
+    )
+    sidecar = next(c for c in pod.spec.containers if c.name == "ssh-agent")
+    sc = sidecar.security_context
+    assert sc.run_as_non_root is True
+    assert sc.read_only_root_filesystem is True
+    assert sc.allow_privilege_escalation is False
+    assert sc.capabilities.drop == ["ALL"]
+
+    main = next(c for c in pod.spec.containers if c.name == "sandbox")
+    sidecar_vols = {m.name for m in sidecar.volume_mounts}
+    main_vols = {m.name for m in main.volume_mounts}
+    # keys mounted ONLY in the sidecar; socket shared with the main container
+    assert "ssh-keys" in sidecar_vols and "ssh-keys" not in main_vols
+    assert "ssh-agent-sock" in sidecar_vols and "ssh-agent-sock" in main_vols
+    # the main container must NOT mount the workspace-less key volume
+    assert "workspace" in main_vols and "workspace" not in sidecar_vols
+
+
+def test_socket_volume_is_in_memory_and_keys_are_0400():
+    pod = _backend()._build_pod_manifest(
+        "sid1", "sandbox-x", "sec", _ssh_spec(),
+        executor_token="t", ssh_secret_name="sandbox-ssh-x",
+    )
+    sock = next(v for v in pod.spec.volumes if v.name == "ssh-agent-sock")
+    assert sock.empty_dir.medium == "Memory"
+    keys = next(v for v in pod.spec.volumes if v.name == "ssh-keys")
+    assert keys.secret.secret_name == "sandbox-ssh-x"
+    assert keys.secret.default_mode == 0o400
+
+
+def test_no_sidecar_without_key_material():
+    spec = SandboxSpec(env={"ORG_ID": "0", "USER_ID": "0"})
+    pod = _backend()._build_pod_manifest(
+        "sid", "sandbox-x", "sec", spec, executor_token="t", ssh_secret_name=None,
+    )
+    assert {c.name for c in pod.spec.containers} == {"sandbox", "s3fs"}
+    assert pod.spec.automount_service_account_token is None
+    assert not any(v.name == "ssh-keys" for v in pod.spec.volumes)
+
+
+def test_require_ssh_egress_enforced_fails_closed():
+    with pytest.raises(SandboxUnavailableError):
+        _backend(ssh_egress_enforced=False)._require_ssh_egress_enforced(_ssh_spec())
+
+
+def test_require_ssh_egress_enforced_allows_when_enforced():
+    # Should not raise.
+    _backend(ssh_egress_enforced=True)._require_ssh_egress_enforced(_ssh_spec())
+
+
+def test_require_ssh_egress_enforced_noop_without_ssh():
+    _backend(ssh_egress_enforced=False)._require_ssh_egress_enforced(SandboxSpec())

--- a/tests/test_kubernetes_ssh_sidecar.py
+++ b/tests/test_kubernetes_ssh_sidecar.py
@@ -33,6 +33,9 @@ def test_manifest_has_isolated_ssh_sidecar():
     assert "ssh-agent" in names
     assert pod.spec.automount_service_account_token is False
     assert not getattr(pod.spec, "share_process_namespace", None)
+    # fsGroup lets the sidecar read the group-readable key and the main
+    # container connect to the group-accessible agent socket.
+    assert pod.spec.security_context.fs_group == 65532
 
 
 def test_sidecar_is_hardened_and_key_only_in_sidecar():
@@ -57,7 +60,7 @@ def test_sidecar_is_hardened_and_key_only_in_sidecar():
     assert "workspace" in main_vols and "workspace" not in sidecar_vols
 
 
-def test_socket_volume_is_in_memory_and_keys_are_0400():
+def test_socket_volume_is_in_memory_and_keys_are_0440():
     pod = _backend()._build_pod_manifest(
         "sid1", "sandbox-x", "sec", _ssh_spec(),
         executor_token="t", ssh_secret_name="sandbox-ssh-x",
@@ -66,7 +69,19 @@ def test_socket_volume_is_in_memory_and_keys_are_0400():
     assert sock.empty_dir.medium == "Memory"
     keys = next(v for v in pod.spec.volumes if v.name == "ssh-keys")
     assert keys.secret.secret_name == "sandbox-ssh-x"
-    assert keys.secret.default_mode == 0o400
+    # Group-readable so the sidecar's fsGroup gid can read the key (the
+    # volume is mounted only in the sidecar, so this is not an exposure).
+    assert keys.secret.default_mode == 0o440
+
+
+def test_sidecar_widens_socket_perms_for_group_access():
+    pod = _backend()._build_pod_manifest(
+        "sid1", "sandbox-x", "sec", _ssh_spec(),
+        executor_token="t", ssh_secret_name="sandbox-ssh-x",
+    )
+    sidecar = next(c for c in pod.spec.containers if c.name == "ssh-agent")
+    script = sidecar.command[-1]
+    assert "chmod 0660 /ssh-agent/auth.sock" in script
 
 
 def test_no_sidecar_without_key_material():
@@ -77,6 +92,9 @@ def test_no_sidecar_without_key_material():
     assert {c.name for c in pod.spec.containers} == {"sandbox", "s3fs"}
     assert pod.spec.automount_service_account_token is None
     assert not any(v.name == "ssh-keys" for v in pod.spec.volumes)
+    # Non-ssh pods carry no pod-level security context (fsGroup only exists
+    # to bridge the ssh sidecar/main-container key + socket sharing).
+    assert getattr(pod.spec, "security_context", None) is None
 
 
 def test_require_ssh_egress_enforced_fails_closed():

--- a/tests/test_local_ssh_agent.py
+++ b/tests/test_local_ssh_agent.py
@@ -1,0 +1,63 @@
+"""Dev-only local ssh-agent lifecycle (process/docker backends)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from surogates.sandbox.ssh_agent_local import (
+    start_local_ssh_agent,
+    stop_local_ssh_agent,
+)
+
+_HAS_AGENT = shutil.which("ssh-agent") is not None and shutil.which("ssh-keygen") is not None
+
+pytestmark = pytest.mark.skipif(not _HAS_AGENT, reason="ssh tooling not installed")
+
+
+async def test_local_agent_starts_and_socket_exists():
+    sock = await start_local_ssh_agent("sid-empty", {})
+    try:
+        assert os.path.exists(sock)
+    finally:
+        await stop_local_ssh_agent("sid-empty")
+    assert not os.path.exists(sock)
+
+
+async def test_local_agent_is_idempotent():
+    a = await start_local_ssh_agent("sid-idem", {})
+    b = await start_local_ssh_agent("sid-idem", {})
+    try:
+        assert a == b
+    finally:
+        await stop_local_ssh_agent("sid-idem")
+
+
+async def test_local_agent_loads_key_and_wipes_disk(tmp_path):
+    # Generate a throwaway unencrypted ed25519 key.
+    key_path = tmp_path / "k"
+    subprocess.run(
+        ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", str(key_path), "-q"],
+        check=True,
+    )
+    private_key = key_path.read_text()
+
+    sock = await start_local_ssh_agent(
+        "sid-key", {"prod": {"private_key": private_key, "passphrase": ""}},
+    )
+    try:
+        # The agent should list one identity.
+        out = subprocess.run(
+            ["ssh-add", "-l"],
+            env={**os.environ, "SSH_AUTH_SOCK": sock},
+            capture_output=True, text=True,
+        )
+        assert "ED25519" in out.stdout or "ssh-ed25519" in out.stdout
+        # No private key file should linger in the agent dir.
+        agent_dir = os.path.dirname(sock)
+        assert not any(f.startswith("id_") for f in os.listdir(agent_dir))
+    finally:
+        await stop_local_ssh_agent("sid-key")

--- a/tests/test_platform_hints.py
+++ b/tests/test_platform_hints.py
@@ -53,6 +53,68 @@ def _make_session(channel: str = "web", workspace_path: str | None = None):
 
 
 # ---------------------------------------------------------------------------
+# Artifact-in-channel guidance
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactInChannel:
+    """create_artifact has no panel in messaging channels, so the builder
+    injects guidance to deliver visual output as an image via MEDIA:."""
+
+    _MARKER = "no artifact panel"
+
+    def test_slack_with_artifact_tool_gets_image_guidance(self, tmp_path: Path):
+        tenant = _make_tenant(tmp_path)
+        session = _make_session(channel="slack")
+        builder = PromptBuilder(
+            tenant, session=session, available_tools={"create_artifact"},
+        )
+        prompt = builder.build()
+        assert self._MARKER in prompt
+        assert "MEDIA:" in prompt
+
+    def test_all_media_channels_get_guidance(self, tmp_path: Path):
+        for channel in ("slack", "discord", "telegram", "whatsapp",
+                        "signal", "email"):
+            tenant = _make_tenant(tmp_path)
+            session = _make_session(channel=channel)
+            builder = PromptBuilder(
+                tenant, session=session,
+                available_tools={"create_artifact"},
+            )
+            prompt = builder.build()
+            assert self._MARKER in prompt, f"missing for {channel}"
+
+    def test_web_channel_no_guidance(self, tmp_path: Path):
+        # The Studio web app HAS the artifact panel -- no override there.
+        tenant = _make_tenant(tmp_path)
+        session = _make_session(channel="web")
+        builder = PromptBuilder(
+            tenant, session=session, available_tools={"create_artifact"},
+        )
+        prompt = builder.build()
+        assert self._MARKER not in prompt
+
+    def test_sms_channel_no_guidance(self, tmp_path: Path):
+        # SMS can't carry image attachments, so the image advice doesn't apply.
+        tenant = _make_tenant(tmp_path)
+        session = _make_session(channel="sms")
+        builder = PromptBuilder(
+            tenant, session=session, available_tools={"create_artifact"},
+        )
+        prompt = builder.build()
+        assert self._MARKER not in prompt
+
+    def test_no_artifact_tool_no_guidance(self, tmp_path: Path):
+        # Without the tool loaded, the override would be noise.
+        tenant = _make_tenant(tmp_path)
+        session = _make_session(channel="slack")
+        builder = PromptBuilder(tenant, session=session, available_tools=set())
+        prompt = builder.build()
+        assert self._MARKER not in prompt
+
+
+# ---------------------------------------------------------------------------
 # Platform hints in PromptBuilder
 # ---------------------------------------------------------------------------
 

--- a/tests/test_sandbox_spec_ssh.py
+++ b/tests/test_sandbox_spec_ssh.py
@@ -1,18 +1,31 @@
-"""The sandbox spec builder resolves SSH keys without leaking them to env."""
+"""The sandbox spec builder resolves SSH keys without leaking them to env.
+
+SSH keys are agent-owned, so they resolve under the agent service account
+regardless of the session's channel-gated credential principal.
+"""
 
 from __future__ import annotations
 
 import json
 from types import SimpleNamespace
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
 from surogates.harness.tool_exec import _build_session_sandbox_spec
 
+_AGENT_SA = "11111111-1111-1111-1111-111111111111"
+
 
 def _session(config):
     return SimpleNamespace(id=str(uuid4()), agent_id="a1", config=config)
+
+
+def _ssh_config(targets, agent_sa=_AGENT_SA):
+    cfg = {"ssh_targets": targets}
+    if agent_sa is not None:
+        cfg["agent_service_account_id"] = agent_sa
+    return cfg
 
 
 def _tenant(org_id="o1", user_id="u1", service_account_id=None):
@@ -41,7 +54,7 @@ _TARGET = {
 
 @pytest.mark.asyncio
 async def test_spec_populates_ssh_without_key_in_env():
-    session = _session({"ssh_targets": [_TARGET]})
+    session = _session(_ssh_config([_TARGET]))
     vault = _FakeVault(
         {"prod": json.dumps({"private_key": "SECRETKEY", "passphrase": None})},
     )
@@ -70,7 +83,7 @@ async def test_no_targets_no_ssh_env():
 
 @pytest.mark.asyncio
 async def test_unpinned_target_fails_closed():
-    session = _session({"ssh_targets": [{**_TARGET, "host_key": None}]})
+    session = _session(_ssh_config([{**_TARGET, "host_key": None}]))
     vault = _FakeVault({"prod": json.dumps({"private_key": "K"})})
     spec = await _build_session_sandbox_spec(
         session, _tenant(), session.id, credential_vault=vault,
@@ -81,7 +94,7 @@ async def test_unpinned_target_fails_closed():
 
 @pytest.mark.asyncio
 async def test_unresolved_key_drops_target():
-    session = _session({"ssh_targets": [_TARGET]})
+    session = _session(_ssh_config([_TARGET]))
     vault = _FakeVault({})  # key "prod" not present
     spec = await _build_session_sandbox_spec(
         session, _tenant(), session.id, credential_vault=vault,
@@ -91,12 +104,29 @@ async def test_unresolved_key_drops_target():
 
 
 @pytest.mark.asyncio
-async def test_service_account_principal_used_for_resolution():
-    session = _session({"ssh_targets": [_TARGET]})
+async def test_resolution_uses_agent_sa_not_session_principal():
+    session = _session(_ssh_config([_TARGET]))
     vault = _FakeVault({"prod": json.dumps({"private_key": "K"})})
+    # Tenant is a plain user (as a web/api session would be) — resolution must
+    # STILL use the agent SA from config, not the user principal.
     await _build_session_sandbox_spec(
-        session, _tenant(user_id="u1", service_account_id="sa1"), session.id,
+        session, _tenant(user_id="u1", service_account_id=None), session.id,
         credential_vault=vault,
     )
     _ref, _org, uid, said = vault.calls[0]
-    assert uid is None and said == "sa1"
+    assert uid is None
+    assert said == UUID(_AGENT_SA)
+
+
+@pytest.mark.asyncio
+async def test_missing_agent_sa_fails_closed():
+    # ssh_targets present but no agent SA in config → no agent-owned key can be
+    # resolved, so SSH stays off.
+    session = _session(_ssh_config([_TARGET], agent_sa=None))
+    vault = _FakeVault({"prod": json.dumps({"private_key": "K"})})
+    spec = await _build_session_sandbox_spec(
+        session, _tenant(), session.id, credential_vault=vault,
+    )
+    assert "SSH_AUTH_SOCK" not in spec.env
+    assert spec.ssh_key_material == {}
+    assert vault.calls == []  # never even queried the vault

--- a/tests/test_sandbox_spec_ssh.py
+++ b/tests/test_sandbox_spec_ssh.py
@@ -1,0 +1,102 @@
+"""The sandbox spec builder resolves SSH keys without leaking them to env."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from surogates.harness.tool_exec import _build_session_sandbox_spec
+
+
+def _session(config):
+    return SimpleNamespace(id=str(uuid4()), agent_id="a1", config=config)
+
+
+def _tenant(org_id="o1", user_id="u1", service_account_id=None):
+    return SimpleNamespace(
+        org_id=org_id, user_id=user_id, service_account_id=service_account_id,
+    )
+
+
+class _FakeVault:
+    def __init__(self, bundles):
+        self._b = bundles  # {name: json}
+        self.calls = []
+
+    async def resolve_ref(self, ref, *, org_id, user_id=None, service_account_id=None):
+        self.calls.append((ref, org_id, user_id, service_account_id))
+        name = ref.split("vault://ssh_key:", 1)[-1]
+        return self._b.get(name)
+
+
+_TARGET = {
+    "alias": "deploy", "host": "deploy.example.com", "port": 22,
+    "user": "ubuntu", "key_name": "prod",
+    "host_key": "deploy.example.com ssh-ed25519 AAAA",
+}
+
+
+@pytest.mark.asyncio
+async def test_spec_populates_ssh_without_key_in_env():
+    session = _session({"ssh_targets": [_TARGET]})
+    vault = _FakeVault(
+        {"prod": json.dumps({"private_key": "SECRETKEY", "passphrase": None})},
+    )
+    spec = await _build_session_sandbox_spec(
+        session, _tenant(), session.id, credential_vault=vault,
+    )
+    assert spec.env["SSH_AUTH_SOCK"] == "/ssh-agent/auth.sock"
+    assert "deploy" in spec.env["SUROGATES_SSH_TARGETS"]
+    assert spec.env["SUROGATES_SSH_KNOWN_HOSTS"].strip() == _TARGET["host_key"]
+    assert spec.ssh_key_material["prod"]["private_key"] == "SECRETKEY"
+    # The secret must never appear in env, and the targets JSON must not carry
+    # the host key (that travels via known_hosts).
+    assert "SECRETKEY" not in json.dumps(spec.env)
+    assert "host_key" not in spec.env["SUROGATES_SSH_TARGETS"]
+
+
+@pytest.mark.asyncio
+async def test_no_targets_no_ssh_env():
+    spec = await _build_session_sandbox_spec(
+        _session({}), _tenant(), "sid", credential_vault=None,
+    )
+    assert "SSH_AUTH_SOCK" not in spec.env
+    assert spec.ssh_key_material == {}
+    assert spec.ssh_targets == []
+
+
+@pytest.mark.asyncio
+async def test_unpinned_target_fails_closed():
+    session = _session({"ssh_targets": [{**_TARGET, "host_key": None}]})
+    vault = _FakeVault({"prod": json.dumps({"private_key": "K"})})
+    spec = await _build_session_sandbox_spec(
+        session, _tenant(), session.id, credential_vault=vault,
+    )
+    assert "SSH_AUTH_SOCK" not in spec.env
+    assert spec.ssh_key_material == {}
+
+
+@pytest.mark.asyncio
+async def test_unresolved_key_drops_target():
+    session = _session({"ssh_targets": [_TARGET]})
+    vault = _FakeVault({})  # key "prod" not present
+    spec = await _build_session_sandbox_spec(
+        session, _tenant(), session.id, credential_vault=vault,
+    )
+    assert "SSH_AUTH_SOCK" not in spec.env
+    assert spec.ssh_targets == []
+
+
+@pytest.mark.asyncio
+async def test_service_account_principal_used_for_resolution():
+    session = _session({"ssh_targets": [_TARGET]})
+    vault = _FakeVault({"prod": json.dumps({"private_key": "K"})})
+    await _build_session_sandbox_spec(
+        session, _tenant(user_id="u1", service_account_id="sa1"), session.id,
+        credential_vault=vault,
+    )
+    _ref, _org, uid, said = vault.calls[0]
+    assert uid is None and said == "sa1"

--- a/tests/test_sandbox_spec_ssh_fields.py
+++ b/tests/test_sandbox_spec_ssh_fields.py
@@ -1,0 +1,28 @@
+"""SSH fields on SandboxSpec default empty and never surface the key in env."""
+
+from __future__ import annotations
+
+from surogates.sandbox.base import SandboxSpec
+
+
+def test_ssh_fields_default_empty():
+    spec = SandboxSpec()
+    assert spec.ssh_targets == []
+    assert spec.ssh_key_material == {}
+
+
+def test_ssh_fields_are_independent_instances():
+    a = SandboxSpec()
+    b = SandboxSpec()
+    a.ssh_targets.append({"alias": "x"})
+    a.ssh_key_material["k"] = {"private_key": "p", "passphrase": ""}
+    assert b.ssh_targets == []
+    assert b.ssh_key_material == {}
+
+
+def test_ssh_key_material_never_in_env():
+    spec = SandboxSpec(
+        ssh_key_material={"prod": {"private_key": "SECRET", "passphrase": ""}},
+    )
+    assert "SECRET" not in repr(spec.env)
+    assert spec.env == {}

--- a/tests/test_ssh_bundle.py
+++ b/tests/test_ssh_bundle.py
@@ -36,5 +36,8 @@ def test_validate_rejects_non_key():
         validate_private_key("not a key")
 
 
-def test_validate_accepts_and_strips():
-    assert validate_private_key(f"  {_KEY}  ") == _KEY.strip()
+def test_validate_accepts_and_ensures_trailing_newline():
+    # _KEY already ends with a newline; surrounding whitespace is stripped and
+    # exactly one trailing newline is guaranteed (ssh-add requires it).
+    assert validate_private_key(f"  {_KEY}  ") == _KEY
+    assert validate_private_key(_KEY.strip()) == _KEY

--- a/tests/test_ssh_bundle.py
+++ b/tests/test_ssh_bundle.py
@@ -1,0 +1,40 @@
+"""Unit tests for the SSH key vault bundle (no DB)."""
+
+from __future__ import annotations
+
+import pytest
+
+from surogates.ssh_access.bundle import SSHKeyBundle, validate_private_key
+
+_KEY = "-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----\n"
+
+
+def test_roundtrip_preserves_fields():
+    bundle = SSHKeyBundle(private_key=_KEY, passphrase="pw")
+    restored = SSHKeyBundle.from_json(bundle.to_json())
+    assert restored.private_key == _KEY
+    assert restored.passphrase == "pw"
+    assert restored.version == 1
+
+
+def test_roundtrip_without_passphrase():
+    bundle = SSHKeyBundle(private_key=_KEY)
+    restored = SSHKeyBundle.from_json(bundle.to_json())
+    assert restored.passphrase is None
+
+
+def test_status_never_leaks_secret():
+    status = SSHKeyBundle(private_key=_KEY, passphrase="pw").status()
+    assert "private_key" not in status
+    assert "passphrase" not in status
+    assert status["connected"] is True
+    assert status["has_passphrase"] is True
+
+
+def test_validate_rejects_non_key():
+    with pytest.raises(ValueError):
+        validate_private_key("not a key")
+
+
+def test_validate_accepts_and_strips():
+    assert validate_private_key(f"  {_KEY}  ") == _KEY.strip()

--- a/tests/test_ssh_resolve.py
+++ b/tests/test_ssh_resolve.py
@@ -106,3 +106,36 @@ async def test_resolve_ssh_key_service_account_principal():
 async def test_resolve_ssh_key_missing_returns_none():
     vault = _FakeVault({})
     assert await resolve_ssh_key(vault, org_id="o1", name="nope") is None
+
+
+def test_write_ssh_home_creates_config_and_known_hosts(tmp_path):
+    from surogates.ssh_access.resolve import write_ssh_home
+    import os
+
+    write_ssh_home(str(tmp_path), [_T], _T["host_key"] + "\n")
+    ssh = tmp_path / ".ssh"
+    assert "Host deploy" in (ssh / "config").read_text()
+    assert "StrictHostKeyChecking yes" in (ssh / "config").read_text()
+    assert (ssh / "known_hosts").read_text().strip() == _T["host_key"]
+    assert oct(os.stat(ssh).st_mode)[-3:] == "700"
+    assert oct(os.stat(ssh / "config").st_mode)[-3:] == "600"
+    assert oct(os.stat(ssh / "known_hosts").st_mode)[-3:] == "600"
+
+
+def test_write_ssh_home_overwrites_tampered_files(tmp_path):
+    from surogates.ssh_access.resolve import write_ssh_home
+
+    ssh = tmp_path / ".ssh"
+    ssh.mkdir()
+    (ssh / "config").write_text("Host evil\n  StrictHostKeyChecking no\n")
+    write_ssh_home(str(tmp_path), [_T], _T["host_key"])
+    text = (ssh / "config").read_text()
+    assert "evil" not in text
+    assert "StrictHostKeyChecking yes" in text
+
+
+def test_write_ssh_home_noop_without_targets(tmp_path):
+    from surogates.ssh_access.resolve import write_ssh_home
+
+    write_ssh_home(str(tmp_path), [], "")
+    assert not (tmp_path / ".ssh").exists()

--- a/tests/test_ssh_resolve.py
+++ b/tests/test_ssh_resolve.py
@@ -48,6 +48,28 @@ def test_validate_normalizes_blank_user_to_none():
     assert out[0]["port"] == 22
 
 
+def test_validate_rejects_newline_in_alias():
+    # An embedded newline would forge extra ~/.ssh/config directives.
+    with pytest.raises(ValueError):
+        validate_targets([{**_T, "alias": "deploy\nHost evil"}])
+
+
+def test_validate_rejects_newline_in_host():
+    with pytest.raises(ValueError):
+        validate_targets([{**_T, "host": "deploy.example.com\n    StrictHostKeyChecking no"}])
+
+
+def test_validate_rejects_newline_in_user():
+    with pytest.raises(ValueError):
+        validate_targets([{**_T, "user": "ubuntu\nHost evil"}])
+
+
+def test_validate_rejects_metachar_key_name():
+    # A shell metachar in key_name reaches the sidecar's shell script.
+    with pytest.raises(ValueError):
+        validate_targets([{**_T, "key_name": "foo;bar"}])
+
+
 def test_config_pins_socket_and_strict_checking():
     cfg = build_ssh_config(validate_targets([_T]))
     assert "Host deploy" in cfg

--- a/tests/test_ssh_resolve.py
+++ b/tests/test_ssh_resolve.py
@@ -1,0 +1,108 @@
+"""Unit tests for SSH key resolution and target config rendering (no DB)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from surogates.ssh_access.resolve import (
+    build_known_hosts,
+    build_ssh_config,
+    render_ssh_targets_prompt,
+    resolve_ssh_key,
+    ssh_key_names,
+    ssh_key_ref,
+    validate_targets,
+)
+
+_T = {
+    "alias": "deploy", "host": "deploy.example.com", "port": 22,
+    "user": "ubuntu", "key_name": "prod",
+    "host_key": "deploy.example.com ssh-ed25519 AAAA",
+}
+
+
+def test_ref_format():
+    assert ssh_key_ref("prod") == "vault://ssh_key:prod"
+
+
+def test_validate_rejects_duplicate_alias():
+    with pytest.raises(ValueError):
+        validate_targets([_T, {**_T, "host": "b.example.com"}])
+
+
+def test_validate_rejects_missing_fields():
+    with pytest.raises(ValueError):
+        validate_targets([{"alias": "x", "host": "", "key_name": "k"}])
+
+
+def test_validate_rejects_bad_port():
+    with pytest.raises(ValueError):
+        validate_targets([{**_T, "port": 0}])
+
+
+def test_validate_normalizes_blank_user_to_none():
+    out = validate_targets([{**_T, "user": "  "}])
+    assert out[0]["user"] is None
+    assert out[0]["port"] == 22
+
+
+def test_config_pins_socket_and_strict_checking():
+    cfg = build_ssh_config(validate_targets([_T]))
+    assert "Host deploy" in cfg
+    assert "HostName deploy.example.com" in cfg
+    assert "User ubuntu" in cfg
+    assert "IdentityAgent ${SSH_AUTH_SOCK}" in cfg
+    assert "StrictHostKeyChecking yes" in cfg
+    assert "IdentitiesOnly yes" in cfg
+
+
+def test_config_empty_for_no_targets():
+    assert build_ssh_config([]) == ""
+
+
+def test_known_hosts_only_from_host_key():
+    assert build_known_hosts([_T]).strip() == _T["host_key"]
+    assert build_known_hosts([{**_T, "host_key": None}]) == ""
+
+
+def test_prompt_lists_aliases_and_is_empty_when_none():
+    assert "deploy" in render_ssh_targets_prompt([_T])
+    assert "ubuntu@deploy.example.com" in render_ssh_targets_prompt([_T])
+    assert render_ssh_targets_prompt([]) == ""
+
+
+def test_key_names_distinct():
+    assert ssh_key_names([_T, {**_T, "alias": "x"}]) == ["prod"]
+
+
+class _FakeVault:
+    def __init__(self, bundles):
+        self._b = bundles
+        self.calls = []
+
+    async def resolve_ref(self, ref, *, org_id, user_id=None, service_account_id=None):
+        self.calls.append((ref, org_id, user_id, service_account_id))
+        name = ref.split("vault://ssh_key:", 1)[-1]
+        return self._b.get(name)
+
+
+@pytest.mark.asyncio
+async def test_resolve_ssh_key_service_account_principal():
+    vault = _FakeVault({"prod": json.dumps({"private_key": "SECRET", "passphrase": "pw"})})
+    bundle = await resolve_ssh_key(
+        vault, org_id="o1", name="prod", user_id="u1", service_account_id="sa1",
+    )
+    assert bundle is not None
+    assert bundle.private_key == "SECRET"
+    # SA wins over user, and user_id is nulled.
+    ref, org, uid, said = vault.calls[0]
+    assert ref == "vault://ssh_key:prod"
+    assert org == "o1" and uid is None and said == "sa1"
+
+
+@pytest.mark.asyncio
+async def test_resolve_ssh_key_missing_returns_none():
+    vault = _FakeVault({})
+    assert await resolve_ssh_key(vault, org_id="o1", name="nope") is None

--- a/tests/test_system_prompt_ssh_section.py
+++ b/tests/test_system_prompt_ssh_section.py
@@ -1,0 +1,75 @@
+"""AgentHarness appends the SSH-targets section to the system prompt."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from surogates.harness.budget import IterationBudget
+from surogates.harness.context import ContextCompressor
+from surogates.harness.loop import AgentHarness
+from surogates.harness.prompt import PromptBuilder
+from surogates.sandbox.pool import SandboxPool
+from surogates.session.models import Session
+from surogates.tenant.context import TenantContext
+from surogates.tools.registry import ToolRegistry
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+_TARGET = {
+    "alias": "deploy",
+    "host": "deploy.example.com",
+    "port": 22,
+    "user": "ubuntu",
+    "key_name": "prod",
+    "host_key": "deploy.example.com ssh-ed25519 AAAA",
+}
+
+
+def _tenant() -> TenantContext:
+    return TenantContext(
+        org_id=UUID("00000000-0000-0000-0000-000000000001"),
+        user_id=UUID("00000000-0000-0000-0000-000000000002"),
+        org_config={}, user_preferences={}, permissions=frozenset(),
+        asset_root="/tmp/test",
+    )
+
+
+def _session() -> Session:
+    now = datetime.now(timezone.utc)
+    return Session(
+        id=uuid4(), user_id=uuid4(), org_id=uuid4(), agent_id="a1",
+        channel="slack", status="active", config={}, created_at=now, updated_at=now,
+    )
+
+
+def _harness(ssh_targets) -> AgentHarness:
+    pb = MagicMock(spec=PromptBuilder)
+    pb.build.return_value = "BASE PROMPT"
+    return AgentHarness(
+        session_store=AsyncMock(),
+        tool_registry=ToolRegistry(),
+        llm_client=AsyncMock(),
+        tenant=_tenant(),
+        worker_id="test-worker",
+        budget=IterationBudget(max_total=10),
+        context_compressor=MagicMock(spec=ContextCompressor),
+        prompt_builder=pb,
+        sandbox_pool=MagicMock(spec=SandboxPool),
+        ssh_targets=ssh_targets,
+    )
+
+
+async def test_prompt_appends_ssh_section():
+    prompt = await _harness((_TARGET,))._build_system_prompt(_session())
+    assert prompt.startswith("BASE PROMPT")
+    assert "SSH remote hosts" in prompt
+    assert "deploy" in prompt
+
+
+async def test_prompt_unchanged_without_ssh_targets():
+    prompt = await _harness(())._build_system_prompt(_session())
+    assert "SSH remote hosts" not in prompt

--- a/tests/test_terminal_srt_ssh.py
+++ b/tests/test_terminal_srt_ssh.py
@@ -1,0 +1,69 @@
+"""Terminal srt + env behavior for SSH-enabled sessions."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from surogates.tools.builtin import terminal
+
+_TARGETS = json.dumps([
+    {"alias": "deploy", "host": "deploy.example.com", "port": 22,
+     "user": "ubuntu", "key_name": "prod"},
+])
+
+
+def _patch_settings_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        terminal, "load_settings",
+        lambda: SimpleNamespace(sandbox=SimpleNamespace(srt_settings_dir=str(tmp_path))),
+        raising=False,
+    )
+
+
+def test_ssh_enabled_allows_ssh_dir_and_hosts(tmp_path, monkeypatch):
+    _patch_settings_dir(monkeypatch, tmp_path)
+    monkeypatch.setenv("SUROGATES_SSH_TARGETS", _TARGETS)
+    path = terminal._get_srt_settings_path("/workspace/x")
+    settings = json.loads(open(path).read())
+    assert "~/.ssh" not in settings["filesystem"]["denyRead"]
+    assert "deploy.example.com" in settings["network"]["allowedDomains"]
+
+
+def test_ssh_disabled_still_denies_ssh_dir(tmp_path, monkeypatch):
+    _patch_settings_dir(monkeypatch, tmp_path)
+    monkeypatch.delenv("SUROGATES_SSH_TARGETS", raising=False)
+    path = terminal._get_srt_settings_path("/workspace/y")
+    settings = json.loads(open(path).read())
+    assert "~/.ssh" in settings["filesystem"]["denyRead"]
+    assert "deploy.example.com" not in settings["network"]["allowedDomains"]
+
+
+def test_ssh_state_changes_settings_hash(tmp_path, monkeypatch):
+    _patch_settings_dir(monkeypatch, tmp_path)
+    monkeypatch.delenv("SUROGATES_SSH_TARGETS", raising=False)
+    off = terminal._get_srt_settings_path("/workspace/z")
+    monkeypatch.setenv("SUROGATES_SSH_TARGETS", _TARGETS)
+    on = terminal._get_srt_settings_path("/workspace/z")
+    assert off != on  # distinct settings files → no stale allowlist reuse
+
+
+def test_ssh_auth_sock_inherited():
+    assert "SSH_AUTH_SOCK" in terminal._ALWAYS_INHERIT
+
+
+def test_setup_ssh_home_writes_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("SUROGATES_SSH_TARGETS", _TARGETS)
+    monkeypatch.setenv("SUROGATES_SSH_KNOWN_HOSTS", "deploy.example.com ssh-ed25519 AAAA\n")
+    env = {"HOME": str(tmp_path)}
+    terminal._setup_ssh_home(env)
+    cfg = tmp_path / ".ssh" / "config"
+    assert "Host deploy" in cfg.read_text()
+    assert (tmp_path / ".ssh" / "known_hosts").read_text().strip().endswith("AAAA")
+
+
+def test_setup_ssh_home_noop_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.delenv("SUROGATES_SSH_TARGETS", raising=False)
+    env = {"HOME": str(tmp_path)}
+    terminal._setup_ssh_home(env)
+    assert not (tmp_path / ".ssh").exists()

--- a/tests/test_tool_exec_sandbox_spec.py
+++ b/tests/test_tool_exec_sandbox_spec.py
@@ -26,11 +26,11 @@ def _session(*, id_=None, parent_id=None, config=None):
     )
 
 
-def test_root_session_mounts_its_own_prefix():
+async def test_root_session_mounts_its_own_prefix():
     sid = uuid4()
     session = _session(id_=sid, config={"storage_bucket": "agent-a-bucket"})
     owner = sandbox_session_key(session)
-    spec = _build_session_sandbox_spec(session, tenant=SimpleNamespace(), sandbox_owner=owner)
+    spec = await _build_session_sandbox_spec(session, tenant=SimpleNamespace(), sandbox_owner=owner)
 
     sources = [r.source_ref for r in spec.resources]
     assert sources == [f"s3://agent-a-bucket/{sid}/"]
@@ -38,7 +38,7 @@ def test_root_session_mounts_its_own_prefix():
     assert mount_paths == [_WORKSPACE_MOUNT_PATH]
 
 
-def test_delegation_child_mounts_root_prefix_via_sandbox_root_session_id():
+async def test_delegation_child_mounts_root_prefix_via_sandbox_root_session_id():
     """The grandparent → parent → child chain must mount grandparent's prefix.
 
     This is the regression: before the fix, the source_ref used
@@ -56,14 +56,14 @@ def test_delegation_child_mounts_root_prefix_via_sandbox_root_session_id():
         },
     )
     owner = sandbox_session_key(child)
-    spec = _build_session_sandbox_spec(child, tenant=SimpleNamespace(), sandbox_owner=owner)
+    spec = await _build_session_sandbox_spec(child, tenant=SimpleNamespace(), sandbox_owner=owner)
 
     assert owner == str(root_id)
     sources = [r.source_ref for r in spec.resources]
     assert sources == [f"s3://agent-a-bucket/{root_id}/"]
 
 
-def test_legacy_child_without_root_falls_back_to_parent_id():
+async def test_legacy_child_without_root_falls_back_to_parent_id():
     """Pre-deploy delegation children (no sandbox_root_session_id) still share.
 
     ``sandbox_session_key`` falls back to ``parent_id`` when the cached
@@ -76,23 +76,23 @@ def test_legacy_child_without_root_falls_back_to_parent_id():
         config={"storage_bucket": "agent-a-bucket"},
     )
     owner = sandbox_session_key(child)
-    spec = _build_session_sandbox_spec(child, tenant=SimpleNamespace(), sandbox_owner=owner)
+    spec = await _build_session_sandbox_spec(child, tenant=SimpleNamespace(), sandbox_owner=owner)
 
     assert owner == str(parent_id)
     sources = [r.source_ref for r in spec.resources]
     assert sources == [f"s3://agent-a-bucket/{parent_id}/"]
 
 
-def test_no_storage_bucket_emits_no_workspace_mount():
+async def test_no_storage_bucket_emits_no_workspace_mount():
     session = _session(config={})
     owner = sandbox_session_key(session)
-    spec = _build_session_sandbox_spec(session, tenant=SimpleNamespace(), sandbox_owner=owner)
+    spec = await _build_session_sandbox_spec(session, tenant=SimpleNamespace(), sandbox_owner=owner)
 
     s3_resources = [r for r in spec.resources if r.source_ref.startswith("s3://")]
     assert s3_resources == []
 
 
-def test_existing_workspace_mount_on_tenant_spec_is_not_duplicated():
+async def test_existing_workspace_mount_on_tenant_spec_is_not_duplicated():
     """A baseline spec that already has /workspace mounted must not get a second one.
 
     The duplicate guard checks ``mount_path``, not just any S3 resource —
@@ -110,14 +110,14 @@ def test_existing_workspace_mount_on_tenant_spec_is_not_duplicated():
     )
     session = _session(config={"storage_bucket": "agent-a-bucket"})
     owner = sandbox_session_key(session)
-    spec = _build_session_sandbox_spec(session, tenant=tenant, sandbox_owner=owner)
+    spec = await _build_session_sandbox_spec(session, tenant=tenant, sandbox_owner=owner)
 
     workspace_mounts = [r for r in spec.resources if r.mount_path == _WORKSPACE_MOUNT_PATH]
     assert len(workspace_mounts) == 1
     assert workspace_mounts[0].source_ref == "s3://preset-bucket/preset/"
 
 
-def test_unrelated_s3_resource_does_not_suppress_workspace_mount():
+async def test_unrelated_s3_resource_does_not_suppress_workspace_mount():
     """An S3 resource at a non-workspace mount path must not suppress workspace setup.
 
     Regression for an over-broad guard: previously the code skipped the
@@ -136,14 +136,14 @@ def test_unrelated_s3_resource_does_not_suppress_workspace_mount():
     sid = uuid4()
     session = _session(id_=sid, config={"storage_bucket": "agent-a-bucket"})
     owner = sandbox_session_key(session)
-    spec = _build_session_sandbox_spec(session, tenant=tenant, sandbox_owner=owner)
+    spec = await _build_session_sandbox_spec(session, tenant=tenant, sandbox_owner=owner)
 
     by_mount = {r.mount_path: r.source_ref for r in spec.resources}
     assert by_mount["/preset"] == "s3://other-bucket/preset/"
     assert by_mount[_WORKSPACE_MOUNT_PATH] == f"s3://agent-a-bucket/{sid}/"
 
 
-def test_baseline_tenant_spec_is_not_mutated():
+async def test_baseline_tenant_spec_is_not_mutated():
     """Building a session spec must not mutate the shared tenant baseline.
 
     Two different sessions on the same tenant context must each get
@@ -157,7 +157,7 @@ def test_baseline_tenant_spec_is_not_mutated():
     tenant = SimpleNamespace(sandbox_spec=baseline)
 
     session_a = _session(config={"storage_bucket": "bucket-a"})
-    spec_a = _build_session_sandbox_spec(
+    spec_a = await _build_session_sandbox_spec(
         session_a, tenant=tenant, sandbox_owner=sandbox_session_key(session_a),
     )
     assert any(r.mount_path == _WORKSPACE_MOUNT_PATH for r in spec_a.resources)
@@ -166,7 +166,7 @@ def test_baseline_tenant_spec_is_not_mutated():
     assert "_passthrough_done" not in baseline.env
 
     session_b = _session(config={"storage_bucket": "bucket-b"})
-    spec_b = _build_session_sandbox_spec(
+    spec_b = await _build_session_sandbox_spec(
         session_b, tenant=tenant, sandbox_owner=sandbox_session_key(session_b),
     )
     workspace_b = next(r for r in spec_b.resources if r.mount_path == _WORKSPACE_MOUNT_PATH)
@@ -174,7 +174,7 @@ def test_baseline_tenant_spec_is_not_mutated():
     assert workspace_b.source_ref.startswith("s3://bucket-b/")
 
 
-def test_env_passthrough_baseline_is_not_mutated():
+async def test_env_passthrough_baseline_is_not_mutated():
     """Env passthrough must not bake the sentinel into the shared baseline."""
     from surogates.sandbox.base import SandboxSpec
 
@@ -182,7 +182,7 @@ def test_env_passthrough_baseline_is_not_mutated():
     tenant = SimpleNamespace(sandbox_spec=baseline)
     session = _session(config={"storage_bucket": "agent-a-bucket"})
 
-    spec = _build_session_sandbox_spec(
+    spec = await _build_session_sandbox_spec(
         session, tenant=tenant, sandbox_owner=sandbox_session_key(session),
     )
     assert spec.env.get("_passthrough_done") == "1"
@@ -191,7 +191,7 @@ def test_env_passthrough_baseline_is_not_mutated():
     assert "_passthrough_done" not in baseline.env
 
 
-def test_no_tenant_baseline_reads_sandbox_settings_env(monkeypatch):
+async def test_no_tenant_baseline_reads_sandbox_settings_env(monkeypatch):
     """Without a tenant baseline, SUROGATES_SANDBOX_DEFAULT_* env wins.
 
     Regression: previously fell through to ``SandboxSpec()`` dataclass
@@ -205,7 +205,7 @@ def test_no_tenant_baseline_reads_sandbox_settings_env(monkeypatch):
     monkeypatch.setenv("SUROGATES_SANDBOX_DEFAULT_MEMORY_LIMIT", "13Gi")
 
     session = _session(config={"storage_bucket": "agent-a-bucket"})
-    spec = _build_session_sandbox_spec(
+    spec = await _build_session_sandbox_spec(
         session, tenant=SimpleNamespace(), sandbox_owner=sandbox_session_key(session),
     )
     assert spec.cpu == "3"
@@ -214,12 +214,12 @@ def test_no_tenant_baseline_reads_sandbox_settings_env(monkeypatch):
     assert spec.memory_limit == "13Gi"
 
 
-def test_no_tenant_baseline_no_env_uses_aligned_defaults():
+async def test_no_tenant_baseline_no_env_uses_aligned_defaults():
     """Without env overrides, fallback matches the documented spec defaults."""
     from surogates.sandbox.base import SandboxSpec
 
     session = _session(config={})
-    spec = _build_session_sandbox_spec(
+    spec = await _build_session_sandbox_spec(
         session, tenant=SimpleNamespace(), sandbox_owner=sandbox_session_key(session),
     )
     fresh = SandboxSpec()
@@ -229,7 +229,7 @@ def test_no_tenant_baseline_no_env_uses_aligned_defaults():
     assert spec.memory_limit == fresh.memory_limit
 
 
-def test_spec_sets_session_id_and_workspace_path():
+async def test_spec_sets_session_id_and_workspace_path():
     session = _session(
         config={
             "storage_bucket": "agent-bucket",
@@ -237,7 +237,7 @@ def test_spec_sets_session_id_and_workspace_path():
         },
     )
 
-    spec = _build_session_sandbox_spec(
+    spec = await _build_session_sandbox_spec(
         session, tenant=SimpleNamespace(), sandbox_owner="root-1",
     )
 
@@ -245,10 +245,10 @@ def test_spec_sets_session_id_and_workspace_path():
     assert spec.workspace_path == "/data/agent-bucket/sessions/root-1"
 
 
-def test_spec_workspace_path_none_when_absent():
+async def test_spec_workspace_path_none_when_absent():
     session = _session(config={"storage_bucket": "agent-bucket"})
 
-    spec = _build_session_sandbox_spec(
+    spec = await _build_session_sandbox_spec(
         session, tenant=SimpleNamespace(), sandbox_owner="root-1",
     )
 
@@ -256,7 +256,7 @@ def test_spec_workspace_path_none_when_absent():
     assert spec.workspace_path is None
 
 
-def test_managed_channel_mounts_boundary_workspace_prefix():
+async def test_managed_channel_mounts_boundary_workspace_prefix():
     sid = uuid4()
     session = _session(
         id_=sid,
@@ -268,7 +268,7 @@ def test_managed_channel_mounts_boundary_workspace_prefix():
         },
     )
 
-    spec = _build_session_sandbox_spec(
+    spec = await _build_session_sandbox_spec(
         session,
         tenant=SimpleNamespace(),
         sandbox_owner=sandbox_session_key(session),
@@ -280,7 +280,7 @@ def test_managed_channel_mounts_boundary_workspace_prefix():
     ]
 
 
-def test_child_mounts_parent_boundary_workspace_prefix():
+async def test_child_mounts_parent_boundary_workspace_prefix():
     parent_id = uuid4()
     child = _session(
         id_=uuid4(),
@@ -293,7 +293,7 @@ def test_child_mounts_parent_boundary_workspace_prefix():
         },
     )
 
-    spec = _build_session_sandbox_spec(
+    spec = await _build_session_sandbox_spec(
         child,
         tenant=SimpleNamespace(),
         sandbox_owner=sandbox_session_key(child),
@@ -305,7 +305,7 @@ def test_child_mounts_parent_boundary_workspace_prefix():
     ]
 
 
-def test_spec_env_uses_service_account_credential_subject():
+async def test_spec_env_uses_service_account_credential_subject():
     org_id = uuid4()
     service_account_id = uuid4()
     agent_id = "agent-1"
@@ -321,7 +321,7 @@ def test_spec_env_uses_service_account_credential_subject():
         service_account_id=service_account_id,
     )
 
-    spec = _build_session_sandbox_spec(
+    spec = await _build_session_sandbox_spec(
         session,
         tenant=tenant,
         sandbox_owner=sandbox_session_key(session),
@@ -333,7 +333,7 @@ def test_spec_env_uses_service_account_credential_subject():
     assert spec.env["SUROGATES_IS_SERVICE_ACCOUNT"] == "1"
 
 
-def test_spec_env_uses_user_credential_subject():
+async def test_spec_env_uses_user_credential_subject():
     org_id = uuid4()
     user_id = uuid4()
     agent_id = "agent-1"
@@ -349,7 +349,7 @@ def test_spec_env_uses_user_credential_subject():
         service_account_id=None,
     )
 
-    spec = _build_session_sandbox_spec(
+    spec = await _build_session_sandbox_spec(
         session,
         tenant=tenant,
         sandbox_owner=sandbox_session_key(session),


### PR DESCRIPTION
## Agent SSH remote access

Lets a managed agent's terminal open authenticated SSH sessions into user-configured remote hosts using a vaulted SSH private key, **without ever exposing the raw key bytes** to the untrusted LLM-generated code in the sandbox.

### How it works
- **Storage**: `SSHKeyBundle` in the Fernet vault (`ssh_key:<name>`, principal-scoped); harness API `/ssh-credentials/*`.
- **Config**: per-agent `ssh_targets` projected onto `AgentRuntimeContext` and overlaid onto the wake-local session (mirrors the `repos` chain). Host keys captured server-side (trusted `ssh-keyscan`, fail-closed).
- **Delivery (k8s)**: the private key is resolved worker-side and delivered **only** into an isolated `ssh-agent` sidecar (distinct uid, read-only rootfs, dropped caps, no SA token, `fsGroup` bridge) via an in-memory, sidecar-only Secret. The main container gets **only** the auth socket over a shared in-memory volume — it can authenticate but can't read/exfiltrate the key. The key never enters `spec.env`, the workspace, or logs.
- **Host scoping**: fail-closed NetworkPolicy egress (DNS→kube-dns, baseline CIDRs, resolved target `ip/32:port` only), gated by `sandbox.ssh_egress_enforced`.
- **Terminal**: `srt` lets `ssh` + the socket through for SSH sessions; `~/.ssh/config`/`known_hosts` are re-pinned before every command (tamper-resistant).
- **Resolution principal**: SSH keys are agent-owned, so they resolve under the **agent service account on every channel** (not only Slack/Telegram).
- **Dev backends**: a non-production local `ssh-agent` for process/docker so the feature is locally testable.

### Not yet done (operational gates — feature ships inert)
- Publish the `surogates-ssh-agent` sidecar image (Dockerfile + build matrix included here).
- Flip `ssh_egress_enforced: true` **only** after confirming the cluster CNI enforces NetworkPolicy egress and the kube-dns pod labels match (`k8s-app: kube-dns`).
- Live-cluster smoke test of the sidecar key/socket perms (`fsGroup`) and the s3fs interaction — unit tests assert manifest shape, not kernel behavior.

Also includes an unrelated harness change (`feat(harness): tell channel agents to deliver artifacts as images`) that rode on this branch, included intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
