### PR TITLE
feat(session-search): owner-scoped search across end-user sessions for ops console chats

### DIFF
--- a/surogates/orchestrator/mcp_client.py
+++ b/surogates/orchestrator/mcp_client.py
@@ -177,10 +177,12 @@ class McpProxyClient:
 
             # Forward the chat user's identity to the upstream MCP server
             # via the MCP ``_meta`` channel. The dev-mode client builds
-            # the same payload in ``surogates.tools.mcp.client``; keep
-            # them in sync so platform MCP servers (e.g. surogate-ops's
-            # copilot) authorise proxy-mode calls the same way they
-            # authorise dev-mode calls.
+            # the same payload in ``surogates.tools.mcp.client``, and
+            # ``_is_owner_scoped`` in ``tools.builtin.session_search``
+            # gates on the same ``config.ops`` stamp; keep all three in
+            # sync so platform MCP servers (e.g. surogate-ops's copilot)
+            # authorise proxy-mode calls the same way they authorise
+            # dev-mode calls.
             meta_payload: dict[str, Any] = {}
             session_config = kwargs.get("session_config") or {}
             ops_meta = (

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -15,7 +15,7 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, not_, select, text, update, delete, func, or_, tuple_
+from sqlalchemy import and_, not_, select, text, true, update, delete, func, or_, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import aliased
 
@@ -661,6 +661,7 @@ class SessionStore:
         limit: int = 50,
         offset: int = 0,
         include_descendants: bool = False,
+        any_principal: bool = False,
     ) -> list[Session]:
         """Return top-level sessions for a principal within an org, newest first.
 
@@ -674,14 +675,24 @@ class SessionStore:
         the tree (the chat sidebar) can show a collapsed-children indicator
         without a separate per-session tree fetch.  Pagination still applies to
         roots only; descendants ride along with their root.
+
+        When *any_principal* is set the principal filter is dropped and the
+        listing spans every user/service-account within the org + agent.
+        Callers own the authorization decision -- the only in-tree user is the
+        ops owner-console scope of ``session_search`` (see
+        ``_is_owner_scoped`` there), which requires a service-account
+        principal plus the ops-stamped session config.
         """
