### PR TITLE
fix(ssh): load generated ssh_config via a PATH wrapper and use the agent key

### DIFF
--- a/surogates/ssh_access/resolve.py
+++ b/surogates/ssh_access/resolve.py
@@ -90,12 +90,19 @@ def validate_targets(raw: Sequence[Mapping[str, Any]] | None) -> list[dict]:
     return out
 
 
-def build_ssh_config(targets: Sequence[Mapping[str, Any]]) -> str:
-    """Render ``~/.ssh/config`` from targets (no secret; safe for the sandbox).
+def build_ssh_config(
+    targets: Sequence[Mapping[str, Any]],
+    known_hosts_path: str = "~/.ssh/known_hosts",
+) -> str:
+    """Render ``ssh_config`` from targets (no secret; safe for the sandbox).
 
-    Every host authenticates only through the agent socket (``IdentityAgent``
-    + ``IdentitiesOnly``) and verifies against the pinned ``known_hosts``
-    (``StrictHostKeyChecking yes``).
+    Each host verifies against the pinned ``known_hosts``
+    (``StrictHostKeyChecking yes`` + ``UserKnownHostsFile <known_hosts_path>``).
+    Authentication uses the agent's key via ``SSH_AUTH_SOCK`` (ssh consults the
+    agent socket by default) — we deliberately emit neither ``IdentityAgent``
+    (the ``${SSH_AUTH_SOCK}`` form isn't reliably expanded in ssh_config) nor
+    ``IdentitiesOnly yes`` (which, with no ``IdentityFile``, would suppress the
+    agent's keys and break publickey auth).
     """
     blocks: list[str] = []
     for t in targets or ():
@@ -107,10 +114,8 @@ def build_ssh_config(targets: Sequence[Mapping[str, Any]]) -> str:
         if t.get("user"):
             lines.append(f"    User {t['user']}")
         lines.extend([
-            "    IdentityAgent ${SSH_AUTH_SOCK}",
-            "    IdentitiesOnly yes",
             "    StrictHostKeyChecking yes",
-            "    UserKnownHostsFile ~/.ssh/known_hosts",
+            f"    UserKnownHostsFile {known_hosts_path}",
         ])
         blocks.append("\n".join(lines))
     return "\n\n".join(blocks) + ("\n" if blocks else "")
@@ -149,12 +154,12 @@ def write_ssh_home(
     ssh_dir = Path(home) / ".ssh"
     ssh_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(ssh_dir, 0o700)
-    cfg = ssh_dir / "config"
-    cfg.write_text(build_ssh_config(targets), encoding="utf-8")
-    os.chmod(cfg, 0o600)
     kh = ssh_dir / "known_hosts"
     kh.write_text(known_hosts or "", encoding="utf-8")
     os.chmod(kh, 0o600)
+    cfg = ssh_dir / "config"
+    cfg.write_text(build_ssh_config(targets, known_hosts_path=str(kh)), encoding="utf-8")
+    os.chmod(cfg, 0o600)
 
 
 def render_ssh_targets_prompt(targets: Sequence[Mapping[str, Any]] | None) -> str:

--- a/surogates/tools/builtin/terminal.py
+++ b/surogates/tools/builtin/terminal.py
@@ -39,6 +39,12 @@ from surogates.tools.utils.workspace_sandbox import (
 
 logger = logging.getLogger(__name__)
 
+# Writable dir for the generated ssh config, known_hosts and PATH wrappers.
+# ``ssh`` reads its user config from the passwd home (read-only in the sandbox),
+# so we can't rely on ``$HOME/.ssh/config``; the wrappers under ``bin/`` force
+# ``-F <this dir>/config`` instead.
+_SSH_DIR = "/tmp/surogates-ssh"
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -84,27 +90,51 @@ def _ssh_hosts_from_env() -> list[str]:
 
 
 def _setup_ssh_home(child_env: dict[str, str]) -> None:
-    """Write the pinned ssh config/known_hosts into the child's HOME.
+    """Install a writable ssh config + a PATH ``ssh`` wrapper that loads it.
 
-    No-op unless the session is SSH-enabled.  Rewrites on every command so the
-    strict host-key config is re-pinned and cannot be persistently weakened by
-    the agent editing the files between commands.  Files are non-secret.
+    No-op unless the session is SSH-enabled (``SUROGATES_SSH_TARGETS`` set to a
+    non-empty JSON list).  ``ssh`` reads its user config from the *passwd* home
+    (read-only in the sandbox), not ``$HOME``, so a config written under the
+    child's HOME is never loaded.  Instead we write config/known_hosts into a
+    fixed writable dir and shadow ``ssh``/``scp``/``sftp`` on PATH with thin
+    wrappers that force ``-F <config>``.  Rewriting on every command re-pins the
+    strict host-key config so the agent cannot persistently weaken it.  All
+    files are non-secret (the private key lives in the isolated ssh-agent).
     """
     raw = os.environ.get("SUROGATES_SSH_TARGETS", "")
     if not raw:
-        return
-    home = child_env.get("HOME")
-    if not home:
         return
     try:
         targets = json.loads(raw)
     except ValueError:
         return
-    from surogates.ssh_access.resolve import write_ssh_home
+    if not targets:
+        return
+    from surogates.ssh_access.resolve import build_ssh_config
 
-    write_ssh_home(
-        home, targets, os.environ.get("SUROGATES_SSH_KNOWN_HOSTS", ""),
-    )
+    bin_dir = os.path.join(_SSH_DIR, "bin")
+    os.makedirs(bin_dir, exist_ok=True)
+    os.chmod(_SSH_DIR, 0o700)
+
+    known_hosts_path = os.path.join(_SSH_DIR, "known_hosts")
+    with open(known_hosts_path, "w", encoding="utf-8") as fh:
+        fh.write(os.environ.get("SUROGATES_SSH_KNOWN_HOSTS", ""))
+    os.chmod(known_hosts_path, 0o600)
+
+    config_path = os.path.join(_SSH_DIR, "config")
+    with open(config_path, "w", encoding="utf-8") as fh:
+        fh.write(build_ssh_config(targets, known_hosts_path=known_hosts_path))
+    os.chmod(config_path, 0o600)
+
+    for tool in ("ssh", "scp", "sftp"):
+        wrapper = os.path.join(bin_dir, tool)
+        with open(wrapper, "w", encoding="utf-8") as fh:
+            fh.write(
+                f"#!/bin/sh\nexec /usr/bin/{tool} -F {config_path} \"$@\"\n",
+            )
+        os.chmod(wrapper, 0o755)
+
+    child_env["PATH"] = bin_dir + ":" + child_env.get("PATH", "")
 
 
 def _get_srt_settings_path(workspace_path: str) -> str:

--- a/tests/test_ssh_resolve.py
+++ b/tests/test_ssh_resolve.py
@@ -70,14 +70,17 @@ def test_validate_rejects_metachar_key_name():
         validate_targets([{**_T, "key_name": "foo;bar"}])
 
 
-def test_config_pins_socket_and_strict_checking():
-    cfg = build_ssh_config(validate_targets([_T]))
+def test_config_pins_known_hosts_and_strict_checking():
+    cfg = build_ssh_config(validate_targets([_T]), known_hosts_path="/x/known_hosts")
     assert "Host deploy" in cfg
     assert "HostName deploy.example.com" in cfg
     assert "User ubuntu" in cfg
-    assert "IdentityAgent ${SSH_AUTH_SOCK}" in cfg
     assert "StrictHostKeyChecking yes" in cfg
-    assert "IdentitiesOnly yes" in cfg
+    assert "UserKnownHostsFile /x/known_hosts" in cfg
+    # The agent-key-blocking / unreliable directives must be gone: with no
+    # IdentityFile they would suppress the ssh-agent key (publickey denied).
+    assert "IdentitiesOnly" not in cfg
+    assert "IdentityAgent" not in cfg
 
 
 def test_config_empty_for_no_targets():

--- a/tests/test_terminal_srt_ssh.py
+++ b/tests/test_terminal_srt_ssh.py
@@ -53,17 +53,48 @@ def test_ssh_auth_sock_inherited():
 
 
 def test_setup_ssh_home_writes_config(tmp_path, monkeypatch):
+    import os
+    import shutil
+
+    ssh_dir = terminal._SSH_DIR
+    shutil.rmtree(ssh_dir, ignore_errors=True)
     monkeypatch.setenv("SUROGATES_SSH_TARGETS", _TARGETS)
     monkeypatch.setenv("SUROGATES_SSH_KNOWN_HOSTS", "deploy.example.com ssh-ed25519 AAAA\n")
-    env = {"HOME": str(tmp_path)}
+    env = {"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
     terminal._setup_ssh_home(env)
-    cfg = tmp_path / ".ssh" / "config"
-    assert "Host deploy" in cfg.read_text()
-    assert (tmp_path / ".ssh" / "known_hosts").read_text().strip().endswith("AAAA")
+
+    config = os.path.join(ssh_dir, "config")
+    known_hosts = os.path.join(ssh_dir, "known_hosts")
+    ssh_wrapper = os.path.join(ssh_dir, "bin", "ssh")
+
+    with open(config) as fh:
+        cfg_text = fh.read()
+    assert "Host deploy" in cfg_text
+    # The config points UserKnownHostsFile at the absolute known_hosts path.
+    assert f"UserKnownHostsFile {known_hosts}" in cfg_text
+    with open(known_hosts) as fh:
+        assert fh.read().strip().endswith("AAAA")
+
+    # The ssh wrapper forces -F <config> and is executable.
+    with open(ssh_wrapper) as fh:
+        wrapper_text = fh.read()
+    assert f"-F {config}" in wrapper_text
+    assert wrapper_text.startswith("#!/bin/sh")
+    assert os.access(ssh_wrapper, os.X_OK)
+
+    # PATH is prefixed with the wrapper bin dir so plain `ssh` hits the wrapper.
+    assert env["PATH"].startswith(os.path.join(ssh_dir, "bin") + ":")
+
+    shutil.rmtree(ssh_dir, ignore_errors=True)
 
 
 def test_setup_ssh_home_noop_when_disabled(tmp_path, monkeypatch):
+    import os
+    import shutil
+
+    shutil.rmtree(terminal._SSH_DIR, ignore_errors=True)
     monkeypatch.delenv("SUROGATES_SSH_TARGETS", raising=False)
-    env = {"HOME": str(tmp_path)}
+    env = {"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
     terminal._setup_ssh_home(env)
-    assert not (tmp_path / ".ssh").exists()
+    assert not os.path.exists(os.path.join(terminal._SSH_DIR, "config"))
+    assert env["PATH"] == "/usr/bin:/bin"


### PR DESCRIPTION
A live test of agent SSH remote access showed plain `ssh <alias>` failing inside the sandbox pod. Three bugs in the generated-ssh_config path caused it; this fixes the two that live in `surogates`.

## Bugs fixed

1. **Generated config was never loaded.** The terminal wrote `<HOME>/.ssh/config`, but the sandbox terminal overrides `HOME=/workspace` for commands while `ssh` reads its user config from the *passwd* home (`/home/sandbox/.ssh/config`), which is read-only. So `ssh <alias>` never saw our config. Fix: `_setup_ssh_home` now writes config/known_hosts into a fixed writable dir (`/tmp/surogates-ssh`) and installs thin `ssh`/`scp`/`sftp` wrappers on `PATH` that force `-F /tmp/surogates-ssh/config`.

2. **`IdentitiesOnly yes` blocked the agent key.** The config set `IdentitiesOnly yes` with no `IdentityFile`, which stops ssh from offering the ssh-agent's key → `Permission denied (publickey)`. It also emitted `IdentityAgent ${SSH_AUTH_SOCK}`, whose `${...}` form isn't reliably expanded in ssh_config. Both directives are removed; ssh uses `SSH_AUTH_SOCK` by default.

3. **`known_hosts` path resolved to the read-only passwd home.** `UserKnownHostsFile ~/.ssh/known_hosts` resolved (in ssh_config) to `/home/sandbox/.ssh/known_hosts` (read-only). `build_ssh_config` now takes a `known_hosts_path` param and the terminal passes the absolute `/tmp/surogates-ssh/known_hosts`.

## Validation

Reproduced the fixed runtime on the PROD k3s cluster (sandbox + ssh-agent sidecar, matching security context and network policy) against a real host. With the wrapper on `PATH`, **plain** `ssh <alias> "echo FIXED_OK; whoami"` (no `-F`, no `-o` overrides) returned `FIXED_OK` and the remote user — confirming the agent authenticates end-to-end.

`build_ssh_config` also ships in the worker image, so rebuild `surogates-worker` for consistency; the terminal change runs in the `surogates-agent-sandbox` image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
