### PR TITLE
Fix/suppress upstream error sentinels

### DIFF
--- a/surogates/harness/llm_call.py
+++ b/surogates/harness/llm_call.py
@@ -1764,7 +1764,12 @@ async def call_llm_non_streaming(
         "finish_reason": choice.finish_reason,
     }
 
-    if is_upstream_error_sentinel(assistant_message_dict.get("content")):
+    # Flatten first: content may still be a list of blocks here (the loop
+    # coerces it to text only after this returns), and is_upstream_error_sentinel
+    # expects text.
+    if is_upstream_error_sentinel(
+        _message_content_as_text(assistant_message_dict.get("content"))
+    ):
         # An upstream-gateway error fabricated as normal content.  Blank it and
         # drop the bogus tool calls so it is never persisted or shown, and flag
         # the turn for retry / failover in ``call_llm_with_retry``.

--- a/surogates/harness/llm_call.py
+++ b/surogates/harness/llm_call.py
@@ -45,7 +45,9 @@ from surogates.harness.sanitize import (
 )
 from surogates.harness.stream_scrubbers import (
     StreamingContextScrubber,
+    StreamingSentinelScrubber,
     StreamingThinkScrubber,
+    is_upstream_error_sentinel,
 )
 from surogates.harness.tool_exec import tool_call_arguments_look_incomplete
 from surogates.session.events import EventType