-        if (user_id is None) == (service_account_id is None):
-            raise ValueError("list_sessions requires exactly one principal id")
-        principal_filter = (
-            SessionRow.service_account_id == service_account_id
-            if service_account_id is not None
-            else SessionRow.user_id == user_id
-        )
+        if any_principal:
+            principal_filter = true()
+        else:
+            if (user_id is None) == (service_account_id is None):
+                raise ValueError("list_sessions requires exactly one principal id")
+            principal_filter = (
+                SessionRow.service_account_id == service_account_id
+                if service_account_id is not None
+                else SessionRow.user_id == user_id
+            )
         async with self._sf() as db:
             result = await db.execute(
                 select(SessionRow)

--- a/surogates/tools/builtin/session_search.py
+++ b/surogates/tools/builtin/session_search.py
@@ -270,6 +270,7 @@ async def _list_recent_sessions(
     limit: int,
     current_session_id: UUID | None = None,
     service_account_id: UUID | None = None,
+    owner_scope: bool = False,
 ) -> str:
     """Return metadata for the most recent sessions (no LLM calls)."""
     try:
@@ -279,20 +280,24 @@ async def _list_recent_sessions(
             agent_id=agent_id,
             service_account_id=service_account_id,
             limit=limit + 5,  # fetch extra to skip current
+            any_principal=owner_scope,
         )
 
-        # Resolve current session lineage to exclude it
+        # Resolve current session lineage to exclude it -- the walked root
+        # is what appears in the roots-only listing, not the child itself.
         current_root: UUID | None = None
         if current_session_id:
             try:
-                sid = current_session_id
+                root = current_session_id
                 visited: set[UUID] = set()
-                while sid and sid not in visited:
-                    visited.add(sid)
-                    s = await session_store.get_session(sid)
+                while root not in visited:
+                    visited.add(root)
+                    s = await session_store.get_session(root)
                     parent = s.parent_id if s else None
-                    sid = parent if parent else None
-                current_root = current_session_id
+                    if not parent:
+                        break
+                    root = parent
+                current_root = root
             except Exception:
                 current_root = current_session_id
 
@@ -320,7 +325,7 @@ async def _list_recent_sessions(
             except Exception:
                 pass
 
-            results.append({
+            entry = {
                 "session_id": str(sid),
                 "title": s.title or None,
                 "channel": s.channel,
@@ -328,7 +333,9 @@ async def _list_recent_sessions(
                 "last_active": _format_timestamp(s.updated_at),
                 "message_count": s.message_count,
                 "preview": preview,
-            })
+            }
+            _attach_session_user(entry, s.user_id, owner_scope)
+            results.append(entry)
             if len(results) >= limit:
                 break
 
@@ -352,6 +359,80 @@ async def _list_recent_sessions(
 # ---------------------------------------------------------------------------
 
 
+def _attach_session_user(
+    entry: dict[str, Any],
+    user_id: Any,
+    owner_scope: bool,
+) -> None:
+    """Under owner scope, stamp the session's owning user onto a result
+    entry so the console can tell principals apart. ``None`` means a
+    principal-less or service-account-owned session."""
+    if owner_scope:
+        entry["user_id"] = str(user_id) if user_id else None
+
+
+# Matches ops_chat_service_account_name in surogate-ops
+# (server/services/agent_forward.py): "ops-chat-{org_id}-{user_id}".
+# Only surogate-ops's live-chat forwarder authenticates with these
+# accounts; creating one with a matching name requires org-admin rights.
+_OPS_CHAT_SA_PREFIX = "ops-chat-"
+
+
+async def _is_owner_scoped(
+    session_store: Any,
+    service_account_id: UUID | None,
+    session_config: Any,
+) -> bool:
+    """Return ``True`` when the calling session is an ops console chat on a
+    managed (non-system) agent.
+
+    Owner scope widens search from "the caller's own sessions" to "every
+    principal's sessions for this org + agent" -- mirroring the ops
+    Sessions Explorer, where ``GET /api/sessions`` defaults to
+    ``scope="all"`` for managed agents but forces ``scope="mine"`` on
+    system agents (copilot chats are private per user).  All three
+    conditions are server-controlled:
+
+    - ``config.ops.user_id`` must be stamped (``create_live_session`` in
+      surogate-ops).  The public session API copies client config
+      verbatim, so this alone is forgeable -- hence the next check.
+      The same stamp is parsed in ``orchestrator/mcp_client.py`` and
+      ``tools/mcp/client.py``; keep all three in sync.
+    - the session principal must be a service account whose name carries
+      the ops live-chat prefix.  End-user surfaces (web SPA, website
+      widget, managed channels) never run under a service account, and an
+      org API token's own service account cannot match the prefix unless
+      an org admin deliberately named it so.
+    - ``config.agent_type`` must be absent: surogate-ops always stamps it
+      for system agents, and their sessions must stay private per user.
+    """
+    if service_account_id is None:
+        return False
+    if not isinstance(session_config, dict):
+        return False
+    ops = session_config.get("ops")
+    if not (isinstance(ops, dict) and ops.get("user_id")):
+        return False
+    if session_config.get("agent_type"):
+        return False
+    try:
+        from sqlalchemy import text as sa_text
+
+        async with session_store._sf() as db:
+            row = await db.execute(
+                sa_text("SELECT name FROM service_accounts WHERE id = :id"),
+                {"id": service_account_id},
+            )
+            name = row.scalar_one_or_none()
+    except Exception:
+        logger.warning(
+            "Owner-scope service-account lookup failed; staying principal-scoped",
+            exc_info=True,
+        )
+        return False
+    return bool(name) and name.startswith(_OPS_CHAT_SA_PREFIX)
+
+
 async def session_search(
     query: str,
     role_filter: str | None = None,
@@ -363,6 +444,7 @@ async def session_search(
     agent_id: str = "",
     current_session_id: UUID | None = None,
     auxiliary_fn: Any | None = None,
+    owner_scope: bool = False,
 ) -> str:
     """Search past sessions and return focused summaries of matching conversations.
 
@@ -414,6 +496,7 @@ async def session_search(
             limit,
             current_session_id,
             service_account_id=service_account_id,
+            owner_scope=owner_scope,
         )
 
     query = query.strip()
@@ -446,15 +529,25 @@ async def session_search(
         raw_results: list[dict[str, Any]] = []
         try:
             async with session_store._sf() as db:
-                principal_column = (
-                    "s.service_account_id"
-                    if service_account_id is not None
-                    else "s.user_id"
-                )
-                principal_param = (
-                    service_account_id
-                    if service_account_id is not None
-                    else user_id
+                params: dict[str, Any] = {
+                    "query": query,
+                    "org_id": org_id,
+                    "agent_id": agent_id,
+                    "limit": 50,  # Get more matches to find unique sessions
+                }
+                # Owner scope (ops console sessions only -- see
+                # _is_owner_scoped) drops the principal predicate so the
+                # search spans every user's sessions for this org + agent.
+                if owner_scope:
+                    principal_clause = ""
+                elif service_account_id is not None:
+                    principal_clause = "AND s.service_account_id = :principal_id"
+                    params["principal_id"] = service_account_id
+                else:
+                    principal_clause = "AND s.user_id = :principal_id"
+                    params["principal_id"] = user_id
+                hidden_clause = "AND s.channel NOT IN ({})".format(
+                    ", ".join(f"'{c}'" for c in _HIDDEN_SESSION_CHANNELS)
                 )
                 # Build full-text search query using PostgreSQL ts_vector
                 # Search event data->>'content' across all sessions for this org
@@ -470,6 +563,7 @@ async def session_search(
                            s.model,
                            s.title,
                            s.parent_id,
+                           s.user_id,
                            ts_rank(
                                to_tsvector('english', COALESCE(e.data->>'content', '') || ' ' || COALESCE(e.data->>'result', '')),
                                plainto_tsquery('english', :query)
@@ -477,7 +571,8 @@ async def session_search(
                     FROM events e
                     JOIN sessions s ON s.id = e.session_id
                     WHERE s.org_id = :org_id
-                      AND {principal_column} = :principal_id
+                      {principal_clause}
+                      {hidden_clause}
                       AND s.agent_id = :agent_id
                       AND s.status != 'archived'
                       AND to_tsvector('english', COALESCE(e.data->>'content', '') || ' ' || COALESCE(e.data->>'result', ''))
@@ -486,13 +581,6 @@ async def session_search(
                     LIMIT :limit
                     """
                 )
-                params: dict[str, Any] = {
-                    "query": query,
-                    "org_id": org_id,
-                    "principal_id": principal_param,
-                    "agent_id": agent_id,
-                    "limit": 50,  # Get more matches to find unique sessions
-                }
 
                 result = await db.execute(fts_query, params)
                 rows = result.mappings().all()
@@ -509,6 +597,7 @@ async def session_search(
                         "model": row["model"],
                         "title": row["title"],
                         "parent_id": row["parent_id"],
+                        "user_id": row["user_id"],
                         "rank": row["rank"],
                     })
         except Exception as e:
@@ -649,6 +738,7 @@ async def session_search(
                 "model": match_info.get("model"),
                 "title": match_info.get("title"),
             }
+            _attach_session_user(entry, match_info.get("user_id"), owner_scope)
 
             if result_val:
                 entry["summary"] = result_val
@@ -707,7 +797,10 @@ SESSION_SEARCH_SCHEMA = ToolSchema(
         "phrases for exact match (\"docker networking\"), boolean (python NOT java), prefix (deploy*). "
         "IMPORTANT: Use OR between keywords for best results — FTS5 defaults to AND which misses "
         "sessions that only mention some terms. If a broad OR query returns nothing, try individual "
-        "keyword searches in parallel. Returns summaries of the top matching sessions."
+        "keyword searches in parallel. Returns summaries of the top matching sessions.\n\n"
+        "In an ops console session, results span EVERY user of this agent and each result carries "
+        "a user_id — attribute those conversations to that user, never to yourself or the person "
+        "you are talking to."
     ),
     parameters={
         "type": "object",
@@ -792,6 +885,10 @@ async def _session_search_handler(
     if isinstance(current_session_id, str):
         current_session_id = UUID(current_session_id)
 
+    owner_scope = await _is_owner_scoped(
+        store, service_account_id, kwargs.get("session_config"),
+    )
+
     return await session_search(
         query=arguments.get("query", ""),
         role_filter=arguments.get("role_filter"),
@@ -803,4 +900,5 @@ async def _session_search_handler(
         agent_id=agent_id,
         current_session_id=current_session_id,
         auxiliary_fn=auxiliary_fn,
+        owner_scope=owner_scope,
     )

--- a/tests/integration/test_session_search.py
+++ b/tests/integration/test_session_search.py
@@ -10,9 +10,26 @@ import pytest
 from surogates.session.events import EventType
 from surogates.tools.builtin.session_search import _session_search_handler
 
-from .conftest import create_org, issue_service_account_token
+from .conftest import create_org, create_user, issue_service_account_token
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def _seed_student_session(
+    session_store, session_factory, org_id, agent_id, content,
+):
+    """Create a user + a session owned by that user with one message."""
+    user_id = await create_user(session_factory, org_id)
+    session = await session_store.create_session(
+        user_id=user_id,
+        org_id=org_id,
+        agent_id=agent_id,
+        channel="web",
+    )
+    await session_store.emit_event(
+        session.id, EventType.USER_MESSAGE, {"content": content},
+    )
+    return user_id, session
 
 
 async def test_session_search_accepts_service_account_principal(
@@ -51,3 +68,258 @@ async def test_session_search_accepts_service_account_principal(
     assert result["success"] is True
     assert result["count"] == 1
     assert result["results"][0]["session_id"] == str(session.id)
+
+
+async def test_owner_scoped_search_sees_end_user_sessions(
+    session_store, session_factory,
+):
+    """An ops owner-console session (SA principal + ops config stamp)
+    searches across every principal's sessions for the same org + agent."""
+    org_id = await create_org(session_factory)
+    other_org = await create_org(session_factory)
+    issued = await issue_service_account_token(
+        session_factory, org_id, name=f"ops-chat-{org_id}-owner",
+    )
+
+    _, student_session = await _seed_student_session(
+        session_store, session_factory, org_id, "agent-a",
+        "the magnesium electron configuration is 2 8 2",
+    )
+    # Same org, different agent -- must stay invisible.
+    await _seed_student_session(
+        session_store, session_factory, org_id, "agent-b",
+        "the magnesium electron configuration is 2 8 2",
+    )
+    # Different org entirely -- must stay invisible.
+    await _seed_student_session(
+        session_store, session_factory, other_org, "agent-a",
+        "the magnesium electron configuration is 2 8 2",
+    )
+
+    result = json.loads(
+        await _session_search_handler(
+            {"query": "magnesium"},
+            session_store=session_store,
+            tenant=SimpleNamespace(
+                org_id=org_id, user_id=None, service_account_id=issued.id,
+            ),
+            agent_id="agent-a",
+            session_config={"ops": {"user_id": "11111111-1111-1111-1111-111111111111"}},
+        )
+    )
+
+    assert result["success"] is True
+    assert result["count"] == 1
+    assert result["results"][0]["session_id"] == str(student_session.id)
+
+
+async def test_forged_ops_config_on_user_principal_stays_scoped(
+    session_store, session_factory,
+):
+    """A user-principal session cannot widen its scope by stamping an
+    ``ops`` block into its own config -- the gate requires a
+    service-account principal, which end-user surfaces never get."""
+    org_id = await create_org(session_factory)
+
+    attacker_id, attacker_session = await _seed_student_session(
+        session_store, session_factory, org_id, "agent-a",
+        "attacker asking about magnesium",
+    )
+    _, victim_session = await _seed_student_session(
+        session_store, session_factory, org_id, "agent-a",
+        "victim discussing magnesium secrets",
+    )
+
+    result = json.loads(
+        await _session_search_handler(
+            {"query": "magnesium"},
+            session_store=session_store,
+            tenant=SimpleNamespace(
+                org_id=org_id, user_id=attacker_id, service_account_id=None,
+            ),
+            agent_id="agent-a",
+            session_config={"ops": {"user_id": str(attacker_id)}},
+        )
+    )
+
+    assert result["success"] is True
+    session_ids = {r["session_id"] for r in result["results"]}
+    assert str(victim_session.id) not in session_ids
+    assert session_ids == {str(attacker_session.id)}
+
+
+async def test_service_account_without_ops_stamp_stays_scoped(
+    session_store, session_factory,
+):
+    """A service-account principal without the ops config stamp keeps
+    the existing behaviour: only its own sessions."""
+    org_id = await create_org(session_factory)
+    issued = await issue_service_account_token(session_factory, org_id)
+
+    own_session = await session_store.create_session(
+        user_id=None,
+        service_account_id=issued.id,
+        org_id=org_id,
+        agent_id="agent-a",
+        channel="api",
+    )
+    await session_store.emit_event(
+        own_session.id, EventType.USER_MESSAGE,
+        {"content": "service account notes about magnesium"},
+    )
+    await _seed_student_session(
+        session_store, session_factory, org_id, "agent-a",
+        "student session about magnesium",
+    )
+
+    result = json.loads(
+        await _session_search_handler(
+            {"query": "magnesium"},
+            session_store=session_store,
+            tenant=SimpleNamespace(
+                org_id=org_id, user_id=None, service_account_id=issued.id,
+            ),
+            agent_id="agent-a",
+        )
+    )
+
+    assert result["success"] is True
+    assert result["count"] == 1
+    assert result["results"][0]["session_id"] == str(own_session.id)
+
+
+async def test_owner_scoped_recent_mode_lists_end_user_sessions(
+    session_store, session_factory,
+):
+    """Empty-query (recent) mode under owner scope lists end-user
+    sessions and carries each session's user_id so the owner can tell
+    principals apart."""
+    org_id = await create_org(session_factory)
+    issued = await issue_service_account_token(
+        session_factory, org_id, name=f"ops-chat-{org_id}-owner",
+    )
+
+    student_id, student_session = await _seed_student_session(
+        session_store, session_factory, org_id, "agent-a",
+        "hello I want to learn chemistry",
+    )
+
+    result = json.loads(
+        await _session_search_handler(
+            {},
+            session_store=session_store,
+            tenant=SimpleNamespace(
+                org_id=org_id, user_id=None, service_account_id=issued.id,
+            ),
+            agent_id="agent-a",
+            session_config={"ops": {"user_id": "11111111-1111-1111-1111-111111111111"}},
+        )
+    )
+
+    assert result["success"] is True
+    assert result["mode"] == "recent"
+    by_id = {r["session_id"]: r for r in result["results"]}
+    assert str(student_session.id) in by_id
+    assert by_id[str(student_session.id)]["user_id"] == str(student_id)
+
+
+async def test_forged_ops_config_on_plain_service_account_stays_scoped(
+    session_store, session_factory,
+):
+    """An org API service account (not an ops live-chat account) cannot
+    widen its scope by stamping a forged ``ops`` block into its own
+    session config -- the gate also requires the ops-chat account-name
+    prefix that only surogate-ops's forwarder uses."""
+    org_id = await create_org(session_factory)
+    issued = await issue_service_account_token(
+        session_factory, org_id, name="partner-integration",
+    )
+
+    own_session = await session_store.create_session(
+        user_id=None,
+        service_account_id=issued.id,
+        org_id=org_id,
+        agent_id="agent-a",
+        channel="api",
+    )
+    await session_store.emit_event(
+        own_session.id, EventType.USER_MESSAGE,
+        {"content": "integration notes about magnesium"},
+    )
+    await _seed_student_session(
+        session_store, session_factory, org_id, "agent-a",
+        "student secrets about magnesium",
+    )
+
+    result = json.loads(
+        await _session_search_handler(
+            {"query": "magnesium"},
+            session_store=session_store,
+            tenant=SimpleNamespace(
+                org_id=org_id, user_id=None, service_account_id=issued.id,
+            ),
+            agent_id="agent-a",
+            session_config={"ops": {"user_id": "forged"}},
+        )
+    )
+
+    assert result["success"] is True
+    assert result["count"] == 1
+    assert result["results"][0]["session_id"] == str(own_session.id)
+
+
+async def test_system_agent_session_stays_scoped(
+    session_store, session_factory,
+):
+    """System-agent console sessions (config.agent_type stamped by
+    surogate-ops) stay private per user -- owner scope must not apply,
+    matching the ops Sessions Explorer's forced scope='mine'."""
+    org_id = await create_org(session_factory)
+    issued = await issue_service_account_token(
+        session_factory, org_id, name=f"ops-chat-{org_id}-member",
+    )
+
+    own_session = await session_store.create_session(
+        user_id=None,
+        service_account_id=issued.id,
+        org_id=org_id,
+        agent_id="copilot",
+        channel="web",
+    )
+    await session_store.emit_event(
+        own_session.id, EventType.USER_MESSAGE,
+        {"content": "my private copilot chat about magnesium"},
+    )
+    other = await issue_service_account_token(
+        session_factory, org_id, name=f"ops-chat-{org_id}-other",
+    )
+    other_session = await session_store.create_session(
+        user_id=None,
+        service_account_id=other.id,
+        org_id=org_id,
+        agent_id="copilot",
+        channel="web",
+    )
+    await session_store.emit_event(
+        other_session.id, EventType.USER_MESSAGE,
+        {"content": "someone else's private copilot chat about magnesium"},
+    )
+
+    result = json.loads(
+        await _session_search_handler(
+            {"query": "magnesium"},
+            session_store=session_store,
+            tenant=SimpleNamespace(
+                org_id=org_id, user_id=None, service_account_id=issued.id,
+            ),
+            agent_id="copilot",
+            session_config={
+                "ops": {"user_id": "11111111-1111-1111-1111-111111111111"},
+                "agent_type": "surogate-platform-copilot",
+            },
+        )
+    )
+
+    assert result["success"] is True
+    assert result["count"] == 1
+    assert result["results"][0]["session_id"] == str(own_session.id)


### PR DESCRIPTION
## What

`session_search` was hard-scoped to the calling principal, so an agent owner chatting with their agent in the ops console could never see end-user (e.g. student) sessions — even though the ops Sessions Explorer already grants owners that visibility. This PR widens the tool to org+agent scope for ops console sessions on managed agents, and only for those.

## Authorization gate (`_is_owner_scoped`)

Owner scope activates only when **all three** server-controlled conditions hold:

1. `config.ops.user_id` stamped by surogate-ops `create_live_session` (the public session API copies client config verbatim, so the stamp alone is deliberately insufficient),
2. the session principal is a **service account whose name carries the `ops-chat-` prefix** — only surogate-ops's live-chat forwarder authenticates with these; a forged `ops` block on a plain org API token stays principal-scoped,
3. **no `config.agent_type`** — surogate-ops always stamps it for system agents, whose chats stay private per user (mirrors the Explorer's forced `scope=mine` for system agents).

## Also in this change

- Owner-scoped results carry each session's `user_id` (both recent and keyword modes) so the console can tell principals apart; the tool schema tells the model to attribute those conversations correctly.
- FTS path now excludes hidden `tool`-channel sessions, matching what recent mode always did.
- Fixed the recent-mode lineage walk discarding its result — the current conversation's root no longer shows up as a "past session".
- `SessionStore.list_sessions` gains a keyword-only `any_principal` flag (default off, validation unchanged otherwise).

## Tests (integration, real Postgres via testcontainers)

- owner console sees an end-user session; same-org/different-agent and different-org sessions stay invisible
- forged `ops` config on a **user** principal stays scoped
- forged `ops` config on a **plain org API service account** stays scoped (name-prefix gate)
- ops-chat SA **without** the stamp stays scoped
- **system-agent** session (agent_type stamped) stays scoped
- recent mode lists end-user sessions with correct `user_id` attribution

7/7 pass; the 268 tests covering `list_sessions`/tooling pass; full integration-suite failures are byte-identical to clean master (pre-existing env flakes).

## Known follow-ups (out of scope)

- Delegation child sessions don't inherit the ops stamp, so subagents fail closed to own-scope — acceptable default, worth a deliberate decision later.
- No GIN/tsvector index on events and no `(org_id, agent_id, created_at)` composite on sessions: owner-scoped search is unindexed at scale (needs an alembic migration).
- `role_filter` has always been a silent no-op in the FTS SQL (pre-existing).
- The recent-mode `limit + 5` overfetch slack can underfill under owner scope when many hidden-channel sessions are newest.