### PR TITLE
feat(harness): render page-aware copilot view-context note (#213)

### DIFF
--- a/surogates/harness/loop_messages.py
+++ b/surogates/harness/loop_messages.py
@@ -55,15 +55,26 @@ def _initial_system_message(system_prompt: str, browser_pause_notice: str | None
 def _view_context_note_from_metadata(metadata: Any) -> str | None:
     """Pure helper: render the view-context note from a metadata dict.
 
+    The Platform Copilot attaches a ``view_context`` describing the Studio
+    page the user is looking at. The current shape carries ``page`` plus a
+    ``docPath`` (the product-doc that explains that screen) and an optional
+    ``resource``; older Studio builds send a flat ``{kind, id, name}`` — both
+    are rendered so a version skew never drops the note.
+
     Returns ``None`` when *metadata* is missing, not a dict, lacks
-    ``view_context``, or the inner ``view_context`` payload is malformed
-    (not a dict, missing ``kind``/``id``).
+    ``view_context``, or the payload is malformed.
     """
     if not isinstance(metadata, dict):
         return None
     view_context = metadata.get("view_context")
     if not isinstance(view_context, dict):
         return None
+
+    # Current shape: a page descriptor with the doc that explains it.
+    if view_context.get("page"):
+        return _page_view_context_note(view_context)
+
+    # Backward-compatible flat resource shape.
     kind = view_context.get("kind")
     target_id = view_context.get("id")
     if not kind or not target_id:
@@ -72,7 +83,32 @@ def _view_context_note_from_metadata(metadata: Any) -> str | None:
     name = view_context.get("name")
     if name:
         note += f" ({name})"
+    return note + "."
+
+
+def _page_view_context_note(view_context: dict[str, Any]) -> str:
+    """Render the page-descriptor form of a ``view_context`` payload."""
+    note = f"The user is currently on the **{view_context.get('page')}** page"
+    mode = view_context.get("mode")
+    if mode:
+        note += f" ({mode} mode)"
+    tab = view_context.get("tab")
+    if tab:
+        note += f' on the "{tab}" tab'
     note += "."
+
+    doc_path = view_context.get("docPath")
+    if doc_path:
+        note += (
+            " To explain this page, its settings, or concepts, read its "
+            f'documentation: call read_doc("{doc_path}").'
+        )
+
+    resource = view_context.get("resource")
+    if isinstance(resource, dict) and resource.get("kind") and resource.get("id"):
+        name = resource.get("name")
+        named = f' "{name}"' if name else ""
+        note += f" They are viewing {resource['kind']}{named} (id {resource['id']})."
     return note
 
 

--- a/tests/test_user_message_metadata.py
+++ b/tests/test_user_message_metadata.py
@@ -365,3 +365,65 @@ def test_view_context_note_skips_non_user_events_when_searching():
         _view_context_note(events)
         == "The user is currently viewing **training_run** tr_77 (Pretrain epoch 3)."
     )
+
+
+def test_view_context_note_renders_page_with_doc_and_resource():
+    events = [
+        _user_event(
+            {
+                "metadata": {
+                    "view_context": {
+                        "mode": "develop",
+                        "page": "Models",
+                        "docPath": "develop/features/models",
+                        "resource": {
+                            "kind": "model",
+                            "id": "m-9",
+                            "name": "llama-3b",
+                        },
+                    }
+                }
+            }
+        ),
+    ]
+    note = _view_context_note(events)
+    assert note == (
+        "The user is currently on the **Models** page (develop mode). "
+        "To explain this page, its settings, or concepts, read its "
+        'documentation: call read_doc("develop/features/models"). '
+        'They are viewing model "llama-3b" (id m-9).'
+    )
+
+
+def test_view_context_note_page_without_doc_omits_read_doc():
+    events = [
+        _user_event(
+            {"metadata": {"view_context": {"mode": "develop", "page": "Experts", "docPath": None}}}
+        ),
+    ]
+    assert (
+        _view_context_note(events)
+        == "The user is currently on the **Experts** page (develop mode)."
+    )
+
+
+def test_view_context_note_page_includes_tab():
+    events = [
+        _user_event(
+            {
+                "metadata": {
+                    "view_context": {
+                        "mode": "work",
+                        "page": "Configure agent",
+                        "docPath": "work/workflow/configure-agent",
+                        "tab": "governance",
+                        "resource": {"kind": "agent", "id": "agt_1"},
+                    }
+                }
+            }
+        ),
+    ]
+    note = _view_context_note(events)
+    assert 'on the "governance" tab.' in note
+    assert 'read_doc("work/workflow/configure-agent")' in note
+    assert "They are viewing agent (id agt_1)." in note


### PR DESCRIPTION
Companion to invergent-ai/surogate-ops#218 for issue invergent-ai/surogate-ops#213 — *"the copilot must know the page you're in and access the product documentation."*

## What this changes

The Platform Copilot now sends a **page descriptor** in each message's `view_context` (`{ mode, page, docPath, tab?, resource? }`) instead of a flat resource. This updates the harness note that folds `view_context` into the turn so it tells the copilot which page the user is on and to read that page's product doc.

`surogates/harness/loop_messages.py` — `_view_context_note_from_metadata` renders, e.g.:

> The user is currently on the **Models** page (develop mode). To explain this page, its settings, or concepts, read its documentation: call `read_doc("develop/features/models")`. They are viewing model "llama-3b" (id m-9).

The older flat `{kind, id, name}` shape is still rendered, so a frontend/harness version skew never drops the note.

## Testing
- `tests/test_user_message_metadata.py` — new cases for the page shape (doc + resource, no-doc page, tab); existing flat-shape cases unchanged.
- Harness note + attachment-note + module-boundary suites pass.

The `read_doc(...)` tool the note points at is added in surogate-ops#218.