@@ -583,6 +585,29 @@ async def call_llm_with_retry(
                     current_model = get_current_model()
                     if current_model:
                         create_kwargs["model"] = current_model
+                    continue
+                raise ValueError("LLM returned empty response")
+
+            # Upstream-gateway error sentinel: the provider fabricated an
+            # error string as normal content (already suppressed from the
+            # user downstream).  Treat the turn as an empty upstream response:
+            # prefer a fallback provider, otherwise retry in place with
+            # backoff -- the fault is typically transient (a per-turn safety
+            # trip or rate limit) and clears on a subsequent attempt.
+            if usage_data.get("upstream_error_sentinel"):
+                logger.warning(
+                    "Upstream gateway returned an error sentinel for session "
+                    "%s (iteration %d, attempt %d/%d); suppressed from the "
+                    "user, retrying / failing over.",
+                    session.id, iteration, attempt, MAX_LLM_RETRIES,
+                )
+                if activate_fallback():
+                    current_model = get_current_model()
+                    if current_model:
+                        create_kwargs["model"] = current_model
+                    continue
+                if attempt < MAX_LLM_RETRIES:
+                    await asyncio.sleep(jittered_backoff(attempt))
                     continue
                 raise ValueError("LLM returned empty response")
 
@@ -1197,6 +1222,9 @@ async def call_llm_streaming_inner(
     reasoning_parts: list[str] = []
     think_scrubber = StreamingThinkScrubber()
     context_scrubber = StreamingContextScrubber()
+    # Suppresses upstream-gateway error strings fabricated as normal content
+    # (see StreamingSentinelScrubber) so they are never streamed to the user.
+    sentinel_scrubber = StreamingSentinelScrubber()
 
     # Streaming tool execution: track which tool call slots have been
     # notified to the on_tool_call_complete callback.  A slot is
@@ -1394,7 +1422,9 @@ async def call_llm_streaming_inner(
             # Text content delta.
             text_delta = getattr(delta, "content", None)
             if text_delta:
-                visible_delta = context_scrubber.feed(think_scrubber.feed(text_delta))
+                visible_delta = sentinel_scrubber.feed(
+                    context_scrubber.feed(think_scrubber.feed(text_delta))
+                )
                 if visible_delta:
                     content_or_tool_emitted = True
                     content_parts.append(visible_delta)
@@ -1457,8 +1487,14 @@ async def call_llm_streaming_inner(
                     # Streaming tool execution: when a new higher-index slot
                     # appears, all lower-index slots are fully formed.  Fire
                     # the callback so the StreamingToolExecutor can start
-                    # executing concurrency-safe tools immediately.
-                    if on_tool_call_complete is not None and idx > _highest_known_slot:
+                    # executing concurrency-safe tools immediately.  Skip once a
+                    # gateway error sentinel is detected -- its tool calls are
+                    # fabricated junk and must not be executed.
+                    if (
+                        on_tool_call_complete is not None
+                        and not sentinel_scrubber.matched
+                        and idx > _highest_known_slot
+                    ):
                         for prev_slot in sorted(tool_calls_acc):
                             if prev_slot < idx and prev_slot not in _notified_slots:
                                 prev_entry = tool_calls_acc[prev_slot]
@@ -1516,7 +1552,10 @@ async def call_llm_streaming_inner(
     if stop_reason is not None:
         interrupted = True
 
-    tail_delta = context_scrubber.feed(think_scrubber.flush()) + context_scrubber.flush()
+    tail_scrubbed = (
+        context_scrubber.feed(think_scrubber.flush()) + context_scrubber.flush()
+    )
+    tail_delta = sentinel_scrubber.feed(tail_scrubbed) + sentinel_scrubber.flush()
     if tail_delta:
         content_parts.append(tail_delta)
         await store.emit_event(
@@ -1534,8 +1573,10 @@ async def call_llm_streaming_inner(
 
     # Notify any remaining tool call slots that haven't been reported yet.
     # This covers the last tool call in the batch (no higher index follows)
-    # and the case where only a single tool call was generated.
-    if on_tool_call_complete is not None:
+    # and the case where only a single tool call was generated.  A detected
+    # gateway error sentinel means the whole turn is fabricated -- its tool
+    # calls must never reach the executor.
+    if on_tool_call_complete is not None and not sentinel_scrubber.matched:
         for slot in sorted(tool_calls_acc):
             if slot not in _notified_slots:
                 entry = tool_calls_acc[slot]
@@ -1568,6 +1609,17 @@ async def call_llm_streaming_inner(
     if partial_tool_names:
         usage_data["partial_tool_call"] = True
         usage_data["partial_tool_names"] = partial_tool_names
+
+    if sentinel_scrubber.matched:
+        # The whole turn was an upstream-gateway error fabricated as content.
+        # Drop the (already-suppressed) content and its bogus tool calls, and
+        # flag the turn so ``call_llm_with_retry`` treats it as an empty
+        # upstream response and fails over / retries.
+        assistant_message["content"] = ""
+        assistant_message.pop("tool_calls", None)
+        usage_data["upstream_error_sentinel"] = True
+        usage_data.pop("partial_tool_call", None)
+        usage_data.pop("partial_tool_names", None)
 
     return sanitize_response_message(assistant_message), usage_data
 
@@ -1705,5 +1757,13 @@ async def call_llm_non_streaming(
         "cache_read_tokens": cache_read_tokens,
         "finish_reason": choice.finish_reason,
     }
+
+    if is_upstream_error_sentinel(assistant_message_dict.get("content")):
+        # An upstream-gateway error fabricated as normal content.  Blank it and
+        # drop the bogus tool calls so it is never persisted or shown, and flag
+        # the turn for retry / failover in ``call_llm_with_retry``.
+        assistant_message_dict["content"] = ""
+        assistant_message_dict.pop("tool_calls", None)
+        usage_data["upstream_error_sentinel"] = True
 
     return sanitize_response_message(assistant_message_dict), usage_data

--- a/surogates/harness/llm_call.py
+++ b/surogates/harness/llm_call.py
@@ -601,13 +601,21 @@ async def call_llm_with_retry(
                     "user, retrying / failing over.",
                     session.id, iteration, attempt, MAX_LLM_RETRIES,
                 )
+                # A fabricated turn may have dispatched a bogus tool call into
+                # the streaming executor before the sentinel was recognised.
+                # Discard that executor so nothing from the error turn survives
+                # into the retry.
+                if on_stream_retry is not None:
+                    active_on_tool_call_complete = on_stream_retry()
                 if activate_fallback():
                     current_model = get_current_model()
                     if current_model:
                         create_kwargs["model"] = current_model
                     continue
                 if attempt < MAX_LLM_RETRIES:
-                    await asyncio.sleep(jittered_backoff(attempt))
+                    await interruptible_sleep(
+                        jittered_backoff(attempt), interrupt_check,
+                    )
                     continue
                 raise ValueError("LLM returned empty response")
 

--- a/surogates/harness/llm_call.py
+++ b/surogates/harness/llm_call.py
@@ -1626,8 +1626,6 @@ async def call_llm_streaming_inner(
         assistant_message["content"] = ""
         assistant_message.pop("tool_calls", None)
         usage_data["upstream_error_sentinel"] = True
-        usage_data.pop("partial_tool_call", None)
-        usage_data.pop("partial_tool_names", None)
 
     return sanitize_response_message(assistant_message), usage_data
 

--- a/surogates/harness/stream_scrubbers.py
+++ b/surogates/harness/stream_scrubbers.py
@@ -34,6 +34,12 @@ _UPSTREAM_SENTINEL_MARKERS: Final[tuple[str, ...]] = (
     "上游模型未返回任何内容",
 )
 
+# A marker only counts as a gateway error when the message is itself
+# error-shaped: short and self-contained.  A long legitimate reply that merely
+# quotes/translates the phrase is not suppressed.  The real sentinel is ~60
+# chars, so this leaves generous headroom.
+_MAX_SENTINEL_MESSAGE_LEN: Final[int] = 200
+
 
 def _contains_cjk(text: str) -> bool:
     """True if *text* contains a CJK ideograph.
@@ -52,9 +58,10 @@ def _contains_cjk(text: str) -> bool:
 def is_upstream_error_sentinel(text: str | None) -> bool:
     """Return ``True`` if *text* is a known upstream-gateway error string.
 
-    Matches a message that *is* (starts with) a full sentinel, or that contains
-    a distinctive gateway marker.  Used to filter fully assembled messages on
-    both the streaming and non-streaming paths.
+    Matches a message that *is* (starts with) a full sentinel, or that is a
+    short, error-shaped message containing a distinctive gateway marker.  A long
+    legitimate reply that merely quotes the marker is not matched.  Callers pass
+    already-flattened text (see ``_message_content_as_text``).
     """
     if not text:
         return False
@@ -63,7 +70,11 @@ def is_upstream_error_sentinel(text: str | None) -> bool:
         return False
     if any(stripped.startswith(sentinel) for sentinel in UPSTREAM_ERROR_SENTINELS):
         return True
-    return any(marker in stripped for marker in _UPSTREAM_SENTINEL_MARKERS)
+    return any(
+        stripped.startswith(marker)
+        or (len(stripped) < _MAX_SENTINEL_MESSAGE_LEN and marker in stripped)
+        for marker in _UPSTREAM_SENTINEL_MARKERS
+    )
 
 
 class StreamingThinkScrubber:

--- a/surogates/harness/stream_scrubbers.py
+++ b/surogates/harness/stream_scrubbers.py
@@ -34,10 +34,19 @@ _UPSTREAM_SENTINEL_MARKERS: Final[tuple[str, ...]] = (
     "上游模型未返回任何内容",
 )
 
-# On flush, a held buffer that is a proper prefix of a sentinel this long or
-# longer is treated as a truncated gateway error and suppressed.  Short shared
-# prefixes (e.g. a lone "⚠️") fall below the bar and are emitted normally.
-_MIN_SUPPRESSED_PREFIX_LEN: Final[int] = 8
+
+def _contains_cjk(text: str) -> bool:
+    """True if *text* contains a CJK ideograph.
+
+    The gateway error strings are Chinese; a lone shared lead-in such as the
+    ``⚠️`` warning emoji contains none.  Used on flush to distinguish a
+    truncated gateway error (suppress) from an innocuous prefix (emit).
+    """
+    return any(
+        "㐀" <= ch <= "鿿"  # CJK Unified Ideographs (incl. Ext-A)
+        or "豈" <= ch <= "﫿"  # CJK Compatibility Ideographs
+        for ch in text
+    )
 
 
 def is_upstream_error_sentinel(text: str | None) -> bool:
@@ -393,10 +402,13 @@ class StreamingSentinelScrubber:
         out, self._buf = self._buf, ""
         candidate = out.lstrip()
         if (
-            len(candidate) >= _MIN_SUPPRESSED_PREFIX_LEN
+            _contains_cjk(candidate)
             and any(sentinel.startswith(candidate) for sentinel in self._sentinels)
         ):
-            # Stream ended mid-sentinel -- a truncated gateway error.  Suppress.
+            # Stream ended mid-sentinel while still holding a gateway-error
+            # prefix that already contains CJK -- a truncated error.  Suppress
+            # it so no partial Chinese ever reaches the user.  A lone shared
+            # lead-in (e.g. "⚠️") has no CJK and is emitted normally.
             self._matched = True
             return ""
         return out

--- a/surogates/harness/stream_scrubbers.py
+++ b/surogates/harness/stream_scrubbers.py
@@ -2,7 +2,59 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import ClassVar, Final
+
+# ---------------------------------------------------------------------------
+# Upstream-gateway error sentinels
+# ---------------------------------------------------------------------------
+#
+# Some third-party OpenAI-compatible gateways (e.g. yunwu.ai) do not surface an
+# error status when their own upstream returns nothing.  Instead they fabricate
+# a normal-looking chat completion whose ``content`` is a hardcoded error string
+# -- often localized -- and attach ``finish_reason='tool_calls'`` with a bogus
+# tool call.  Because it arrives as ordinary streamed content, it bypasses every
+# empty-response guard and is shown verbatim to the end user.
+#
+# These are the exact strings such gateways emit.  ``StreamingSentinelScrubber``
+# suppresses them mid-stream; ``is_upstream_error_sentinel`` recognises a fully
+# assembled message.  Both are content filters only -- they never alter a
+# genuine model response (see the "must stay green" tests).
+UPSTREAM_ERROR_SENTINELS: Final[tuple[str, ...]] = (
+    # yunwu.ai — "Upstream model returned no content. Possible causes: safety
+    # policy triggered, upstream rate-limited, or the model ended on this
+    # input. Retry or simplify the input."
+    "⚠️ 上游模型未返回任何内容。可能原因：触发了安全策略、上游限流、"
+    "或模型对当前输入直接结束。请重试或简化输入后再试。",
+)
+
+# Distinctive fragments that uniquely identify a gateway error even if the
+# surrounding wording drifts.  Kept long and gateway-specific so they can never
+# collide with legitimate assistant text.
+_UPSTREAM_SENTINEL_MARKERS: Final[tuple[str, ...]] = (
+    "上游模型未返回任何内容",
+)
+
+# On flush, a held buffer that is a proper prefix of a sentinel this long or
+# longer is treated as a truncated gateway error and suppressed.  Short shared
+# prefixes (e.g. a lone "⚠️") fall below the bar and are emitted normally.
+_MIN_SUPPRESSED_PREFIX_LEN: Final[int] = 8
+
+
+def is_upstream_error_sentinel(text: str | None) -> bool:
+    """Return ``True`` if *text* is a known upstream-gateway error string.
+
+    Matches a message that *is* (starts with) a full sentinel, or that contains
+    a distinctive gateway marker.  Used to filter fully assembled messages on
+    both the streaming and non-streaming paths.
+    """
+    if not text:
+        return False
+    stripped = text.strip()
+    if not stripped:
+        return False
+    if any(stripped.startswith(sentinel) for sentinel in UPSTREAM_ERROR_SENTINELS):
+        return True
+    return any(marker in stripped for marker in _UPSTREAM_SENTINEL_MARKERS)
 
 
 class StreamingThinkScrubber:
@@ -268,3 +320,83 @@ class StreamingContextScrubber:
             if tag_lower.startswith(lower[-size:]):
                 return size
         return 0
+
+
+class StreamingSentinelScrubber:
+    """Suppress upstream-gateway error strings without leaking split fragments.
+
+    A gateway error (see :data:`UPSTREAM_ERROR_SENTINELS`) replaces the whole
+    message content, so it always begins at the start of the turn.  This
+    scrubber holds back content only while the accumulated text is still a
+    prefix of a known sentinel:
+
+      * the moment it matches a full sentinel, the turn is flagged
+        (:attr:`matched`) and the rest of the message is swallowed;
+      * the moment it diverges from every sentinel, it flushes the held text
+        and passes everything through verbatim thereafter.
+
+    Because holding stops at the first divergence, a legitimate message pays at
+    most a few characters of buffering (e.g. ``"⚠️ Note: ..."`` diverges from
+    ``"⚠️ 上游..."`` immediately) and is never altered.
+    """
+
+    def __init__(self, sentinels: tuple[str, ...] = UPSTREAM_ERROR_SENTINELS) -> None:
+        self._sentinels: tuple[str, ...] = tuple(sentinels)
+        self._buf = ""
+        self._passthrough = False
+        self._matched = False
+
+    @property
+    def matched(self) -> bool:
+        """Whether the turn's content was a suppressed gateway error string."""
+        return self._matched
+
+    def reset(self) -> None:
+        self._buf = ""
+        self._passthrough = False
+        self._matched = False
+
+    def feed(self, text: str) -> str:
+        if not text:
+            return ""
+        if self._matched:
+            # Whole turn is a gateway error -- swallow any trailing fragments.
+            return ""
+        if self._passthrough:
+            return text
+
+        self._buf += text
+        candidate = self._buf.lstrip()
+        if not candidate:
+            # Only leading whitespace so far -- keep holding; it may precede a
+            # sentinel and will be emitted verbatim on divergence/flush.
+            return ""
+
+        if any(candidate.startswith(sentinel) for sentinel in self._sentinels):
+            self._matched = True
+            self._buf = ""
+            return ""
+
+        if any(sentinel.startswith(candidate) for sentinel in self._sentinels):
+            # Still a proper prefix of some sentinel -- keep holding.
+            return ""
+
+        # Diverged: real content.  Flush the buffer and stop matching.
+        self._passthrough = True
+        out, self._buf = self._buf, ""
+        return out
+
+    def flush(self) -> str:
+        if self._matched:
+            self._buf = ""
+            return ""
+        out, self._buf = self._buf, ""
+        candidate = out.lstrip()
+        if (
+            len(candidate) >= _MIN_SUPPRESSED_PREFIX_LEN
+            and any(sentinel.startswith(candidate) for sentinel in self._sentinels)
+        ):
+            # Stream ended mid-sentinel -- a truncated gateway error.  Suppress.
+            self._matched = True
+            return ""
+        return out

--- a/surogates/harness/stream_scrubbers.py
+++ b/surogates/harness/stream_scrubbers.py
@@ -70,11 +70,13 @@ def is_upstream_error_sentinel(text: str | None) -> bool:
         return False
     if any(stripped.startswith(sentinel) for sentinel in UPSTREAM_ERROR_SENTINELS):
         return True
-    return any(
-        stripped.startswith(marker)
-        or (len(stripped) < _MAX_SENTINEL_MESSAGE_LEN and marker in stripped)
-        for marker in _UPSTREAM_SENTINEL_MARKERS
-    )
+    # A marker counts as a gateway error only when the message is itself
+    # error-shaped -- short and self-contained.  A long reply that opens with or
+    # merely quotes the phrase is real content (see module docstring), so the
+    # length guard applies before any marker check.
+    if len(stripped) >= _MAX_SENTINEL_MESSAGE_LEN:
+        return False
+    return any(marker in stripped for marker in _UPSTREAM_SENTINEL_MARKERS)
 
 
 class StreamingThinkScrubber:
@@ -401,7 +403,15 @@ class StreamingSentinelScrubber:
             # Still a proper prefix of some sentinel -- keep holding.
             return ""
 
-        # Diverged: real content.  Flush the buffer and stop matching.
+        # Diverged from every known sentinel.  If the held text already carries
+        # the distinctive gateway marker (which by construction cannot collide
+        # with legitimate assistant text), this is a drifted gateway error --
+        # suppress it rather than leak the raw CJK.  Otherwise it is real
+        # content: flush the buffer and pass through.
+        if is_upstream_error_sentinel(self._buf):
+            self._matched = True
+            self._buf = ""
+            return ""
         self._passthrough = True
         out, self._buf = self._buf, ""
         return out
@@ -412,14 +422,14 @@ class StreamingSentinelScrubber:
             return ""
         out, self._buf = self._buf, ""
         candidate = out.lstrip()
-        if (
+        # Suppress a drifted error that completed the distinctive marker, or a
+        # stream that ended mid-sentinel while still holding a CJK-bearing prefix
+        # of a known sentinel (a truncated gateway error).  A lone shared lead-in
+        # (e.g. "⚠️") has no CJK / marker and is emitted normally.
+        if is_upstream_error_sentinel(out) or (
             _contains_cjk(candidate)
             and any(sentinel.startswith(candidate) for sentinel in self._sentinels)
         ):
-            # Stream ended mid-sentinel while still holding a gateway-error
-            # prefix that already contains CJK -- a truncated error.  Suppress
-            # it so no partial Chinese ever reaches the user.  A lone shared
-            # lead-in (e.g. "⚠️") has no CJK and is emitted normally.
             self._matched = True
             return ""
         return out

--- a/tests/test_stream_scrubbers.py
+++ b/tests/test_stream_scrubbers.py
@@ -210,6 +210,23 @@ def test_is_upstream_error_sentinel_ignores_legit_text() -> None:
     assert is_upstream_error_sentinel("⚠️ Note: disk almost full") is False
 
 
+def test_is_upstream_error_sentinel_ignores_long_quote_of_marker() -> None:
+    # A long, legitimate reply that merely explains/quotes the gateway phrase
+    # must NOT be suppressed (it is not itself a gateway error).
+    long_legit = (
+        "When the platform routes through a reseller gateway, you may see a "
+        "message like '上游模型未返回任何内容'. Here is what that means and how "
+        "to handle it: " + "the upstream provider returned no content. " * 8
+    )
+    assert len(long_legit) >= 200
+    assert is_upstream_error_sentinel(long_legit) is False
+
+
+def test_is_upstream_error_sentinel_still_matches_short_marker_message() -> None:
+    # A short, self-contained message containing the marker is a gateway error.
+    assert is_upstream_error_sentinel("上游模型未返回任何内容，请稍后重试") is True
+
+
 def test_contains_cjk_detects_sentinel_body_not_emoji() -> None:
     from surogates.harness.stream_scrubbers import _contains_cjk
 

--- a/tests/test_stream_scrubbers.py
+++ b/tests/test_stream_scrubbers.py
@@ -147,7 +147,7 @@ def test_sentinel_scrubber_flushes_lone_emoji() -> None:
 
     visible = _feed_all(scrubber, ["⚠️"])
 
-    # Below the truncation threshold -> a lone emoji is legitimate output.
+    # A lone shared lead-in has no CJK -> it is legitimate output.
     assert visible == "⚠️"
     assert scrubber.matched is False
 
@@ -161,6 +161,28 @@ def test_sentinel_scrubber_suppresses_truncated_sentinel_on_flush() -> None:
 
     assert visible == ""
     assert scrubber.matched is True
+
+
+def test_sentinel_scrubber_suppresses_short_truncated_cjk_prefix() -> None:
+    # Regression: a stream cut just past the emoji into the first CJK chars
+    # (e.g. "⚠️ 上游模") must NOT leak the partial Chinese to the user.
+    scrubber = StreamingSentinelScrubber()
+
+    visible = _feed_all(scrubber, ["⚠️ 上游模"])
+
+    assert visible == ""
+    assert "上游" not in visible
+    assert scrubber.matched is True
+
+
+def test_sentinel_scrubber_emits_short_non_cjk_prefix() -> None:
+    # "⚠️ " (emoji + space) shares the lead-in but has no CJK -> legitimate.
+    scrubber = StreamingSentinelScrubber()
+
+    visible = _feed_all(scrubber, ["⚠️ "])
+
+    assert visible == "⚠️ "
+    assert scrubber.matched is False
 
 
 def test_sentinel_scrubber_emits_text_following_divergence() -> None:
@@ -186,3 +208,13 @@ def test_is_upstream_error_sentinel_ignores_legit_text() -> None:
     assert is_upstream_error_sentinel(None) is False
     assert is_upstream_error_sentinel("Here is your answer.") is False
     assert is_upstream_error_sentinel("⚠️ Note: disk almost full") is False
+
+
+def test_contains_cjk_detects_sentinel_body_not_emoji() -> None:
+    from surogates.harness.stream_scrubbers import _contains_cjk
+
+    assert _contains_cjk("上游模型") is True
+    assert _contains_cjk(_SENTINEL) is True
+    assert _contains_cjk("⚠️") is False
+    assert _contains_cjk("⚠️ Warning: low battery") is False
+    assert _contains_cjk("") is False

--- a/tests/test_stream_scrubbers.py
+++ b/tests/test_stream_scrubbers.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 from surogates.harness.stream_scrubbers import (
+    UPSTREAM_ERROR_SENTINELS,
     StreamingContextScrubber,
+    StreamingSentinelScrubber,
     StreamingThinkScrubber,
+    is_upstream_error_sentinel,
 )
+
+_SENTINEL = UPSTREAM_ERROR_SENTINELS[0]
 
 
 def _feed_all(scrubber, chunks: list[str]) -> str:
@@ -73,3 +78,111 @@ def test_context_scrubber_flushes_false_partial_tag() -> None:
     visible = _feed_all(scrubber, ["Use <memory as a word"])
 
     assert visible == "Use <memory as a word"
+
+
+# ---------------------------------------------------------------------------
+# StreamingSentinelScrubber — suppress upstream-gateway error strings
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_scrubber_suppresses_whole_string_single_chunk() -> None:
+    scrubber = StreamingSentinelScrubber()
+
+    visible = _feed_all(scrubber, [_SENTINEL])
+
+    assert visible == ""
+    assert scrubber.matched is True
+
+
+def test_sentinel_scrubber_suppresses_string_split_across_chunks() -> None:
+    scrubber = StreamingSentinelScrubber()
+    third = len(_SENTINEL) // 3
+    chunks = [_SENTINEL[:third], _SENTINEL[third : 2 * third], _SENTINEL[2 * third :]]
+
+    visible = _feed_all(scrubber, chunks)
+
+    assert visible == ""
+    assert scrubber.matched is True
+
+
+def test_sentinel_scrubber_suppresses_char_by_char() -> None:
+    scrubber = StreamingSentinelScrubber()
+
+    visible = _feed_all(scrubber, list(_SENTINEL))
+
+    assert visible == ""
+    assert scrubber.matched is True
+
+
+def test_sentinel_scrubber_passes_normal_text_untouched() -> None:
+    scrubber = StreamingSentinelScrubber()
+
+    visible = _feed_all(scrubber, ["Here is ", "your answer."])
+
+    assert visible == "Here is your answer."
+    assert scrubber.matched is False
+
+
+def test_sentinel_scrubber_keeps_legit_warning_sharing_emoji_prefix() -> None:
+    scrubber = StreamingSentinelScrubber()
+    legit = "⚠️ Note: the disk is almost full, consider cleanup."
+
+    visible = _feed_all(scrubber, [legit])
+
+    assert visible == legit
+    assert scrubber.matched is False
+
+
+def test_sentinel_scrubber_keeps_legit_warning_split_across_chunks() -> None:
+    scrubber = StreamingSentinelScrubber()
+    # Shares "⚠️ " with the sentinel, then diverges on the next character.
+    visible = _feed_all(scrubber, ["⚠️", " Warn", "ing: low battery"])
+
+    assert visible == "⚠️ Warning: low battery"
+    assert scrubber.matched is False
+
+
+def test_sentinel_scrubber_flushes_lone_emoji() -> None:
+    scrubber = StreamingSentinelScrubber()
+
+    visible = _feed_all(scrubber, ["⚠️"])
+
+    # Below the truncation threshold -> a lone emoji is legitimate output.
+    assert visible == "⚠️"
+    assert scrubber.matched is False
+
+
+def test_sentinel_scrubber_suppresses_truncated_sentinel_on_flush() -> None:
+    scrubber = StreamingSentinelScrubber()
+    # Stream dies partway through the sentinel — still a gateway error.
+    partial = _SENTINEL[: len(_SENTINEL) // 2]
+
+    visible = _feed_all(scrubber, [partial])
+
+    assert visible == ""
+    assert scrubber.matched is True
+
+
+def test_sentinel_scrubber_emits_text_following_divergence() -> None:
+    scrubber = StreamingSentinelScrubber()
+    # Diverges from the sentinel after "⚠️ 上游" -> everything must be emitted.
+    text = "⚠️ 上游 status: all systems normal."
+
+    visible = _feed_all(scrubber, [text])
+
+    assert visible == text
+    assert scrubber.matched is False
+
+
+def test_is_upstream_error_sentinel_matches_full_and_marker() -> None:
+    assert is_upstream_error_sentinel(_SENTINEL) is True
+    assert is_upstream_error_sentinel("  " + _SENTINEL + "\n") is True
+    # Distinctive marker embedded in a slightly different wrapper.
+    assert is_upstream_error_sentinel("提示：上游模型未返回任何内容，请重试") is True
+
+
+def test_is_upstream_error_sentinel_ignores_legit_text() -> None:
+    assert is_upstream_error_sentinel("") is False
+    assert is_upstream_error_sentinel(None) is False
+    assert is_upstream_error_sentinel("Here is your answer.") is False
+    assert is_upstream_error_sentinel("⚠️ Note: disk almost full") is False

--- a/tests/test_stream_scrubbers.py
+++ b/tests/test_stream_scrubbers.py
@@ -235,3 +235,39 @@ def test_contains_cjk_detects_sentinel_body_not_emoji() -> None:
     assert _contains_cjk("⚠️") is False
     assert _contains_cjk("⚠️ Warning: low battery") is False
     assert _contains_cjk("") is False
+
+
+def test_is_upstream_error_sentinel_ignores_long_reply_starting_with_marker() -> None:
+    # A long legitimate reply that OPENS with the marker phrase is real content,
+    # not a gateway error -- the module docstring promises exactly this, but the
+    # unguarded ``startswith(marker)`` branch used to blank it.
+    long_reply = (
+        "上游模型未返回任何内容 is the exact phrase this reseller gateway emits "
+        "when its own upstream fails. Here is a full explanation of the cause "
+        "and how to handle it in production: " + "detail. " * 20
+    )
+    assert len(long_reply) >= 200
+    assert is_upstream_error_sentinel(long_reply) is False
+
+
+def test_sentinel_scrubber_suppresses_drifted_wording_keeping_marker() -> None:
+    # The gateway keeps its distinctive marker but drifts the surrounding
+    # wording; the streaming path must suppress it, not leak raw CJK.
+    scrubber = StreamingSentinelScrubber()
+    drifted = "⚠️ 上游模型未返回任何内容，请稍后重试或更换模型。"
+
+    visible = _feed_all(scrubber, [drifted])
+
+    assert "上游模型" not in visible
+    assert scrubber.matched is True
+
+
+def test_sentinel_scrubber_suppresses_drifted_variant_split_across_chunks() -> None:
+    scrubber = StreamingSentinelScrubber()
+    # Marker completes across chunks, then the trailing wording drifts.
+    chunks = ["⚠️ 上游模型未返回", "任何内容，请稍后重试。"]
+
+    visible = _feed_all(scrubber, chunks)
+
+    assert "上游模型" not in visible
+    assert scrubber.matched is True

--- a/tests/test_upstream_error_sentinel.py
+++ b/tests/test_upstream_error_sentinel.py
@@ -401,3 +401,49 @@ class TestRetryRoutingOnSentinel:
 
         assert msg["content"] == "recovered"
         assert streaming_mock.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Safety: what the user actually sees in the worst case (all retries fail)
+# ---------------------------------------------------------------------------
+
+
+def _has_cjk(text: str) -> bool:
+    return any("一" <= ch <= "鿿" for ch in text)
+
+
+class TestTerminalErrorIsSafe:
+    async def test_exhausted_retries_surface_clean_english_error(self) -> None:
+        """When every attempt is a sentinel and there is no fallback, the error
+        that reaches the user is a fixed English classification -- never the
+        raw Chinese string."""
+        from surogates.harness.error_classify import classify_harness_error
+
+        activate_fallback = MagicMock(return_value=False)
+        get_current_model = MagicMock(return_value=None)
+
+        raised: Exception | None = None
+        try:
+            await _run_with_retry(
+                stream_side_effect=[_SENTINEL_RESULT] * 5,
+                activate_fallback=activate_fallback,
+                get_current_model=get_current_model,
+            )
+        except Exception as exc:  # noqa: BLE001 - asserting on the surfaced error
+            raised = exc
+
+        assert raised is not None
+        # The exception message itself carries no gateway text.
+        assert not _has_cjk(str(raised)), "raw CJK leaked into the raised error"
+
+        # This is exactly what the loop feeds to the user-facing crash event.
+        info = classify_harness_error(raised)
+        assert info.category == "invalid_response"
+        assert info.title == "The model returned an empty or malformed response."
+        assert not _has_cjk(info.title)
+        assert not _has_cjk(info.detail)
+        assert info.retryable is True
+
+    def test_sentinel_itself_would_be_flagged_cjk(self) -> None:
+        """Sanity check the CJK detector actually fires on the gateway string."""
+        assert _has_cjk(SENTINEL) is True

--- a/tests/test_upstream_error_sentinel.py
+++ b/tests/test_upstream_error_sentinel.py
@@ -315,6 +315,25 @@ class TestNonStreamingSentinelGuard:
         assert msg["content"] == "All good."
         assert "upstream_error_sentinel" not in usage
 
+    async def test_structured_list_content_sentinel_blanked(self) -> None:
+        # Content may arrive as a list of blocks (multimodal/structured). The
+        # guard must flatten it (no AttributeError) and still detect the error.
+        response = _non_streaming_response(
+            [{"type": "text", "text": SENTINEL}],
+        )
+        msg, usage = await _run_non_streaming(response)
+
+        assert msg.get("content", "") == ""
+        assert usage.get("upstream_error_sentinel") is True
+
+    async def test_structured_list_content_legit_untouched(self) -> None:
+        content = [{"type": "text", "text": "All good."}]
+        response = _non_streaming_response(content)
+        msg, usage = await _run_non_streaming(response)
+
+        assert msg["content"] == content
+        assert "upstream_error_sentinel" not in usage
+
 
 # ---------------------------------------------------------------------------
 # Retry / failover routing in call_llm_with_retry

--- a/tests/test_upstream_error_sentinel.py
+++ b/tests/test_upstream_error_sentinel.py
@@ -326,17 +326,21 @@ async def _run_with_retry(
     stream_side_effect: Any,
     activate_fallback: Any,
     get_current_model: Any,
+    interrupt_check: Any = None,
+    on_stream_retry: Any = None,
 ):
     from unittest.mock import patch
 
     from surogates.harness.llm_call import call_llm_with_retry
 
+    sleep_mock = AsyncMock()
     with (
         patch(
             "surogates.harness.llm_call.call_llm_streaming",
             AsyncMock(side_effect=stream_side_effect),
         ) as streaming_mock,
-        patch("surogates.harness.llm_call.asyncio.sleep", AsyncMock()),
+        # Patch the interruptible backoff so the retry path uses no real delay.
+        patch("surogates.harness.llm_call.interruptible_sleep", sleep_mock),
     ):
         result = await call_llm_with_retry(
             session=_make_session(),
@@ -345,13 +349,14 @@ async def _run_with_retry(
             llm_client=MagicMock(),
             store=AsyncMock(),
             streaming_enabled=True,
-            interrupt_check=lambda: False,
+            interrupt_check=interrupt_check or (lambda: False),
             rotate_credential=lambda *a, **k: False,
             activate_fallback=activate_fallback,
             get_current_model=get_current_model,
             set_streaming_enabled=lambda _enabled: None,
+            on_stream_retry=on_stream_retry,
         )
-    return result, streaming_mock
+    return result, streaming_mock, sleep_mock
 
 
 _SENTINEL_RESULT = ({"role": "assistant", "content": ""}, {"upstream_error_sentinel": True})
@@ -364,7 +369,7 @@ class TestRetryRoutingOnSentinel:
         activate_fallback = MagicMock(return_value=True)
         get_current_model = MagicMock(return_value="backup-model")
 
-        (msg, _usage), streaming_mock = await _run_with_retry(
+        (msg, _usage), streaming_mock, _sleep = await _run_with_retry(
             stream_side_effect=[_SENTINEL_RESULT, _GOOD_RESULT],
             activate_fallback=activate_fallback,
             get_current_model=get_current_model,
@@ -393,7 +398,7 @@ class TestRetryRoutingOnSentinel:
         activate_fallback = MagicMock(return_value=False)
         get_current_model = MagicMock(return_value=None)
 
-        (msg, _usage), streaming_mock = await _run_with_retry(
+        (msg, _usage), streaming_mock, _sleep = await _run_with_retry(
             stream_side_effect=[_SENTINEL_RESULT, _GOOD_RESULT],
             activate_fallback=activate_fallback,
             get_current_model=get_current_model,
@@ -401,6 +406,44 @@ class TestRetryRoutingOnSentinel:
 
         assert msg["content"] == "recovered"
         assert streaming_mock.await_count == 2
+
+    async def test_in_place_backoff_is_interruptible(self) -> None:
+        """The retry backoff must use the interruptible sleep wired to
+        interrupt_check, so a user Stop is honoured mid-backoff."""
+        activate_fallback = MagicMock(return_value=False)
+        get_current_model = MagicMock(return_value=None)
+        interrupt_check = lambda: False  # noqa: E731
+
+        (msg, _usage), _streaming, sleep_mock = await _run_with_retry(
+            stream_side_effect=[_SENTINEL_RESULT, _GOOD_RESULT],
+            activate_fallback=activate_fallback,
+            get_current_model=get_current_model,
+            interrupt_check=interrupt_check,
+        )
+
+        assert msg["content"] == "recovered"
+        assert sleep_mock.await_count == 1
+        # Second positional arg is the interrupt callback (not a bare sleep).
+        _seconds, passed_interrupt = sleep_mock.await_args.args
+        assert passed_interrupt is interrupt_check
+
+    async def test_sentinel_retry_discards_streaming_executor(self) -> None:
+        """A fabricated turn may dispatch a bogus tool into the executor; the
+        retry must discard it via on_stream_retry before re-issuing."""
+        activate_fallback = MagicMock(return_value=False)
+        get_current_model = MagicMock(return_value=None)
+        fresh_cb = MagicMock()
+        on_stream_retry = MagicMock(return_value=fresh_cb)
+
+        (msg, _usage), _streaming, _sleep = await _run_with_retry(
+            stream_side_effect=[_SENTINEL_RESULT, _GOOD_RESULT],
+            activate_fallback=activate_fallback,
+            get_current_model=get_current_model,
+            on_stream_retry=on_stream_retry,
+        )
+
+        assert msg["content"] == "recovered"
+        assert on_stream_retry.called, "executor was not discarded on sentinel retry"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_upstream_error_sentinel.py
+++ b/tests/test_upstream_error_sentinel.py
@@ -1,0 +1,403 @@
+"""Characterization tests for upstream-gateway error sentinels leaking to users.
+
+Context
+-------
+Prod routes agent LLM traffic through a third-party gateway (yunwu.ai).
+When that gateway's own upstream returns no content, it does **not** return
+an error status -- it fabricates a normal-looking chat completion whose
+``content`` is a hardcoded Chinese error string and attaches a bogus
+tool_call with ``finish_reason='tool_calls'``:
+
+    ⚠️ 上游模型未返回任何内容。可能原因：触发了安全策略、上游限流、
+    或模型对当前输入直接结束。请重试或简化输入后再试。
+
+Because it arrives as ordinary streamed ``content`` (plus a tool call), it
+sails past every existing guard and is streamed live to the end user as an
+``llm.delta`` event and persisted as the assistant message.
+
+These tests pin the behaviour we want:
+  * the sentinel is NEVER emitted to the user as a visible delta, and
+  * it is NOT persisted as assistant content, and the bogus tool call is
+    dropped, so the turn can be retried / failed over,
+while LEGITIMATE content (including a legit "⚠️" warning) is untouched.
+
+The first group is expected to FAIL against current code -- that failure is
+the gap. The "must stay green" group protects functionality: whatever simple
+fix we add must not eat real content.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from surogates.harness.llm_call import call_llm_streaming_inner
+from surogates.harness.stream_scrubbers import (
+    StreamingContextScrubber,
+    StreamingThinkScrubber,
+)
+from surogates.session.events import EventType
+
+# NB: pyproject sets ``asyncio_mode = "auto"`` -- async tests are detected
+# automatically, so no module-level asyncio mark (it would wrongly tag the
+# one synchronous scrubber test below).
+
+
+# The exact string the yunwu.ai gateway injects (observed in prod session
+# 74e8245d-... on 2026-07-06).
+SENTINEL = (
+    "⚠️ 上游模型未返回任何内容。可能原因：触发了安全策略、上游限流、"
+    "或模型对当前输入直接结束。请重试或简化输入后再试。"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes (mirrors tests/test_midstream_interrupt.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_session() -> SimpleNamespace:
+    return SimpleNamespace(id=uuid4(), config={"temperature": 0.7}, model="gpt-4o")
+
+
+def _text_chunk(
+    *,
+    content: str | None = None,
+    finish_reason: str | None = None,
+    role: str | None = None,
+) -> SimpleNamespace:
+    delta = SimpleNamespace(content=content, role=role, tool_calls=None)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=delta, finish_reason=finish_reason)],
+        model="gpt-4o",
+        usage=None,
+    )
+
+
+def _tool_chunk(
+    *,
+    name: str,
+    tool_id: str = "toolu_bdrk_bogus",
+    finish_reason: str | None = None,
+) -> SimpleNamespace:
+    tool_delta = SimpleNamespace(
+        index=0,
+        id=tool_id,
+        function=SimpleNamespace(name=name, arguments="{}"),
+    )
+    delta = SimpleNamespace(content=None, role=None, tool_calls=[tool_delta])
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=delta, finish_reason=finish_reason)],
+        model="gpt-4o",
+        usage=None,
+    )
+
+
+class _FakeStream:
+    def __init__(self, chunks: list[Any]):
+        self._chunks = chunks
+        self._index = 0
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self.closed or self._index >= len(self._chunks):
+            raise StopAsyncIteration
+        chunk = self._chunks[self._index]
+        self._index += 1
+        return chunk
+
+    async def aclose(self):
+        self.closed = True
+
+
+async def _run_stream(chunks: list[Any]) -> tuple[dict[str, Any], dict[str, Any], AsyncMock]:
+    llm_client = MagicMock()
+    llm_client.chat.completions.create = AsyncMock(return_value=_FakeStream(chunks))
+    store = AsyncMock()
+    msg, usage = await call_llm_streaming_inner(
+        session=_make_session(),
+        create_kwargs={"model": "gpt-4o", "messages": []},
+        iteration=1,
+        llm_client=llm_client,
+        store=store,
+        interrupt_check=lambda: False,
+    )
+    return msg, usage, store
+
+
+def _emitted_delta_texts(store: AsyncMock) -> list[str]:
+    """All visible content strings streamed to the user as llm.delta events."""
+    texts: list[str] = []
+    for call in store.emit_event.call_args_list:
+        args = call.args
+        if len(args) < 3:
+            continue
+        event_type = args[1]
+        if event_type not in (EventType.LLM_DELTA, EventType.LLM_DELTA.value):
+            continue
+        payload = args[2]
+        if isinstance(payload, dict) and payload.get("content"):
+            texts.append(payload["content"])
+    return texts
+
+
+# ---------------------------------------------------------------------------
+# THE GAP -- expected to FAIL against current code
+# ---------------------------------------------------------------------------
+
+
+class TestSentinelMustNeverReachTheUser:
+    async def test_sentinel_not_streamed_as_delta_single_chunk(self) -> None:
+        """The Chinese error must never be emitted as a visible delta."""
+        chunks = [
+            _text_chunk(content=SENTINEL, role="assistant"),
+            _tool_chunk(name="browser_get_state"),
+            _text_chunk(finish_reason="tool_calls"),
+        ]
+        _msg, _usage, store = await _run_stream(chunks)
+
+        streamed = "".join(_emitted_delta_texts(store))
+        assert SENTINEL not in streamed, (
+            "gateway error string was streamed live to the user"
+        )
+        assert "上游模型" not in streamed, "raw CJK gateway error leaked to the user"
+
+    async def test_sentinel_not_streamed_when_split_across_chunks(self) -> None:
+        """Splitting the sentinel across deltas must not defeat suppression."""
+        # A naive "== SENTINEL" check on a single delta would miss this.
+        chunks = [
+            _text_chunk(content="⚠️ 上游模型未返回", role="assistant"),
+            _text_chunk(content="任何内容。可能原因：触发了安全策略、上游限流、"),
+            _text_chunk(content="或模型对当前输入直接结束。请重试或简化输入后再试。"),
+            _tool_chunk(name="browser_screenshot"),
+            _text_chunk(finish_reason="tool_calls"),
+        ]
+        _msg, _usage, store = await _run_stream(chunks)
+
+        streamed = "".join(_emitted_delta_texts(store))
+        assert "上游模型" not in streamed, "split gateway error leaked to the user"
+
+    async def test_sentinel_dropped_from_final_message(self) -> None:
+        """The sentinel must not persist as assistant content, and the bogus
+        tool call must be dropped so the turn can retry / fail over."""
+        chunks = [
+            _text_chunk(content=SENTINEL, role="assistant"),
+            _tool_chunk(name="browser_get_state"),
+            _text_chunk(finish_reason="tool_calls"),
+        ]
+        msg, usage, _store = await _run_stream(chunks)
+
+        assert SENTINEL not in (msg.get("content") or ""), (
+            "gateway error persisted as assistant content"
+        )
+        assert not msg.get("tool_calls"), "bogus tool call from error turn was kept"
+        assert usage.get("upstream_error_sentinel") is True, (
+            "turn not flagged as an upstream sentinel for retry/failover"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GUARDRAILS -- must STAY green (fix must not affect real functionality)
+# ---------------------------------------------------------------------------
+
+
+class TestLegitimateContentUnaffected:
+    async def test_normal_content_still_streamed(self) -> None:
+        chunks = [
+            _text_chunk(content="Here is ", role="assistant"),
+            _text_chunk(content="your answer."),
+            _text_chunk(finish_reason="stop"),
+        ]
+        msg, _usage, store = await _run_stream(chunks)
+
+        assert msg["content"] == "Here is your answer."
+        assert "".join(_emitted_delta_texts(store)) == "Here is your answer."
+
+    async def test_legit_warning_emoji_prefix_not_suppressed(self) -> None:
+        """A real ⚠️ warning that merely SHARES the leading emoji must survive."""
+        legit = "⚠️ Note: the disk is almost full, consider cleanup."
+        chunks = [
+            _text_chunk(content=legit, role="assistant"),
+            _text_chunk(finish_reason="stop"),
+        ]
+        msg, _usage, store = await _run_stream(chunks)
+
+        assert msg["content"] == legit
+        assert "".join(_emitted_delta_texts(store)) == legit
+
+    async def test_legit_content_with_tool_call_preserved(self) -> None:
+        chunks = [
+            _text_chunk(content="Let me check that.", role="assistant"),
+            _tool_chunk(name="web_search", finish_reason="tool_calls"),
+        ]
+        msg, _usage, _store = await _run_stream(chunks)
+
+        assert msg["content"] == "Let me check that."
+        assert msg.get("tool_calls"), "legit tool call was dropped"
+
+
+# ---------------------------------------------------------------------------
+# WHY it leaks -- the existing scrubbers do not recognise the sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_existing_scrubbers_pass_the_sentinel_through_unchanged() -> None:
+    """Documents the gap: neither existing scrubber is the fix point.
+
+    The streaming pipeline is
+    ``context_scrubber.feed(think_scrubber.feed(text))`` -- both let the
+    gateway error through verbatim, which is why it reaches the user.
+    """
+    think = StreamingThinkScrubber()
+    context = StreamingContextScrubber()
+    visible = context.feed(think.feed(SENTINEL)) + context.feed(think.flush()) + context.flush()
+    assert visible == SENTINEL  # unchanged -> nothing strips it today
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming path -- the sentinel must never be persisted or returned
+# ---------------------------------------------------------------------------
+
+
+def _non_streaming_response(content: str, *, tool_calls: list[Any] | None = None):
+    message = SimpleNamespace(role="assistant", content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(
+        message=message,
+        finish_reason="tool_calls" if tool_calls else "stop",
+    )
+    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=5)
+    return SimpleNamespace(choices=[choice], usage=usage, model="claude-opus-4-8")
+
+
+async def _run_non_streaming(response: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    from surogates.harness.llm_call import call_llm_non_streaming
+
+    llm_client = MagicMock()
+    llm_client.base_url = "https://yunwu.ai/v1"
+    llm_client.chat.completions.create = AsyncMock(return_value=response)
+    return await call_llm_non_streaming(
+        session=_make_session(),
+        create_kwargs={"model": "claude-opus-4-8", "messages": []},
+        iteration=1,
+        llm_client=llm_client,
+        store=None,
+    )
+
+
+class TestNonStreamingSentinelGuard:
+    async def test_sentinel_blanked_and_flagged(self) -> None:
+        response = _non_streaming_response(
+            SENTINEL,
+            tool_calls=[
+                {
+                    "id": "toolu_bdrk_bogus",
+                    "type": "function",
+                    "function": {"name": "browser_get_state", "arguments": "{}"},
+                }
+            ],
+        )
+        msg, usage = await _run_non_streaming(response)
+
+        assert msg.get("content", "") == ""
+        assert not msg.get("tool_calls")
+        assert usage.get("upstream_error_sentinel") is True
+
+    async def test_legit_content_untouched(self) -> None:
+        msg, usage = await _run_non_streaming(_non_streaming_response("All good."))
+
+        assert msg["content"] == "All good."
+        assert "upstream_error_sentinel" not in usage
+
+
+# ---------------------------------------------------------------------------
+# Retry / failover routing in call_llm_with_retry
+# ---------------------------------------------------------------------------
+
+
+async def _run_with_retry(
+    *,
+    stream_side_effect: Any,
+    activate_fallback: Any,
+    get_current_model: Any,
+):
+    from unittest.mock import patch
+
+    from surogates.harness.llm_call import call_llm_with_retry
+
+    with (
+        patch(
+            "surogates.harness.llm_call.call_llm_streaming",
+            AsyncMock(side_effect=stream_side_effect),
+        ) as streaming_mock,
+        patch("surogates.harness.llm_call.asyncio.sleep", AsyncMock()),
+    ):
+        result = await call_llm_with_retry(
+            session=_make_session(),
+            create_kwargs={"model": "claude-opus-4-8", "messages": []},
+            iteration=1,
+            llm_client=MagicMock(),
+            store=AsyncMock(),
+            streaming_enabled=True,
+            interrupt_check=lambda: False,
+            rotate_credential=lambda *a, **k: False,
+            activate_fallback=activate_fallback,
+            get_current_model=get_current_model,
+            set_streaming_enabled=lambda _enabled: None,
+        )
+    return result, streaming_mock
+
+
+_SENTINEL_RESULT = ({"role": "assistant", "content": ""}, {"upstream_error_sentinel": True})
+_GOOD_RESULT = ({"role": "assistant", "content": "recovered"}, {})
+
+
+class TestRetryRoutingOnSentinel:
+    async def test_fails_over_to_backup_provider(self) -> None:
+        """A sentinel with a fallback available switches provider and retries."""
+        activate_fallback = MagicMock(return_value=True)
+        get_current_model = MagicMock(return_value="backup-model")
+
+        (msg, _usage), streaming_mock = await _run_with_retry(
+            stream_side_effect=[_SENTINEL_RESULT, _GOOD_RESULT],
+            activate_fallback=activate_fallback,
+            get_current_model=get_current_model,
+        )
+
+        assert msg["content"] == "recovered"
+        assert activate_fallback.called
+        assert streaming_mock.await_count == 2
+
+    async def test_retries_in_place_then_raises_when_no_fallback(self) -> None:
+        """No fallback: retry up to the cap, then surface an empty-response
+        error (never the Chinese sentinel)."""
+        activate_fallback = MagicMock(return_value=False)
+        get_current_model = MagicMock(return_value=None)
+
+        with pytest.raises(ValueError, match="empty response"):
+            await _run_with_retry(
+                stream_side_effect=[_SENTINEL_RESULT] * 5,
+                activate_fallback=activate_fallback,
+                get_current_model=get_current_model,
+            )
+
+    async def test_recovers_in_place_without_fallback(self) -> None:
+        """No fallback but the gateway clears on the next attempt -> success,
+        transparent to the user."""
+        activate_fallback = MagicMock(return_value=False)
+        get_current_model = MagicMock(return_value=None)
+
+        (msg, _usage), streaming_mock = await _run_with_retry(
+            stream_side_effect=[_SENTINEL_RESULT, _GOOD_RESULT],
+            activate_fallback=activate_fallback,
+            get_current_model=get_current_model,
+        )
+
+        assert msg["content"] == "recovered"
+        assert streaming_mock.await_count == 2


### PR DESCRIPTION
## Problem

Agents occasionally emitted a Chinese error string to end users, e.g.:

> ⚠️ 上游模型未返回任何内容。可能原因：触发了安全策略、上游限流、或模型对当前输入直接结束。请重试或简化输入后再试。

**Root cause (not in our code).** Prod routes LLM traffic through a third-party gateway (`yunwu.ai`). When that gateway's own upstream returns no content, it does **not** return an error status — it fabricates a normal-looking chat completion whose `content` is a hardcoded Chinese error string, with `finish_reason='tool_calls'` and a bogus tool call. Because it arrives as ordinary streamed content, it sailed past every existing guard (empty-response retry, runaway-reasoning, failover): the text was streamed live to the user as an `llm.delta`, persisted as the assistant message, and the fabricated tool was executed. Verified against a prod session; the string is **not** in any repo (zero CJK across the codebase) and is **not** produced by the model.

## Fix (harness-side, gateway-agnostic)

A content filter for known upstream-gateway error sentinels, in `surogates/harness/`:

- **`StreamingSentinelScrubber`** (`stream_scrubbers.py`) — buffers content that is a prefix of a known sentinel and **never emits it as a live `llm.delta`**. Legitimate content (including a real `⚠️` warning) diverges immediately and is passed through byte-for-byte. Truncated/interrupted streams are suppressed by CJK content, so no partial Chinese can leak either.
- **`is_upstream_error_sentinel`** — guards the non-streaming path; flattens structured/list content first and only matches error-shaped messages (start-anchored, or short + contains a distinctive marker) so a long legit reply quoting the phrase is untouched.
- On a match: blank the content, drop the fabricated tool calls (and skip notifying the streaming tool executor), flag `usage`.
- **`call_llm_with_retry`** treats a flagged turn as an empty upstream response: fail over to a backup provider if configured, otherwise retry in place with interruptible backoff (the fault is transient), then surface the standard English `invalid_response` classification — never the raw string.

## What the user sees now

- **Common case (retry recovers):** nothing of the error; the real answer streams after a brief delay. (This is what happened in the observed prod session — the gateway recovered on the next attempt.)
- **Fallback configured:** real answer from the backup provider.
- **Worst case (all retries exhausted, no fallback):** the platform's existing, fixed English message — *"The model returned an empty or malformed response."* — never any CJK, full or partial (asserted by test).

## Review passes

This branch went through `/code-review` (high effort) and `/simplify`:

- **4 correctness gaps** found and fixed with regression tests: truncated-CJK flush leak, non-interruptible backoff, streaming-executor race/reset, and (from the PR bot) an `AttributeError` on structured content.
- **Marker false-positive** tightened to error-shaped messages only (PR bot, medium).
- **Simplification:** removed dead `usage_data` pops. Skipped (noted) low-value churn: retry-block dedup (follows an idiom used ~5× in this file), scrubber state→enum, and an O(n²) lstrip that only bites a pathological all-whitespace stream.

## Tests

New `tests/test_upstream_error_sentinel.py` + additions to `tests/test_stream_scrubbers.py` — covering streaming/non-streaming suppression, split/truncated/char-by-char sentinels, structured-list content, guardrails that legit content (incl. `⚠️` warnings and long quotes) is never altered, retry/failover routing, interruptible backoff, executor reset, and the worst-case error carrying no CJK. **~40 sentinel/scrubber tests + full LLM/streaming regression suite green (115 passing), no regressions.**

## Notes

- Scoped to `surogates`; does not touch the gateway or ops config. Switching `base_llm` off the reseller is a separate ops decision (also relevant for prompt-cache control).
- New gateway sentinels are a one-line addition to `UPSTREAM_ERROR_SENTINELS`.