### PR TITLE
feat(website): enforce agent monetization on the widget channel

### DIFF
--- a/sdk/website-widget/src/agent.ts
+++ b/sdk/website-widget/src/agent.ts
@@ -291,6 +291,16 @@ export class WebsiteAgent extends AbstractAgent {
           code: err.code,
           ...(err.buyUrl !== undefined && { buyUrl: err.buyUrl }),
         };
+        if (err.code === 'sign_in_required') {
+          // The buyer identity binds at bootstrap, and this session
+          // bootstrapped anonymously. Drop it so the next send
+          // re-bootstraps — picking up whatever token
+          // getFirebaseIdToken returns after the visitor signs in —
+          // instead of paywalling a signed-in customer until a full
+          // page reload.
+          this.bootstrapResult = undefined;
+          this.cursor = 0;
+        }
       }
       subscriber.next({
         type: EventType.RUN_ERROR,

--- a/sdk/website-widget/src/agent.ts
+++ b/sdk/website-widget/src/agent.ts
@@ -54,7 +54,7 @@ import {
   sendMessage,
 } from './protocol.js';
 import { type SurogatesFrame, Translator } from './translator.js';
-import { SurogatesAuthError } from './errors.js';
+import { SurogatesAuthError, SurogatesPaywallError } from './errors.js';
 import { SURG_EVENT } from './constants.js';
 
 /**
@@ -69,6 +69,21 @@ export interface WebsiteAgentConfig extends AgentConfig {
   apiUrl: string;
   /** Publishable key issued by ops (``surg_wk_...``). */
   publishableKey: string;
+  /**
+   * Supplies the signed-in visitor's Firebase ID token at bootstrap.
+   * Required to chat with monetized agents: sites that authenticate
+   * end users against the agent project's Firebase pass a getter
+   * here, the SDK sends the token with the session bootstrap, and the
+   * server binds the verified buyer identity to the visitor session.
+   * Returning ``null``/``undefined`` (or omitting the hook) keeps the
+   * session anonymous — monetized agents then answer with a
+   * ``sign_in_required`` paywall instead of replies.
+   */
+  getFirebaseIdToken?: () =>
+    | Promise<string | null | undefined>
+    | string
+    | null
+    | undefined;
 }
 
 /** Set of Surogates SSE event names the agent subscribes to by default. */
@@ -90,10 +105,19 @@ export class WebsiteAgent extends AbstractAgent {
   readonly apiUrl: string;
   readonly publishableKey: string;
 
+  /**
+   * Details of the last paywall refusal (RUN_ERROR ``code:
+   * 'paywall'``).  The AG-UI ``RUN_ERROR`` event only carries a
+   * message + code string, so the structured sentinel and buy URL are
+   * exposed here for UIs to read when they receive that code.
+   */
+  lastPaywall: { code: string; buyUrl?: string } | undefined;
+
   /** Cached bootstrap result.  ``undefined`` until the first ``run()``. */
   private bootstrapResult: BootstrapResult | undefined;
   /** Monotonic cursor across runs.  Passed to the SSE ``?after=`` param. */
   private cursor = 0;
+  private readonly getFirebaseIdToken: WebsiteAgentConfig['getFirebaseIdToken'];
 
   constructor(config: WebsiteAgentConfig) {
     super(config);
@@ -106,6 +130,7 @@ export class WebsiteAgent extends AbstractAgent {
     // Strip a trailing slash so ``${apiUrl}/v1/...`` never double-slashes.
     this.apiUrl = config.apiUrl.replace(/\/+$/, '');
     this.publishableKey = config.publishableKey;
+    this.getFirebaseIdToken = config.getFirebaseIdToken;
   }
 
   /**
@@ -119,10 +144,16 @@ export class WebsiteAgent extends AbstractAgent {
    */
   async ensureBootstrapped(): Promise<BootstrapResult> {
     if (this.bootstrapResult) return this.bootstrapResult;
+    // Resolved per bootstrap (not cached) so cookie-expiry recovery
+    // picks up a token the visitor acquired after the first attempt.
+    const firebaseIdToken = this.getFirebaseIdToken
+      ? await this.getFirebaseIdToken()
+      : undefined;
     this.bootstrapResult = await bootstrap(
       this.apiUrl,
       this.publishableKey,
       this.agentId,
+      firebaseIdToken ?? undefined,
     );
     return this.bootstrapResult;
   }
@@ -251,7 +282,16 @@ export class WebsiteAgent extends AbstractAgent {
       if (ctx.terminated) return;
       ctx.terminated = true;
       const message = err instanceof Error ? err.message : String(err);
-      const code = err instanceof SurogatesAuthError ? 'auth' : 'error';
+      let code = 'error';
+      if (err instanceof SurogatesAuthError) {
+        code = 'auth';
+      } else if (err instanceof SurogatesPaywallError) {
+        code = 'paywall';
+        this.lastPaywall = {
+          code: err.code,
+          ...(err.buyUrl !== undefined && { buyUrl: err.buyUrl }),
+        };
+      }
       subscriber.next({
         type: EventType.RUN_ERROR,
         message,

--- a/sdk/website-widget/src/errors.ts
+++ b/sdk/website-widget/src/errors.ts
@@ -80,3 +80,29 @@ export class SurogatesNetworkError extends SurogatesError {
     this.name = 'SurogatesNetworkError';
   }
 }
+
+/**
+ * The agent is monetized and the visitor has no usable entitlement
+ * (HTTP 402).  ``code`` is the machine sentinel from the server --
+ * ``sign_in_required`` (no buyer identity bound to the session),
+ * ``subscription_required``, or ``insufficient_tokens`` -- and
+ * ``buyUrl`` is the hosted buy page where access can be purchased.
+ * Non-retryable until the visitor signs in / buys; the widget renders
+ * it as a paywall panel rather than a generic failure.
+ */
+export class SurogatesPaywallError extends SurogatesError {
+  /** Machine sentinel identifying which gate refused the message. */
+  readonly code: string;
+  /** Hosted buy page for this agent, when the platform exposes one. */
+  readonly buyUrl?: string;
+
+  constructor(
+    message: string,
+    opts: { code: string; buyUrl?: string; detail?: string },
+  ) {
+    super(message, { status: 402, ...(opts.detail !== undefined && { detail: opts.detail }) });
+    this.name = 'SurogatesPaywallError';
+    this.code = opts.code;
+    if (opts.buyUrl !== undefined) this.buyUrl = opts.buyUrl;
+  }
+}

--- a/sdk/website-widget/src/protocol.ts
+++ b/sdk/website-widget/src/protocol.ts
@@ -29,6 +29,7 @@ import {
 import {
   SurogatesAuthError,
   SurogatesNetworkError,
+  SurogatesPaywallError,
   SurogatesProtocolError,
   SurogatesRateLimitError,
 } from './errors.js';
@@ -141,18 +142,34 @@ async function doFetch(
   return response;
 }
 
-/** Pull the ``detail`` string out of the server's error body, best-effort. */
-async function extractDetail(response: Response): Promise<string | undefined> {
+/** Pull the raw ``detail`` value out of the server's error body, best-effort.
+ * Usually a string; the commerce 402 sends a structured object
+ * (``{code, buy_url}``), so callers branch on the runtime type. */
+async function extractDetailValue(response: Response): Promise<unknown> {
   try {
     const body = (await response.json()) as { detail?: unknown };
-    return typeof body.detail === 'string' ? body.detail : undefined;
+    return body?.detail;
   } catch {
     return undefined;
   }
 }
 
 async function raiseForStatus(response: Response, action: string): Promise<never> {
-  const detail = await extractDetail(response);
+  const detailValue = await extractDetailValue(response);
+  const detail = typeof detailValue === 'string' ? detailValue : undefined;
+  if (response.status === 402) {
+    const structured =
+      detailValue && typeof detailValue === 'object'
+        ? (detailValue as { code?: unknown; buy_url?: unknown })
+        : {};
+    const code = typeof structured.code === 'string' ? structured.code : detail || 'payment_required';
+    const buyUrl = typeof structured.buy_url === 'string' ? structured.buy_url : undefined;
+    throw new SurogatesPaywallError(`${action} requires access (402)`, {
+      code,
+      ...(buyUrl !== undefined && { buyUrl }),
+      ...(detail !== undefined && { detail }),
+    });
+  }
   if (response.status === 401 || response.status === 403) {
     throw new SurogatesAuthError(`${action} rejected (${response.status})`, {
       status: response.status,
@@ -198,6 +215,7 @@ export async function bootstrap(
   apiUrl: string,
   publishableKey: string,
   agentId?: string,
+  firebaseIdToken?: string,
 ): Promise<BootstrapResult> {
   const response = await doFetch(apiUrl + withAgentId(PATH_BOOTSTRAP, agentId), {
     method: 'POST',
@@ -205,6 +223,13 @@ export async function bootstrap(
       Authorization: `Bearer ${publishableKey}`,
       'Content-Type': 'application/json',
     },
+    // Binds a signed-in end user to the visitor session — required
+    // before a monetized agent accepts messages.  Anonymous
+    // bootstraps send no body at all, preserving the historical wire
+    // shape byte-for-byte.
+    ...(firebaseIdToken
+      ? { body: JSON.stringify({ firebase_id_token: firebaseIdToken }) }
+      : {}),
   });
   // Accept any 2xx -- the route currently declares 201, but a future
   // server change to 200 (or a proxy that strips the status to 200)

--- a/sdk/website-widget/src/ui/styles.ts
+++ b/sdk/website-widget/src/ui/styles.ts
@@ -178,6 +178,31 @@ export const WIDGET_STYLES = `
   flex-shrink: 0;
 }
 
+.surg-paywall {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0 16px;
+  padding: 12px;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  color: #92400e;
+  border-radius: 10px;
+  font-size: 13px;
+  flex-shrink: 0;
+}
+.surg-paywall-cta {
+  align-self: flex-start;
+  padding: 6px 14px;
+  background: var(--surg-accent, #0f172a);
+  color: #ffffff;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+}
+.surg-paywall-cta:hover { opacity: 0.9; }
+
 .surg-composer {
   display: flex;
   gap: 8px;

--- a/sdk/website-widget/src/ui/widget.tsx
+++ b/sdk/website-widget/src/ui/widget.tsx
@@ -49,6 +49,20 @@ function snapshot(messages: ReadonlyArray<{ id?: string; role?: string; content?
   return out;
 }
 
+/** Visitor-facing copy per paywall sentinel from the server. */
+function paywallCopy(code: string): string {
+  if (code === 'sign_in_required') {
+    return 'This assistant requires an account. Get access, then sign in on this site and reopen the chat.';
+  }
+  if (code === 'subscription_required') {
+    return 'This assistant requires an active subscription.';
+  }
+  if (code === 'insufficient_tokens') {
+    return 'You’re out of tokens for this assistant.';
+  }
+  return 'This assistant requires paid access.';
+}
+
 /** Map an SDK error (thrown or via RUN_ERROR) to visitor-facing copy. */
 function friendlyError(err: { code?: string; message?: string } | unknown): string {
   if (err instanceof SurogatesAuthError) {
@@ -91,6 +105,7 @@ export function Widget({ agent, config, registerOpenControl, onOpenChange }: Wid
   const [messages, setMessages] = useState<ChatMessage[]>(() => snapshot(agent.messages));
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [paywall, setPaywall] = useState<{ code: string; buyUrl?: string } | null>(null);
   const [input, setInput] = useState('');
   // Only the async input is state; the title is derived at render so a
   // configured title (incl. live handle.update()) always wins, falling back
@@ -112,10 +127,16 @@ export function Widget({ agent, config, registerOpenControl, onOpenChange }: Wid
       onRunStartedEvent: () => {
         setRunning(true);
         setError(null);
+        setPaywall(null);
       },
       onRunFinishedEvent: () => setRunning(false),
       onRunErrorEvent: ({ event }) => {
         setRunning(false);
+        const code = (event as { code?: string }).code;
+        if (code === 'paywall') {
+          setPaywall(agent.lastPaywall ?? { code: 'payment_required' });
+          return;
+        }
         setError(friendlyError(event));
       },
     });
@@ -244,6 +265,22 @@ export function Widget({ agent, config, registerOpenControl, onOpenChange }: Wid
       </div>
 
       {error && <div class="surg-error">{error}</div>}
+
+      {paywall && (
+        <div class="surg-paywall">
+          <span>{paywallCopy(paywall.code)}</span>
+          {paywall.buyUrl && (
+            <a
+              class="surg-paywall-cta"
+              href={paywall.buyUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Get access
+            </a>
+          )}
+        </div>
+      )}
 
       <div class="surg-composer">
         <textarea

--- a/sdk/website-widget/src/ui/widget.tsx
+++ b/sdk/website-widget/src/ui/widget.tsx
@@ -49,10 +49,17 @@ function snapshot(messages: ReadonlyArray<{ id?: string; role?: string; content?
   return out;
 }
 
+/** Only render CTA links with a web protocol — the buy URL rides in
+ * from server config, but an SDK running on third-party sites must
+ * not let any upstream compromise turn it into a `javascript:` URI. */
+function safeBuyUrl(url: string | undefined): string | undefined {
+  return url && /^https?:\/\//i.test(url) ? url : undefined;
+}
+
 /** Visitor-facing copy per paywall sentinel from the server. */
 function paywallCopy(code: string): string {
   if (code === 'sign_in_required') {
-    return 'This assistant requires an account. Get access, then sign in on this site and reopen the chat.';
+    return 'This assistant requires an account. Get access, sign in on this site, then send your message again.';
   }
   if (code === 'subscription_required') {
     return 'This assistant requires an active subscription.';
@@ -269,10 +276,10 @@ export function Widget({ agent, config, registerOpenControl, onOpenChange }: Wid
       {paywall && (
         <div class="surg-paywall">
           <span>{paywallCopy(paywall.code)}</span>
-          {paywall.buyUrl && (
+          {safeBuyUrl(paywall.buyUrl) && (
             <a
               class="surg-paywall-cta"
-              href={paywall.buyUrl}
+              href={safeBuyUrl(paywall.buyUrl)}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/sdk/website-widget/tests/paywall.test.ts
+++ b/sdk/website-widget/tests/paywall.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Paywall (HTTP 402) handling across the wire layer and the agent.
+ *
+ * The server refuses monetized-agent messages with a structured 402
+ * detail (``{code, buy_url}``); the SDK must surface it as the typed
+ * :class:`SurogatesPaywallError`, the agent must translate it into a
+ * ``RUN_ERROR`` with ``code: 'paywall'`` and expose the structured
+ * sentinel on ``lastPaywall``, and the bootstrap must carry the
+ * embedder-supplied Firebase ID token.
+ */
+
+import { EventType } from '@ag-ui/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WebsiteAgent } from '../src/agent.js';
+import { SurogatesPaywallError } from '../src/errors.js';
+import { bootstrap, sendMessage } from '../src/protocol.js';
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('protocol 402 handling', () => {
+  it('maps a structured 402 detail to SurogatesPaywallError', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(402, {
+        detail: {
+          code: 'insufficient_tokens',
+          buy_url: 'https://studio.example/buy/helper',
+        },
+      }),
+    ) as unknown as typeof fetch;
+
+    const err = await sendMessage('https://api', 's-1', 'csrf', 'hi').catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(SurogatesPaywallError);
+    const paywall = err as SurogatesPaywallError;
+    expect(paywall.status).toBe(402);
+    expect(paywall.code).toBe('insufficient_tokens');
+    expect(paywall.buyUrl).toBe('https://studio.example/buy/helper');
+  });
+
+  it('maps a plain-string 402 detail to a paywall error too', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(402, { detail: 'subscription_required' }),
+    ) as unknown as typeof fetch;
+
+    const err = await sendMessage('https://api', 's-1', 'csrf', 'hi').catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(SurogatesPaywallError);
+    expect((err as SurogatesPaywallError).code).toBe('subscription_required');
+    expect((err as SurogatesPaywallError).buyUrl).toBeUndefined();
+  });
+
+  it('falls back to payment_required on a bodyless 402', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response('', { status: 402 }),
+    ) as unknown as typeof fetch;
+
+    const err = await sendMessage('https://api', 's-1', 'csrf', 'hi').catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(SurogatesPaywallError);
+    expect((err as SurogatesPaywallError).code).toBe('payment_required');
+  });
+});
+
+describe('bootstrap firebase token pass-through', () => {
+  const bootBody = {
+    session_id: 's-1',
+    csrf_token: 'csrf',
+    expires_at: 123,
+    agent_name: 'helper',
+  };
+
+  it('sends the token as the bootstrap body when supplied', async () => {
+    const fetchMock = vi.fn(
+      async (_url: unknown, _init?: RequestInit) => jsonResponse(201, bootBody),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await bootstrap('https://api', 'surg_wk_k', undefined, 'fb-id-token');
+
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(JSON.parse(String(init?.body))).toEqual({
+      firebase_id_token: 'fb-id-token',
+    });
+  });
+
+  it('sends no body at all for anonymous bootstraps', async () => {
+    const fetchMock = vi.fn(
+      async (_url: unknown, _init?: RequestInit) => jsonResponse(201, bootBody),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await bootstrap('https://api', 'surg_wk_k');
+
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(init?.body).toBeUndefined();
+  });
+});
+
+describe('WebsiteAgent paywall run flow', () => {
+  beforeEach(() => {
+    // The agent opens an SSE stream before sending; a inert stub keeps
+    // the run driving into sendMessage where the 402 fires.
+    class StubEventSource {
+      onmessage: unknown = null;
+      onerror: unknown = null;
+      constructor(public url: string) {}
+      addEventListener() {}
+      close() {}
+    }
+    vi.stubGlobal('EventSource', StubEventSource);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('emits RUN_ERROR code paywall and records lastPaywall', async () => {
+    const bootBody = {
+      session_id: 's-1',
+      csrf_token: 'csrf',
+      expires_at: 123,
+      agent_name: 'helper',
+    };
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      if (String(url).includes('/messages')) {
+        return jsonResponse(402, {
+          detail: {
+            code: 'sign_in_required',
+            buy_url: 'https://studio.example/buy/helper',
+          },
+        });
+      }
+      return jsonResponse(201, bootBody);
+    }) as unknown as typeof fetch;
+
+    const agent = new WebsiteAgent({
+      apiUrl: 'https://api',
+      publishableKey: 'surg_wk_k',
+      getFirebaseIdToken: () => null,
+    });
+
+    const events: Array<{ type: string; code?: string }> = [];
+    await new Promise<void>((resolve) => {
+      agent
+        .run({
+          threadId: 't-1',
+          runId: 'r-1',
+          messages: [{ id: 'm-1', role: 'user', content: 'hi' }],
+          state: {},
+          tools: [],
+          context: [],
+          forwardedProps: {},
+        })
+        .subscribe({
+          next: (event) => events.push(event as { type: string; code?: string }),
+          error: () => resolve(),
+          complete: () => resolve(),
+        });
+    });
+
+    const runError = events.find((e) => e.type === EventType.RUN_ERROR);
+    expect(runError).toBeDefined();
+    expect(runError?.code).toBe('paywall');
+    expect(agent.lastPaywall).toEqual({
+      code: 'sign_in_required',
+      buyUrl: 'https://studio.example/buy/helper',
+    });
+  });
+});

--- a/sdk/website-widget/tests/paywall.test.ts
+++ b/sdk/website-widget/tests/paywall.test.ts
@@ -182,4 +182,53 @@ describe('WebsiteAgent paywall run flow', () => {
       buyUrl: 'https://studio.example/buy/helper',
     });
   });
+
+  it('drops the cached anonymous session on sign_in_required so the next send re-bootstraps with a token', async () => {
+    const bootBody = {
+      session_id: 's-1',
+      csrf_token: 'csrf',
+      expires_at: 123,
+      agent_name: 'helper',
+    };
+    const bootstrapBodies: Array<string | undefined> = [];
+    globalThis.fetch = vi.fn(async (url: unknown, init?: RequestInit) => {
+      if (String(url).includes('/messages')) {
+        return jsonResponse(402, { detail: { code: 'sign_in_required' } });
+      }
+      bootstrapBodies.push(init?.body ? String(init.body) : undefined);
+      return jsonResponse(201, bootBody);
+    }) as unknown as typeof fetch;
+
+    let token: string | null = null;
+    const agent = new WebsiteAgent({
+      apiUrl: 'https://api',
+      publishableKey: 'surg_wk_k',
+      getFirebaseIdToken: () => token,
+    });
+
+    const runOnce = () =>
+      new Promise<void>((resolve) => {
+        agent
+          .run({
+            threadId: 't-1',
+            runId: 'r-1',
+            messages: [{ id: 'm-1', role: 'user', content: 'hi' }],
+            state: {},
+            tools: [],
+            context: [],
+            forwardedProps: {},
+          })
+          .subscribe({ error: () => resolve(), complete: () => resolve() });
+      });
+
+    await runOnce();
+    expect(bootstrapBodies).toEqual([undefined]);
+
+    token = 'fb-token';
+    await runOnce();
+    expect(bootstrapBodies).toHaveLength(2);
+    expect(JSON.parse(String(bootstrapBodies[1]))).toEqual({
+      firebase_id_token: 'fb-token',
+    });
+  });
 });

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -62,9 +62,17 @@ from surogates.channels.website_session import (
     verify_csrf_token,
 )
 from surogates.config import Settings, enqueue_session
+from surogates.runtime.platform_client import (
+    CommercePaymentRequiredError,
+    PlatformAuthError,
+)
 from surogates.session.events import EventType
 from surogates.session.store import SessionNotFoundError, SessionStore
 from surogates.storage.tenant import agent_session_bucket
+from surogates.tenant.auth.firebase import (
+    FirebaseTokenError,
+    verify_firebase_id_token,
+)
 from surogates.tenant.auth.jwt import InvalidTokenError
 
 logger = logging.getLogger(__name__)
@@ -106,6 +114,20 @@ class BootstrapResponse(BaseModel):
     csrf_token: str
     expires_at: int
     agent_name: str
+
+
+class BootstrapRequest(BaseModel):
+    """Optional bootstrap body.
+
+    ``firebase_id_token`` binds a signed-in end user to the visitor
+    session — required before a monetized agent will accept messages.
+    The embedding site supplies it via the widget's
+    ``getFirebaseIdToken`` hook (same Firebase project the agent's
+    self-registration and hosted buy page use). Anonymous bootstraps
+    (no body) keep working unchanged for free agents.
+    """
+
+    firebase_id_token: str | None = None
 
 
 class SendMessageRequest(BaseModel):
@@ -356,6 +378,148 @@ async def _enforce_website_rate_limit(
         )
 
 
+# ---------------------------------------------------------------------------
+# Commerce enforcement (monetized agents)
+# ---------------------------------------------------------------------------
+
+
+def _estimate_turn_tokens(content: str) -> int:
+    """~4-chars/token heuristic, matching what ops reserves for the
+    hosted buy page so a visitor's hold is the same either way."""
+    return len(content) // 4 + 16
+
+
+async def _resolve_commerce_buyer(
+    request: Request, agent_id: str, firebase_id_token: str,
+) -> dict:
+    """Verify a visitor-supplied Firebase ID token and return the buyer
+    identity to pin on the session.
+
+    Verification runs against the agent project's own Firebase (the
+    same one the buy page and self-registration use), so the returned
+    ``firebase_uid`` IS the buyer identity ops meters against.
+    """
+    runtime_cache = getattr(request.app.state, "runtime_config_cache", None)
+    firebase_cache = getattr(request.app.state, "firebase_config_cache", None)
+    payload: dict = {}
+    if runtime_cache is not None:
+        try:
+            payload = await runtime_cache.get(agent_id) or {}
+        except LookupError:
+            payload = {}
+    project_id = payload.get("project_id")
+    fb = None
+    if firebase_cache is not None and project_id:
+        try:
+            fb = await firebase_cache.get(project_id)
+        except LookupError:
+            fb = None
+    if fb is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=(
+                "Sign-in is not available for this agent "
+                "(no Firebase auth configured)."
+            ),
+        )
+    try:
+        claims = await verify_firebase_id_token(
+            firebase_id_token, fb.firebase_project_id,
+        )
+    except FirebaseTokenError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc),
+        ) from exc
+    subject = claims.get("sub")
+    if not isinstance(subject, str) or not subject:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Firebase token subject is missing.",
+        )
+    email = claims.get("email")
+    name = claims.get("name")
+    return {
+        "firebase_uid": subject,
+        "email": email if isinstance(email, str) and email else None,
+        "name": name if isinstance(name, str) and name else None,
+    }
+
+
+async def _authorize_commerce_turn(
+    request: Request, session, content: str,
+) -> None:
+    """Gate one visitor message behind the agent's monetization mode.
+
+    Free agents (the default, and every agent while the platform's
+    commerce rollout flag is off — ops reports them as free) return
+    immediately.  Monetized agents require a session-bound buyer
+    identity and a successful ops-side token reservation; the receipt
+    is pinned on ``session.config`` for the worker to settle after the
+    turn.  402 details are structured (``{"code", "buy_url"}``) so the
+    widget can render a paywall instead of a generic error.
+    """
+    runtime_cache = getattr(request.app.state, "runtime_config_cache", None)
+    if runtime_cache is None:
+        return
+    try:
+        payload = await runtime_cache.get(str(session.agent_id)) or {}
+    except LookupError:
+        return
+    mode = str(payload.get("commerce_mode") or "free")
+    if mode == "free":
+        return
+    buy_url = payload.get("commerce_buy_url")
+    buyer = (session.config or {}).get("commerce_buyer") or {}
+    if not buyer.get("firebase_uid"):
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={"code": "sign_in_required", "buy_url": buy_url},
+        )
+    client = getattr(request.app.state, "platform_client", None)
+    if client is None:
+        logger.error("platform_client is not wired on app.state")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Access checks are temporarily unavailable; try again.",
+        )
+    try:
+        receipt = await client.commerce_authorize(
+            str(session.agent_id),
+            firebase_uid=buyer["firebase_uid"],
+            estimated_tokens=_estimate_turn_tokens(content),
+            email=buyer.get("email"),
+            name=buyer.get("name"),
+        )
+    except CommercePaymentRequiredError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={"code": exc.detail, "buy_url": buy_url},
+        ) from exc
+    except Exception as exc:
+        # Fail closed: a paid agent must not serve free turns because
+        # the metering plane blinked.
+        logger.error(
+            "Commerce authorization failed for session %s: %s",
+            session.id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Access checks are temporarily unavailable; try again.",
+        ) from exc
+    if receipt.get("entitlement_id"):
+        store = _get_session_store(request)
+        await store.update_session_config_key(
+            session.id,
+            "commerce_reservation",
+            {
+                "entitlement_id": receipt["entitlement_id"],
+                "reserved_tokens": int(receipt.get("reserved_tokens") or 0),
+                "reservation_id": receipt.get("reservation_id") or "",
+            },
+        )
+
+
 @router.post(
     "/website/sessions",
     response_model=BootstrapResponse,
@@ -364,6 +528,7 @@ async def _enforce_website_rate_limit(
 async def bootstrap_website_session(
     request: Request,
     response: Response,
+    body: BootstrapRequest | None = None,
 ) -> BootstrapResponse:
     """Exchange a publishable key + approved origin for a session cookie.
 
@@ -425,6 +590,14 @@ async def bootstrap_website_session(
     # knob while the session is in flight.
     if settings.website.session_message_cap:
         config["session_message_cap"] = settings.website.session_message_cap
+
+    # Server-verified buyer identity, pinned at bootstrap so every
+    # later message inherits it from the session row rather than
+    # re-verifying a client-supplied token per message.
+    if body is not None and body.firebase_id_token:
+        config["commerce_buyer"] = await _resolve_commerce_buyer(
+            request, agent_id, body.firebase_id_token,
+        )
 
     session = await store.create_session(
         session_id=session_id,
@@ -534,6 +707,8 @@ async def send_website_message(
                 "Session message cap reached; bootstrap a new session to continue."
             ),
         )
+
+    await _authorize_commerce_turn(request, session, body.content)
 
     if session.status in ("failed", "paused", "completed"):
         await store.update_session_status(session_id, "active")

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -384,21 +384,38 @@ async def _enforce_website_rate_limit(
 
 
 def _estimate_turn_tokens(content: str) -> int:
-    """~4-chars/token heuristic, matching what ops reserves for the
-    hosted buy page so a visitor's hold is the same either way."""
-    return len(content) // 4 + 16
+    """~4-chars/token heuristic — the same shape ops's
+    estimate_prompt_tokens computes for the hosted buy page
+    ((chars + 16) // 4 with the per-message framing overhead), so a
+    visitor's hold is the same through either surface."""
+    return (len(content) + 16) // 4
 
 
 async def _resolve_commerce_buyer(
     request: Request, agent_id: str, firebase_id_token: str,
-) -> dict:
+) -> dict | None:
     """Verify a visitor-supplied Firebase ID token and return the buyer
-    identity to pin on the session.
+    identity to pin on the session, or ``None`` when no identity can
+    be bound.
 
     Verification runs against the agent project's own Firebase (the
     same one the buy page and self-registration use), so the returned
-    ``firebase_uid`` IS the buyer identity ops meters against.
+    ``firebase_uid`` IS the buyer identity ops meters against. Claim
+    normalisation is shared with the ``/auth/firebase/exchange`` flow
+    so both paths derive the identical identity for the same user.
+
+    Failures degrade to an anonymous session rather than failing the
+    bootstrap: binding an identity only matters for monetized agents,
+    and those enforce at message time (a missing buyer 402s with
+    ``sign_in_required``, which the widget answers by re-bootstrapping
+    with a fresh token) — a stale token or an unconfigured project
+    must not break the widget for free agents.
     """
+    from surogates.api.routes.auth import (
+        _display_name_from_firebase_claims,
+        _email_from_firebase_claims,
+    )
+
     runtime_cache = getattr(request.app.state, "runtime_config_cache", None)
     firebase_cache = getattr(request.app.state, "firebase_config_cache", None)
     payload: dict = {}
@@ -415,33 +432,32 @@ async def _resolve_commerce_buyer(
         except LookupError:
             fb = None
     if fb is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=(
-                "Sign-in is not available for this agent "
-                "(no Firebase auth configured)."
-            ),
+        logger.info(
+            "Ignoring firebase_id_token at website bootstrap for agent "
+            "%s: project has no Firebase auth configured",
+            agent_id,
         )
+        return None
     try:
         claims = await verify_firebase_id_token(
             firebase_id_token, fb.firebase_project_id,
         )
     except FirebaseTokenError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc),
-        ) from exc
+        logger.info(
+            "Ignoring invalid firebase_id_token at website bootstrap "
+            "for agent %s: %s",
+            agent_id,
+            exc,
+        )
+        return None
     subject = claims.get("sub")
     if not isinstance(subject, str) or not subject:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Firebase token subject is missing.",
-        )
-    email = claims.get("email")
-    name = claims.get("name")
+        return None
+    email, _verified = _email_from_firebase_claims(claims)
     return {
         "firebase_uid": subject,
-        "email": email if isinstance(email, str) and email else None,
-        "name": name if isinstance(name, str) and name else None,
+        "email": email,
+        "name": _display_name_from_firebase_claims(claims, email),
     }
 
 
@@ -509,9 +525,12 @@ async def _authorize_commerce_turn(
         ) from exc
     if receipt.get("entitlement_id"):
         store = _get_session_store(request)
-        await store.update_session_config_key(
+        # Appended, not overwritten: a second message can land while a
+        # turn is still running, and each hold must survive until the
+        # worker's settlement takes the whole list atomically.
+        await store.append_session_config_list(
             session.id,
-            "commerce_reservation",
+            "commerce_reservations",
             {
                 "entitlement_id": receipt["entitlement_id"],
                 "reserved_tokens": int(receipt.get("reserved_tokens") or 0),
@@ -595,9 +614,11 @@ async def bootstrap_website_session(
     # later message inherits it from the session row rather than
     # re-verifying a client-supplied token per message.
     if body is not None and body.firebase_id_token:
-        config["commerce_buyer"] = await _resolve_commerce_buyer(
+        buyer = await _resolve_commerce_buyer(
             request, agent_id, body.firebase_id_token,
         )
+        if buyer is not None:
+            config["commerce_buyer"] = buyer
 
     session = await store.create_session(
         session_id=session_id,

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -389,6 +389,7 @@ class AgentHarness(
         ssh_targets: tuple[dict[str, Any], ...] = (),
         agent_service_account_id: str | None = None,
         acting_principal: Any | None = None,
+        platform_client: Any | None = None,
     ) -> None:
         self._store = session_store
         self._tools = tool_registry
@@ -434,6 +435,10 @@ class AgentHarness(
                 service_account_id=tenant.service_account_id,
             )
         )
+        # Management-plane client for monetized-turn settlement
+        # (``_settle_commerce_reservation``).  Optional: sessions
+        # without a commerce reservation never touch it.
+        self._platform_client = platform_client
         self._worker_id = worker_id
         self._budget = budget
         self._compressor = context_compressor

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -533,63 +533,85 @@ class ArtifactCompletionMixin:
         session: Session,
         cost_tracker: SessionCostTracker | None,
     ) -> None:
-        """Settle the monetized-turn hold pinned at message accept.
+        """Settle the monetized-turn holds pinned at message accept.
 
-        Debits the turn's actual LLM usage (input + output, the same
-        summing the hosted buy page's forwarder reports) against the
-        reservation the website channel wrote to ``session.config``.
-        Best-effort: a failed settlement leaves the hold for the ops
-        reservation reaper, which releases it after the stale window.
-        Without a cost tracker the reserved amount is consumed as the
-        floor — content may already have been delivered, and a hold
-        must never turn into a free turn.
+        Takes the whole ``commerce_reservations`` list from the LIVE
+        session config atomically (not the session object loaded at
+        wake start — follow-up messages may have appended holds since),
+        then debits the wake's total LLM usage (input + output, the
+        same summing the hosted buy page's forwarder reports) against
+        the oldest hold. The remaining holds release with zero usage:
+        their messages were folded into this wake, so the total already
+        charges their consumption. Best-effort throughout — a hold
+        whose settlement fails is reclaimed by the ops reservation
+        reaper, and a debit that arrives after the reaper released the
+        hold still charges the usage without double-releasing.
+        Without a cost tracker each hold's reserved amount is consumed
+        as the floor: content may already have been delivered, and a
+        hold must never turn into a free turn.
         """
-        reservation = (session.config or {}).get("commerce_reservation")
-        if not reservation:
+        # Channel gate, not a config gate: the wake-time session object
+        # is stale, and a hold appended after wake start must still be
+        # taken — only website sessions ever carry these, so every
+        # other channel skips the extra round trip.
+        if getattr(session, "channel", None) != "website" and not (
+            (session.config or {}).get("commerce_reservations")
+        ):
             return
         client = getattr(self, "_platform_client", None)
         if client is None:
             logger.warning(
-                "Session %s carries a commerce reservation but the "
-                "worker has no platform client; leaving the hold to "
+                "Session %s carries commerce reservations but the "
+                "worker has no platform client; leaving the holds to "
                 "the ops reaper",
                 session.id,
             )
             return
-        reserved = int(reservation.get("reserved_tokens") or 0)
-        if cost_tracker is not None:
-            actual = (
-                cost_tracker.total_input_tokens
-                + cost_tracker.total_output_tokens
-            )
-        else:
-            actual = reserved
         try:
-            await client.commerce_debit(
-                session.agent_id,
-                entitlement_id=str(reservation.get("entitlement_id") or ""),
-                reserved_tokens=reserved,
-                actual_tokens=actual,
-                reservation_id=reservation.get("reservation_id") or None,
+            taken = await self._store.pop_session_config_key(
+                session.id, "commerce_reservations",
             )
         except Exception:
             logger.warning(
-                "Commerce settlement failed for session %s; the ops "
-                "reservation reaper will release the hold",
+                "Failed to take commerce reservations for session %s; "
+                "the ops reaper will release them",
                 session.id,
                 exc_info=True,
             )
             return
-        try:
-            await self._store.clear_session_config_key(
-                session.id, "commerce_reservation",
-            )
-        except Exception:
-            logger.debug(
-                "Failed to clear settled commerce reservation for %s",
-                session.id,
-                exc_info=True,
-            )
+        reservations = [r for r in (taken or []) if isinstance(r, dict)]
+        if not reservations:
+            return
+        actual_total = (
+            cost_tracker.total_input_tokens + cost_tracker.total_output_tokens
+            if cost_tracker is not None
+            else None
+        )
+        for index, reservation in enumerate(reservations):
+            reserved = int(reservation.get("reserved_tokens") or 0)
+            if actual_total is None:
+                actual = reserved
+            else:
+                actual = actual_total if index == 0 else 0
+            try:
+                await client.commerce_debit(
+                    session.agent_id,
+                    entitlement_id=str(
+                        reservation.get("entitlement_id") or "",
+                    ),
+                    reserved_tokens=reserved,
+                    actual_tokens=actual,
+                    reservation_id=reservation.get("reservation_id") or None,
+                )
+            except Exception:
+                logger.warning(
+                    "Commerce settlement failed for session %s "
+                    "(reservation %s); the ops reservation reaper will "
+                    "release the hold",
+                    session.id,
+                    reservation.get("reservation_id"),
+                    exc_info=True,
+                )
 
     async def _complete_session(
         self,

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -528,6 +528,69 @@ class ArtifactCompletionMixin:
             return None
         return parent
 
+    async def _settle_commerce_reservation(
+        self,
+        session: Session,
+        cost_tracker: SessionCostTracker | None,
+    ) -> None:
+        """Settle the monetized-turn hold pinned at message accept.
+
+        Debits the turn's actual LLM usage (input + output, the same
+        summing the hosted buy page's forwarder reports) against the
+        reservation the website channel wrote to ``session.config``.
+        Best-effort: a failed settlement leaves the hold for the ops
+        reservation reaper, which releases it after the stale window.
+        Without a cost tracker the reserved amount is consumed as the
+        floor — content may already have been delivered, and a hold
+        must never turn into a free turn.
+        """
+        reservation = (session.config or {}).get("commerce_reservation")
+        if not reservation:
+            return
+        client = getattr(self, "_platform_client", None)
+        if client is None:
+            logger.warning(
+                "Session %s carries a commerce reservation but the "
+                "worker has no platform client; leaving the hold to "
+                "the ops reaper",
+                session.id,
+            )
+            return
+        reserved = int(reservation.get("reserved_tokens") or 0)
+        if cost_tracker is not None:
+            actual = (
+                cost_tracker.total_input_tokens
+                + cost_tracker.total_output_tokens
+            )
+        else:
+            actual = reserved
+        try:
+            await client.commerce_debit(
+                session.agent_id,
+                entitlement_id=str(reservation.get("entitlement_id") or ""),
+                reserved_tokens=reserved,
+                actual_tokens=actual,
+                reservation_id=reservation.get("reservation_id") or None,
+            )
+        except Exception:
+            logger.warning(
+                "Commerce settlement failed for session %s; the ops "
+                "reservation reaper will release the hold",
+                session.id,
+                exc_info=True,
+            )
+            return
+        try:
+            await self._store.clear_session_config_key(
+                session.id, "commerce_reservation",
+            )
+        except Exception:
+            logger.debug(
+                "Failed to clear settled commerce reservation for %s",
+                session.id,
+                exc_info=True,
+            )
+
     async def _complete_session(
         self,
         session: Session,
@@ -610,6 +673,8 @@ class ArtifactCompletionMixin:
         }
         if cost_tracker is not None:
             complete_data["cost_summary"] = cost_tracker.summary()
+
+        await self._settle_commerce_reservation(session, cost_tracker)
 
         session_complete_event_id = await self._store.emit_event(
             session.id,

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -943,6 +943,7 @@ async def run_worker(settings: Settings) -> None:
     worker_state["agent_principal_cache"] = agent_principal_resolver.cache
     _start_worker_invalidator(worker_state)
     runtime_config_cache = worker_state["runtime_config_cache"]
+    platform_client = worker_state["platform_client"]
 
     # Credential vault — required for per-session ``vault://<name>``
     # resolution.  Pod cannot serve sessions without it.
@@ -1551,6 +1552,9 @@ async def run_worker(settings: Settings) -> None:
             # (/loop, /mission, /auto-research), distinct from the agent
             # credential principal the tenant carries on managed channels.
             acting_principal=acting,
+            # Settlement of monetized website turns
+            # (``commerce_reservation`` on the session config).
+            platform_client=platform_client,
         )
         # Stash the bundle so the dispatcher can
         # aclose its four connection pools at session retirement.

--- a/surogates/runtime/context.py
+++ b/surogates/runtime/context.py
@@ -178,6 +178,15 @@ class AgentRuntimeContext:
     bundle_hub_ref: str | None = None
     bundle_version: str | None = None
 
+    # Monetization gate for runtime channels (website widget).  "free"
+    # means no enforcement — the safe default for payloads that predate
+    # the field AND for platforms whose commerce rollout flag is off
+    # (ops reports "free" for every agent until then).
+    commerce_mode: str = "free"
+    # Hosted buy page unpaid visitors are sent to.  ``None`` for free
+    # agents or when ops has no public frontend URL configured.
+    commerce_buy_url: str | None = None
+
     @property
     def asset_root(self) -> str:
         """Path to the tenant's on-disk asset directory.

--- a/surogates/runtime/platform_client.py
+++ b/surogates/runtime/platform_client.py
@@ -29,11 +29,27 @@ from typing import Any
 
 import httpx
 
-__all__ = ["PlatformAuthError", "PlatformClient"]
+__all__ = [
+    "CommercePaymentRequiredError",
+    "PlatformAuthError",
+    "PlatformClient",
+]
 
 
 class PlatformAuthError(RuntimeError):
     """Surogate-ops rejected our bearer token (401)."""
+
+
+class CommercePaymentRequiredError(RuntimeError):
+    """Ops refused a commerce authorization with 402.
+
+    ``detail`` carries the machine sentinel (``subscription_required``
+    / ``insufficient_tokens``) the widget maps to its paywall copy.
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
 
 
 class PlatformClient:
@@ -322,6 +338,90 @@ class PlatformClient:
         resp = await self._client.delete(
             f"/api/agents/agents/{agent_id}/composio/connections/{toolkit}",
             params={"user_id": user_id},
+        )
+        if resp.status_code == 401:
+            raise PlatformAuthError(
+                "surogate-ops rejected runtime token (401); "
+                "is the token revoked or missing the 'runtime' scope?",
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def commerce_authorize(
+        self,
+        agent_id: str,
+        *,
+        firebase_uid: str,
+        estimated_tokens: int,
+        email: str | None = None,
+        name: str | None = None,
+    ) -> dict:
+        """Reserve tokens for one end-user turn on a monetized agent.
+
+        Returns the reservation receipt
+        ``{entitlement_id, reserved_tokens, reservation_id}`` (all-zero
+        /empty for free-mode agents).  Raises:
+
+        * :class:`CommercePaymentRequiredError` on 402 — the visitor
+          must buy access; ``detail`` is the paywall sentinel.
+        * :class:`PlatformAuthError` on 401 — operations problem.
+        * ``httpx.HTTPStatusError`` on any other non-2xx.
+        """
+        body: dict = {
+            "firebase_uid": firebase_uid,
+            "estimated_tokens": estimated_tokens,
+        }
+        if email is not None:
+            body["email"] = email
+        if name is not None:
+            body["name"] = name
+        resp = await self._client.post(
+            f"/api/agents/agents/{agent_id}/commerce/authorize",
+            json=body,
+        )
+        if resp.status_code == 402:
+            detail = ""
+            try:
+                detail = str(resp.json().get("detail") or "")
+            except ValueError:
+                pass
+            raise CommercePaymentRequiredError(
+                detail or "payment_required",
+            )
+        if resp.status_code == 401:
+            raise PlatformAuthError(
+                "surogate-ops rejected runtime token (401); "
+                "is the token revoked or missing the 'runtime' scope?",
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def commerce_debit(
+        self,
+        agent_id: str,
+        *,
+        entitlement_id: str,
+        reserved_tokens: int,
+        actual_tokens: int,
+        reservation_id: str | None = None,
+    ) -> dict:
+        """Settle a reservation with the turn's actual token usage.
+
+        Returns ``{"debited_tokens": int}``.  Raises
+        :class:`PlatformAuthError` on 401, ``httpx.HTTPStatusError`` on
+        any other non-2xx.  Callers treat failures as best-effort — an
+        unsettled hold is reclaimed by the ops reservation reaper.
+        """
+        body: dict = {
+            "entitlement_id": entitlement_id,
+            "reserved_tokens": reserved_tokens,
+            "actual_tokens": actual_tokens,
+        }
+        if reservation_id:
+            body["reservation_id"] = reservation_id
+        resp = await self._client.post(
+            f"/api/agents/agents/{agent_id}/commerce/debit",
+            json=body,
         )
         if resp.status_code == 401:
             raise PlatformAuthError(

--- a/surogates/runtime/resolver.py
+++ b/surogates/runtime/resolver.py
@@ -109,6 +109,8 @@ def build_agent_runtime_context(payload: dict) -> AgentRuntimeContext:
         # a Hub fetch against an empty ref).
         bundle_hub_ref=payload.get("bundle_hub_ref") or None,
         bundle_version=payload.get("bundle_version") or None,
+        commerce_mode=str(payload.get("commerce_mode") or "free"),
+        commerce_buy_url=payload.get("commerce_buy_url") or None,
     )
 
 

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -634,6 +634,69 @@ class SessionStore:
             row.updated_at = func.now()
             await db.commit()
 
+    async def append_session_config_list(
+        self,
+        session_id: UUID,
+        key: str,
+        value: Any,
+    ) -> None:
+        """Append ``value`` to the list at ``config[key]`` atomically.
+
+        The row lock makes concurrent appends compose instead of
+        overwriting each other — required for per-turn records (e.g.
+        commerce reservations) that several in-flight requests may
+        write to the same session.
+        """
+        if not key:
+            raise ValueError("config key must be non-empty")
+        async with self._sf() as db:
+            result = await db.execute(
+                select(SessionRow)
+                .where(SessionRow.id == session_id)
+                .with_for_update()
+            )
+            row = result.scalar_one_or_none()
+            if row is None:
+                raise SessionNotFoundError(f"session {session_id} not found")
+            config = dict(row.config or {})
+            existing = config.get(key)
+            items = list(existing) if isinstance(existing, list) else []
+            items.append(value)
+            config[key] = items
+            row.config = config
+            row.updated_at = func.now()
+            await db.commit()
+
+    async def pop_session_config_key(
+        self, session_id: UUID, key: str,
+    ) -> Any:
+        """Atomically read-and-remove ``config[key]``; ``None`` if absent.
+
+        The take is exclusive under the row lock, so exactly one caller
+        observes the value — a writer appending concurrently lands
+        either before the take (and is included) or after (and stays
+        for the next take).
+        """
+        if not key:
+            raise ValueError("config key must be non-empty")
+        async with self._sf() as db:
+            result = await db.execute(
+                select(SessionRow)
+                .where(SessionRow.id == session_id)
+                .with_for_update()
+            )
+            row = result.scalar_one_or_none()
+            if row is None:
+                raise SessionNotFoundError(f"session {session_id} not found")
+            config = dict(row.config or {})
+            if key not in config:
+                return None
+            value = config.pop(key)
+            row.config = config
+            row.updated_at = func.now()
+            await db.commit()
+            return value
+
     async def emit_synthetic_user_message(
         self,
         session_id: UUID,

--- a/tests/api/test_website_commerce.py
+++ b/tests/api/test_website_commerce.py
@@ -39,7 +39,7 @@ class _FakeStore:
     def __init__(self):
         self.updates: list[tuple] = []
 
-    async def update_session_config_key(self, session_id, key, value):
+    async def append_session_config_list(self, session_id, key, value):
         self.updates.append((session_id, key, value))
 
 
@@ -147,7 +147,7 @@ async def test_paid_with_buyer_reserves_and_pins_receipt():
         {
             "agent_id": "a-1",
             "firebase_uid": "fb-1",
-            "estimated_tokens": 100 // 4 + 16,
+            "estimated_tokens": (100 + 16) // 4,
             "email": "b@example.com",
             "name": "B",
         },
@@ -155,7 +155,7 @@ async def test_paid_with_buyer_reserves_and_pins_receipt():
     assert store.updates == [
         (
             session.id,
-            "commerce_reservation",
+            "commerce_reservations",
             {
                 "entitlement_id": "ent-1",
                 "reserved_tokens": 41,
@@ -248,7 +248,29 @@ async def test_resolve_buyer_verifies_and_returns_identity(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_resolve_buyer_invalid_token_401(monkeypatch):
+async def test_resolve_buyer_normalizes_claims(monkeypatch):
+    async def fake_verify(token, project):
+        return {"sub": "fb-2", "email": "  MiXeD@Example.COM "}
+
+    monkeypatch.setattr(website, "verify_firebase_id_token", fake_verify)
+    request = _request(
+        runtime_payload={"project_id": "p-1"},
+        firebase_rows={
+            "p-1": SimpleNamespace(firebase_project_id="fb-project"),
+        },
+    )
+    buyer = await website._resolve_commerce_buyer(request, "a-1", "id-token")
+    assert buyer == {
+        "firebase_uid": "fb-2",
+        "email": "mixed@example.com",
+        "name": "mixed",
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolve_buyer_invalid_token_degrades_to_anonymous(
+    monkeypatch,
+):
     from surogates.tenant.auth.firebase import FirebaseTokenError
 
     async def fake_verify(token, project):
@@ -261,23 +283,23 @@ async def test_resolve_buyer_invalid_token_401(monkeypatch):
             "p-1": SimpleNamespace(firebase_project_id="fb-project"),
         },
     )
-    with pytest.raises(HTTPException) as exc_info:
+    assert (
         await website._resolve_commerce_buyer(request, "a-1", "id-token")
-    assert exc_info.value.status_code == 401
+    ) is None
 
 
 @pytest.mark.asyncio
-async def test_resolve_buyer_unconfigured_firebase_401():
+async def test_resolve_buyer_unconfigured_firebase_degrades():
     request = _request(
         runtime_payload={"project_id": "p-1"}, firebase_rows={},
     )
-    with pytest.raises(HTTPException) as exc_info:
+    assert (
         await website._resolve_commerce_buyer(request, "a-1", "id-token")
-    assert exc_info.value.status_code == 401
+    ) is None
 
 
 @pytest.mark.asyncio
-async def test_resolve_buyer_missing_subject_401(monkeypatch):
+async def test_resolve_buyer_missing_subject_degrades(monkeypatch):
     async def fake_verify(token, project):
         return {"email": "b@example.com"}
 
@@ -288,6 +310,6 @@ async def test_resolve_buyer_missing_subject_401(monkeypatch):
             "p-1": SimpleNamespace(firebase_project_id="fb-project"),
         },
     )
-    with pytest.raises(HTTPException) as exc_info:
+    assert (
         await website._resolve_commerce_buyer(request, "a-1", "id-token")
-    assert exc_info.value.status_code == 401
+    ) is None

--- a/tests/api/test_website_commerce.py
+++ b/tests/api/test_website_commerce.py
@@ -1,0 +1,293 @@
+"""Commerce enforcement on the website channel.
+
+Covers the two route-level hooks:
+
+- ``_resolve_commerce_buyer`` — bootstrap-time Firebase verification
+  that pins the buyer identity on the session config.
+- ``_authorize_commerce_turn`` — message-accept gate: free agents pass
+  through untouched; monetized agents require a bound buyer and an
+  ops-side reservation, with structured 402 details the widget maps to
+  its paywall.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from surogates.api.routes import website
+from surogates.runtime.platform_client import (
+    CommercePaymentRequiredError,
+    PlatformAuthError,
+)
+
+
+class _FakeCache:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def get(self, key):
+        if key not in self._rows:
+            raise LookupError(key)
+        return self._rows[key]
+
+
+class _FakeStore:
+    def __init__(self):
+        self.updates: list[tuple] = []
+
+    async def update_session_config_key(self, session_id, key, value):
+        self.updates.append((session_id, key, value))
+
+
+class _FakePlatformClient:
+    def __init__(self, *, receipt=None, error=None):
+        self.receipt = receipt
+        self.error = error
+        self.calls: list[dict] = []
+
+    async def commerce_authorize(self, agent_id, **kwargs):
+        self.calls.append({"agent_id": agent_id, **kwargs})
+        if self.error is not None:
+            raise self.error
+        return self.receipt
+
+
+def _request(
+    *,
+    runtime_payload=None,
+    platform_client=None,
+    firebase_rows=None,
+    store=None,
+):
+    state = SimpleNamespace()
+    if runtime_payload is not None:
+        state.runtime_config_cache = _FakeCache({"a-1": runtime_payload})
+    if platform_client is not None:
+        state.platform_client = platform_client
+    if firebase_rows is not None:
+        state.firebase_config_cache = _FakeCache(firebase_rows)
+    if store is not None:
+        state.session_store = store
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+def _session(config=None):
+    return SimpleNamespace(
+        id=uuid.uuid4(), agent_id="a-1", config=config or {},
+    )
+
+
+_PAID_PAYLOAD = {
+    "project_id": "p-1",
+    "commerce_mode": "token_packs_only",
+    "commerce_buy_url": "https://studio.example/buy/a-1",
+}
+
+
+# ── _authorize_commerce_turn ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_free_mode_passes_without_touching_the_platform():
+    client = _FakePlatformClient()
+    request = _request(
+        runtime_payload={"commerce_mode": "free"}, platform_client=client,
+    )
+    await website._authorize_commerce_turn(request, _session(), "hello")
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_missing_runtime_cache_passes_through():
+    request = _request()
+    await website._authorize_commerce_turn(request, _session(), "hello")
+
+
+@pytest.mark.asyncio
+async def test_paid_without_buyer_402_sign_in_required():
+    request = _request(runtime_payload=_PAID_PAYLOAD)
+    with pytest.raises(HTTPException) as exc_info:
+        await website._authorize_commerce_turn(request, _session(), "hello")
+    assert exc_info.value.status_code == 402
+    assert exc_info.value.detail == {
+        "code": "sign_in_required",
+        "buy_url": "https://studio.example/buy/a-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_paid_with_buyer_reserves_and_pins_receipt():
+    client = _FakePlatformClient(
+        receipt={
+            "entitlement_id": "ent-1",
+            "reserved_tokens": 41,
+            "reservation_id": "res-1",
+        },
+    )
+    store = _FakeStore()
+    request = _request(
+        runtime_payload=_PAID_PAYLOAD, platform_client=client, store=store,
+    )
+    session = _session(
+        config={
+            "commerce_buyer": {
+                "firebase_uid": "fb-1",
+                "email": "b@example.com",
+                "name": "B",
+            },
+        },
+    )
+    await website._authorize_commerce_turn(request, session, "x" * 100)
+
+    assert client.calls == [
+        {
+            "agent_id": "a-1",
+            "firebase_uid": "fb-1",
+            "estimated_tokens": 100 // 4 + 16,
+            "email": "b@example.com",
+            "name": "B",
+        },
+    ]
+    assert store.updates == [
+        (
+            session.id,
+            "commerce_reservation",
+            {
+                "entitlement_id": "ent-1",
+                "reserved_tokens": 41,
+                "reservation_id": "res-1",
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_paid_402_from_ops_maps_to_structured_detail():
+    client = _FakePlatformClient(
+        error=CommercePaymentRequiredError("insufficient_tokens"),
+    )
+    request = _request(
+        runtime_payload=_PAID_PAYLOAD, platform_client=client,
+    )
+    session = _session(config={"commerce_buyer": {"firebase_uid": "fb-1"}})
+    with pytest.raises(HTTPException) as exc_info:
+        await website._authorize_commerce_turn(request, session, "hello")
+    assert exc_info.value.status_code == 402
+    assert exc_info.value.detail == {
+        "code": "insufficient_tokens",
+        "buy_url": "https://studio.example/buy/a-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_paid_platform_failure_fails_closed_503():
+    client = _FakePlatformClient(error=PlatformAuthError("bad token"))
+    request = _request(
+        runtime_payload=_PAID_PAYLOAD, platform_client=client,
+    )
+    session = _session(config={"commerce_buyer": {"firebase_uid": "fb-1"}})
+    with pytest.raises(HTTPException) as exc_info:
+        await website._authorize_commerce_turn(request, session, "hello")
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_paid_without_platform_client_fails_closed_503():
+    request = _request(runtime_payload=_PAID_PAYLOAD)
+    session = _session(config={"commerce_buyer": {"firebase_uid": "fb-1"}})
+    with pytest.raises(HTTPException) as exc_info:
+        await website._authorize_commerce_turn(request, session, "hello")
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_free_receipt_is_not_pinned():
+    client = _FakePlatformClient(
+        receipt={
+            "entitlement_id": "",
+            "reserved_tokens": 0,
+            "reservation_id": "",
+        },
+    )
+    store = _FakeStore()
+    request = _request(
+        runtime_payload=_PAID_PAYLOAD, platform_client=client, store=store,
+    )
+    session = _session(config={"commerce_buyer": {"firebase_uid": "fb-1"}})
+    await website._authorize_commerce_turn(request, session, "hello")
+    assert store.updates == []
+
+
+# ── _resolve_commerce_buyer ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_buyer_verifies_and_returns_identity(monkeypatch):
+    async def fake_verify(token, project):
+        assert token == "id-token"
+        assert project == "fb-project"
+        return {"sub": "fb-1", "email": "b@example.com", "name": "B"}
+
+    monkeypatch.setattr(website, "verify_firebase_id_token", fake_verify)
+    request = _request(
+        runtime_payload={"project_id": "p-1"},
+        firebase_rows={
+            "p-1": SimpleNamespace(firebase_project_id="fb-project"),
+        },
+    )
+    buyer = await website._resolve_commerce_buyer(request, "a-1", "id-token")
+    assert buyer == {
+        "firebase_uid": "fb-1",
+        "email": "b@example.com",
+        "name": "B",
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolve_buyer_invalid_token_401(monkeypatch):
+    from surogates.tenant.auth.firebase import FirebaseTokenError
+
+    async def fake_verify(token, project):
+        raise FirebaseTokenError("expired")
+
+    monkeypatch.setattr(website, "verify_firebase_id_token", fake_verify)
+    request = _request(
+        runtime_payload={"project_id": "p-1"},
+        firebase_rows={
+            "p-1": SimpleNamespace(firebase_project_id="fb-project"),
+        },
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await website._resolve_commerce_buyer(request, "a-1", "id-token")
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_resolve_buyer_unconfigured_firebase_401():
+    request = _request(
+        runtime_payload={"project_id": "p-1"}, firebase_rows={},
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await website._resolve_commerce_buyer(request, "a-1", "id-token")
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_resolve_buyer_missing_subject_401(monkeypatch):
+    async def fake_verify(token, project):
+        return {"email": "b@example.com"}
+
+    monkeypatch.setattr(website, "verify_firebase_id_token", fake_verify)
+    request = _request(
+        runtime_payload={"project_id": "p-1"},
+        firebase_rows={
+            "p-1": SimpleNamespace(firebase_project_id="fb-project"),
+        },
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await website._resolve_commerce_buyer(request, "a-1", "id-token")
+    assert exc_info.value.status_code == 401

--- a/tests/harness/test_commerce_settlement.py
+++ b/tests/harness/test_commerce_settlement.py
@@ -1,0 +1,129 @@
+"""Worker-side settlement of monetized website turns.
+
+``_settle_commerce_reservation`` runs inside ``_complete_session``:
+it debits the turn's summed LLM usage against the reservation the
+website channel pinned on ``session.config`` and clears the pin.
+Failures leave the hold to the ops reservation reaper — never a
+crash in the completion path.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from surogates.harness.cost_tracker import SessionCostTracker
+from surogates.harness.loop_artifact_completion import ArtifactCompletionMixin
+
+
+class _Harness(ArtifactCompletionMixin):
+    def __init__(self, *, platform_client, store):
+        self._platform_client = platform_client
+        self._store = store
+
+
+class _FakeStore:
+    def __init__(self):
+        self.cleared: list[tuple] = []
+
+    async def clear_session_config_key(self, session_id, key):
+        self.cleared.append((session_id, key))
+
+
+class _FakePlatformClient:
+    def __init__(self, *, error=None):
+        self.error = error
+        self.debits: list[dict] = []
+
+    async def commerce_debit(self, agent_id, **kwargs):
+        if self.error is not None:
+            raise self.error
+        self.debits.append({"agent_id": agent_id, **kwargs})
+        return {"debited_tokens": kwargs["actual_tokens"]}
+
+
+def _session(reservation=None):
+    config = {}
+    if reservation is not None:
+        config["commerce_reservation"] = reservation
+    return SimpleNamespace(id=uuid.uuid4(), agent_id="a-1", config=config)
+
+
+_RESERVATION = {
+    "entitlement_id": "ent-1",
+    "reserved_tokens": 500,
+    "reservation_id": "res-1",
+}
+
+
+@pytest.mark.asyncio
+async def test_settles_actual_usage_and_clears_pin():
+    client = _FakePlatformClient()
+    store = _FakeStore()
+    harness = _Harness(platform_client=client, store=store)
+    tracker = SessionCostTracker()
+    tracker.record_call(150, 90, 0.01)
+    session = _session(_RESERVATION)
+
+    await harness._settle_commerce_reservation(session, tracker)
+
+    assert client.debits == [
+        {
+            "agent_id": "a-1",
+            "entitlement_id": "ent-1",
+            "reserved_tokens": 500,
+            "actual_tokens": 240,
+            "reservation_id": "res-1",
+        },
+    ]
+    assert store.cleared == [(session.id, "commerce_reservation")]
+
+
+@pytest.mark.asyncio
+async def test_no_reservation_is_a_noop():
+    client = _FakePlatformClient()
+    store = _FakeStore()
+    harness = _Harness(platform_client=client, store=store)
+
+    await harness._settle_commerce_reservation(_session(), SessionCostTracker())
+
+    assert client.debits == []
+    assert store.cleared == []
+
+
+@pytest.mark.asyncio
+async def test_missing_tracker_consumes_the_reserved_floor():
+    client = _FakePlatformClient()
+    store = _FakeStore()
+    harness = _Harness(platform_client=client, store=store)
+
+    await harness._settle_commerce_reservation(_session(_RESERVATION), None)
+
+    assert client.debits[0]["actual_tokens"] == 500
+
+
+@pytest.mark.asyncio
+async def test_debit_failure_keeps_the_pin_for_the_reaper():
+    client = _FakePlatformClient(error=RuntimeError("ops down"))
+    store = _FakeStore()
+    harness = _Harness(platform_client=client, store=store)
+
+    await harness._settle_commerce_reservation(
+        _session(_RESERVATION), SessionCostTracker(),
+    )
+
+    assert store.cleared == []
+
+
+@pytest.mark.asyncio
+async def test_missing_platform_client_leaves_hold_to_the_reaper():
+    store = _FakeStore()
+    harness = _Harness(platform_client=None, store=store)
+
+    await harness._settle_commerce_reservation(
+        _session(_RESERVATION), SessionCostTracker(),
+    )
+
+    assert store.cleared == []

--- a/tests/harness/test_commerce_settlement.py
+++ b/tests/harness/test_commerce_settlement.py
@@ -1,10 +1,12 @@
 """Worker-side settlement of monetized website turns.
 
-``_settle_commerce_reservation`` runs inside ``_complete_session``:
-it debits the turn's summed LLM usage against the reservation the
-website channel pinned on ``session.config`` and clears the pin.
-Failures leave the hold to the ops reservation reaper — never a
-crash in the completion path.
+``_settle_commerce_reservation`` runs inside ``_complete_session``: it
+takes the ``commerce_reservations`` list from the LIVE session config
+(follow-up messages may have appended holds after wake start), debits
+the wake's summed LLM usage against the oldest hold, and releases the
+rest — the total already covers their consumption. Failures leave the
+holds to the ops reservation reaper; never a crash in the completion
+path.
 """
 
 from __future__ import annotations
@@ -25,11 +27,14 @@ class _Harness(ArtifactCompletionMixin):
 
 
 class _FakeStore:
-    def __init__(self):
-        self.cleared: list[tuple] = []
+    def __init__(self, reservations=None):
+        self.reservations = reservations
+        self.pops: list[tuple] = []
 
-    async def clear_session_config_key(self, session_id, key):
-        self.cleared.append((session_id, key))
+    async def pop_session_config_key(self, session_id, key):
+        self.pops.append((session_id, key))
+        taken, self.reservations = self.reservations, None
+        return taken
 
 
 class _FakePlatformClient:
@@ -44,30 +49,39 @@ class _FakePlatformClient:
         return {"debited_tokens": kwargs["actual_tokens"]}
 
 
-def _session(reservation=None):
-    config = {}
-    if reservation is not None:
-        config["commerce_reservation"] = reservation
-    return SimpleNamespace(id=uuid.uuid4(), agent_id="a-1", config=config)
+def _session(*, channel="website", config=None):
+    return SimpleNamespace(
+        id=uuid.uuid4(), agent_id="a-1", channel=channel, config=config or {},
+    )
 
 
-_RESERVATION = {
+_R1 = {
     "entitlement_id": "ent-1",
     "reserved_tokens": 500,
     "reservation_id": "res-1",
 }
+_R2 = {
+    "entitlement_id": "ent-1",
+    "reserved_tokens": 40,
+    "reservation_id": "res-2",
+}
+
+
+def _tracker(input_tokens: int, output_tokens: int) -> SessionCostTracker:
+    tracker = SessionCostTracker()
+    tracker.record_call(input_tokens, output_tokens, 0.01)
+    return tracker
 
 
 @pytest.mark.asyncio
-async def test_settles_actual_usage_and_clears_pin():
+async def test_settles_total_usage_against_the_oldest_hold():
     client = _FakePlatformClient()
-    store = _FakeStore()
+    store = _FakeStore(reservations=[_R1])
     harness = _Harness(platform_client=client, store=store)
-    tracker = SessionCostTracker()
-    tracker.record_call(150, 90, 0.01)
-    session = _session(_RESERVATION)
 
-    await harness._settle_commerce_reservation(session, tracker)
+    await harness._settle_commerce_reservation(
+        _session(), _tracker(150, 90),
+    )
 
     assert client.debits == [
         {
@@ -78,52 +92,83 @@ async def test_settles_actual_usage_and_clears_pin():
             "reservation_id": "res-1",
         },
     ]
-    assert store.cleared == [(session.id, "commerce_reservation")]
 
 
 @pytest.mark.asyncio
-async def test_no_reservation_is_a_noop():
+async def test_extra_holds_release_with_zero_usage():
+    """Steer messages folded into the wake pinned extra holds; the
+    total charged on the first already covers them."""
     client = _FakePlatformClient()
-    store = _FakeStore()
-    harness = _Harness(platform_client=client, store=store)
-
-    await harness._settle_commerce_reservation(_session(), SessionCostTracker())
-
-    assert client.debits == []
-    assert store.cleared == []
-
-
-@pytest.mark.asyncio
-async def test_missing_tracker_consumes_the_reserved_floor():
-    client = _FakePlatformClient()
-    store = _FakeStore()
-    harness = _Harness(platform_client=client, store=store)
-
-    await harness._settle_commerce_reservation(_session(_RESERVATION), None)
-
-    assert client.debits[0]["actual_tokens"] == 500
-
-
-@pytest.mark.asyncio
-async def test_debit_failure_keeps_the_pin_for_the_reaper():
-    client = _FakePlatformClient(error=RuntimeError("ops down"))
-    store = _FakeStore()
+    store = _FakeStore(reservations=[_R1, _R2])
     harness = _Harness(platform_client=client, store=store)
 
     await harness._settle_commerce_reservation(
-        _session(_RESERVATION), SessionCostTracker(),
+        _session(), _tracker(1000, 500),
     )
 
-    assert store.cleared == []
+    assert [d["reservation_id"] for d in client.debits] == ["res-1", "res-2"]
+    assert [d["actual_tokens"] for d in client.debits] == [1500, 0]
 
 
 @pytest.mark.asyncio
-async def test_missing_platform_client_leaves_hold_to_the_reaper():
-    store = _FakeStore()
+async def test_website_session_pops_even_when_wake_config_is_stale():
+    """The hold may have been appended after the wake loaded the
+    session row — website sessions always take the live list."""
+    client = _FakePlatformClient()
+    store = _FakeStore(reservations=[_R1])
+    harness = _Harness(platform_client=client, store=store)
+
+    await harness._settle_commerce_reservation(
+        _session(config={}), _tracker(10, 5),
+    )
+
+    assert store.pops != []
+    assert len(client.debits) == 1
+
+
+@pytest.mark.asyncio
+async def test_non_website_channel_without_pin_skips_the_round_trip():
+    client = _FakePlatformClient()
+    store = _FakeStore(reservations=[_R1])
+    harness = _Harness(platform_client=client, store=store)
+
+    await harness._settle_commerce_reservation(
+        _session(channel="web", config={}), _tracker(10, 5),
+    )
+
+    assert store.pops == []
+    assert client.debits == []
+
+
+@pytest.mark.asyncio
+async def test_missing_tracker_consumes_each_reserved_floor():
+    client = _FakePlatformClient()
+    store = _FakeStore(reservations=[_R1, _R2])
+    harness = _Harness(platform_client=client, store=store)
+
+    await harness._settle_commerce_reservation(_session(), None)
+
+    assert [d["actual_tokens"] for d in client.debits] == [500, 40]
+
+
+@pytest.mark.asyncio
+async def test_debit_failure_never_raises():
+    client = _FakePlatformClient(error=RuntimeError("ops down"))
+    store = _FakeStore(reservations=[_R1])
+    harness = _Harness(platform_client=client, store=store)
+
+    await harness._settle_commerce_reservation(
+        _session(), _tracker(10, 5),
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_platform_client_leaves_holds_to_the_reaper():
+    store = _FakeStore(reservations=[_R1])
     harness = _Harness(platform_client=None, store=store)
 
     await harness._settle_commerce_reservation(
-        _session(_RESERVATION), SessionCostTracker(),
+        _session(), _tracker(10, 5),
     )
 
-    assert store.cleared == []
+    assert store.pops == []

--- a/tests/runtime/test_platform_client_commerce.py
+++ b/tests/runtime/test_platform_client_commerce.py
@@ -1,0 +1,139 @@
+"""PlatformClient commerce methods (authorize / debit).
+
+MockTransport-level tests: the wire shapes must match the ops
+runtime-plane endpoints exactly, 402 must surface as the typed
+paywall error (not a generic HTTPStatusError), and 401 keeps the
+established ``PlatformAuthError`` semantics.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from surogates.runtime.platform_client import (
+    CommercePaymentRequiredError,
+    PlatformAuthError,
+    PlatformClient,
+)
+
+
+def _client(handler) -> PlatformClient:
+    return PlatformClient(
+        base_url="http://ops.test",
+        token="tok",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+@pytest.mark.asyncio
+async def test_authorize_posts_body_and_returns_receipt():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "entitlement_id": "ent-1",
+                "reserved_tokens": 500,
+                "reservation_id": "res-1",
+            },
+        )
+
+    receipt = await _client(handler).commerce_authorize(
+        "a-1",
+        firebase_uid="fb-1",
+        estimated_tokens=500,
+        email="b@example.com",
+    )
+    assert seen["url"].endswith("/api/agents/agents/a-1/commerce/authorize")
+    assert seen["body"] == {
+        "firebase_uid": "fb-1",
+        "estimated_tokens": 500,
+        "email": "b@example.com",
+    }
+    assert receipt["entitlement_id"] == "ent-1"
+    assert receipt["reservation_id"] == "res-1"
+
+
+@pytest.mark.asyncio
+async def test_authorize_402_raises_typed_paywall_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(402, json={"detail": "insufficient_tokens"})
+
+    with pytest.raises(CommercePaymentRequiredError) as exc_info:
+        await _client(handler).commerce_authorize(
+            "a-1", firebase_uid="fb-1", estimated_tokens=100,
+        )
+    assert exc_info.value.detail == "insufficient_tokens"
+
+
+@pytest.mark.asyncio
+async def test_authorize_402_without_json_body_still_typed():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(402, text="nope")
+
+    with pytest.raises(CommercePaymentRequiredError) as exc_info:
+        await _client(handler).commerce_authorize(
+            "a-1", firebase_uid="fb-1", estimated_tokens=100,
+        )
+    assert exc_info.value.detail == "payment_required"
+
+
+@pytest.mark.asyncio
+async def test_authorize_401_raises_platform_auth_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401)
+
+    with pytest.raises(PlatformAuthError):
+        await _client(handler).commerce_authorize(
+            "a-1", firebase_uid="fb-1", estimated_tokens=100,
+        )
+
+
+@pytest.mark.asyncio
+async def test_debit_posts_settlement_body():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"debited_tokens": 240})
+
+    result = await _client(handler).commerce_debit(
+        "a-1",
+        entitlement_id="ent-1",
+        reserved_tokens=500,
+        actual_tokens=240,
+        reservation_id="res-1",
+    )
+    assert seen["url"].endswith("/api/agents/agents/a-1/commerce/debit")
+    assert seen["body"] == {
+        "entitlement_id": "ent-1",
+        "reserved_tokens": 500,
+        "actual_tokens": 240,
+        "reservation_id": "res-1",
+    }
+    assert result["debited_tokens"] == 240
+
+
+@pytest.mark.asyncio
+async def test_debit_omits_empty_reservation_id():
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"debited_tokens": 0})
+
+    await _client(handler).commerce_debit(
+        "a-1",
+        entitlement_id="",
+        reserved_tokens=0,
+        actual_tokens=0,
+        reservation_id=None,
+    )
+    assert "reservation_id" not in seen["body"]

--- a/tests/runtime/test_resolver_projection.py
+++ b/tests/runtime/test_resolver_projection.py
@@ -167,3 +167,33 @@ def test_missing_optional_collections_default_safely():
     assert ctx.mcp_server_ids == ()
     assert ctx.governance == {}
     assert ctx.api_web_url is None
+
+
+def test_commerce_fields_default_free_when_absent():
+    from surogates.runtime import build_agent_runtime_context
+
+    ctx = build_agent_runtime_context(_minimum_payload())
+    assert ctx.commerce_mode == "free"
+    assert ctx.commerce_buy_url is None
+
+
+def test_commerce_fields_project_when_present():
+    from surogates.runtime import build_agent_runtime_context
+
+    payload = _minimum_payload()
+    payload["commerce_mode"] = "subscription_required"
+    payload["commerce_buy_url"] = "https://studio.example/buy/a-1"
+    ctx = build_agent_runtime_context(payload)
+    assert ctx.commerce_mode == "subscription_required"
+    assert ctx.commerce_buy_url == "https://studio.example/buy/a-1"
+
+
+def test_commerce_empty_strings_normalise_to_safe_defaults():
+    from surogates.runtime import build_agent_runtime_context
+
+    payload = _minimum_payload()
+    payload["commerce_mode"] = ""
+    payload["commerce_buy_url"] = ""
+    ctx = build_agent_runtime_context(payload)
+    assert ctx.commerce_mode == "free"
+    assert ctx.commerce_buy_url is None


### PR DESCRIPTION
## What

Monetized agents currently have a free side door: the website widget serves anonymous visitors regardless of the agent's commerce mode. This PR makes the widget channel a second consumer of the platform's buyer entitlement ledger — same identities, same reservations, same ledger as the hosted buy page.

**Deploys inert.** Ops reports `commerce_mode: "free"` for every agent until its `website_commerce_enforcement` config flag flips (see the companion surogate-ops PR), so nothing changes for existing free agents when this merges.

## How it works

**Identity (bootstrap).** `POST /v1/website/sessions` accepts an optional `{firebase_id_token}` body. The token is verified against the agent project's own Firebase (the same project the buy page and agent-web self-registration use) and the resulting `firebase_uid` — the buyer identity ops meters against — is pinned on `session.config`. Anonymous bootstraps keep the historical no-body wire shape.

**Gate (message accept).** For `commerce_mode != free`, the route requires a pinned buyer and reserves estimated tokens through the new runtime-scoped ops endpoint. Refusals return a structured 402 detail `{code, buy_url}` (`sign_in_required` / `subscription_required` / `insufficient_tokens`). Platform failures fail closed (503) — a paid agent never serves free turns because the metering plane blinked.

**Settlement (worker).** After the turn completes, the worker debits the turn's summed LLM usage (input + output, matching the buy-page forwarder) against the reservation and clears the pin. A settlement that never happens (crash, deploy) is reclaimed by the ops reservation reaper — late refund, never a free turn.

**Widget UI.** New `SurogatesPaywallError` in the SDK error taxonomy; 402s render as a paywall panel with per-sentinel copy and a **Get access** link to the hosted buy page. Embedders pass `getFirebaseIdToken` in the mount config to bind their signed-in users.

## Runtime config additions

`AgentRuntimeContext` gains `commerce_mode` (default `"free"`) and `commerce_buy_url` — both tolerant of payloads that predate the fields.

## Tests

- `tests/api/test_website_commerce.py` — gate behaviour: free pass-through, 402 shapes, fail-closed paths, Firebase verification (12 tests)
- `tests/runtime/test_platform_client_commerce.py` — wire shapes, typed 402/401 (6 tests)
- `tests/harness/test_commerce_settlement.py` — debit summing, reserved-floor fallback, reaper-safe failure paths (5 tests)
- `tests/runtime/test_resolver_projection.py` — projection defaults (3 new)
- `sdk/website-widget/tests/paywall.test.ts` — protocol 402 mapping, bootstrap token pass-through, RUN_ERROR paywall flow (6 tests)

`tests/api` + `tests/runtime` + `tests/harness` + website channel: **520 passed**. SDK: **54 passed**, `tsc --noEmit` clean, build clean.

## Rollout

1. Merge the companion surogate-ops PR (endpoints + flag, also inert).
2. Deploy both.
3. Flip `website_commerce_enforcement: true` in ops config once verified on staging.