### PR TITLE
feat(channels): Telegram parity, website per-agent config, delivery hardening

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1,182 +1,106 @@
-# Slack Integration Guide
+# Slack Channel
 
-Connect your Surogates agent to Slack so users can interact with it via DMs and channel @mentions.
+Connect an agent to Slack so users can interact with it via DMs, channel
+@mentions, threads, slash commands, and Block Kit buttons. The integration
+is **webhook-based** (Slack Events API): Slack POSTs events to the shared
+channels service (`surogates channels`), which resolves the owning agent
+per app, verifies the signature, and feeds the shared inbound pipeline.
+Socket Mode is not used.
 
-## Prerequisites
+## How it works
 
-- Surogates API server and worker running
-- PostgreSQL and Redis accessible
-- A Slack workspace where you have admin permissions
-
-## 1. Create a Slack App
-
-1. Go to [api.slack.com/apps](https://api.slack.com/apps) and click **Create New App** → **From scratch**
-2. Name it (e.g., "Surogates Agent") and select your workspace
-3. Under **Socket Mode**, click **Enable Socket Mode** and generate an app-level token with `connections:write` scope — this is your `SUROGATES_SLACK_APP_TOKEN` (starts with `xapp-`)
-
-## 2. Configure Bot Permissions
-
-Go to **OAuth & Permissions** → **Scopes** → **Bot Token Scopes** and add:
-
-| Scope               | Purpose                       |
-| ------------------- | ----------------------------- |
-| `app_mentions:read` | Detect @mentions in channels  |
-| `channels:history`  | Read channel messages         |
-| `channels:read`     | List channels                 |
-| `chat:write`        | Send messages                 |
-| `files:read`        | Download file attachments     |
-| `files:write`       | Upload agent files            |
-| `groups:history`    | Read private channel messages |
-| `groups:read`       | List private channels         |
-| `im:history`        | Read DM messages              |
-| `im:read`           | List DMs                      |
-| `im:write`          | Open DMs                      |
-| `mpim:history`      | Read group DM messages        |
-| `reactions:read`    | Read reactions                |
-| `reactions:write`   | Add/remove reactions          |
-| `users:read`        | Resolve user names            |
-
-These scopes also let the agent read channel metadata and recent history when it joins a channel.
-
-## 3. Subscribe to Events
-
-Go to **Event Subscriptions** → **Enable Events**, then under **Subscribe to bot events** add:
-
-- `message.channels`
-- `message.groups`
-- `message.im`
-- `message.mpim`
-- `app_mention`
-- `member_joined_channel` — lets the agent pre-fetch a channel's recent history when it is added
-
-If using the AI Assistant feature (optional):
-
-- `assistant_thread_started`
-- `assistant_thread_context_changed`
-
-### Channel context on join
-
-When the agent is added to a channel (or on its first message there), it backfills the channel's metadata and recent history — the most recent messages, bounded to roughly 7 days / 200 messages / 8k tokens — so it has context from the first reply. This needs the `channels:history` / `groups:history` read scopes and the `member_joined_channel` bot event above. DMs and group DMs are not backfilled. Private-channel history is only readable in channels the bot is a member of, and stays isolated to that channel's memory.
-
-## 4. Install the App
-
-Click **Install to Workspace** and authorize. Copy the **Bot User OAuth Token** — this is your `SUROGATES_SLACK_BOT_TOKEN` (starts with `xoxb-`).
-
-## 5. Link Slack Users
-
-Slack users must link their account to a Surogates user before they can interact with the agent. This happens automatically via **self-registration**:
-
-1. An unlinked Slack user sends a message to the bot
-2. The bot replies with an ephemeral message containing a pairing link and code
-3. The user clicks the link, logs in to the Surogates web UI, and clicks "Link"
-4. Their Slack ID is bound to their Surogates account — future messages work instantly
-
-The pairing code expires after 10 minutes and is single-use. Users are rate-limited to one code per 10 minutes.
-
-### Admin Registration (alternative)
-
-Admins can also link users manually via the API:
-
-```bash
-curl -X POST http://localhost:8000/v1/admin/channel-identities \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "user_id": "SUROGATES_USER_UUID",
-    "platform": "slack",
-    "platform_user_id": "U0123ABCDEF"
-  }'
+```
+Slack → POST https://<channels-host>/slack/{app_id}            (events)
+        POST https://<channels-host>/slack/{app_id}/interact   (buttons/modals)
+        POST https://<channels-host>/slack/{app_id}/commands   (slash commands)
+             │  verify v0 HMAC signature (vault signing_secret, ±5min replay window)
+             ▼
+        channel_routing lookup (ops) → (org, agent, config)
+             ▼
+        shared inbound pipeline → session → worker
+             ▼
+        delivery_outbox → chat.postMessage / chat.update / files_upload_v2
 ```
 
-## 6. Configure and Run
+- **Routing** — each Slack app maps to one agent via a `channel_routing`
+  row (kind `slack`, identifier = App ID) managed by Studio's Channels
+  form in `surogate-ops`; resolved with a 30s cache invalidated over
+  Redis pub/sub.
+- **Credentials** — `bot_token` (`xoxb-`) and `signing_secret` live in
+  the per-tenant credential vault. There is no app-level `xapp-` token —
+  that was the retired Socket Mode design.
+- **Webhook registration is manual**: paste the three request URLs shown
+  in Studio into the Slack app console (Event Subscriptions,
+  Interactivity & Shortcuts, Slash Commands).
 
-### Option A: Environment Variables
+## Setup
 
-```bash
-export SUROGATES_SLACK_APP_TOKEN="xapp-1-..."
-export SUROGATES_SLACK_BOT_TOKEN="xoxb-..."
-SUROGATES_CONFIG=config.dev.yaml surogates channel slack
-```
+1. Create an app at [api.slack.com/apps](https://api.slack.com/apps)
+   (From scratch), in the target workspace.
+2. **OAuth & Permissions → Bot Token Scopes**: `app_mentions:read`,
+   `channels:history`, `channels:read`, `chat:write`, `files:read`,
+   `files:write`, `groups:history`, `groups:read`, `im:history`,
+   `im:read`, `im:write`, `mpim:history`, `reactions:read`,
+   `reactions:write`, `users:read`.
+3. **Event Subscriptions → bot events**: `message.channels`,
+   `message.groups`, `message.im`, `message.mpim`, `app_mention`,
+   `member_joined_channel` (enables history backfill on join).
+4. Install the app, copy the **App ID**, **Bot Token**, and **Signing
+   Secret** into Studio → agent → **Channels** → **Slack**, and save.
+   The platform validates the bot token against Slack (`auth.test`) at
+   save time — an invalid token deactivates the channel — and shows the
+   request URLs to paste back into the Slack console.
 
-### Option B: Config File
+## Identity
 
-Add to your `config.yaml`:
+Same two policies as every channel (`identity_policy`): **shadow**
+auto-provisions a user per Slack sender (channel membership is the
+authorization boundary); **linked** requires a pairing code + account
+link before any session is created.
 
-```yaml
-slack:
-  app_token: "xapp-1-..."
-  bot_token: "xoxb-..."
-  require_mention: true
-  allow_bots: "none"
-```
+## Sessions & behavior
 
-Then run:
+Session keying: `agent:slack:{chat_type}:{channel_id}[:{thread_ts}]` —
+DMs get one session per user, channels share a session, threads get their
+own.
 
-```bash
-SUROGATES_CONFIG=config.yaml surogates channel slack
-```
+- **Mention gating**: `require_mention` gates channel messages on
+  @mention; threads the bot participated in stay open;
+  `free_response_channels` bypasses the gate; `allow_bots`
+  (`none`/`mentions`/`all`) controls other bots.
+- **Progress**: the bot posts a "_Thinking…_" placeholder and edits it in
+  place with intermediate narration and coding-run heartbeats; the final
+  answer replaces it.
+- **Backfill**: on joining a channel (or first message there) the bot
+  seeds the session with recent channel history (~7 days / 200 messages /
+  8k tokens). DMs are not backfilled.
+- **Long replies** are split at natural boundaries to stay under Slack's
+  message-size limit and posted sequentially in the same thread.
+- `/stop` (or `/cancel`) interrupts the running turn out-of-band.
 
-### Option C: VSCode
+## Files
 
-Set `SUROGATES_SLACK_BOT_TOKEN` and `SUROGATES_SLACK_APP_TOKEN` in your shell environment, then use the **"Surogates: Channel (Slack)"** launch configuration, or **"Surogates: Full Stack + Slack"** to start everything together.
+- **Inbound** attachments are downloaded (bot-token auth, 20 MB / 10
+  files caps) and ingested into the session workspace; the agent can also
+  fetch older shared files on demand.
+- **Outbound**: `MEDIA:<workspace-path>` markers in a reply upload the
+  referenced workspace files via `files_upload_v2` into the thread.
 
-## 7. Test It
+## Interactive input (`ask_user_question`)
 
-- **DM the bot** — send a message directly. The bot responds immediately.
-- **@mention in a channel** — type `@Surogates Agent hello`. The bot responds in a thread.
-- **Thread replies** — once mentioned in a thread, the bot responds to all follow-up messages in that thread without needing another @mention.
+Mid-run questions render as a Block Kit message with an **Answer**
+button that opens a modal (choices, free-text "Other"). Submitting the
+modal resolves the durable pending record, replaces the button message
+with the recorded answer, and wakes the waiting tool. While a question
+is pending, plain replies get a nudge toward the Answer button instead
+of piling onto the blocked worker.
 
-## Behavior Configuration
+## Ops notes
 
-### Mention Gating
-
-By default, the bot only responds in channels when @mentioned. Configure this:
-
-```yaml
-slack:
-  require_mention: true # default: require @mention in channels
-  free_response_channels: "C123,C456" # channels where no mention needed
-```
-
-### Bot Message Handling
-
-Control whether the bot responds to other bots:
-
-```yaml
-slack:
-  allow_bots: "none"       # ignore all bot messages (default)
-  allow_bots: "mentions"   # respond to bots only if they @mention us
-  allow_bots: "all"        # respond to all bot messages (except our own)
-```
-
-### Threading
-
-```yaml
-slack:
-  reply_in_thread: true # respond in thread (default)
-  reply_broadcast: false # also post to channel when replying in thread
-```
-
-## Multi-Workspace
-
-For Slack apps installed in multiple workspaces (e.g., via OAuth distribution), provide comma-separated bot tokens:
-
-```bash
-export SUROGATES_SLACK_BOT_TOKEN="xoxb-workspace1-token,xoxb-workspace2-token"
-```
-
-Each workspace is authenticated independently. The adapter routes API calls to the correct workspace based on the channel's team ID.
-
-## Slash Commands (Optional)
-
-Register a slash command `/surogates` in your Slack app settings to allow users to invoke the agent via `/surogates <message>`. The command is treated as a regular message.
-
-## Troubleshooting
-
-| Problem                            | Solution                                                                                                              |
-| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| Bot doesn't respond in channels    | Check `require_mention` is `true` and you're @mentioning it                                                           |
-| "Your Slack account is not linked" | Click the pairing link the bot sent, log in, and link your account. Or ask an admin to register via the API (step 5). |
-| Bot responds twice                 | Check for duplicate Socket Mode connections (only one adapter process per app token)                                  |
-| File attachments not working       | Ensure `files:read` scope is added and the bot is in the channel                                                      |
-| Rate limit errors in logs          | Normal for thread context fetching — the adapter retries automatically                                                |
+- Enable the platform on the channels deployment via the runtime config
+  (`channels.slack.enabled: true`); routing rows control which apps are
+  live.
+- Delivery is a durable outbox: transient failures retry every 30s and
+  dead-letter after 30 minutes or on permanent errors.
+- Unknown app ids are fast-acked with 200 and no side effects; the URL
+  verification challenge is answered automatically.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -1,246 +1,101 @@
-# Telegram Integration Guide
+# Telegram Channel
 
-Connect your Surogates agent to Telegram so users can interact with it via DMs, groups, and forum topics.
+Connect an agent to Telegram so users can talk to it in DMs, groups, and
+forum topics. The integration is **webhook-based**: Telegram pushes updates
+to the shared channels service (`surogates channels`), which resolves the
+owning agent per bot, verifies the request, and feeds the shared inbound
+pipeline. There is no long-polling process and no per-agent adapter.
 
-## Prerequisites
+## How it works
 
-- Surogates API server and worker running
-- PostgreSQL and Redis accessible
-- A Telegram account to create the bot
-
-## 1. Create a Telegram Bot
-
-1. Open Telegram and message [@BotFather](https://t.me/BotFather)
-2. Send `/newbot` and follow the prompts to choose a name and username
-3. BotFather replies with a bot token — this is your `SUROGATES_TELEGRAM_BOT_TOKEN`
-
-Optional BotFather settings:
-
-- `/setprivacy` → **Disable** — allows the bot to see all group messages (not just commands and @mentions)
-- `/setjoingroups` → **Enable** — allows the bot to be added to groups
-- `/setcommands` → set a command list for the Telegram menu hint
-
-## 2. Link Telegram Users
-
-Telegram users must be linked to a Surogates user before they can interact with the agent. Currently this is done via the admin API:
-
-```bash
-curl -X POST http://localhost:8000/v1/admin/channel-identities \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "user_id": "SUROGATES_USER_UUID",
-    "platform": "telegram",
-    "platform_user_id": "TELEGRAM_NUMERIC_USER_ID"
-  }'
+```
+Telegram → POST https://<channels-host>/telegram/{bot_username}
+             │  verify X-Telegram-Bot-Api-Secret-Token (vault webhook_secret)
+             ▼
+        channel_routing lookup (ops) → (org, agent, config)
+             ▼
+        shared inbound pipeline → session → worker
+             ▼
+        delivery_outbox → Telegram sendMessage (HTML, chunked)
 ```
 
-To find a user's numeric Telegram ID, have them message [@userinfobot](https://t.me/userinfobot) or check the logs when they send a message to the bot (the adapter logs unknown user IDs).
+- **Routing** — each bot maps to one agent via a `channel_routing` row
+  (kind `telegram`, identifier `@botusername`) managed by Studio's
+  Channels form in `surogate-ops`. The channels service resolves it over
+  HTTP with a 30s cache invalidated by Redis pub/sub.
+- **Credentials** — `bot_token` and `webhook_secret` live in the
+  per-tenant credential vault, never in env vars or config files.
+- **Webhook registration** — automatic. The reconciler calls
+  `setWebhook` for every active routing with a minted secret token;
+  verification compares the `X-Telegram-Bot-Api-Secret-Token` header in
+  constant time.
 
-## 3. Configure and Run
+## Setup
 
-### Option A: Environment Variables
+1. Message [@BotFather](https://t.me/BotFather), `/newbot`, copy the token.
+   Optional: `/setprivacy` → **Disable** so the bot sees all group
+   messages (not only commands/@mentions); `/setjoingroups` → **Enable**.
+2. In Studio, open the agent → **Channels** → **Telegram**, paste the bot
+   token, and save. The platform calls `getMe` to validate the token and
+   derive the `@username` (an invalid token deactivates the channel), then
+   registers the webhook automatically.
 
-```bash
-export SUROGATES_TELEGRAM_BOT_TOKEN="123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
-SUROGATES_CONFIG=config.dev.yaml surogates channel telegram
-```
+## Identity
 
-### Option B: Config File
+Two policies, chosen per channel in Studio (`identity_policy`):
 
-Add to your `config.yaml`:
+- **shadow** (default) — every Telegram sender is auto-provisioned a
+  shadow user on first contact. Chat membership is the authorization
+  boundary (the "Mate" model).
+- **linked** — only linked Surogate accounts may talk. Unknown senders
+  receive a private pairing code and a link prompt; no session is created
+  until they link.
 
-```yaml
-telegram:
-  bot_token: "123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
-```
+## Sessions & threading
 
-Then run:
+Session keying: `agent:telegram:{chat_type}:{chat_id}[:{user_id}][:{thread_id}]` —
+one session per DM user; one shared session per group (or per user with
+**per-user groups**); forum topics get their own sessions.
 
-```bash
-SUROGATES_CONFIG=config.yaml surogates channel telegram
-```
+- **Reply threading** (`reply_to_mode`): `first` replies to the message
+  that opened the session; `all` replies to the sender's latest message;
+  `off` posts plain messages. Groups only — DMs never use reply-to.
+- **Reactions** (`reactions_enabled`): the bot reacts 👀 to a message it
+  accepted for processing — the "seen, working on it" signal.
+- **Mention gating**: in groups, `require_mention` gates on `@botusername`;
+  `mention_patterns` (CSV) adds extra trigger words (e.g. a nickname);
+  `free_response_channels` lists chat ids that bypass the gate.
+- `/stop` (or `/cancel`) interrupts the running turn out-of-band.
 
-## 4. Test It
+## Media
 
-- **DM the bot** -- send a message directly. The bot responds with MarkdownV2 formatting.
-- **Add to a group** -- add the bot to a group chat. By default it responds to all messages; set `require_mention: true` to require @mentions.
-- **Send a photo** -- the bot downloads it to a local cache for vision tool access.
-- **Send a document** -- supported types: PDF, Markdown, TXT, DOCX, XLSX, PPTX, ZIP (max 20 MB).
-- **Send a voice message** -- the bot caches it for speech-to-text processing.
-- **Share a location** -- the bot receives coordinates and venue details.
+- **Inbound**: photos, documents, voice, audio, video, and video notes
+  are downloaded via `getFile` (20 MB cap, 10 files per message) and
+  ingested into the session workspace; captions become the message text.
+- **Outbound**: replies are rendered from markdown to Telegram HTML
+  (bold/italic/code/pre/links; plain-text retry if Telegram rejects the
+  parse) and split at natural boundaries to fit the 4096-char limit.
 
-## Behavior Configuration
+## Interactive input (`ask_user_question`)
 
-### Connection Mode
+When the agent asks a question mid-run:
 
-By default, the adapter uses **long polling** (outbound connection to Telegram). For cloud deployments where inbound HTTP can wake a suspended container, use **webhook mode**:
+- A single choice-question renders as an **inline keyboard** — tapping a
+  button resolves the durable pending record, edits the prompt message to
+  show the recorded answer, and wakes the waiting tool.
+- Free-text (or multi-question) prompts are answered by simply replying;
+  the pipeline matches choice labels case-insensitively and records
+  anything else as a free-form answer, acking with "Got it".
 
-```yaml
-telegram:
-  bot_token: "..."
-  webhook_url: "https://your-app.fly.dev/telegram"  # public HTTPS URL
-  webhook_port: 8443                                  # local listen port
-  webhook_secret: "a-random-secret"                   # update verification
-```
+Button callbacks are bound to the session's chat — a forged
+`callback_data` from another chat is acked and ignored.
 
-When `webhook_url` is empty (the default), polling mode is used.
+## Ops notes
 
-### Mention Gating
-
-In group chats, control when the bot responds:
-
-```yaml
-telegram:
-  require_mention: false        # respond to all group messages (default)
-  free_response_chats: "123,456" # chat IDs where no mention is needed regardless
-  mention_patterns: '["hey bot", "\\bsurogates\\b"]'  # regex wake-word patterns (JSON list or comma-separated)
-```
-
-When `require_mention` is `true`, the bot only responds in groups when:
-
-- The bot is @mentioned
-- The message is a reply to one of the bot's messages
-- The message is a `/command`
-- The message text matches a `mention_patterns` regex
-- The chat is listed in `free_response_chats`
-
-DMs are always unrestricted.
-
-### Reply Threading
-
-Control how the bot threads its replies to user messages:
-
-```yaml
-telegram:
-  reply_to_mode: "first"  # "first" (default), "all", or "off"
-```
-
-- `first` -- only the first chunk of a multi-chunk response threads to the user's message
-- `all` -- every chunk threads to the user's message
-- `off` -- responses are never threaded
-
-### Message Reactions
-
-Enable emoji reactions to show processing status:
-
-```yaml
-telegram:
-  reactions_enabled: false  # default: off
-```
-
-When enabled, the bot sets a reaction on the user's message when processing starts, and a thumbs-up when the response is delivered.
-
-### Session Isolation
-
-In group chats, each user gets their own session by default. To use a single shared session per group:
-
-```yaml
-telegram:
-  per_user_groups: false  # default: true (separate session per user)
-```
-
-## Message Handling
-
-### Text Message Aggregation
-
-Telegram clients split long messages (>4096 characters) into multiple updates. The adapter buffers rapid successive messages from the same user and aggregates them into a single event before dispatching. The buffer uses an adaptive delay:
-
-- **Normal messages**: 0.6 seconds quiet period (`text_batch_delay`)
-- **Near-split-point chunks** (>4000 chars): 2.0 seconds (`text_batch_split_delay`)
-
-### Photo and Album Batching
-
-When a user sends multiple photos rapidly (or a Telegram album), the adapter merges them into a single event instead of interrupting the agent with each one. Album items sharing a `media_group_id` are always merged. Individual photos are batched with a 0.8 second delay (`media_batch_delay`).
-
-### MarkdownV2 Formatting
-
-Outbound messages are converted from standard Markdown to Telegram MarkdownV2. Code blocks, inline code, links, bold, italic, strikethrough, spoilers, and blockquotes are supported. If MarkdownV2 parsing fails (malformed markup), the adapter falls back to plain text automatically.
-
-### Media Sending
-
-The adapter supports sending rich media in responses:
-
-| Type | Bot API method | Notes |
-|---|---|---|
-| Text | `sendMessage` | MarkdownV2 with plain-text fallback, chunked at 4096 chars |
-| Photo (URL) | `sendPhoto` | Falls back to download+upload for >5 MB images |
-| Photo (file) | `sendPhoto` | Local file upload |
-| Voice/Audio | `sendVoice` / `sendAudio` | `.ogg`/`.opus` as voice bubble, others as audio file |
-| Video | `sendVideo` | Local file upload |
-| Document | `sendDocument` | Any file with display name |
-| Animation | `sendAnimation` | GIF auto-play, falls back to photo |
-| Edit | `editMessageText` | For streaming response updates |
-
-## Network Resilience
-
-### Fallback IP Transport
-
-In networks where `api.telegram.org` is unreachable (DNS poisoning, geo-blocking), the adapter auto-discovers alternative IPs via DNS-over-HTTPS (Google and Cloudflare) and routes requests through them while preserving TLS/SNI. This is transparent and requires no configuration.
-
-To provide explicit fallback IPs:
-
-```yaml
-telegram:
-  fallback_ips: "149.154.167.220,149.154.167.221"
-```
-
-To disable fallback transport (e.g., when using a proxy):
-
-```bash
-export SUROGATES_TELEGRAM_DISABLE_FALLBACK_IPS=true
-```
-
-The adapter also respects standard proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`).
-
-### Polling Error Recovery
-
-The adapter handles transient failures automatically:
-
-- **Network errors** (connection reset, timeout): exponential backoff (5s, 10s, 20s... up to 60s), up to 10 retries
-- **409 Conflict** (another instance polling the same token): 3 retries at 10-second intervals, then stops
-- **Send failures**: 3 retries with exponential backoff; flood control (`429 Too Many Requests`) waits the `retry_after` duration
-
-### Custom Bot API Server
-
-For self-hosted [Telegram Bot API servers](https://core.telegram.org/bots/api#using-a-local-bot-api-server):
-
-```yaml
-telegram:
-  base_url: "http://localhost:8081/bot"
-```
-
-## Advanced Configuration
-
-All settings use the `SUROGATES_TELEGRAM_` environment variable prefix:
-
-| Setting | Env var | Default | Description |
-|---|---|---|---|
-| `bot_token` | `SUROGATES_TELEGRAM_BOT_TOKEN` | | Bot token from BotFather |
-| `webhook_url` | `SUROGATES_TELEGRAM_WEBHOOK_URL` | | Webhook URL (empty = polling) |
-| `webhook_port` | `SUROGATES_TELEGRAM_WEBHOOK_PORT` | `8443` | Webhook listen port |
-| `webhook_secret` | `SUROGATES_TELEGRAM_WEBHOOK_SECRET` | | Webhook verification secret |
-| `require_mention` | `SUROGATES_TELEGRAM_REQUIRE_MENTION` | `false` | Require @mention in groups |
-| `free_response_chats` | `SUROGATES_TELEGRAM_FREE_RESPONSE_CHATS` | | Comma-separated chat IDs |
-| `mention_patterns` | `SUROGATES_TELEGRAM_MENTION_PATTERNS` | | JSON list or comma-separated regexes |
-| `reply_to_mode` | `SUROGATES_TELEGRAM_REPLY_TO_MODE` | `first` | Reply threading mode |
-| `reactions_enabled` | `SUROGATES_TELEGRAM_REACTIONS_ENABLED` | `false` | Processing lifecycle reactions |
-| `per_user_groups` | `SUROGATES_TELEGRAM_PER_USER_GROUPS` | `true` | Per-user sessions in groups |
-| `fallback_ips` | `SUROGATES_TELEGRAM_FALLBACK_IPS` | | Comma-separated fallback IPs |
-| `base_url` | `SUROGATES_TELEGRAM_BASE_URL` | | Custom Bot API server URL |
-| `media_batch_delay` | `SUROGATES_TELEGRAM_MEDIA_BATCH_DELAY` | `0.8` | Photo/album batch delay (seconds) |
-| `text_batch_delay` | `SUROGATES_TELEGRAM_TEXT_BATCH_DELAY` | `0.6` | Text batch delay (seconds) |
-| `text_batch_split_delay` | `SUROGATES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY` | `2.0` | Delay for near-split-point chunks |
-
-## Troubleshooting
-
-| Problem | Solution |
-|---|---|
-| Bot doesn't respond | Check `SUROGATES_TELEGRAM_BOT_TOKEN` is set correctly. Check logs for "Connected (polling mode)". |
-| "Unknown user ... ignoring message" in logs | The Telegram user is not linked. Register them via the admin API (step 2). |
-| Bot doesn't respond in groups | If `require_mention` is `true`, @mention the bot. Also check BotFather `/setprivacy` is disabled. |
-| "Another process is already polling" | Only one adapter instance can poll per bot token. Stop the other process. |
-| Messages are delayed | Check `text_batch_delay` and `media_batch_delay` settings. The adapter buffers rapid messages to handle Telegram's client-side splitting. |
-| MarkdownV2 parse errors in logs | Normal -- the adapter falls back to plain text automatically. Check for malformed markdown in agent responses. |
-| "Telegram network error, scheduling reconnect" | Transient network issue. The adapter retries automatically with exponential backoff. |
-| Photos not processed | Ensure the bot has permission to download files (default for Bot API). Check `/tmp/surogates/cache/images` for cached files. |
+- Enable the platform on the channels deployment via the runtime config
+  (`channels.telegram.enabled: true`); routing rows control which bots are
+  live.
+- Delivery is a durable outbox: transient failures retry every 30s and
+  dead-letter after 30 minutes or on permanent errors.
+- Unknown bot usernames are fast-acked with 200 and no side effects, so
+  the webhook endpoint is not an enumeration oracle.

--- a/docs/channels/website.md
+++ b/docs/channels/website.md
@@ -63,6 +63,18 @@ The Helm chart packages it into the `{release}-website` Secret and injects it as
 | `allowed_origins` | Comma-separated, exact-match list (scheme + host + port). Wildcards not supported; every embedding domain must be enumerated. |
 | `session_message_cap` | Per-session message ceiling. `0` means "no cap"; a non-zero value triggers HTTP 429 on the message endpoint when reached. Materialised onto `session.config` at bootstrap so the cap a visitor was admitted under stays stable for the whole session. |
 
+### Per-agent overrides via channel routing
+
+The global fields above are deployment-wide fallbacks. When Studio's
+Website channel form is used, the per-agent `channel_routing` row's
+`config` carries `allowed_origins` (list) and `session_message_cap`,
+and those take precedence for that agent's key: bootstrap checks the
+per-agent allow-list, the session cookie records its publishable key
+(`channel_identifier` claim), and every later request re-resolves the
+routing row — so deactivating the channel in Studio cuts live visitor
+sessions with 403, and origin-list changes apply to in-flight sessions
+without a redeploy.
+
 ### What is *not* on the channel
 
 The channel deliberately does **not** carry agent-defining fields — `model`, `system_prompt`, `tool_allow_list`, `skill_pins` — because a channel is a transport, not an agent. Different visitor populations that genuinely need different model behaviour, prompts, or tool surfaces are different agents and belong in different deployments.

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -18,15 +18,19 @@ needs to talk to the deployment's agent embedded on a public website:
   headers, so the CSRF header isn't required (GETs are safe by
   CSRF's standard assumption — nothing is mutated).
 
-The channel on-switch and the origin allow-list come from
-:class:`WebsiteSettings` (global, per-deployment).  The agent identity
-is resolved per-request from the publishable key via
+The deployment-wide on-switch comes from :class:`WebsiteSettings`; the
+agent identity is resolved per-request from the publishable key via
 ``channel_routing(website:<key>)`` -- the same mechanism the
-Slack/Telegram adapters use -- so each agent has its own key.  Origin
-validation is the conjunction of two checks: the configured allow-list
-(authoritative) and the session cookie's ``origin`` claim (anchors a
-bootstrapped session to the embed it came from).  A request must
-satisfy both.
+Slack/Telegram adapters use -- so each agent has its own key.  The
+origin allow-list and session message cap are per-agent when the
+routing row's ``config`` carries them (projected from Studio's Website
+channel form), falling back to the global :class:`WebsiteSettings`
+values otherwise.  Origin validation is the conjunction of two checks:
+the effective allow-list (authoritative) and the session cookie's
+``origin`` claim (anchors a bootstrapped session to the embed it came
+from).  A request must satisfy both; cookie-authenticated calls also
+re-resolve the routing row so deactivating the channel cuts live
+sessions.
 """
 
 from __future__ import annotations
@@ -290,6 +294,32 @@ def _enforce_origin_binding(
         )
 
 
+def _routing_channel_config(routing: dict | None) -> dict:
+    """The per-agent behavior blob projected into ``channel_routing.config``."""
+    config = (routing or {}).get("config")
+    return config if isinstance(config, dict) else {}
+
+
+def _agent_allowed_origins(routing_config: dict) -> tuple[str, ...] | None:
+    """Per-agent origin allow-list from routing config, or ``None`` when the
+    agent has not configured one (fall back to the deployment-global list).
+
+    Accepts both the projected list form and a legacy CSV string.
+    """
+    raw = routing_config.get("allowed_origins")
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        origins = parse_allowed_origins(raw)
+    else:
+        origins = tuple(
+            normalize_origin(str(origin))
+            for origin in raw
+            if str(origin).strip()
+        )
+    return origins or None
+
+
 async def _load_and_authorize_session(
     request: Request,
     path_session_id: UUID,
@@ -300,6 +330,13 @@ async def _load_and_authorize_session(
     must match the claim so a visitor of one session cannot target
     another visitor's session by swapping the URL — the session JWT
     scopes to exactly one session.
+
+    When the cookie names its bootstrap ``channel_identifier``, the
+    per-agent routing row is re-resolved on every call: turning the
+    agent's website channel off (row deactivated) cuts live sessions
+    with 403, and a per-agent origin allow-list — when configured —
+    replaces the deployment-global one.  Cookies minted before the
+    claim existed keep the legacy global-only behavior.
     """
     settings = _get_settings(request)
     _require_website_enabled(settings)
@@ -311,8 +348,20 @@ async def _load_and_authorize_session(
             detail=f"Session {path_session_id} not found.",
         )
 
-    request_origin = _extract_origin(request)
     allowed = parse_allowed_origins(settings.website.allowed_origins)
+    cache = getattr(request.app.state, "channel_routing_cache", None)
+    if claims.channel_identifier and cache is not None:
+        routing = await cache.get(f"website:{claims.channel_identifier}")
+        if not routing or not routing.get("agent_id"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="The website channel for this agent has been turned off.",
+            )
+        agent_origins = _agent_allowed_origins(_routing_channel_config(routing))
+        if agent_origins is not None:
+            allowed = agent_origins
+
+    request_origin = _extract_origin(request)
     _enforce_origin_binding(claims, request_origin, allowed)
     return claims
 
@@ -565,7 +614,10 @@ async def bootstrap_website_session(
     )
 
     request_origin = _extract_origin(request)
-    allowed = parse_allowed_origins(settings.website.allowed_origins)
+    routing_config = _routing_channel_config(routing)
+    allowed = _agent_allowed_origins(routing_config)
+    if allowed is None:
+        allowed = parse_allowed_origins(settings.website.allowed_origins)
     if not origin_allowed(request_origin, allowed):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -598,17 +650,25 @@ async def bootstrap_website_session(
     bucket = agent_session_bucket(settings.storage.bucket)
     normalized_origin = normalize_origin(request_origin)
 
+    publishable_key = _extract_bearer(request) or ""
     config: dict = {
         "storage_bucket": bucket,
         "workspace_path": storage.resolve_workspace_path(bucket, session_id),
         "website_origin": normalized_origin,
+        "channel_identifier": publishable_key,
     }
     # Materialise the message cap onto session.config so the route's
     # 429 enforcement is decoupled from settings — the cookie-bound
     # cap stays stable for the visitor even if ops adjusts the channel
-    # knob while the session is in flight.
-    if settings.website.session_message_cap:
-        config["session_message_cap"] = settings.website.session_message_cap
+    # knob while the session is in flight.  A per-agent cap from the
+    # routing config takes precedence over the deployment-global one.
+    try:
+        agent_cap = int(routing_config.get("session_message_cap") or 0)
+    except (TypeError, ValueError):
+        agent_cap = 0
+    cap = agent_cap or settings.website.session_message_cap
+    if cap:
+        config["session_message_cap"] = cap
 
     # Server-verified buyer identity, pinned at bootstrap so every
     # later message inherits it from the session row rather than
@@ -654,6 +714,7 @@ async def bootstrap_website_session(
         org_id=org_uuid,
         origin=normalized_origin,
         csrf_token=csrf_token,
+        channel_identifier=publishable_key,
     )
     _set_session_cookie(
         response, token=cookie_token, expires_seconds=DEFAULT_SESSION_TTL_SECONDS,

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -304,20 +304,15 @@ def _agent_allowed_origins(routing_config: dict) -> tuple[str, ...] | None:
     """Per-agent origin allow-list from routing config, or ``None`` when the
     agent has not configured one (fall back to the deployment-global list).
 
-    Accepts both the projected list form and a legacy CSV string.
+    Ops projects a parsed list; a CSV string is accepted too so a
+    hand-written routing row behaves the same.  Both funnel through
+    :func:`parse_allowed_origins` so normalization has one home.
     """
     raw = routing_config.get("allowed_origins")
     if raw is None:
         return None
-    if isinstance(raw, str):
-        origins = parse_allowed_origins(raw)
-    else:
-        origins = tuple(
-            normalize_origin(str(origin))
-            for origin in raw
-            if str(origin).strip()
-        )
-    return origins or None
+    csv = raw if isinstance(raw, str) else ",".join(str(origin) for origin in raw)
+    return parse_allowed_origins(csv) or None
 
 
 async def _load_and_authorize_session(

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -601,8 +601,9 @@ async def bootstrap_website_session(
     """Exchange a publishable key + approved origin for a session cookie.
 
     The publishable key resolves the owning agent via ``channel_routing``
-    (``website:<key>``); the request Origin is checked against the global
-    allow-list.  Creates a fresh session owned by the agent's org (no user
+    (``website:<key>``); the request Origin is checked against the agent's
+    allow-list from the routing config, falling back to the deployment
+    global.  Creates a fresh session owned by the agent's org (no user
     row), mints the HttpOnly cookie the browser presents on subsequent
     requests, and returns the CSRF token echoed in ``X-CSRF-Token``.
     """

--- a/surogates/channels/constants.py
+++ b/surogates/channels/constants.py
@@ -1,0 +1,26 @@
+"""Channel capability constants shared across process boundaries.
+
+The session store (worker process) must know facts about the channel
+adapters (channels process) without importing the httpx-heavy platform
+modules: which channels have a delivery loop claiming their outbox rows,
+and which can render an interactive ``ask_user_question`` prompt.  Keeping
+both sets here — next to the platform package that must stay in lockstep
+with them — gives registration and consumption one shared source instead
+of literals scattered per file.
+"""
+
+from __future__ import annotations
+
+__all__ = ["ADAPTER_CHANNELS", "INTERACTIVE_PROMPT_CHANNELS"]
+
+#: Channels with a registered outbound delivery adapter (a delivery loop
+#: that claims their outbox rows).  Must match the platforms registered in
+#: :mod:`surogates.channels.platforms` — an outbox row for any other
+#: channel value would never be claimed and sit "pending" forever.
+ADAPTER_CHANNELS = frozenset({"slack", "telegram"})
+
+#: Channels whose platform can render an ``ask_user_question`` prompt
+#: (Slack: Answer button + modal; Telegram: inline keyboard).  Channels
+#: outside this set must not receive content-less ``input_prompt`` outbox
+#: rows — their ``send`` would post an empty message.
+INTERACTIVE_PROMPT_CHANNELS = frozenset({"slack", "telegram"})

--- a/surogates/channels/dispatcher.py
+++ b/surogates/channels/dispatcher.py
@@ -38,7 +38,12 @@ from fastapi.responses import JSONResponse, PlainTextResponse, Response
 
 from surogates.channels.credentials import resolve_channel_credentials
 from surogates.channels.delivery import delivery_exhausted, is_permanent_delivery_error
-from surogates.channels.inbound import ChannelInboundPipeline, InboundMessage, PipelineDeps
+from surogates.channels.inbound import (
+    ChannelInboundPipeline,
+    InboundMessage,
+    InboundOutcome,
+    PipelineDeps,
+)
 from surogates.channels.registry import ChannelPlatform, ChannelRegistry, VerificationResult
 from surogates.channels.resolve import resolve_tenant
 
@@ -380,7 +385,20 @@ class ChannelWebhookDispatcher:
             # ----------------------------------------------------------------
             # Step 9: Run inbound pipeline.
             # ----------------------------------------------------------------
-            await pipeline.handle(msg, routing=routing, config=config, deps=deps)
+            outcome = await pipeline.handle(
+                msg, routing=routing, config=config, deps=deps
+            )
+            # Platform-native received-ack (e.g. Telegram emoji reaction)
+            # for messages that were accepted for processing. Best-effort.
+            ack = getattr(platform, "ack_received", None)
+            if ack is not None and outcome is InboundOutcome.PROCESSED:
+                try:
+                    await ack(msg, creds=creds, config=config)
+                except Exception:
+                    logger.warning(
+                        "[dispatcher] ack_received failed on %s", platform.kind,
+                        exc_info=True,
+                    )
             return Response(status_code=200)
 
         # Assign a unique name so FastAPI doesn't complain about duplicate routes.

--- a/surogates/channels/dispatcher.py
+++ b/surogates/channels/dispatcher.py
@@ -389,16 +389,21 @@ class ChannelWebhookDispatcher:
                 msg, routing=routing, config=config, deps=deps
             )
             # Platform-native received-ack (e.g. Telegram emoji reaction)
-            # for messages that were accepted for processing. Best-effort.
+            # for messages that were accepted for processing. Fired without
+            # awaiting: it is best-effort decoration, and a slow platform
+            # API call here would delay the webhook 200 (which platforms
+            # treat as a redelivery signal).
             ack = getattr(platform, "ack_received", None)
             if ack is not None and outcome is InboundOutcome.PROCESSED:
-                try:
-                    await ack(msg, creds=creds, config=config)
-                except Exception:
-                    logger.warning(
-                        "[dispatcher] ack_received failed on %s", platform.kind,
-                        exc_info=True,
-                    )
+                async def _ack_task(ack=ack, msg=msg, creds=creds, config=config):
+                    try:
+                        await ack(msg, creds=creds, config=config)
+                    except Exception:
+                        logger.warning(
+                            "[dispatcher] ack_received failed on %s",
+                            platform.kind, exc_info=True,
+                        )
+                asyncio.get_running_loop().create_task(_ack_task())
             return Response(status_code=200)
 
         # Assign a unique name so FastAPI doesn't complain about duplicate routes.

--- a/surogates/channels/dispatcher.py
+++ b/surogates/channels/dispatcher.py
@@ -120,6 +120,10 @@ class ChannelWebhookDispatcher:
         self._deps_factory = deps_factory
         self._settings = settings
         self._registry = registry
+        # Strong refs to fire-and-forget ack tasks: the event loop keeps
+        # only weak references, so an unreferenced task can be garbage
+        # collected mid-execution.
+        self._ack_tasks: set = set()
 
     # ------------------------------------------------------------------
     # App factory
@@ -403,7 +407,9 @@ class ChannelWebhookDispatcher:
                             "[dispatcher] ack_received failed on %s",
                             platform.kind, exc_info=True,
                         )
-                asyncio.get_running_loop().create_task(_ack_task())
+                task = asyncio.get_running_loop().create_task(_ack_task())
+                self._ack_tasks.add(task)
+                task.add_done_callback(self._ack_tasks.discard)
             return Response(status_code=200)
 
         # Assign a unique name so FastAPI doesn't complain about duplicate routes.

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -175,7 +175,11 @@ def _mention_pattern_regex(csv: str) -> re.Pattern | None:
     if not patterns:
         return None
     alternation = "|".join(re.escape(p) for p in patterns)
-    return re.compile(rf"\b(?:{alternation})\b", re.IGNORECASE)
+    # Lookarounds, not \b: a word boundary needs a \w on one side, so
+    # patterns that start or end with punctuation ("@bot", "libra!") would
+    # never match after a space.  (?<!\w)/(?!\w) behaves like \b for plain
+    # words and still works for punctuated patterns.
+    return re.compile(rf"(?<!\w)(?:{alternation})(?!\w)", re.IGNORECASE)
 
 
 def is_stop_command(text: str | None) -> bool:

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -27,6 +27,7 @@ the cache TTL).
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Awaitable, Callable
@@ -387,9 +388,11 @@ class ChannelInboundPipeline:
         # Runs before the mention/firehose gates: an empty message (no text,
         # no media) is dropped outright and never becomes a firehose
         # observation, matching the Slack reference where the firehose helper
-        # also no-ops on empty text.
+        # also no-ops on empty text.  Media can arrive as pre-resolved
+        # ``media_urls`` or as platform file refs in ``files`` (Telegram
+        # attachments carry only file ids) — either counts as a body.
         # ------------------------------------------------------------------
-        if not msg.text and not msg.media_urls:
+        if not msg.text and not msg.media_urls and not msg.files:
             return InboundOutcome.DROPPED
 
         # ------------------------------------------------------------------
@@ -616,38 +619,7 @@ class ChannelInboundPipeline:
             except Exception:
                 logger.warning("[channels] pending input lookup failed - continuing", exc_info=True)
                 pending = None
-            if pending:
-                if routing.platform == "telegram" and msg.text.strip():
-                    from surogates.channels.platforms.telegram_interactive import (
-                        resolve_text_answer,
-                    )
-                    from surogates.session.interactive_input import (
-                        resolve_input_response,
-                    )
-
-                    responses = resolve_text_answer(
-                        pending.get("questions") or [], msg.text,
-                    )
-                    resolved = False
-                    try:
-                        resolved = await resolve_input_response(
-                            deps.session_store,
-                            session_id=session_id,
-                            tool_call_id=pending.get("tool_call_id", ""),
-                            responses=responses,
-                        )
-                    except Exception:
-                        logger.warning(
-                            "[channels] pending input resolution failed", exc_info=True,
-                        )
-                    if resolved and deps.input_nudge is not None:
-                        try:
-                            await deps.input_nudge(
-                                session_id, msg, "✅ Got it — continuing.",
-                            )
-                        except Exception:
-                            logger.warning("[channels] answer ack failed", exc_info=True)
-                    return InboundOutcome.DROPPED
+            if pending and routing.platform == "slack":
                 if deps.input_nudge is not None:
                     try:
                         await deps.input_nudge(
@@ -658,6 +630,44 @@ class ChannelInboundPipeline:
                     except Exception:
                         logger.warning("[channels] pending input nudge failed", exc_info=True)
                 return InboundOutcome.DROPPED
+            if pending and msg.text.strip():  # telegram
+                from surogates.channels.platforms.telegram_interactive import (
+                    resolve_text_answer,
+                )
+                from surogates.session.interactive_input import (
+                    resolve_input_response,
+                )
+
+                responses = resolve_text_answer(
+                    pending.get("questions") or [], msg.text,
+                )
+                resolved = False
+                try:
+                    resolved = await resolve_input_response(
+                        deps.session_store,
+                        session_id=session_id,
+                        tool_call_id=pending.get("tool_call_id", ""),
+                        responses=responses,
+                    )
+                except Exception:
+                    logger.warning(
+                        "[channels] pending input resolution failed", exc_info=True,
+                    )
+                if resolved:
+                    if deps.input_nudge is not None:
+                        try:
+                            await deps.input_nudge(
+                                session_id, msg, "✅ Got it — continuing.",
+                            )
+                        except Exception:
+                            logger.warning(
+                                "[channels] answer ack failed", exc_info=True,
+                            )
+                    return InboundOutcome.DROPPED
+                # Resolution lost a race (the button answered first) or
+                # failed — the text is a real user message, not an answer;
+                # fall through so it becomes a normal turn instead of
+                # vanishing.
 
         # Seed channel history on the first message of a Slack channel session
         # (lazy fallback for channels where the join event was missed). Best
@@ -801,16 +811,18 @@ class ChannelInboundPipeline:
 
         # Extra mention patterns (e.g. a nickname for a Telegram bot that
         # can't be @-mentioned by non-members): CSV in routing config,
-        # matched case-insensitively against the text.
+        # matched case-insensitively on word boundaries — plain containment
+        # would let "max" fire on "maximum" and invite accidental triggers.
         raw_patterns = config.get("mention_patterns") or ""
         if isinstance(raw_patterns, str):
-            patterns = [p.strip().lower() for p in raw_patterns.split(",") if p.strip()]
+            patterns = [p.strip() for p in raw_patterns.split(",") if p.strip()]
         else:
-            patterns = [str(p).strip().lower() for p in raw_patterns if str(p).strip()]
-        if patterns:
-            text = (msg.text or "").lower()
-            if any(p in text for p in patterns):
-                return True
+            patterns = [str(p).strip() for p in raw_patterns if str(p).strip()]
+        text = msg.text or ""
+        if patterns and any(
+            re.search(rf"\b{re.escape(p)}\b", text, re.IGNORECASE) for p in patterns
+        ):
+            return True
 
         return False
 

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
+from functools import lru_cache
 from enum import Enum
 from typing import Any, Awaitable, Callable
 from uuid import UUID
@@ -160,6 +161,21 @@ class InboundOutcome(str, Enum):
     INTERRUPTED = "interrupted"
     """A ``/stop`` command — the running turn was interrupted out-of-band; no
     session message was emitted or enqueued."""
+
+
+@lru_cache(maxsize=256)
+def _mention_pattern_regex(csv: str) -> re.Pattern | None:
+    """Compile a routing config's ``mention_patterns`` CSV into one regex.
+
+    Cached per distinct config string — the gate runs on every group
+    message, and routing configs change rarely.  ``None`` when no patterns
+    are configured.
+    """
+    patterns = [p.strip() for p in csv.split(",") if p.strip()]
+    if not patterns:
+        return None
+    alternation = "|".join(re.escape(p) for p in patterns)
+    return re.compile(rf"\b(?:{alternation})\b", re.IGNORECASE)
 
 
 def is_stop_command(text: str | None) -> bool:
@@ -607,67 +623,13 @@ class ChannelInboundPipeline:
             return InboundOutcome.INTERRUPTED
 
         # While a question is pending, the platforms diverge on what a plain
-        # reply means:
-        #   - Slack has a modal surface, so a plain in-thread reply is NOT
-        #     the answer — nudge toward the Answer button and suppress the
-        #     turn so it doesn't pile into a blocked worker.
-        #   - Telegram has no modal; a plain reply IS the answer — resolve
-        #     the durable pending record with it and ack.
+        # reply means — see _intercept_pending_input.
         if deps.pending_input is not None and routing.platform in ("slack", "telegram"):
-            try:
-                pending = await deps.pending_input(session_id)
-            except Exception:
-                logger.warning("[channels] pending input lookup failed - continuing", exc_info=True)
-                pending = None
-            if pending and routing.platform == "slack":
-                if deps.input_nudge is not None:
-                    try:
-                        await deps.input_nudge(
-                            session_id,
-                            msg,
-                            "I'm waiting on your answer - tap *Answer* above, or use the web inbox.",
-                        )
-                    except Exception:
-                        logger.warning("[channels] pending input nudge failed", exc_info=True)
-                return InboundOutcome.DROPPED
-            if pending and msg.text.strip():  # telegram
-                from surogates.channels.platforms.telegram_interactive import (
-                    resolve_text_answer,
-                )
-                from surogates.session.interactive_input import (
-                    resolve_input_response,
-                )
-
-                responses = resolve_text_answer(
-                    pending.get("questions") or [], msg.text,
-                )
-                resolved = False
-                try:
-                    resolved = await resolve_input_response(
-                        deps.session_store,
-                        session_id=session_id,
-                        tool_call_id=pending.get("tool_call_id", ""),
-                        responses=responses,
-                    )
-                except Exception:
-                    logger.warning(
-                        "[channels] pending input resolution failed", exc_info=True,
-                    )
-                if resolved:
-                    if deps.input_nudge is not None:
-                        try:
-                            await deps.input_nudge(
-                                session_id, msg, "✅ Got it — continuing.",
-                            )
-                        except Exception:
-                            logger.warning(
-                                "[channels] answer ack failed", exc_info=True,
-                            )
-                    return InboundOutcome.DROPPED
-                # Resolution lost a race (the button answered first) or
-                # failed — the text is a real user message, not an answer;
-                # fall through so it becomes a normal turn instead of
-                # vanishing.
+            intercepted = await self._intercept_pending_input(
+                msg, routing=routing, deps=deps, session_id=session_id,
+            )
+            if intercepted is not None:
+                return intercepted
 
         # Seed channel history on the first message of a Slack channel session
         # (lazy fallback for channels where the join event was missed). Best
@@ -675,32 +637,9 @@ class ChannelInboundPipeline:
         if deps.backfill is not None and routing.platform == "slack" and not msg.is_dm:
             await deps.backfill(session_id, msg.identifier, routing)
 
-        # Telegram reply threading: remember which inbound message the reply
-        # should attach to. "all" tracks the latest message; "first" pins the
-        # session's opening message; anything else leaves replies unthreaded.
-        # Groups only — replying to the only other party in a DM is noise.
-        _tg_message_id = (msg.source or {}).get("message_id")
-        if (
-            routing.platform == "telegram"
-            and not msg.is_dm
-            and _tg_message_id is not None
-        ):
-            reply_to_mode = str(config.get("reply_to_mode") or "").lower()
-            try:
-                if reply_to_mode == "all":
-                    await deps.session_store.update_session_config_key(
-                        session_id, "telegram_reply_to_message_id", _tg_message_id,
-                    )
-                elif reply_to_mode == "first":
-                    session_row = await deps.session_store.get_session(session_id)
-                    if "telegram_reply_to_message_id" not in (session_row.config or {}):
-                        await deps.session_store.update_session_config_key(
-                            session_id, "telegram_reply_to_message_id", _tg_message_id,
-                        )
-            except Exception:
-                logger.warning(
-                    "[channels] recording reply-to message id failed", exc_info=True,
-                )
+        await self._record_reply_target(
+            msg, routing=routing, config=config, deps=deps, session_id=session_id,
+        )
 
         # Download + ingest platform file attachments into the harness's
         # images/attachments event shapes. Best-effort: never drop the message.
@@ -785,6 +724,111 @@ class ChannelInboundPipeline:
     # ------------------------------------------------------------------
 
     @staticmethod
+    async def _intercept_pending_input(
+        msg: InboundMessage,
+        *,
+        routing: Any,
+        deps: PipelineDeps,
+        session_id: Any,
+    ) -> InboundOutcome | None:
+        """Handle a message that arrives while ``ask_user_question`` waits.
+
+        The platforms diverge on what a plain reply means:
+
+        - Slack has a modal surface, so a plain in-thread reply is NOT the
+          answer — nudge toward the Answer button and suppress the turn so
+          it doesn't pile into a blocked worker.
+        - Telegram has no modal; a plain reply IS the answer — resolve the
+          durable pending record with it and ack.
+
+        Returns the outcome when the message was consumed, or ``None`` to
+        continue normal processing (no question pending, or a Telegram
+        resolution lost the race against a button tap — the text is then a
+        real user message, not an answer, and must not vanish).
+        """
+        try:
+            pending = await deps.pending_input(session_id)
+        except Exception:
+            logger.warning(
+                "[channels] pending input lookup failed - continuing", exc_info=True,
+            )
+            return None
+        if not pending:
+            return None
+
+        async def _nudge(text: str) -> None:
+            if deps.input_nudge is None:
+                return
+            try:
+                await deps.input_nudge(session_id, msg, text)
+            except Exception:
+                logger.warning("[channels] pending input nudge failed", exc_info=True)
+
+        if routing.platform == "slack":
+            await _nudge(
+                "I'm waiting on your answer - tap *Answer* above, or use the web inbox."
+            )
+            return InboundOutcome.DROPPED
+
+        if not msg.text.strip():
+            return None
+
+        from surogates.channels.platforms.telegram_interactive import (
+            resolve_text_answer,
+        )
+        from surogates.session.interactive_input import resolve_input_response
+
+        resolved = False
+        try:
+            resolved = await resolve_input_response(
+                deps.session_store,
+                session_id=session_id,
+                tool_call_id=pending.get("tool_call_id", ""),
+                responses=resolve_text_answer(pending.get("questions") or [], msg.text),
+            )
+        except Exception:
+            logger.warning("[channels] pending input resolution failed", exc_info=True)
+        if resolved:
+            await _nudge("✅ Got it — continuing.")
+            return InboundOutcome.DROPPED
+        return None
+
+    @staticmethod
+    async def _record_reply_target(
+        msg: InboundMessage,
+        *,
+        routing: Any,
+        config: dict,
+        deps: PipelineDeps,
+        session_id: Any,
+    ) -> None:
+        """Remember which inbound message the outbound reply should attach to.
+
+        Driven by the routing config's ``reply_to_mode`` (today only
+        Telegram routings carry it): ``all`` tracks the latest message,
+        ``first`` pins the session's opening message, anything else leaves
+        replies unthreaded.  Groups only — replying to the only other party
+        in a DM is noise.  Best-effort; never raises.
+        """
+        reply_to_mode = str(config.get("reply_to_mode") or "").lower()
+        message_id = (msg.source or {}).get("message_id")
+        if msg.is_dm or message_id is None or reply_to_mode not in ("all", "first"):
+            return
+        key = f"{routing.platform}_reply_to_message_id"
+        try:
+            if reply_to_mode == "first":
+                session_row = await deps.session_store.get_session(session_id)
+                if key in (session_row.config or {}):
+                    return
+            await deps.session_store.update_session_config_key(
+                session_id, key, message_id,
+            )
+        except Exception:
+            logger.warning(
+                "[channels] recording reply-to message id failed", exc_info=True,
+            )
+
+    @staticmethod
     def _evaluate_mention_gate(msg: InboundMessage, config: dict) -> bool:
         """Decide whether the message passes static mention-gating rules.
 
@@ -813,15 +857,8 @@ class ChannelInboundPipeline:
         # can't be @-mentioned by non-members): CSV in routing config,
         # matched case-insensitively on word boundaries — plain containment
         # would let "max" fire on "maximum" and invite accidental triggers.
-        raw_patterns = config.get("mention_patterns") or ""
-        if isinstance(raw_patterns, str):
-            patterns = [p.strip() for p in raw_patterns.split(",") if p.strip()]
-        else:
-            patterns = [str(p).strip() for p in raw_patterns if str(p).strip()]
-        text = msg.text or ""
-        if patterns and any(
-            re.search(rf"\b{re.escape(p)}\b", text, re.IGNORECASE) for p in patterns
-        ):
+        pattern = _mention_pattern_regex(str(config.get("mention_patterns") or ""))
+        if pattern is not None and pattern.search(msg.text or ""):
             return True
 
         return False

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -603,16 +603,51 @@ class ChannelInboundPipeline:
                     logger.warning("[channels] /stop ack failed", exc_info=True)
             return InboundOutcome.INTERRUPTED
 
-        # While a question is pending, a plain in-thread reply is NOT the answer
-        # (the user must use the Answer button / modal). Intercept: nudge and
-        # suppress the turn so it doesn't pile into a blocked worker.
-        if deps.pending_input is not None and routing.platform == "slack":
+        # While a question is pending, the platforms diverge on what a plain
+        # reply means:
+        #   - Slack has a modal surface, so a plain in-thread reply is NOT
+        #     the answer — nudge toward the Answer button and suppress the
+        #     turn so it doesn't pile into a blocked worker.
+        #   - Telegram has no modal; a plain reply IS the answer — resolve
+        #     the durable pending record with it and ack.
+        if deps.pending_input is not None and routing.platform in ("slack", "telegram"):
             try:
                 pending = await deps.pending_input(session_id)
             except Exception:
                 logger.warning("[channels] pending input lookup failed - continuing", exc_info=True)
                 pending = None
             if pending:
+                if routing.platform == "telegram" and msg.text.strip():
+                    from surogates.channels.platforms.telegram_interactive import (
+                        resolve_text_answer,
+                    )
+                    from surogates.session.interactive_input import (
+                        resolve_input_response,
+                    )
+
+                    responses = resolve_text_answer(
+                        pending.get("questions") or [], msg.text,
+                    )
+                    resolved = False
+                    try:
+                        resolved = await resolve_input_response(
+                            deps.session_store,
+                            session_id=session_id,
+                            tool_call_id=pending.get("tool_call_id", ""),
+                            responses=responses,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "[channels] pending input resolution failed", exc_info=True,
+                        )
+                    if resolved and deps.input_nudge is not None:
+                        try:
+                            await deps.input_nudge(
+                                session_id, msg, "✅ Got it — continuing.",
+                            )
+                        except Exception:
+                            logger.warning("[channels] answer ack failed", exc_info=True)
+                    return InboundOutcome.DROPPED
                 if deps.input_nudge is not None:
                     try:
                         await deps.input_nudge(
@@ -630,13 +665,39 @@ class ChannelInboundPipeline:
         if deps.backfill is not None and routing.platform == "slack" and not msg.is_dm:
             await deps.backfill(session_id, msg.identifier, routing)
 
-        # Download + ingest Slack file attachments into the harness's
+        # Telegram reply threading: remember which inbound message the reply
+        # should attach to. "all" tracks the latest message; "first" pins the
+        # session's opening message; anything else leaves replies unthreaded.
+        # Groups only — replying to the only other party in a DM is noise.
+        _tg_message_id = (msg.source or {}).get("message_id")
+        if (
+            routing.platform == "telegram"
+            and not msg.is_dm
+            and _tg_message_id is not None
+        ):
+            reply_to_mode = str(config.get("reply_to_mode") or "").lower()
+            try:
+                if reply_to_mode == "all":
+                    await deps.session_store.update_session_config_key(
+                        session_id, "telegram_reply_to_message_id", _tg_message_id,
+                    )
+                elif reply_to_mode == "first":
+                    session_row = await deps.session_store.get_session(session_id)
+                    if "telegram_reply_to_message_id" not in (session_row.config or {}):
+                        await deps.session_store.update_session_config_key(
+                            session_id, "telegram_reply_to_message_id", _tg_message_id,
+                        )
+            except Exception:
+                logger.warning(
+                    "[channels] recording reply-to message id failed", exc_info=True,
+                )
+
+        # Download + ingest platform file attachments into the harness's
         # images/attachments event shapes. Best-effort: never drop the message.
         _images: list = []
         _attachments: list = []
         _att_note = ""
-        if (deps.attachments is not None and routing.platform == "slack"
-                and getattr(msg, "files", None)):
+        if deps.attachments is not None and getattr(msg, "files", None):
             try:
                 _ingested = await deps.attachments(session_id, msg)
                 _images = _ingested.get("images") or []
@@ -737,6 +798,19 @@ class ChannelInboundPipeline:
         # Explicit @mention → process.
         if msg.is_mention:
             return True
+
+        # Extra mention patterns (e.g. a nickname for a Telegram bot that
+        # can't be @-mentioned by non-members): CSV in routing config,
+        # matched case-insensitively against the text.
+        raw_patterns = config.get("mention_patterns") or ""
+        if isinstance(raw_patterns, str):
+            patterns = [p.strip().lower() for p in raw_patterns.split(",") if p.strip()]
+        else:
+            patterns = [str(p).strip().lower() for p in raw_patterns if str(p).strip()]
+        if patterns:
+            text = (msg.text or "").lower()
+            if any(p in text for p in patterns):
+                return True
 
         return False
 

--- a/surogates/channels/platforms/slack.py
+++ b/surogates/channels/platforms/slack.py
@@ -74,6 +74,7 @@ from surogates.channels.channel_backfill import (
 )
 from surogates.channels.inbound import InboundFileRef, InboundMessage
 from surogates.channels.registry import ChannelDescriptor, VerificationResult
+from surogates.channels.text_split import split_text
 
 
 def _form_timestamp() -> str:
@@ -492,6 +493,10 @@ class SlackPlatform:
 
     kind = "slack"
     supports_edit = True
+
+    # Slack rejects chat.postMessage over ~40k chars (msg_too_long); stay
+    # under it with headroom for Slack's own escaping.
+    _MAX_MESSAGE_CHARS = 39000
     topology = "webhook"
 
     _THINKING_TEXT = "_Thinking…_"
@@ -1003,30 +1008,46 @@ class SlackPlatform:
         text: str = item.payload.get("content", "")
         thread_ts: str | None = item.destination.get("thread_ts")
 
-        kwargs: dict[str, Any] = {
-            "channel": channel_id,
-            "text": text,
-        }
-        if thread_ts:
-            kwargs["thread_ts"] = thread_ts
+        # Slack rejects chat.postMessage bodies over ~40k chars with
+        # msg_too_long; split long replies at natural boundaries and post
+        # them sequentially so the full answer still lands.
+        chunks = split_text(text, self._MAX_MESSAGE_CHARS) or [text]
 
         update_ts = item.destination.get("update_ts")
+        edited_ts: str | None = None
         if update_ts:
             try:
-                edited = await client.chat_update(channel=channel_id, ts=update_ts, text=text)
-                return SendResult(success=True, message_id=edited.get("ts") or update_ts)
+                edited = await client.chat_update(
+                    channel=channel_id, ts=update_ts, text=chunks[0],
+                )
+                edited_ts = edited.get("ts") or update_ts
+                chunks = chunks[1:]
             except Exception as exc:
                 logger.warning(
                     "[SlackPlatform] chat_update failed (%s); posting a fresh message", exc,
                 )
-                # fall through to a fresh post so the reply still lands
+                # fall through to fresh posts so the reply still lands
 
-        try:
-            result = await client.chat_postMessage(**kwargs)
-            return SendResult(success=True, message_id=result.get("ts"))
-        except Exception as exc:
-            logger.error("[SlackPlatform] chat_postMessage failed: %s", exc)
-            return SendResult(success=False, error=str(exc))
+        last_ts: str | None = edited_ts
+        for chunk in chunks:
+            kwargs: dict[str, Any] = {
+                "channel": channel_id,
+                "text": chunk,
+            }
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
+            try:
+                result = await client.chat_postMessage(**kwargs)
+                last_ts = result.get("ts") or last_ts
+            except Exception as exc:
+                logger.error("[SlackPlatform] chat_postMessage failed: %s", exc)
+                if last_ts is not None:
+                    # Part of the reply already landed — report success with
+                    # the last delivered ts rather than re-delivering the
+                    # whole message on retry (duplicate spam).
+                    return SendResult(success=True, message_id=last_ts)
+                return SendResult(success=False, error=str(exc))
+        return SendResult(success=True, message_id=last_ts)
 
     # ------------------------------------------------------------------
     # download_file — fetch a private Slack file URL

--- a/surogates/channels/platforms/telegram.py
+++ b/surogates/channels/platforms/telegram.py
@@ -630,7 +630,12 @@ class TelegramPlatform:
         for index, chunk in enumerate(chunks):
             chunk_base = dict(base)
             if reply_to and index == 0:
-                chunk_base["reply_parameters"] = {"message_id": reply_to}
+                # allow_sending_without_reply: a user-deleted reply target
+                # must degrade to a plain message, not fail the delivery.
+                chunk_base["reply_parameters"] = {
+                    "message_id": reply_to,
+                    "allow_sending_without_reply": True,
+                }
             html_text = render_html(chunk)
             plain_text = render_plain(chunk)
             if len(html_text) > self._MAX_MESSAGE_CHARS:
@@ -679,6 +684,7 @@ class TelegramPlatform:
             session_id=str(getattr(item, "session_id", "")),
             questions=item.payload.get("questions") or [],
             context=item.payload.get("context", ""),
+            tool_call_id=item.payload.get("tool_call_id", ""),
         )
         payload = dict(base)
         if reply_markup is not None:
@@ -722,6 +728,39 @@ class TelegramPlatform:
     # ------------------------------------------------------------------
     # handle_non_message_update — callback_query ack-only
     # ------------------------------------------------------------------
+
+    async def post_input_nudge(
+        self, *, creds: dict, channel: str, thread_ts: Any, text: str,
+    ) -> str | None:
+        """Post a short status line (answer ack, /stop ack) to the chat.
+
+        Same optional-member contract as the Slack implementation: the
+        pipeline's ``input_nudge`` hook getattr-dispatches to this. Returns
+        the message id, or ``None`` on any failure (never raises).
+        """
+        bot_token: str = (creds or {}).get("bot_token") or ""
+        if not bot_token or not channel:
+            return None
+        payload: dict[str, Any] = {"chat_id": channel, "text": text}
+        if thread_ts:
+            try:
+                payload["message_thread_id"] = int(thread_ts)
+            except (TypeError, ValueError):
+                pass
+        try:
+            resp = await self._http.post(
+                _bot_api_url(bot_token, "sendMessage"), json=payload
+            )
+            data = resp.json()
+            if data.get("ok"):
+                return str(data["result"]["message_id"])
+            return None
+        except Exception:
+            logger.warning(
+                "[TelegramPlatform] post_input_nudge failed for %s",
+                channel, exc_info=True,
+            )
+            return None
 
     # ------------------------------------------------------------------
     # download_file — resolve a file_id via getFile and fetch the bytes
@@ -864,6 +903,7 @@ class TelegramPlatform:
         from surogates.channels.platforms.telegram_interactive import (
             build_answered_text,
             parse_callback_data,
+            tool_call_digest,
         )
         from surogates.session.interactive_input import (
             pending_input_for_session,
@@ -877,7 +917,7 @@ class TelegramPlatform:
         if parsed is None or store is None:
             await self._answer_callback(bot_token, callback_id)
             return True
-        session_id_raw, _question_index, choice_index = parsed
+        session_id_raw, _question_index, choice_index, digest = parsed
 
         try:
             from uuid import UUID
@@ -908,7 +948,10 @@ class TelegramPlatform:
             return True
 
         pending = await pending_input_for_session(store, session_id=session_id)
-        if not pending:
+        if not pending or tool_call_digest(pending.get("tool_call_id", "")) != digest:
+            # No pending question, or the button belongs to an EARLIER
+            # prompt than the one currently pending — a stale button must
+            # never resolve a newer question with its coordinates.
             await self._answer_callback(
                 bot_token, callback_id, "This question was already answered."
             )

--- a/surogates/channels/platforms/telegram.py
+++ b/surogates/channels/platforms/telegram.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import hmac
 import logging
-from typing import Any
+from typing import Any, Callable
 
 import httpx
 
@@ -37,6 +37,12 @@ from surogates.channels.base import SendResult
 from surogates.channels.inbound import InboundFileRef, InboundMessage
 from surogates.channels.registry import ChannelDescriptor
 from surogates.channels.platforms.telegram_format import render_html, render_plain
+from surogates.channels.platforms.telegram_interactive import (
+    build_answered_text,
+    build_input_prompt,
+    parse_callback_data,
+    tool_call_digest,
+)
 from surogates.channels.text_split import split_text
 
 __all__ = [
@@ -543,44 +549,59 @@ class TelegramPlatform:
     _MAX_MESSAGE_CHARS = 4096
     _MAX_SOURCE_CHUNK = 3500
 
+    async def _api(
+        self, bot_token: str, method: str, payload: dict[str, Any],
+    ) -> tuple[dict | None, str]:
+        """POST one Bot API *method*.  Never raises.
+
+        Returns ``(result, "")`` on ``ok``, ``(None, error)`` on any API
+        rejection or HTTP failure — the single transport primitive every
+        best-effort caller (send, acks, edits, nudges) shares so error
+        handling cannot drift between them.
+        """
+        try:
+            resp = await self._http.post(_bot_api_url(bot_token, method), json=payload)
+            data = resp.json()
+        except Exception as exc:
+            logger.warning("[TelegramPlatform] %s failed: %s", method, exc)
+            return None, str(exc)
+        if data.get("ok"):
+            return data.get("result") or {}, ""
+        error: str = data.get("description", "Telegram API error")
+        logger.debug("[TelegramPlatform] %s ok=false: %s", method, error)
+        return None, error
+
     async def _post_text(
         self,
-        api_url: str,
+        bot_token: str,
         base: dict[str, Any],
         *,
         html_text: str,
-        plain_text: str,
+        plain_text: Callable[[], str],
     ) -> tuple[str | None, str | None]:
         """POST one message, preferring HTML with a plain-text retry.
 
         Returns ``(message_id, None)`` on success, ``(None, error)`` on
         failure.  A parse rejection of the HTML body (Telegram's
-        "can't parse entities") is retried once as plain text so a
+        "can't parse entities") is retried once as plain text — rendered
+        lazily via the *plain_text* thunk, since the retry is rare — so a
         formatting edge case never loses the reply.
         """
-        attempts: list[dict[str, Any]] = [
+        result, error = await self._api(
+            bot_token, "sendMessage",
             {**base, "text": html_text, "parse_mode": "HTML"},
-            {**base, "text": plain_text},
-        ]
-        error: str | None = None
-        for attempt_no, payload in enumerate(attempts):
-            try:
-                resp = await self._http.post(api_url, json=payload)
-                data = resp.json()
-            except Exception as exc:
-                logger.error("[TelegramPlatform] sendMessage failed: %s", exc)
-                return None, str(exc)
-            if data.get("ok"):
-                return str(data["result"]["message_id"]), None
-            error = data.get("description", "Telegram API error")
-            if attempt_no == 0 and "parse" in error.lower():
-                logger.warning(
-                    "[TelegramPlatform] HTML rejected (%s); retrying as plain text",
-                    error,
-                )
-                continue
+        )
+        if result is None and "parse" in error.lower():
+            logger.warning(
+                "[TelegramPlatform] HTML rejected (%s); retrying as plain text",
+                error,
+            )
+            result, error = await self._api(
+                bot_token, "sendMessage", {**base, "text": plain_text()},
+            )
+        if result is None:
             return None, error
-        return None, error
+        return str(result["message_id"]), None
 
     async def send(self, item: Any, *, creds: dict) -> SendResult:
         """Post an outbox item to Telegram via ``sendMessage``.
@@ -610,7 +631,6 @@ class TelegramPlatform:
             redelivery retry cannot spam duplicates.
         """
         bot_token: str = creds.get("bot_token") or ""
-        api_url = _bot_api_url(bot_token, "sendMessage")
 
         chat_id = item.destination.get("chat_id")
         message_thread_id: Any = item.destination.get("message_thread_id")
@@ -621,13 +641,27 @@ class TelegramPlatform:
             base["message_thread_id"] = message_thread_id
 
         if item.payload.get("input_prompt"):
-            return await self._send_input_prompt(item, api_url=api_url, base=base)
+            return await self._send_input_prompt(item, bot_token=bot_token, base=base)
 
         text: str = item.payload.get("content", "")
-        chunks = split_text(text, self._MAX_SOURCE_CHUNK) or [text]
+
+        # Build every outgoing body up front — (html_text, lazy plain) —
+        # so a single delivery loop owns the partial-failure bookkeeping.
+        # A chunk whose HTML rendering overflows the cap (pathological
+        # escaping inflation) is downgraded to plain sub-chunks.
+        outgoing: list[tuple[str, Callable[[], str]]] = []
+        for chunk in split_text(text, self._MAX_SOURCE_CHUNK) or [text]:
+            html_text = render_html(chunk)
+            if len(html_text) <= self._MAX_MESSAGE_CHARS:
+                outgoing.append((html_text, lambda c=chunk: render_plain(c)))
+            else:
+                outgoing.extend(
+                    (sub, lambda s=sub: s)
+                    for sub in split_text(render_plain(chunk), self._MAX_MESSAGE_CHARS)
+                )
 
         last_id: str | None = None
-        for index, chunk in enumerate(chunks):
+        for index, (html_text, plain_text) in enumerate(outgoing):
             chunk_base = dict(base)
             if reply_to and index == 0:
                 # allow_sending_without_reply: a user-deleted reply target
@@ -636,24 +670,8 @@ class TelegramPlatform:
                     "message_id": reply_to,
                     "allow_sending_without_reply": True,
                 }
-            html_text = render_html(chunk)
-            plain_text = render_plain(chunk)
-            if len(html_text) > self._MAX_MESSAGE_CHARS:
-                # Pathological escaping inflation — deliver plain sub-chunks
-                # rather than risking a hard API rejection.
-                sub_error: str | None = None
-                for sub in split_text(plain_text, self._MAX_MESSAGE_CHARS):
-                    msg_id, sub_error = await self._post_text(
-                        api_url, chunk_base, html_text=sub, plain_text=sub,
-                    )
-                    if msg_id is None:
-                        break
-                    last_id = msg_id
-                if sub_error is not None:
-                    break
-                continue
             msg_id, error = await self._post_text(
-                api_url, chunk_base, html_text=html_text, plain_text=plain_text,
+                bot_token, chunk_base, html_text=html_text, plain_text=plain_text,
             )
             if msg_id is None:
                 if last_id is not None:
@@ -667,19 +685,15 @@ class TelegramPlatform:
         return SendResult(success=True, message_id=last_id)
 
     async def _send_input_prompt(
-        self, item: Any, *, api_url: str, base: dict[str, Any],
+        self, item: Any, *, bot_token: str, base: dict[str, Any],
     ) -> SendResult:
         """Post an ``ask_user_question`` prompt with inline-keyboard choices.
 
-        The button ``callback_data`` carries only coordinates
-        (``si:<session>:<q>:<c>``); the durable pending-input record is the
-        source of truth when the button is tapped (see
+        The button ``callback_data`` carries only coordinates plus a
+        tool-call digest; the durable pending-input record is the source of
+        truth when the button is tapped (see
         :meth:`handle_non_message_update`).
         """
-        from surogates.channels.platforms.telegram_interactive import (
-            build_input_prompt,
-        )
-
         html_text, plain_text, reply_markup = build_input_prompt(
             session_id=str(getattr(item, "session_id", "")),
             questions=item.payload.get("questions") or [],
@@ -690,7 +704,7 @@ class TelegramPlatform:
         if reply_markup is not None:
             payload["reply_markup"] = reply_markup
         msg_id, error = await self._post_text(
-            api_url, payload, html_text=html_text, plain_text=plain_text,
+            bot_token, payload, html_text=html_text, plain_text=lambda: plain_text,
         )
         if msg_id is None:
             return SendResult(success=False, error=error or "send failed")
@@ -717,13 +731,10 @@ class TelegramPlatform:
         private delivery fails.
         """
         bot_token: str = creds.get("bot_token") or ""
-        api_url = _bot_api_url(bot_token, "sendMessage")
-        try:
-            resp = await self._http.post(api_url, json={"chat_id": sender_id, "text": text})
-            return bool(resp.json().get("ok"))
-        except Exception as exc:
-            logger.error("[TelegramPlatform] send_private failed: %s", exc)
-            return False
+        result, _ = await self._api(
+            bot_token, "sendMessage", {"chat_id": sender_id, "text": text}
+        )
+        return result is not None
 
     # ------------------------------------------------------------------
     # handle_non_message_update — callback_query ack-only
@@ -747,20 +758,10 @@ class TelegramPlatform:
                 payload["message_thread_id"] = int(thread_ts)
             except (TypeError, ValueError):
                 pass
-        try:
-            resp = await self._http.post(
-                _bot_api_url(bot_token, "sendMessage"), json=payload
-            )
-            data = resp.json()
-            if data.get("ok"):
-                return str(data["result"]["message_id"])
+        result, _ = await self._api(bot_token, "sendMessage", payload)
+        if result is None:
             return None
-        except Exception:
-            logger.warning(
-                "[TelegramPlatform] post_input_nudge failed for %s",
-                channel, exc_info=True,
-            )
-            return None
+        return str(result["message_id"])
 
     # ------------------------------------------------------------------
     # download_file — resolve a file_id via getFile and fetch the bytes
@@ -781,18 +782,13 @@ class TelegramPlatform:
         file_id = url or ""
         if not bot_token or not file_id:
             return None
-        try:
-            resp = await self._http.post(
-                _bot_api_url(bot_token, "getFile"), json={"file_id": file_id}
+        result, error = await self._api(bot_token, "getFile", {"file_id": file_id})
+        if result is None:
+            logger.warning(
+                "[TelegramPlatform] getFile failed for %s: %s", file_id, error,
             )
-            data = resp.json()
-            if not data.get("ok"):
-                logger.warning(
-                    "[TelegramPlatform] getFile failed for %s: %s",
-                    file_id, data.get("description", ""),
-                )
-                return None
-            result = data.get("result") or {}
+            return None
+        try:
             file_path = result.get("file_path") or ""
             declared = result.get("file_size")
             if not file_path or ".." in file_path:
@@ -845,17 +841,15 @@ class TelegramPlatform:
         message_id = (msg.source or {}).get("message_id")
         if not bot_token or message_id is None:
             return
-        try:
-            await self._http.post(
-                _bot_api_url(bot_token, "setMessageReaction"),
-                json={
-                    "chat_id": msg.identifier,
-                    "message_id": message_id,
-                    "reaction": [{"type": "emoji", "emoji": "👀"}],
-                },
-            )
-        except Exception as exc:
-            logger.debug("[TelegramPlatform] setMessageReaction failed: %s", exc)
+        await self._api(
+            bot_token,
+            "setMessageReaction",
+            {
+                "chat_id": msg.identifier,
+                "message_id": message_id,
+                "reaction": [{"type": "emoji", "emoji": "👀"}],
+            },
+        )
 
     async def _answer_callback(
         self, bot_token: str, callback_id: str, text: str | None = None,
@@ -866,12 +860,92 @@ class TelegramPlatform:
         payload: dict[str, Any] = {"callback_query_id": callback_id}
         if text:
             payload["text"] = text
+        await self._api(bot_token, "answerCallbackQuery", payload)
+
+    async def _resolve_input_callback(
+        self, callback_query: dict, *, bot_token: str, deps: Any,
+    ) -> str | None:
+        """Resolve an input-prompt button tap against the durable record.
+
+        Returns the ack text to show the tapper (``None`` = silent ack).
+        Every guard failure — malformed data, unknown session, foreign
+        chat, stale button — degrades to an ack with no side effects.
+        """
+        from surogates.session.interactive_input import (
+            pending_input_for_session,
+            resolve_input_response,
+        )
+
+        parsed = parse_callback_data(callback_query.get("data") or "")
+        store = getattr(deps, "session_store", None)
+        if parsed is None or store is None:
+            return None
+        session_id_raw, _question_index, choice_index, digest = parsed
+
         try:
-            await self._http.post(
-                _bot_api_url(bot_token, "answerCallbackQuery"), json=payload
+            from uuid import UUID
+
+            session_id = UUID(session_id_raw)
+            session = await store.get_session(session_id)
+        except Exception:
+            logger.warning(
+                "[TelegramPlatform] callback for unknown session %r",
+                session_id_raw,
             )
-        except Exception as exc:
-            logger.debug("[TelegramPlatform] answerCallbackQuery failed: %s", exc)
+            return None
+
+        # Anti-forgery: the callback must originate from the chat this
+        # session is bound to — callback_data is attacker-visible, the chat
+        # binding is not attacker-controllable.
+        chat_id = str(
+            ((callback_query.get("message") or {}).get("chat") or {}).get("id", "")
+        )
+        bound_chat = str((session.config or {}).get("telegram_channel_id", ""))
+        if not chat_id or chat_id != bound_chat:
+            logger.warning(
+                "[TelegramPlatform] callback chat %r does not match session chat %r",
+                chat_id, bound_chat,
+            )
+            return None
+
+        pending = await pending_input_for_session(store, session_id=session_id)
+        if not pending or tool_call_digest(pending.get("tool_call_id", "")) != digest:
+            # No pending question, or the button belongs to an EARLIER
+            # prompt than the one currently pending — a stale button must
+            # never resolve a newer question with its coordinates.
+            return "This question was already answered."
+
+        questions: list = pending.get("questions") or []
+        choices = (questions[0] if questions else {}).get("choices") or []
+        if choice_index < 0 or choice_index >= len(choices):
+            return None
+        prompt = (questions[0].get("prompt") if questions else "") or "Question 1"
+        answer = choices[choice_index].get("label") or ""
+        responses = [{"question": prompt, "answer": answer, "is_other": False}]
+
+        resolved = await resolve_input_response(
+            store,
+            session_id=session_id,
+            tool_call_id=pending.get("tool_call_id", ""),
+            responses=responses,
+        )
+        if not resolved:
+            return "This question was already answered."
+
+        # Replace the button message with the recorded answer. Best-effort.
+        message_id = (callback_query.get("message") or {}).get("message_id")
+        if message_id is not None:
+            await self._api(
+                bot_token,
+                "editMessageText",
+                {
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "text": build_answered_text(responses),
+                    "parse_mode": "HTML",
+                },
+            )
+        return "Got it."
 
     async def handle_non_message_update(
         self, body: Any, *, routing: Any, creds: dict, deps: Any
@@ -879,9 +953,9 @@ class TelegramPlatform:
         """Handle non-message Telegram updates.
 
         ``callback_query`` updates from input-prompt buttons
-        (``si:<session>:<q>:<c>`` callback data) resolve the session's
-        durable pending ``ask_user_question`` record: the choice is written
-        via :func:`resolve_input_response` (which emits the
+        (``si:<session>:<q>:<c>:<digest>`` callback data) resolve the
+        session's durable pending ``ask_user_question`` record: the choice
+        is written via ``resolve_input_response`` (which emits the
         ``ASK_USER_QUESTION_RESPONSE`` event the waiting tool polls for),
         the button message is edited to show the answer, and the callback is
         acked.  Stale or foreign callbacks are acked without side effects.
@@ -900,104 +974,13 @@ class TelegramPlatform:
         if callback_query is None:
             return False
 
-        from surogates.channels.platforms.telegram_interactive import (
-            build_answered_text,
-            parse_callback_data,
-            tool_call_digest,
-        )
-        from surogates.session.interactive_input import (
-            pending_input_for_session,
-            resolve_input_response,
-        )
-
         bot_token: str = creds.get("bot_token") or ""
-        callback_id: str = str(callback_query.get("id", ""))
-        parsed = parse_callback_data(callback_query.get("data") or "")
-        store = getattr(deps, "session_store", None)
-        if parsed is None or store is None:
-            await self._answer_callback(bot_token, callback_id)
-            return True
-        session_id_raw, _question_index, choice_index, digest = parsed
-
-        try:
-            from uuid import UUID
-
-            session_id = UUID(session_id_raw)
-            session = await store.get_session(session_id)
-        except Exception:
-            logger.warning(
-                "[TelegramPlatform] callback for unknown session %r",
-                session_id_raw,
-            )
-            await self._answer_callback(bot_token, callback_id)
-            return True
-
-        # Anti-forgery: the callback must originate from the chat this
-        # session is bound to — callback_data is attacker-visible, the chat
-        # binding is not attacker-controllable.
-        chat_id = str(
-            ((callback_query.get("message") or {}).get("chat") or {}).get("id", "")
+        ack_text = await self._resolve_input_callback(
+            callback_query, bot_token=bot_token, deps=deps,
         )
-        bound_chat = str((session.config or {}).get("telegram_channel_id", ""))
-        if not chat_id or chat_id != bound_chat:
-            logger.warning(
-                "[TelegramPlatform] callback chat %r does not match session chat %r",
-                chat_id, bound_chat,
-            )
-            await self._answer_callback(bot_token, callback_id)
-            return True
-
-        pending = await pending_input_for_session(store, session_id=session_id)
-        if not pending or tool_call_digest(pending.get("tool_call_id", "")) != digest:
-            # No pending question, or the button belongs to an EARLIER
-            # prompt than the one currently pending — a stale button must
-            # never resolve a newer question with its coordinates.
-            await self._answer_callback(
-                bot_token, callback_id, "This question was already answered."
-            )
-            return True
-
-        questions: list = pending.get("questions") or []
-        choices = (questions[0] if questions else {}).get("choices") or []
-        if choice_index < 0 or choice_index >= len(choices):
-            await self._answer_callback(bot_token, callback_id)
-            return True
-        prompt = (questions[0].get("prompt") if questions else "") or "Question 1"
-        answer = choices[choice_index].get("label") or ""
-        responses = [{"question": prompt, "answer": answer, "is_other": False}]
-
-        resolved = await resolve_input_response(
-            store,
-            session_id=session_id,
-            tool_call_id=pending.get("tool_call_id", ""),
-            responses=responses,
+        await self._answer_callback(
+            bot_token, str(callback_query.get("id", "")), ack_text
         )
-        if not resolved:
-            await self._answer_callback(
-                bot_token, callback_id, "This question was already answered."
-            )
-            return True
-
-        # Replace the button message with the recorded answer. Best-effort.
-        message = callback_query.get("message") or {}
-        message_id = message.get("message_id")
-        if message_id is not None:
-            try:
-                await self._http.post(
-                    _bot_api_url(bot_token, "editMessageText"),
-                    json={
-                        "chat_id": chat_id,
-                        "message_id": message_id,
-                        "text": build_answered_text(responses),
-                        "parse_mode": "HTML",
-                    },
-                )
-            except Exception as exc:
-                logger.debug(
-                    "[TelegramPlatform] editMessageText failed: %s", exc
-                )
-
-        await self._answer_callback(bot_token, callback_id, "Got it.")
         return True
 
 

--- a/surogates/channels/platforms/telegram.py
+++ b/surogates/channels/platforms/telegram.py
@@ -34,8 +34,10 @@ from typing import Any
 import httpx
 
 from surogates.channels.base import SendResult
-from surogates.channels.inbound import InboundMessage
+from surogates.channels.inbound import InboundFileRef, InboundMessage
 from surogates.channels.registry import ChannelDescriptor
+from surogates.channels.platforms.telegram_format import render_html, render_plain
+from surogates.channels.text_split import split_text
 
 __all__ = [
     "TelegramPlatform",
@@ -240,11 +242,12 @@ def _parse(body: dict, *, bot_username: str) -> InboundMessage | None:
         is_bot = True
 
     # ------------------------------------------------------------------
-    # Text and content guard
+    # Text, media, and content guard
     # ------------------------------------------------------------------
-    text: str = message.get("text", "")
-    if not text:
-        # No usable text content — nothing to do.
+    text: str = message.get("text") or message.get("caption") or ""
+    files = _extract_files(message)
+    if not text and not files:
+        # No usable content — nothing to do.
         return None
 
     # ------------------------------------------------------------------
@@ -277,11 +280,23 @@ def _parse(body: dict, *, bot_username: str) -> InboundMessage | None:
         "chat_id": identifier,
         "is_forum": is_forum,
     }
+    if message_id is not None:
+        source["message_id"] = message_id
     if message_thread_id is not None:
         source["message_thread_id"] = message_thread_id
 
+    kind = "text"
+    if files:
+        first_mime = files[0].mime_type
+        if first_mime.startswith("image/"):
+            kind = "image"
+        elif first_mime.startswith("audio/"):
+            kind = "audio"
+        else:
+            kind = "document"
+
     return InboundMessage(
-        kind="text",
+        kind=kind,
         identifier=identifier,
         thread_key=thread_key,
         platform_user_id=platform_user_id,
@@ -295,6 +310,7 @@ def _parse(body: dict, *, bot_username: str) -> InboundMessage | None:
         source=source,
         is_bot=is_bot,
         visibility=visibility,
+        files=files,
     )
 
 
@@ -306,6 +322,63 @@ def _parse(body: dict, *, bot_username: str) -> InboundMessage | None:
 def _bot_api_url(bot_token: str, method: str) -> str:
     """Return the full Telegram Bot API URL for *method*."""
     return f"https://api.telegram.org/bot{bot_token}/{method}"
+
+
+def _extract_files(message: dict) -> list[InboundFileRef]:
+    """Extract media attachments from a Telegram message as file refs.
+
+    Telegram exposes attachments as ``file_id`` handles, not URLs — the
+    actual download URL is only resolvable with the bot token via
+    ``getFile``.  The ref therefore carries the ``file_id`` in *both*
+    ``url`` and ``file_id``: :meth:`TelegramPlatform.download_file` accepts
+    a file id where other platforms take a URL.
+    """
+    files: list[InboundFileRef] = []
+
+    photos = message.get("photo") or []
+    if photos:
+        # PhotoSize array is ordered smallest→largest; take the largest.
+        best = max(photos, key=lambda p: p.get("file_size") or 0)
+        file_id = best.get("file_id")
+        if file_id:
+            files.append(
+                InboundFileRef(
+                    url=file_id,
+                    filename=f"photo-{best.get('file_unique_id', file_id)}.jpg",
+                    mime_type="image/jpeg",
+                    size=best.get("file_size"),
+                    file_id=file_id,
+                )
+            )
+
+    for key, default_name, default_mime in (
+        ("document", "document", "application/octet-stream"),
+        ("voice", "voice.ogg", "audio/ogg"),
+        ("audio", "audio", "audio/mpeg"),
+        ("video", "video.mp4", "video/mp4"),
+        ("video_note", "video-note.mp4", "video/mp4"),
+    ):
+        media = message.get(key)
+        if not media:
+            continue
+        file_id = media.get("file_id")
+        if not file_id:
+            continue
+        filename = media.get("file_name") or (
+            f"{default_name}-{media.get('file_unique_id', file_id)}"
+            if "." not in default_name
+            else default_name
+        )
+        files.append(
+            InboundFileRef(
+                url=file_id,
+                filename=filename,
+                mime_type=media.get("mime_type") or default_mime,
+                size=media.get("file_size"),
+                file_id=file_id,
+            )
+        )
+    return files
 
 
 # ---------------------------------------------------------------------------
@@ -465,50 +538,157 @@ class TelegramPlatform:
     # send — POST sendMessage to the Telegram Bot API
     # ------------------------------------------------------------------
 
+    # Telegram hard-caps sendMessage text at 4096 chars.  Source chunks are
+    # cut shorter so the HTML rendering (tags + entity escaping) still fits.
+    _MAX_MESSAGE_CHARS = 4096
+    _MAX_SOURCE_CHUNK = 3500
+
+    async def _post_text(
+        self,
+        api_url: str,
+        base: dict[str, Any],
+        *,
+        html_text: str,
+        plain_text: str,
+    ) -> tuple[str | None, str | None]:
+        """POST one message, preferring HTML with a plain-text retry.
+
+        Returns ``(message_id, None)`` on success, ``(None, error)`` on
+        failure.  A parse rejection of the HTML body (Telegram's
+        "can't parse entities") is retried once as plain text so a
+        formatting edge case never loses the reply.
+        """
+        attempts: list[dict[str, Any]] = [
+            {**base, "text": html_text, "parse_mode": "HTML"},
+            {**base, "text": plain_text},
+        ]
+        error: str | None = None
+        for attempt_no, payload in enumerate(attempts):
+            try:
+                resp = await self._http.post(api_url, json=payload)
+                data = resp.json()
+            except Exception as exc:
+                logger.error("[TelegramPlatform] sendMessage failed: %s", exc)
+                return None, str(exc)
+            if data.get("ok"):
+                return str(data["result"]["message_id"]), None
+            error = data.get("description", "Telegram API error")
+            if attempt_no == 0 and "parse" in error.lower():
+                logger.warning(
+                    "[TelegramPlatform] HTML rejected (%s); retrying as plain text",
+                    error,
+                )
+                continue
+            return None, error
+        return None, error
+
     async def send(self, item: Any, *, creds: dict) -> SendResult:
         """Post an outbox item to Telegram via ``sendMessage``.
+
+        Markdown content is rendered to Telegram HTML (plain-text retry on a
+        parse rejection), split at natural boundaries to stay under the 4096
+        char cap, and — when the session carries a ``reply_to_message_id`` —
+        the first chunk is sent as a reply to the triggering message.
 
         Parameters
         ----------
         item:
             Outbox item with ``destination`` (``chat_id``, optional
-            ``message_thread_id`` for Telegram forum topics) and ``payload``
-            (``content``).
+            ``message_thread_id`` for Telegram forum topics, optional
+            ``reply_to_message_id``) and ``payload`` (``content``, optional
+            ``input_prompt``).
         creds:
             Credential dict with ``bot_token``.
 
         Returns
         -------
         SendResult
-            ``success=True`` with ``message_id`` on success; ``success=False``
-            with ``error`` on any Telegram API error or HTTP failure.  Never
-            raises.
+            ``success=True`` with the last ``message_id`` on success;
+            ``success=False`` with ``error`` on any Telegram API error or
+            HTTP failure.  Never raises.  When a multi-chunk send fails
+            midway, the already-delivered prefix is reported as success so a
+            redelivery retry cannot spam duplicates.
         """
         bot_token: str = creds.get("bot_token") or ""
         api_url = _bot_api_url(bot_token, "sendMessage")
 
         chat_id = item.destination.get("chat_id")
-        text: str = item.payload.get("content", "")
         message_thread_id: Any = item.destination.get("message_thread_id")
+        reply_to: Any = item.destination.get("reply_to_message_id")
 
-        payload: dict[str, Any] = {
-            "chat_id": chat_id,
-            "text": text,
-        }
+        base: dict[str, Any] = {"chat_id": chat_id}
         if message_thread_id is not None:
-            payload["message_thread_id"] = message_thread_id
+            base["message_thread_id"] = message_thread_id
 
-        try:
-            resp = await self._http.post(api_url, json=payload)
-            data = resp.json()
-            if data.get("ok"):
-                msg_id = str(data["result"]["message_id"])
-                return SendResult(success=True, message_id=msg_id)
-            description: str = data.get("description", "Telegram API error")
-            return SendResult(success=False, error=description)
-        except Exception as exc:
-            logger.error("[TelegramPlatform] sendMessage failed: %s", exc)
-            return SendResult(success=False, error=str(exc))
+        if item.payload.get("input_prompt"):
+            return await self._send_input_prompt(item, api_url=api_url, base=base)
+
+        text: str = item.payload.get("content", "")
+        chunks = split_text(text, self._MAX_SOURCE_CHUNK) or [text]
+
+        last_id: str | None = None
+        for index, chunk in enumerate(chunks):
+            chunk_base = dict(base)
+            if reply_to and index == 0:
+                chunk_base["reply_parameters"] = {"message_id": reply_to}
+            html_text = render_html(chunk)
+            plain_text = render_plain(chunk)
+            if len(html_text) > self._MAX_MESSAGE_CHARS:
+                # Pathological escaping inflation — deliver plain sub-chunks
+                # rather than risking a hard API rejection.
+                sub_error: str | None = None
+                for sub in split_text(plain_text, self._MAX_MESSAGE_CHARS):
+                    msg_id, sub_error = await self._post_text(
+                        api_url, chunk_base, html_text=sub, plain_text=sub,
+                    )
+                    if msg_id is None:
+                        break
+                    last_id = msg_id
+                if sub_error is not None:
+                    break
+                continue
+            msg_id, error = await self._post_text(
+                api_url, chunk_base, html_text=html_text, plain_text=plain_text,
+            )
+            if msg_id is None:
+                if last_id is not None:
+                    # Part of the reply landed; report the delivered prefix
+                    # instead of triggering a duplicate redelivery.
+                    return SendResult(success=True, message_id=last_id)
+                return SendResult(success=False, error=error or "send failed")
+            last_id = msg_id
+        if last_id is None:
+            return SendResult(success=False, error="send failed")
+        return SendResult(success=True, message_id=last_id)
+
+    async def _send_input_prompt(
+        self, item: Any, *, api_url: str, base: dict[str, Any],
+    ) -> SendResult:
+        """Post an ``ask_user_question`` prompt with inline-keyboard choices.
+
+        The button ``callback_data`` carries only coordinates
+        (``si:<session>:<q>:<c>``); the durable pending-input record is the
+        source of truth when the button is tapped (see
+        :meth:`handle_non_message_update`).
+        """
+        from surogates.channels.platforms.telegram_interactive import (
+            build_input_prompt,
+        )
+
+        html_text, plain_text, reply_markup = build_input_prompt(
+            session_id=str(getattr(item, "session_id", "")),
+            questions=item.payload.get("questions") or [],
+            context=item.payload.get("context", ""),
+        )
+        payload = dict(base)
+        if reply_markup is not None:
+            payload["reply_markup"] = reply_markup
+        msg_id, error = await self._post_text(
+            api_url, payload, html_text=html_text, plain_text=plain_text,
+        )
+        if msg_id is None:
+            return SendResult(success=False, error=error or "send failed")
+        return SendResult(success=True, message_id=msg_id)
 
     # ------------------------------------------------------------------
     # send_private — DM the sender a link prompt
@@ -543,39 +723,132 @@ class TelegramPlatform:
     # handle_non_message_update — callback_query ack-only
     # ------------------------------------------------------------------
 
+    # ------------------------------------------------------------------
+    # download_file — resolve a file_id via getFile and fetch the bytes
+    # ------------------------------------------------------------------
+
+    async def download_file(
+        self, *, creds: dict, url: str, max_bytes: int,
+    ) -> bytes | None:
+        """Download a Telegram file by its ``file_id``.
+
+        *url* is the Telegram ``file_id`` (see :func:`_extract_files`) — it
+        is resolved to a real path via ``getFile`` and fetched from
+        ``api.telegram.org``.  Returns the bytes, or ``None`` on a missing
+        token/file, oversize content, or any API/HTTP failure (never raises)
+        — the same contract as the Slack downloader.
+        """
+        bot_token = (creds or {}).get("bot_token") or ""
+        file_id = url or ""
+        if not bot_token or not file_id:
+            return None
+        try:
+            resp = await self._http.post(
+                _bot_api_url(bot_token, "getFile"), json={"file_id": file_id}
+            )
+            data = resp.json()
+            if not data.get("ok"):
+                logger.warning(
+                    "[TelegramPlatform] getFile failed for %s: %s",
+                    file_id, data.get("description", ""),
+                )
+                return None
+            result = data.get("result") or {}
+            file_path = result.get("file_path") or ""
+            declared = result.get("file_size")
+            if not file_path or ".." in file_path:
+                return None
+            if declared is not None and int(declared) > max_bytes:
+                logger.warning(
+                    "[TelegramPlatform] file %s over cap (%s bytes)",
+                    file_id, declared,
+                )
+                return None
+            download_url = (
+                f"https://api.telegram.org/file/bot{bot_token}/{file_path}"
+            )
+            resp = await self._http.get(download_url)
+            if resp.status_code < 200 or resp.status_code >= 300:
+                logger.warning(
+                    "[TelegramPlatform] file download %s -> HTTP %s",
+                    file_id, resp.status_code,
+                )
+                return None
+            body = resp.content
+            if len(body) > max_bytes:
+                logger.warning(
+                    "[TelegramPlatform] file %s body over cap (%d bytes)",
+                    file_id, len(body),
+                )
+                return None
+            return body
+        except Exception:
+            logger.warning(
+                "[TelegramPlatform] download_file failed for %s",
+                file_id, exc_info=True,
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # ack_received — emoji reaction on the inbound message
+    # ------------------------------------------------------------------
+
+    async def ack_received(self, msg: Any, *, creds: dict, config: dict) -> None:
+        """React 👀 to the just-received message when ``reactions_enabled``.
+
+        Called by the dispatcher after the inbound pipeline accepts a
+        message — the Telegram-native "seen, working on it" signal (the
+        Thinking-placeholder equivalent).  Best-effort; never raises.
+        """
+        if not (config or {}).get("reactions_enabled"):
+            return
+        bot_token: str = (creds or {}).get("bot_token") or ""
+        message_id = (msg.source or {}).get("message_id")
+        if not bot_token or message_id is None:
+            return
+        try:
+            await self._http.post(
+                _bot_api_url(bot_token, "setMessageReaction"),
+                json={
+                    "chat_id": msg.identifier,
+                    "message_id": message_id,
+                    "reaction": [{"type": "emoji", "emoji": "👀"}],
+                },
+            )
+        except Exception as exc:
+            logger.debug("[TelegramPlatform] setMessageReaction failed: %s", exc)
+
+    async def _answer_callback(
+        self, bot_token: str, callback_id: str, text: str | None = None,
+    ) -> None:
+        """Ack a callback query (stops the loading spinner). Best-effort."""
+        if not bot_token or not callback_id:
+            return
+        payload: dict[str, Any] = {"callback_query_id": callback_id}
+        if text:
+            payload["text"] = text
+        try:
+            await self._http.post(
+                _bot_api_url(bot_token, "answerCallbackQuery"), json=payload
+            )
+        except Exception as exc:
+            logger.debug("[TelegramPlatform] answerCallbackQuery failed: %s", exc)
+
     async def handle_non_message_update(
         self, body: Any, *, routing: Any, creds: dict, deps: Any
     ) -> bool:
         """Handle non-message Telegram updates.
 
-        Currently handles ``callback_query`` updates by sending an
-        ``answerCallbackQuery`` ack (which stops Telegram's loading spinner)
-        and returning ``True`` (handled; inbound pipeline skipped).
+        ``callback_query`` updates from input-prompt buttons
+        (``si:<session>:<q>:<c>`` callback data) resolve the session's
+        durable pending ``ask_user_question`` record: the choice is written
+        via :func:`resolve_input_response` (which emits the
+        ``ASK_USER_QUESTION_RESPONSE`` event the waiting tool polls for),
+        the button message is edited to show the answer, and the callback is
+        acked.  Stale or foreign callbacks are acked without side effects.
 
         All other update types return ``False`` so the dispatcher falls
         through to ``parse``.
-
-        Approval rendering and resolution
-        ----------------------------------
-        This method ACKs the callback query but does **not** implement
-        approval resolution.  Full approval handling (rendering approval
-        buttons in ``send``, persisting the decision to a durable store such
-        as Redis, and unblocking the waiting session) is a unified
-        cross-platform follow-up task that applies to both Slack (``/interact``
-        is also ack-only today) and Telegram.  The old in-process dict pattern
-        from the Socket Mode adapter is intentionally not ported — it is
-        process-local and wrong for the stateless multi-replica model.
-
-        Parameters
-        ----------
-        body:
-            Parsed Telegram JSON update.
-        routing:
-            Routing object from the dispatcher (may be ``None`` in tests).
-        creds:
-            Resolved credential dict with ``bot_token``.
-        deps:
-            Pipeline deps (not used here).
 
         Returns
         -------
@@ -588,27 +861,100 @@ class TelegramPlatform:
         if callback_query is None:
             return False
 
-        callback_id: str = str(callback_query.get("id", ""))
-        callback_data: str | None = callback_query.get("data")
-        logger.debug(
-            "[TelegramPlatform] callback_query ack — id=%r data=%r "
-            "(approval handling is a follow-up)",
-            callback_id,
-            callback_data,
+        from surogates.channels.platforms.telegram_interactive import (
+            build_answered_text,
+            parse_callback_data,
+        )
+        from surogates.session.interactive_input import (
+            pending_input_for_session,
+            resolve_input_response,
         )
 
         bot_token: str = creds.get("bot_token") or ""
-        if bot_token and callback_id:
+        callback_id: str = str(callback_query.get("id", ""))
+        parsed = parse_callback_data(callback_query.get("data") or "")
+        store = getattr(deps, "session_store", None)
+        if parsed is None or store is None:
+            await self._answer_callback(bot_token, callback_id)
+            return True
+        session_id_raw, _question_index, choice_index = parsed
+
+        try:
+            from uuid import UUID
+
+            session_id = UUID(session_id_raw)
+            session = await store.get_session(session_id)
+        except Exception:
+            logger.warning(
+                "[TelegramPlatform] callback for unknown session %r",
+                session_id_raw,
+            )
+            await self._answer_callback(bot_token, callback_id)
+            return True
+
+        # Anti-forgery: the callback must originate from the chat this
+        # session is bound to — callback_data is attacker-visible, the chat
+        # binding is not attacker-controllable.
+        chat_id = str(
+            ((callback_query.get("message") or {}).get("chat") or {}).get("id", "")
+        )
+        bound_chat = str((session.config or {}).get("telegram_channel_id", ""))
+        if not chat_id or chat_id != bound_chat:
+            logger.warning(
+                "[TelegramPlatform] callback chat %r does not match session chat %r",
+                chat_id, bound_chat,
+            )
+            await self._answer_callback(bot_token, callback_id)
+            return True
+
+        pending = await pending_input_for_session(store, session_id=session_id)
+        if not pending:
+            await self._answer_callback(
+                bot_token, callback_id, "This question was already answered."
+            )
+            return True
+
+        questions: list = pending.get("questions") or []
+        choices = (questions[0] if questions else {}).get("choices") or []
+        if choice_index < 0 or choice_index >= len(choices):
+            await self._answer_callback(bot_token, callback_id)
+            return True
+        prompt = (questions[0].get("prompt") if questions else "") or "Question 1"
+        answer = choices[choice_index].get("label") or ""
+        responses = [{"question": prompt, "answer": answer, "is_other": False}]
+
+        resolved = await resolve_input_response(
+            store,
+            session_id=session_id,
+            tool_call_id=pending.get("tool_call_id", ""),
+            responses=responses,
+        )
+        if not resolved:
+            await self._answer_callback(
+                bot_token, callback_id, "This question was already answered."
+            )
+            return True
+
+        # Replace the button message with the recorded answer. Best-effort.
+        message = callback_query.get("message") or {}
+        message_id = message.get("message_id")
+        if message_id is not None:
             try:
-                api_url = _bot_api_url(bot_token, "answerCallbackQuery")
                 await self._http.post(
-                    api_url, json={"callback_query_id": callback_id}
+                    _bot_api_url(bot_token, "editMessageText"),
+                    json={
+                        "chat_id": chat_id,
+                        "message_id": message_id,
+                        "text": build_answered_text(responses),
+                        "parse_mode": "HTML",
+                    },
                 )
             except Exception as exc:
                 logger.debug(
-                    "[TelegramPlatform] answerCallbackQuery failed: %s", exc
+                    "[TelegramPlatform] editMessageText failed: %s", exc
                 )
 
+        await self._answer_callback(bot_token, callback_id, "Got it.")
         return True
 
 

--- a/surogates/channels/platforms/telegram_format.py
+++ b/surogates/channels/platforms/telegram_format.py
@@ -1,0 +1,85 @@
+"""Markdown → Telegram-HTML rendering for outbound Telegram messages.
+
+Agents write standard markdown; Telegram's ``sendMessage`` renders either
+MarkdownV2 (which requires escaping *every* reserved character and fails the
+whole message on one mistake) or a small HTML subset.  HTML is the robust
+choice: everything is escaped first, then a conservative markdown subset is
+re-introduced as tags Telegram documents (``b``, ``i``, ``code``, ``pre``,
+``a``).  :func:`render_plain` is the fallback used when Telegram still
+rejects the HTML — same marker stripping, no tags.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+
+__all__ = ["render_html", "render_plain"]
+
+_FENCE_RE = re.compile(r"```[^\n`]*\n(.*?)```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
+_LINK_RE = re.compile(r"\[([^\]\n]+)\]\((https?://[^)\s]+)\)")
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*|__(.+?)__", re.DOTALL)
+_ITALIC_RE = re.compile(r"(?<![\w*])\*([^*\n]+)\*(?![\w*])|(?<![\w_])_([^_\n]+)_(?![\w_])")
+_HEADING_RE = re.compile(r"^#{1,6}\s+(.*)$", re.MULTILINE)
+_BULLET_RE = re.compile(r"^(\s*)[-*]\s+", re.MULTILINE)
+
+_PLACEHOLDER = "\x00{}\x00"
+
+
+def _stash(pattern: re.Pattern, text: str, stash: list[str], wrap) -> str:
+    def _sub(match: re.Match) -> str:
+        stash.append(wrap(match))
+        return _PLACEHOLDER.format(len(stash) - 1)
+    return pattern.sub(_sub, text)
+
+
+def _unstash(text: str, stash: list[str]) -> str:
+    for index, chunk in enumerate(stash):
+        text = text.replace(_PLACEHOLDER.format(index), chunk)
+    return text
+
+
+def render_html(text: str) -> str:
+    """Render markdown *text* as Telegram-safe HTML."""
+    stash: list[str] = []
+    out = text or ""
+    # Code first: its content must never be styled or double-processed.
+    out = _stash(
+        _FENCE_RE, out, stash,
+        lambda m: f"<pre>{html.escape(m.group(1).rstrip())}</pre>",
+    )
+    out = _stash(
+        _INLINE_CODE_RE, out, stash,
+        lambda m: f"<code>{html.escape(m.group(1))}</code>",
+    )
+    out = _stash(
+        _LINK_RE, out, stash,
+        lambda m: (
+            f'<a href="{html.escape(m.group(2), quote=True)}">'
+            f"{html.escape(m.group(1), quote=False)}</a>"
+        ),
+    )
+    out = html.escape(out, quote=False)
+    out = _BOLD_RE.sub(lambda m: f"<b>{m.group(1) or m.group(2)}</b>", out)
+    out = _ITALIC_RE.sub(lambda m: f"<i>{m.group(1) or m.group(2)}</i>", out)
+    out = _HEADING_RE.sub(lambda m: f"<b>{m.group(1)}</b>", out)
+    out = _BULLET_RE.sub(lambda m: f"{m.group(1)}• ", out)
+    return _unstash(out, stash)
+
+
+def render_plain(text: str) -> str:
+    """Strip the same markdown subset without introducing any tags.
+
+    Used as the retry body when Telegram rejects the HTML rendering —
+    the visitor still gets readable text instead of raw ``**`` noise.
+    """
+    out = text or ""
+    out = _FENCE_RE.sub(lambda m: m.group(1).rstrip(), out)
+    out = _INLINE_CODE_RE.sub(lambda m: m.group(1), out)
+    out = _LINK_RE.sub(lambda m: f"{m.group(1)} ({m.group(2)})", out)
+    out = _BOLD_RE.sub(lambda m: m.group(1) or m.group(2), out)
+    out = _ITALIC_RE.sub(lambda m: m.group(1) or m.group(2), out)
+    out = _HEADING_RE.sub(lambda m: m.group(1), out)
+    out = _BULLET_RE.sub(lambda m: f"{m.group(1)}• ", out)
+    return out

--- a/surogates/channels/platforms/telegram_interactive.py
+++ b/surogates/channels/platforms/telegram_interactive.py
@@ -5,9 +5,13 @@ Slack Block Kit flow:
 
 - A single question with choices renders as an ``inline_keyboard`` — one
   button per choice.  ``callback_data`` is capped at 64 bytes by Telegram,
-  so a button carries only ``si:<session_id>:<question>:<choice>``
-  (≤ 48 bytes); the question text and answer are re-resolved from the
-  durable pending-input record when the button is tapped.
+  so a button carries only coordinates plus a short digest of the
+  ``tool_call_id`` it belongs to:
+  ``si:<session_id>:<question>:<choice>:<digest>`` (≤ 56 bytes).  The
+  question text and answer are re-resolved from the durable pending-input
+  record when the button is tapped; the digest keeps a *stale* button (an
+  earlier prompt still visible in chat history) from resolving a newer
+  question with the wrong choice.
 - Free-text questions (and multi-question prompts) render as text; the
   visitor answers by simply replying, which the inbound pipeline resolves
   against the same durable record.
@@ -15,6 +19,7 @@ Slack Block Kit flow:
 
 from __future__ import annotations
 
+import hashlib
 import html
 
 __all__ = [
@@ -23,11 +28,17 @@ __all__ = [
     "parse_callback_data",
     "build_answered_text",
     "resolve_text_answer",
+    "tool_call_digest",
 ]
 
 CALLBACK_PREFIX = "si"
 
 _FREE_TEXT_HINT = "Reply to this message to answer in your own words."
+
+
+def tool_call_digest(tool_call_id: str) -> str:
+    """Short stable digest binding a button to one ``ask_user_question``."""
+    return hashlib.sha256((tool_call_id or "").encode()).hexdigest()[:8]
 
 
 def _esc(text: str) -> str:
@@ -39,6 +50,7 @@ def build_input_prompt(
     session_id: str,
     questions: list[dict],
     context: str = "",
+    tool_call_id: str = "",
 ) -> tuple[str, str, dict | None]:
     """Render an input prompt as ``(html_text, plain_text, reply_markup)``.
 
@@ -69,12 +81,15 @@ def build_input_prompt(
     single = questions[0] if len(questions) == 1 else None
     choices = (single or {}).get("choices") or []
     if single is not None and choices:
+        digest = tool_call_digest(tool_call_id)
         reply_markup = {
             "inline_keyboard": [
                 [
                     {
                         "text": (choice.get("label") or f"Choice {ci + 1}")[:64],
-                        "callback_data": f"{CALLBACK_PREFIX}:{session_id}:0:{ci}",
+                        "callback_data": (
+                            f"{CALLBACK_PREFIX}:{session_id}:0:{ci}:{digest}"
+                        ),
                     }
                 ]
                 for ci, choice in enumerate(choices)
@@ -90,20 +105,20 @@ def build_input_prompt(
     return "\n".join(lines_html), "\n".join(lines_plain), reply_markup
 
 
-def parse_callback_data(data: str) -> tuple[str, int, int] | None:
-    """Parse ``si:<session_id>:<question>:<choice>`` callback data.
+def parse_callback_data(data: str) -> tuple[str, int, int, str] | None:
+    """Parse ``si:<session_id>:<question>:<choice>:<digest>`` callback data.
 
-    Returns ``(session_id, question_index, choice_index)`` or ``None`` for
-    anything that is not a well-formed input callback.
+    Returns ``(session_id, question_index, choice_index, digest)`` or
+    ``None`` for anything that is not a well-formed input callback.
     """
     parts = (data or "").split(":")
-    if len(parts) != 4 or parts[0] != CALLBACK_PREFIX:
+    if len(parts) != 5 or parts[0] != CALLBACK_PREFIX:
         return None
-    session_id, q_raw, c_raw = parts[1], parts[2], parts[3]
-    if not session_id:
+    session_id, q_raw, c_raw, digest = parts[1], parts[2], parts[3], parts[4]
+    if not session_id or not digest:
         return None
     try:
-        return session_id, int(q_raw), int(c_raw)
+        return session_id, int(q_raw), int(c_raw), digest
     except ValueError:
         return None
 

--- a/surogates/channels/platforms/telegram_interactive.py
+++ b/surogates/channels/platforms/telegram_interactive.py
@@ -1,0 +1,149 @@
+"""Inline-keyboard helpers for Telegram ``ask_user_question`` prompts.
+
+Telegram has no modal surface, so the interaction model differs from the
+Slack Block Kit flow:
+
+- A single question with choices renders as an ``inline_keyboard`` — one
+  button per choice.  ``callback_data`` is capped at 64 bytes by Telegram,
+  so a button carries only ``si:<session_id>:<question>:<choice>``
+  (≤ 48 bytes); the question text and answer are re-resolved from the
+  durable pending-input record when the button is tapped.
+- Free-text questions (and multi-question prompts) render as text; the
+  visitor answers by simply replying, which the inbound pipeline resolves
+  against the same durable record.
+"""
+
+from __future__ import annotations
+
+import html
+
+__all__ = [
+    "CALLBACK_PREFIX",
+    "build_input_prompt",
+    "parse_callback_data",
+    "build_answered_text",
+    "resolve_text_answer",
+]
+
+CALLBACK_PREFIX = "si"
+
+_FREE_TEXT_HINT = "Reply to this message to answer in your own words."
+
+
+def _esc(text: str) -> str:
+    return html.escape(text or "", quote=False)
+
+
+def build_input_prompt(
+    *,
+    session_id: str,
+    questions: list[dict],
+    context: str = "",
+) -> tuple[str, str, dict | None]:
+    """Render an input prompt as ``(html_text, plain_text, reply_markup)``.
+
+    ``reply_markup`` is an ``inline_keyboard`` dict when the prompt is a
+    single choice-question, else ``None``.
+    """
+    lines_html: list[str] = ["❓ <b>I need your input</b>"]
+    lines_plain: list[str] = ["❓ I need your input"]
+    if context.strip():
+        lines_html.append(_esc(context.strip()))
+        lines_plain.append(context.strip())
+
+    for index, question in enumerate(questions):
+        prompt = question.get("prompt") or f"Question {index + 1}"
+        prefix = f"{index + 1}. " if len(questions) > 1 else ""
+        lines_html.append(f"{prefix}<b>{_esc(prompt)}</b>")
+        lines_plain.append(f"{prefix}{prompt}")
+        choices = question.get("choices") or []
+        if choices and len(questions) > 1:
+            # Buttons only work for the single-question form; list the
+            # options inline for multi-question prompts.
+            for choice in choices:
+                label = choice.get("label") or ""
+                lines_html.append(f"  • {_esc(label)}")
+                lines_plain.append(f"  • {label}")
+
+    reply_markup: dict | None = None
+    single = questions[0] if len(questions) == 1 else None
+    choices = (single or {}).get("choices") or []
+    if single is not None and choices:
+        reply_markup = {
+            "inline_keyboard": [
+                [
+                    {
+                        "text": (choice.get("label") or f"Choice {ci + 1}")[:64],
+                        "callback_data": f"{CALLBACK_PREFIX}:{session_id}:0:{ci}",
+                    }
+                ]
+                for ci, choice in enumerate(choices)
+            ]
+        }
+        if single.get("allow_other", True):
+            lines_html.append(_esc(_FREE_TEXT_HINT))
+            lines_plain.append(_FREE_TEXT_HINT)
+    else:
+        lines_html.append(_esc(_FREE_TEXT_HINT))
+        lines_plain.append(_FREE_TEXT_HINT)
+
+    return "\n".join(lines_html), "\n".join(lines_plain), reply_markup
+
+
+def parse_callback_data(data: str) -> tuple[str, int, int] | None:
+    """Parse ``si:<session_id>:<question>:<choice>`` callback data.
+
+    Returns ``(session_id, question_index, choice_index)`` or ``None`` for
+    anything that is not a well-formed input callback.
+    """
+    parts = (data or "").split(":")
+    if len(parts) != 4 or parts[0] != CALLBACK_PREFIX:
+        return None
+    session_id, q_raw, c_raw = parts[1], parts[2], parts[3]
+    if not session_id:
+        return None
+    try:
+        return session_id, int(q_raw), int(c_raw)
+    except ValueError:
+        return None
+
+
+def build_answered_text(responses: list[dict]) -> str:
+    """Render the resolved prompt (HTML) that replaces the button message."""
+    lines = ["✅ <b>Answered</b>"]
+    for response in responses:
+        question = (response.get("question") or "").strip()
+        answer = (response.get("answer") or "").strip()
+        if question:
+            lines.append(f"<b>{_esc(question)}</b>: {_esc(answer)}")
+        else:
+            lines.append(_esc(answer))
+    return "\n".join(lines)
+
+
+def resolve_text_answer(questions: list[dict], text: str) -> list[dict]:
+    """Map a free-text reply onto the pending questions.
+
+    A reply that exactly matches a choice label (case-insensitive) selects
+    that choice; anything else is recorded as an "other" answer.  Multi-
+    question prompts get the whole reply attached to each question — the
+    agent asked them as one message and receives the answer the same way.
+    """
+    stripped = (text or "").strip()
+    responses: list[dict] = []
+    for index, question in enumerate(questions):
+        prompt = question.get("prompt") or f"Question {index + 1}"
+        matched = None
+        for choice in question.get("choices") or []:
+            label = (choice.get("label") or "").strip()
+            if label and label.lower() == stripped.lower():
+                matched = label
+                break
+        responses.append(
+            {
+                "question": prompt,
+                "answer": matched or stripped,
+                "is_other": matched is None,
+            }
+        )
+    return responses

--- a/surogates/channels/runner.py
+++ b/surogates/channels/runner.py
@@ -274,7 +274,7 @@ def _make_deps_factory(
                 if data is None:
                     skipped.append(safe_display_name(safe))
                     continue
-                path = f"uploads/slack/{ts}-{index}-{safe}"
+                path = f"uploads/{platform.kind}/{ts}-{index}-{safe}"
                 try:
                     out = await ingest_attachment_bytes(
                         storage, session=session, root_id=root_id, bucket=bucket,

--- a/surogates/channels/text_split.py
+++ b/surogates/channels/text_split.py
@@ -38,9 +38,7 @@ def split_text(text: str, limit: int) -> list[str]:
         window = remaining[: limit + 1]
         cut = -1
         for sep in _SEPARATORS:
-            idx = window.rfind(sep, 0, limit + 1 if sep != " " else limit + 1)
-            # For multi-char separators the cut point is the separator start;
-            # for a space it is the space itself.
+            idx = window.rfind(sep)
             if idx >= int(limit * _MIN_FILL):
                 cut = idx
                 sep_len = len(sep)

--- a/surogates/channels/text_split.py
+++ b/surogates/channels/text_split.py
@@ -1,0 +1,57 @@
+"""Outbound message splitting shared by channel platforms.
+
+Every messaging platform caps message length (Slack ~40k chars, Telegram
+4096).  :func:`split_text` cuts an over-limit reply into chunks at the most
+natural boundary available — paragraph break, then line break, then word
+boundary, then a hard cut — so no chunk ever exceeds the platform limit and
+no content is lost.
+"""
+
+from __future__ import annotations
+
+__all__ = ["split_text"]
+
+# Boundary separators in preference order.  Each is searched backwards from
+# the limit so the chunk is as full as possible while still ending cleanly.
+_SEPARATORS = ("\n\n", "\n", " ")
+
+# Don't accept a boundary that would leave a tiny fragment as the chunk —
+# below this fraction of the limit, fall through to the next separator.
+_MIN_FILL = 0.25
+
+
+def split_text(text: str, limit: int) -> list[str]:
+    """Split *text* into chunks of at most *limit* characters.
+
+    Returns ``[text]`` unchanged when it already fits.  Chunks are stripped
+    of the boundary whitespace they were cut on; empty chunks are never
+    returned.  ``limit`` must be positive.
+    """
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    if len(text) <= limit:
+        return [text] if text else []
+
+    chunks: list[str] = []
+    remaining = text
+    while len(remaining) > limit:
+        window = remaining[: limit + 1]
+        cut = -1
+        for sep in _SEPARATORS:
+            idx = window.rfind(sep, 0, limit + 1 if sep != " " else limit + 1)
+            # For multi-char separators the cut point is the separator start;
+            # for a space it is the space itself.
+            if idx >= int(limit * _MIN_FILL):
+                cut = idx
+                sep_len = len(sep)
+                break
+        if cut == -1:
+            cut = limit
+            sep_len = 0
+        chunk = remaining[:cut].rstrip()
+        if chunk:
+            chunks.append(chunk)
+        remaining = remaining[cut + sep_len:].lstrip("\n") if sep_len else remaining[cut:]
+    if remaining.strip():
+        chunks.append(remaining.rstrip())
+    return chunks

--- a/surogates/channels/website_session.py
+++ b/surogates/channels/website_session.py
@@ -96,6 +96,12 @@ class WebsiteSessionClaims:
     csrf_token: str
     issued_at: int
     expires_at: int
+    # Publishable key the session bootstrapped through.  Lets every later
+    # request re-resolve the per-agent channel_routing row (origin
+    # allow-list, active flag) without a client-supplied key.  Empty for
+    # cookies minted before this claim existed — callers fall back to the
+    # deployment-global settings in that case.
+    channel_identifier: str = ""
 
 
 def create_website_session_token(
@@ -104,6 +110,7 @@ def create_website_session_token(
     org_id: UUID,
     origin: str,
     csrf_token: str,
+    channel_identifier: str = "",
     expires_seconds: int = DEFAULT_SESSION_TTL_SECONDS,
 ) -> str:
     """Sign a JWT binding a website session to its org + origin + CSRF.
@@ -122,6 +129,7 @@ def create_website_session_token(
         "org_id": str(org_id),
         "origin": origin,
         "csrf": csrf_token,
+        "channel_identifier": channel_identifier,
         "iat": now,
         "exp": now + expires_seconds,
     }
@@ -166,6 +174,7 @@ def decode_website_session_token(token: str) -> WebsiteSessionClaims:
             csrf_token=str(payload["csrf"]),
             issued_at=int(payload["iat"]),
             expires_at=int(payload["exp"]),
+            channel_identifier=str(payload.get("channel_identifier") or ""),
         )
     except (ValueError, TypeError) as exc:
         raise InvalidTokenError(f"Website-session token has malformed claims: {exc}") from exc

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -84,6 +84,12 @@ _INBOX_EVENTS = frozenset({
 # returning thousands of rows on every poll.
 _MAX_LISTED_DESCENDANTS = 1000
 
+# Channels with a registered outbound delivery adapter (a delivery loop that
+# claims their outbox rows).  Must match the platforms registered in
+# surogates.channels.platforms — an outbox row for any other channel value
+# would never be claimed and sit "pending" forever.
+_ADAPTER_CHANNELS = frozenset({"slack", "telegram"})
+
 
 def _build_channel_payload(event_type: EventType, data: dict, channel: str) -> dict:
     """Extract the deliverable payload from an event. Empty dict = nothing to
@@ -994,13 +1000,11 @@ class SessionStore:
 
             channel, config = self._channel_cache[session_id]
 
-            # Web sessions use SSE — no outbox delivery needed.
-            if channel == "web":
-                return
-
-            # Ambient sessions reason privately; their only outbound path is
-            # the gated mate_ambient_post tool. Never auto-deliver them.
-            if channel == "ambient":
+            # Only channels with a registered delivery adapter get outbox rows.
+            # Everything else (web/website SSE, api/task/delegation/worker
+            # consumers, ambient's gated mate_ambient_post path) has no claimer
+            # — rows for those channels would sit "pending" forever.
+            if channel not in _ADAPTER_CHANNELS:
                 return
 
             # Build channel-specific destination from session config.
@@ -1011,20 +1015,13 @@ class SessionStore:
                     "thread_ts": config.get("slack_thread_key"),
                     "channel_identifier": config.get("channel_identifier", ""),
                 }
-            elif channel == "teams":
-                destination = {
-                    "conversation_id": config.get("teams_channel_id", ""),
-                    "activity_id": config.get("teams_thread_key"),
-                    "channel_identifier": config.get("channel_identifier", ""),
-                }
             elif channel == "telegram":
                 destination = {
                     "chat_id": config.get("telegram_channel_id", ""),
                     "message_thread_id": config.get("telegram_thread_key"),
+                    "reply_to_message_id": config.get("telegram_reply_to_message_id"),
                     "channel_identifier": config.get("channel_identifier", ""),
                 }
-            else:
-                destination = {"session_id": str(session_id)}
 
             # Build payload: extract the user-facing content from the event.
             payload = _build_channel_payload(event_type, data, channel)

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -19,6 +19,10 @@ from sqlalchemy import and_, not_, select, text, true, update, delete, func, or_
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import aliased
 
+from surogates.channels.constants import (
+    ADAPTER_CHANNELS,
+    INTERACTIVE_PROMPT_CHANNELS,
+)
 from surogates.db.models import (
     Event as EventRow,
     IdeaNode,
@@ -84,11 +88,6 @@ _INBOX_EVENTS = frozenset({
 # returning thousands of rows on every poll.
 _MAX_LISTED_DESCENDANTS = 1000
 
-# Channels with a registered outbound delivery adapter (a delivery loop that
-# claims their outbox rows).  Must match the platforms registered in
-# surogates.channels.platforms — an outbox row for any other channel value
-# would never be claimed and sit "pending" forever.
-_ADAPTER_CHANNELS = frozenset({"slack", "telegram"})
 
 
 def _build_channel_payload(event_type: EventType, data: dict, channel: str) -> dict:
@@ -121,13 +120,10 @@ def _build_channel_payload(event_type: EventType, data: dict, channel: str) -> d
                 payload["code_run"] = str(run_id)
     elif event_type == EventType.SESSION_STOPPED:
         payload["content"] = _STOPPED_CONFIRMATION
-    elif event_type == EventType.INBOX_INPUT_REQUIRED and channel in (
-        "slack",
-        "telegram",
+    elif (
+        event_type == EventType.INBOX_INPUT_REQUIRED
+        and channel in INTERACTIVE_PROMPT_CHANNELS
     ):
-        # Slack renders an Answer button + modal; Telegram an inline
-        # keyboard. Other channels have no interactive prompt surface, so a
-        # content-less input_prompt row must not be enqueued for them.
         questions = data.get("questions") or []
         if questions:
             payload = {
@@ -1010,7 +1006,7 @@ class SessionStore:
             # Everything else (web/website SSE, api/task/delegation/worker
             # consumers, ambient's gated mate_ambient_post path) has no claimer
             # — rows for those channels would sit "pending" forever.
-            if channel not in _ADAPTER_CHANNELS:
+            if channel not in ADAPTER_CHANNELS:
                 return
 
             # Build channel-specific destination from session config.
@@ -1039,13 +1035,15 @@ class SessionStore:
             dedupe_key = f"{channel}:{event_id}"
 
             async with self._sf() as db:
-                if channel == "telegram":
+                if channel == "telegram" and "telegram_reply_to_message_id" in config:
                     # Reply threading tracks the latest inbound message id in
                     # session config (written by the channels process), so it
                     # must be read fresh — the per-session config cache above
                     # is primed once and would pin every reply to the first
-                    # message.  Best-effort: a read failure falls back to the
-                    # cached value rather than dropping the delivery.
+                    # message.  Gated on the cached config carrying the key at
+                    # all, so sessions that never use reply threading pay no
+                    # extra query.  Best-effort: a read failure falls back to
+                    # the cached value rather than dropping the delivery.
                     try:
                         fresh = await db.get(SessionRow, session_id)
                         if fresh is not None:

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -121,7 +121,13 @@ def _build_channel_payload(event_type: EventType, data: dict, channel: str) -> d
                 payload["code_run"] = str(run_id)
     elif event_type == EventType.SESSION_STOPPED:
         payload["content"] = _STOPPED_CONFIRMATION
-    elif event_type == EventType.INBOX_INPUT_REQUIRED and channel == "slack":
+    elif event_type == EventType.INBOX_INPUT_REQUIRED and channel in (
+        "slack",
+        "telegram",
+    ):
+        # Slack renders an Answer button + modal; Telegram an inline
+        # keyboard. Other channels have no interactive prompt surface, so a
+        # content-less input_prompt row must not be enqueued for them.
         questions = data.get("questions") or []
         if questions:
             payload = {
@@ -947,8 +953,8 @@ class SessionStore:
             except Exception:
                 pass
 
-        # Channel delivery: enqueue deliverable events to the outbox
-        # for non-web channels (Slack, Teams, Telegram, etc.).
+        # Channel delivery: enqueue deliverable events to the outbox for
+        # adapter-backed channels (Slack, Telegram).
         if event_type in _DELIVERABLE_EVENTS:
             await self._enqueue_channel_delivery(
                 session_id,

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -1033,6 +1033,21 @@ class SessionStore:
             dedupe_key = f"{channel}:{event_id}"
 
             async with self._sf() as db:
+                if channel == "telegram":
+                    # Reply threading tracks the latest inbound message id in
+                    # session config (written by the channels process), so it
+                    # must be read fresh — the per-session config cache above
+                    # is primed once and would pin every reply to the first
+                    # message.  Best-effort: a read failure falls back to the
+                    # cached value rather than dropping the delivery.
+                    try:
+                        fresh = await db.get(SessionRow, session_id)
+                        if fresh is not None:
+                            destination["reply_to_message_id"] = (
+                                fresh.config or {}
+                            ).get("telegram_reply_to_message_id")
+                    except Exception:
+                        pass
                 outbox = DeliveryOutbox(
                     session_id=session_id,
                     event_id=event_id,

--- a/tests/test_channel_delivery.py
+++ b/tests/test_channel_delivery.py
@@ -1491,10 +1491,10 @@ class TestInputRequiredOutboxDelivery:
 
         assert captured == []
 
-    async def test_telegram_input_required_does_not_enqueue_prompt_payload(self):
-        """Only Slack renders the interactive modal.  A non-Slack channel must
-        not enqueue a content-less input_prompt row — Telegram's send() reads
-        payload['content'] ('' here) and the API rejects an empty-text message.
+    async def test_telegram_input_required_enqueues_prompt_payload(self):
+        """Telegram renders questions as an inline keyboard, so its
+        INBOX_INPUT_REQUIRED events must enqueue the input_prompt payload —
+        send() routes them to _send_input_prompt, never the plain-text path.
         """
         import unittest.mock as mock
         from uuid import uuid4
@@ -1542,7 +1542,12 @@ class TestInputRequiredOutboxDelivery:
                 data={"tool_call_id": "tc1", "questions": [{"prompt": "q"}]},
             )
 
-        assert captured == []
+        assert len(captured) == 1
+        payload = captured[0]["payload"]
+        assert payload["input_prompt"] is True
+        assert payload["tool_call_id"] == "tc1"
+        assert payload["questions"] == [{"prompt": "q"}]
+        assert captured[0]["destination"]["chat_id"] == "-100123456789"
 
     async def test_slack_input_required_no_tool_call_id_still_enqueues(self):
         """questions present but no tool_call_id key must still enqueue (gate is questions-only)."""

--- a/tests/test_channel_delivery_allowlist.py
+++ b/tests/test_channel_delivery_allowlist.py
@@ -1,0 +1,92 @@
+"""Outbox enqueue is limited to channels with a delivery adapter.
+
+Rows for channels no delivery loop claims (api, website, task, delegation,
+worker, web, ambient, teams) would sit "pending" forever — the store must
+not create them in the first place.
+"""
+
+import pytest
+
+from surogates.session import store as store_mod
+from surogates.session.events import EventType
+
+
+class _SFTracker:
+    """Tracks whether the session factory was invoked (i.e. an outbox enqueue
+    was attempted).  The store method swallows exceptions, so we assert on a
+    flag rather than relying on a raise propagating."""
+    def __init__(self): self.called = False
+    def __call__(self):
+        self.called = True
+        raise RuntimeError("stop before real db work")
+
+
+def _store_with_channel(channel: str, config: dict | None = None):
+    inst = store_mod.SessionStore.__new__(store_mod.SessionStore)
+    inst._channel_cache = {"sess-1": (channel, config or {})}
+    inst._sf = _SFTracker()
+    return inst
+
+
+_EVENT_DATA = {"message": {"content": "hello"}}
+
+
+@pytest.mark.parametrize(
+    "channel",
+    ["api", "website", "task", "delegation", "worker", "web", "ambient", "teams", "scheduled"],
+)
+async def test_adapterless_channels_skip_outbox(channel):
+    inst = _store_with_channel(channel)
+    await store_mod.SessionStore._enqueue_channel_delivery(
+        inst, "sess-1", 1, EventType.LLM_RESPONSE, _EVENT_DATA,
+    )
+    assert inst._sf.called is False
+
+
+@pytest.mark.parametrize("channel", ["slack", "telegram"])
+async def test_adapter_channels_reach_enqueue(channel):
+    inst = _store_with_channel(channel, {f"{channel}_channel_id": "C1"})
+    await store_mod.SessionStore._enqueue_channel_delivery(
+        inst, "sess-1", 1, EventType.LLM_RESPONSE, _EVENT_DATA,
+    )
+    assert inst._sf.called is True
+
+
+async def test_telegram_destination_carries_reply_to():
+    """The telegram destination forwards the session's reply-to message id."""
+    captured: dict = {}
+
+    inst = store_mod.SessionStore.__new__(store_mod.SessionStore)
+    inst._channel_cache = {
+        "sess-1": (
+            "telegram",
+            {
+                "telegram_channel_id": "12345",
+                "telegram_thread_key": None,
+                "telegram_reply_to_message_id": 777,
+                "channel_identifier": "@bot",
+            },
+        )
+    }
+
+    class _CaptureSF:
+        def __call__(self):
+            raise RuntimeError("stop before real db work")
+
+    inst._sf = _CaptureSF()
+
+    original_build = store_mod._build_channel_payload
+
+    def _spy_build(event_type, data, channel):
+        captured["channel"] = channel
+        return original_build(event_type, data, channel)
+
+    store_mod._build_channel_payload = _spy_build
+    try:
+        await store_mod.SessionStore._enqueue_channel_delivery(
+            inst, "sess-1", 1, EventType.LLM_RESPONSE, _EVENT_DATA,
+        )
+    finally:
+        store_mod._build_channel_payload = original_build
+
+    assert captured["channel"] == "telegram"

--- a/tests/test_channel_delivery_payload.py
+++ b/tests/test_channel_delivery_payload.py
@@ -34,10 +34,13 @@ def test_tool_call_only_response_yields_empty_payload():
     assert _build_channel_payload(EventType.LLM_RESPONSE, data, "slack") == {}
 
 
-def test_input_required_payload_slack_only():
+def test_input_required_payload_interactive_channels_only():
+    # Slack (Answer button + modal) and Telegram (inline keyboard) can render
+    # a question; channels with no interactive surface must get no row.
     data = {"questions": [{"q": "?"}], "tool_call_id": "t1", "context": "ctx"}
     assert _build_channel_payload(EventType.INBOX_INPUT_REQUIRED, data, "slack")["input_prompt"] is True
-    assert _build_channel_payload(EventType.INBOX_INPUT_REQUIRED, data, "telegram") == {}
+    assert _build_channel_payload(EventType.INBOX_INPUT_REQUIRED, data, "telegram")["input_prompt"] is True
+    assert _build_channel_payload(EventType.INBOX_INPUT_REQUIRED, data, "teams") == {}
 
 
 def test_session_stopped_is_deliverable():

--- a/tests/test_channel_pipeline_telegram.py
+++ b/tests/test_channel_pipeline_telegram.py
@@ -57,6 +57,20 @@ async def test_mention_pattern_grants_processing():
     assert result == InboundOutcome.PROCESSED
 
 
+async def test_mention_pattern_with_punctuation_matches():
+    """Patterns starting with non-word chars ("@bot") must still match —
+    a plain \\b boundary would silently never fire for them."""
+    deps = _make_deps()
+    msg = _make_msg(text="hey @libra run the report", is_mention=False)
+    result = await ChannelInboundPipeline().handle(
+        msg,
+        routing=_make_routing(),
+        config={**_make_config(require_mention=True), "mention_patterns": "@libra"},
+        deps=deps,
+    )
+    assert result == InboundOutcome.PROCESSED
+
+
 async def test_mention_pattern_miss_still_gated():
     deps = _make_deps()
     msg = _make_msg(text="unrelated chatter", is_mention=False)

--- a/tests/test_channel_pipeline_telegram.py
+++ b/tests/test_channel_pipeline_telegram.py
@@ -1,0 +1,188 @@
+"""Pipeline behavior added for Telegram: mention patterns, free-text answers
+to pending input, reply-to threading state, and platform-agnostic
+attachment ingest."""
+
+import dataclasses
+from unittest.mock import AsyncMock
+
+from surogates.channels.inbound import (
+    ChannelInboundPipeline,
+    InboundFileRef,
+    InboundOutcome,
+)
+from surogates.session.events import EventType
+
+from tests.test_channel_pipeline import (
+    SESSION_ID,
+    _make_config,
+    _make_deps,
+    _make_msg,
+    _make_routing,
+    _Routing,
+)
+
+
+def _telegram_routing() -> _Routing:
+    return _Routing(platform="telegram", identifier="@bot")
+
+
+class _ConfigStore:
+    """Session-store fake that records config-key writes."""
+
+    def __init__(self, existing_config: dict | None = None) -> None:
+        self.events = []
+        self.config_writes: list[tuple[str, object]] = []
+        self._config = dict(existing_config or {})
+
+    async def emit_event(self, session_id, event_type, data) -> None:
+        self.events.append((session_id, event_type, data))
+
+    async def update_session_config_key(self, session_id, key, value) -> None:
+        self.config_writes.append((key, value))
+        self._config[key] = value
+
+    async def get_session(self, session_id):
+        return dataclasses.make_dataclass("S", ["config"])(config=dict(self._config))
+
+
+async def test_mention_pattern_grants_processing():
+    deps = _make_deps()
+    msg = _make_msg(text="hey libra, run the report", is_mention=False)
+    result = await ChannelInboundPipeline().handle(
+        msg,
+        routing=_make_routing(),
+        config={**_make_config(require_mention=True), "mention_patterns": "libra, other"},
+        deps=deps,
+    )
+    assert result == InboundOutcome.PROCESSED
+
+
+async def test_mention_pattern_miss_still_gated():
+    deps = _make_deps()
+    msg = _make_msg(text="unrelated chatter", is_mention=False)
+    result = await ChannelInboundPipeline().handle(
+        msg,
+        routing=_make_routing(),
+        config={**_make_config(require_mention=True), "mention_patterns": "libra"},
+        deps=deps,
+    )
+    assert result == InboundOutcome.DROPPED
+
+
+async def test_telegram_plain_reply_resolves_pending_input(monkeypatch):
+    deps = _make_deps()
+    nudges = []
+
+    async def pending_input(session_id):
+        return {
+            "tool_call_id": "tc9",
+            "questions": [{"prompt": "Deploy?", "choices": [{"label": "Yes"}, {"label": "No"}]}],
+            "context": "",
+        }
+
+    async def input_nudge(session_id, msg, text):
+        nudges.append(text)
+
+    deps.pending_input = pending_input
+    deps.input_nudge = input_nudge
+
+    resolve = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "surogates.session.interactive_input.resolve_input_response", resolve,
+    )
+
+    msg = _make_msg(is_dm=True, text="yes", ts="900.0")
+    result = await ChannelInboundPipeline().handle(
+        msg, routing=_telegram_routing(), config=_make_config(), deps=deps,
+    )
+
+    assert result == InboundOutcome.DROPPED
+    resolve.assert_awaited_once()
+    kwargs = resolve.await_args.kwargs
+    assert kwargs["session_id"] == SESSION_ID
+    assert kwargs["tool_call_id"] == "tc9"
+    assert kwargs["responses"][0]["answer"] == "Yes"
+    assert nudges and "Got it" in nudges[0]
+    assert not any(t == EventType.USER_MESSAGE for _, t, _ in deps.session_store.events)
+
+
+async def test_telegram_reply_to_mode_all_tracks_latest():
+    deps = _make_deps()
+    store = _ConfigStore()
+    deps.session_store = store
+
+    base = _make_msg(text="first", ts="901.0")
+    msg = dataclasses.replace(base, source={"message_id": 11})
+    await ChannelInboundPipeline().handle(
+        msg,
+        routing=_telegram_routing(),
+        config={**_make_config(require_mention=False), "reply_to_mode": "all"},
+        deps=deps,
+    )
+    msg2 = dataclasses.replace(
+        _make_msg(text="second", ts="902.0"), source={"message_id": 12},
+    )
+    await ChannelInboundPipeline().handle(
+        msg2,
+        routing=_telegram_routing(),
+        config={**_make_config(require_mention=False), "reply_to_mode": "all"},
+        deps=deps,
+    )
+    assert store.config_writes == [
+        ("telegram_reply_to_message_id", 11),
+        ("telegram_reply_to_message_id", 12),
+    ]
+
+
+async def test_telegram_reply_to_mode_first_pins_opening_message():
+    deps = _make_deps()
+    store = _ConfigStore()
+    deps.session_store = store
+
+    for ts, mid in (("903.0", 21), ("904.0", 22)):
+        msg = dataclasses.replace(
+            _make_msg(text="x", ts=ts), source={"message_id": mid},
+        )
+        await ChannelInboundPipeline().handle(
+            msg,
+            routing=_telegram_routing(),
+            config={**_make_config(require_mention=False), "reply_to_mode": "first"},
+            deps=deps,
+        )
+    assert store.config_writes == [("telegram_reply_to_message_id", 21)]
+
+
+async def test_telegram_dm_never_records_reply_to():
+    deps = _make_deps()
+    store = _ConfigStore()
+    deps.session_store = store
+    msg = dataclasses.replace(
+        _make_msg(is_dm=True, text="x", ts="905.0"), source={"message_id": 31},
+    )
+    await ChannelInboundPipeline().handle(
+        msg,
+        routing=_telegram_routing(),
+        config={**_make_config(), "reply_to_mode": "all"},
+        deps=deps,
+    )
+    assert store.config_writes == []
+
+
+async def test_telegram_files_reach_attachment_ingest():
+    deps = _make_deps()
+    ingested = []
+
+    async def attachments(session_id, msg):
+        ingested.append([f.file_id for f in msg.files])
+        return {"images": [], "attachments": [], "note": ""}
+
+    deps.attachments = attachments
+    msg = dataclasses.replace(
+        _make_msg(is_dm=True, text="see file", ts="906.0"),
+        files=[InboundFileRef(url="fid", filename="a.pdf", mime_type="application/pdf", size=1, file_id="fid")],
+    )
+    result = await ChannelInboundPipeline().handle(
+        msg, routing=_telegram_routing(), config=_make_config(), deps=deps,
+    )
+    assert result == InboundOutcome.PROCESSED
+    assert ingested == [["fid"]]

--- a/tests/test_channel_pipeline_telegram.py
+++ b/tests/test_channel_pipeline_telegram.py
@@ -168,6 +168,44 @@ async def test_telegram_dm_never_records_reply_to():
     assert store.config_writes == []
 
 
+async def test_telegram_plain_reply_falls_through_when_resolution_races(monkeypatch):
+    """A reply that loses the answer race (button tapped first) must become a
+    normal turn, not vanish."""
+    deps = _make_deps()
+
+    async def pending_input(session_id):
+        return {"tool_call_id": "tc9", "questions": [{"prompt": "Deploy?"}], "context": ""}
+
+    deps.pending_input = pending_input
+    monkeypatch.setattr(
+        "surogates.session.interactive_input.resolve_input_response",
+        AsyncMock(return_value=False),
+    )
+
+    msg = _make_msg(is_dm=True, text="also check the invoice", ts="910.0")
+    result = await ChannelInboundPipeline().handle(
+        msg, routing=_telegram_routing(), config=_make_config(), deps=deps,
+    )
+
+    assert result == InboundOutcome.PROCESSED
+    assert deps._enqueued
+    assert any(t == EventType.USER_MESSAGE for _, t, _ in deps.session_store.events)
+
+
+async def test_caption_less_media_passes_body_gate():
+    """Telegram attachments arrive with empty text and empty media_urls —
+    the files alone must count as a message body."""
+    deps = _make_deps()
+    msg = dataclasses.replace(
+        _make_msg(is_dm=True, text="", ts="911.0"),
+        files=[InboundFileRef(url="fid", filename="a.jpg", mime_type="image/jpeg", size=1, file_id="fid")],
+    )
+    result = await ChannelInboundPipeline().handle(
+        msg, routing=_telegram_routing(), config=_make_config(), deps=deps,
+    )
+    assert result == InboundOutcome.PROCESSED
+
+
 async def test_telegram_files_reach_attachment_ingest():
     deps = _make_deps()
     ingested = []

--- a/tests/test_slack_send_split.py
+++ b/tests/test_slack_send_split.py
@@ -1,0 +1,77 @@
+"""SlackPlatform.send splits over-limit messages into sequential posts."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from surogates.channels.platforms.slack import SlackPlatform
+
+
+def _item(content: str, *, update_ts: str | None = None, thread_ts: str | None = None):
+    destination = {"channel_id": "C1"}
+    if update_ts:
+        destination["update_ts"] = update_ts
+    if thread_ts:
+        destination["thread_ts"] = thread_ts
+    return SimpleNamespace(
+        id=1, session_id="s1", destination=destination, payload={"content": content},
+    )
+
+
+@pytest.fixture
+def platform(monkeypatch):
+    p = SlackPlatform()
+    client = SimpleNamespace(
+        chat_postMessage=AsyncMock(side_effect=[{"ts": f"1.{i}"} for i in range(10)]),
+        chat_update=AsyncMock(return_value={"ts": "0.9"}),
+    )
+    monkeypatch.setattr(p, "_get_client", lambda token: client)
+    return p, client
+
+
+async def test_short_message_single_post(platform):
+    p, client = platform
+    result = await p.send(_item("hello"), creds={"bot_token": "xoxb-1"})
+    assert result.success and result.message_id == "1.0"
+    assert client.chat_postMessage.await_count == 1
+
+
+async def test_long_message_splits_into_multiple_posts(platform):
+    p, client = platform
+    text = ("paragraph one. " * 2000) + "\n\n" + ("paragraph two. " * 2000)
+    result = await p.send(_item(text), creds={"bot_token": "xoxb-1"})
+    assert result.success
+    assert client.chat_postMessage.await_count >= 2
+    for call in client.chat_postMessage.await_args_list:
+        assert len(call.kwargs["text"]) <= p._MAX_MESSAGE_CHARS
+    # last posted ts wins
+    assert result.message_id == f"1.{client.chat_postMessage.await_count - 1}"
+
+
+async def test_update_ts_edits_first_chunk_then_posts_rest(platform):
+    p, client = platform
+    text = "a" * (p._MAX_MESSAGE_CHARS + 100)
+    result = await p.send(
+        _item(text, update_ts="0.5"), creds={"bot_token": "xoxb-1"},
+    )
+    assert result.success
+    client.chat_update.assert_awaited_once()
+    assert len(client.chat_update.await_args.kwargs["text"]) <= p._MAX_MESSAGE_CHARS
+    assert client.chat_postMessage.await_count == 1
+
+
+async def test_thread_ts_propagates_to_every_chunk(platform):
+    p, client = platform
+    text = ("x" * p._MAX_MESSAGE_CHARS) + "\n\n" + ("y" * 100)
+    await p.send(_item(text, thread_ts="9.9"), creds={"bot_token": "xoxb-1"})
+    for call in client.chat_postMessage.await_args_list:
+        assert call.kwargs["thread_ts"] == "9.9"
+
+
+async def test_mid_split_failure_reports_delivered_prefix(platform):
+    p, client = platform
+    client.chat_postMessage.side_effect = [{"ts": "1.0"}, RuntimeError("boom")]
+    text = ("x" * p._MAX_MESSAGE_CHARS) + "\n\n" + ("y" * 100)
+    result = await p.send(_item(text), creds={"bot_token": "xoxb-1"})
+    assert result.success and result.message_id == "1.0"

--- a/tests/test_telegram_format.py
+++ b/tests/test_telegram_format.py
@@ -1,0 +1,56 @@
+"""Markdown → Telegram-HTML rendering tests."""
+
+from surogates.channels.platforms.telegram_format import render_html, render_plain
+
+
+def test_escapes_html_entities():
+    assert render_html("a < b & c > d") == "a &lt; b &amp; c &gt; d"
+
+
+def test_bold_and_italic():
+    assert render_html("**bold** and *ital*") == "<b>bold</b> and <i>ital</i>"
+    assert render_html("__bold__ and _ital_") == "<b>bold</b> and <i>ital</i>"
+
+
+def test_snake_case_not_italicized():
+    assert render_html("use tool_name here") == "use tool_name here"
+
+
+def test_inline_code_escaped_and_wrapped():
+    assert render_html("run `a < b`") == "run <code>a &lt; b</code>"
+
+
+def test_fenced_block():
+    out = render_html("```python\nx = 1 < 2\n```")
+    assert out == "<pre>x = 1 &lt; 2</pre>"
+
+
+def test_code_content_not_styled():
+    out = render_html("`**not bold**`")
+    assert out == "<code>**not bold**</code>"
+
+
+def test_link_rendering():
+    out = render_html("see [docs](https://example.com/a?b=1&c=2)")
+    assert out == 'see <a href="https://example.com/a?b=1&amp;c=2">docs</a>'
+
+
+def test_non_http_link_untouched():
+    out = render_html("[x](javascript:alert(1))")
+    assert "<a" not in out
+
+
+def test_heading_becomes_bold_line():
+    assert render_html("## Summary\nbody") == "<b>Summary</b>\nbody"
+
+
+def test_bullets_become_dots():
+    assert render_html("- one\n- two") == "• one\n• two"
+
+
+def test_render_plain_strips_markers():
+    text = "**bold** `code` [docs](https://e.com) ## h\n- item"
+    out = render_plain(text)
+    assert "**" not in out and "`" not in out and "](" not in out
+    assert "docs (https://e.com)" in out
+    assert "• item" in out

--- a/tests/test_telegram_platform.py
+++ b/tests/test_telegram_platform.py
@@ -367,8 +367,22 @@ class TestParse:
     # Message with no text → None
     # ------------------------------------------------------------------
 
-    def test_message_without_text_returns_none(self):
-        """A photo-only message with no text (or caption) returns None."""
+    def test_message_without_text_or_media_returns_none(self):
+        """A message with neither text nor media returns None."""
+        update = {
+            "update_id": 200,
+            "message": {
+                "message_id": 10,
+                "from": {"id": 1, "is_bot": False, "first_name": "Alice"},
+                "chat": {"id": 111, "type": "private"},
+                "date": 1700000005,
+                # No "text", no media keys
+            },
+        }
+        assert parse(update, bot_username=BOT_USERNAME) is None
+
+    def test_photo_only_message_is_processable(self):
+        """A photo-only message now parses into a media-bearing message."""
         update = {
             "update_id": 200,
             "message": {
@@ -377,10 +391,12 @@ class TestParse:
                 "chat": {"id": 111, "type": "private"},
                 "date": 1700000005,
                 "photo": [{"file_id": "abc", "width": 100, "height": 100, "file_size": 1000}],
-                # No "text" key
             },
         }
-        assert parse(update, bot_username=BOT_USERNAME) is None
+        msg = parse(update, bot_username=BOT_USERNAME)
+        assert msg is not None
+        assert msg.kind == "image"
+        assert msg.files and msg.files[0].file_id == "abc"
 
     def test_message_with_empty_text_returns_none(self):
         update = _private_message(text="")

--- a/tests/test_telegram_platform_features.py
+++ b/tests/test_telegram_platform_features.py
@@ -16,6 +16,7 @@ from surogates.channels.platforms.telegram_interactive import (
     build_input_prompt,
     parse_callback_data,
     resolve_text_answer,
+    tool_call_digest,
 )
 
 BOT = "@my_test_bot"
@@ -201,7 +202,10 @@ class TestSend:
             creds={"bot_token": "tok"},
         )
         calls = _capture_send(route)
-        assert calls[0]["reply_parameters"] == {"message_id": 42}
+        assert calls[0]["reply_parameters"] == {
+            "message_id": 42,
+            "allow_sending_without_reply": True,
+        }
         assert all("reply_parameters" not in c for c in calls[1:])
 
     @respx.mock
@@ -254,17 +258,21 @@ QUESTIONS = [{"prompt": "Deploy to prod?", "choices": [{"label": "Yes"}, {"label
 class TestInteractive:
     def test_build_prompt_single_choice_question(self):
         html_text, plain_text, markup = build_input_prompt(
-            session_id="s-1", questions=QUESTIONS, context="Release 1.2 ready.",
+            session_id="s-1",
+            questions=QUESTIONS,
+            context="Release 1.2 ready.",
+            tool_call_id="tc-1",
         )
         assert "Deploy to prod?" in html_text and "Release 1.2" in plain_text
         rows = markup["inline_keyboard"]
         assert [r[0]["text"] for r in rows] == ["Yes", "No"]
-        assert rows[0][0]["callback_data"] == "si:s-1:0:0"
+        assert rows[0][0]["callback_data"] == f"si:s-1:0:0:{tool_call_digest('tc-1')}"
 
     def test_callback_data_fits_telegram_cap(self):
         _, _, markup = build_input_prompt(
             session_id="11111111-2222-3333-4444-555555555555",
             questions=QUESTIONS,
+            tool_call_id="toolu_" + "x" * 120,
         )
         for row in markup["inline_keyboard"]:
             assert len(row[0]["callback_data"].encode()) <= 64
@@ -276,9 +284,10 @@ class TestInteractive:
         assert markup is None
 
     def test_parse_callback_roundtrip(self):
-        assert parse_callback_data("si:abc:0:1") == ("abc", 0, 1)
+        assert parse_callback_data("si:abc:0:1:deadbeef") == ("abc", 0, 1, "deadbeef")
+        assert parse_callback_data("si:abc:0:1") is None
         assert parse_callback_data("nope") is None
-        assert parse_callback_data("si:abc:x:1") is None
+        assert parse_callback_data("si:abc:x:1:deadbeef") is None
 
     def test_resolve_text_answer_matches_choice(self):
         responses = resolve_text_answer(QUESTIONS, "yes")
@@ -340,7 +349,9 @@ class TestCallbackResolution:
         )
 
         p = TelegramPlatform()
-        body = self._callback_body("si:11111111-2222-3333-4444-555555555555:0:1")
+        body = self._callback_body(
+            f"si:11111111-2222-3333-4444-555555555555:0:1:{tool_call_digest('tc-1')}"
+        )
         handled = await p.handle_non_message_update(
             body, routing=None, creds={"bot_token": "tok"}, deps=deps,
         )
@@ -350,6 +361,32 @@ class TestCallbackResolution:
         assert kwargs["tool_call_id"] == "tc-1"
         assert kwargs["responses"][0]["answer"] == "No"
         assert edit_route.called and answer_route.called
+
+    @respx.mock
+    async def test_stale_button_does_not_answer_newer_question(self, monkeypatch):
+        respx.post(f"{API}/bottok/answerCallbackQuery").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        deps, _ = self._deps()
+        # A NEWER question is pending than the one the button was built for.
+        pending = {"tool_call_id": "tc-NEW", "questions": QUESTIONS, "context": ""}
+        monkeypatch.setattr(
+            "surogates.session.interactive_input.pending_input_for_session",
+            AsyncMock(return_value=pending),
+        )
+        resolve = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            "surogates.session.interactive_input.resolve_input_response", resolve,
+        )
+        p = TelegramPlatform()
+        body = self._callback_body(
+            f"si:11111111-2222-3333-4444-555555555555:0:1:{tool_call_digest('tc-OLD')}"
+        )
+        handled = await p.handle_non_message_update(
+            body, routing=None, creds={"bot_token": "tok"}, deps=deps,
+        )
+        assert handled is True
+        resolve.assert_not_awaited()
 
     @respx.mock
     async def test_chat_mismatch_is_rejected(self, monkeypatch):
@@ -362,7 +399,9 @@ class TestCallbackResolution:
             "surogates.session.interactive_input.resolve_input_response", resolve,
         )
         p = TelegramPlatform()
-        body = self._callback_body("si:11111111-2222-3333-4444-555555555555:0:1")
+        body = self._callback_body(
+            f"si:11111111-2222-3333-4444-555555555555:0:1:{tool_call_digest('tc-1')}"
+        )
         handled = await p.handle_non_message_update(
             body, routing=None, creds={"bot_token": "tok"}, deps=deps,
         )

--- a/tests/test_telegram_platform_features.py
+++ b/tests/test_telegram_platform_features.py
@@ -1,0 +1,382 @@
+"""Tests for the Telegram platform upgrades: media parse, download, HTML
+send with chunking/reply-threading, reaction ack, and interactive input."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import respx
+
+from surogates.channels.platforms.telegram import TelegramPlatform, parse
+from surogates.channels.platforms.telegram_interactive import (
+    build_input_prompt,
+    parse_callback_data,
+    resolve_text_answer,
+)
+
+BOT = "@my_test_bot"
+API = "https://api.telegram.org"
+
+
+def _message(extra: dict, *, text: str | None = None, caption: str | None = None):
+    message = {
+        "message_id": 42,
+        "from": {"id": 1, "is_bot": False, "first_name": "Alice"},
+        "chat": {"id": 111, "type": "private"},
+        "date": 1700000005,
+        **extra,
+    }
+    if text is not None:
+        message["text"] = text
+    if caption is not None:
+        message["caption"] = caption
+    return {"update_id": 7, "message": message}
+
+
+def _item(content: str = "hi", *, destination: dict | None = None, payload: dict | None = None):
+    return SimpleNamespace(
+        id=1,
+        session_id="11111111-2222-3333-4444-555555555555",
+        destination={"chat_id": "111", **(destination or {})},
+        payload={"content": content, **(payload or {})},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inbound media parse
+# ---------------------------------------------------------------------------
+
+
+class TestMediaParse:
+    def test_photo_takes_largest_size(self):
+        update = _message(
+            {
+                "photo": [
+                    {"file_id": "small", "file_unique_id": "u1", "file_size": 100},
+                    {"file_id": "big", "file_unique_id": "u2", "file_size": 9000},
+                ]
+            },
+            caption="look",
+        )
+        msg = parse(update, bot_username=BOT)
+        assert msg.text == "look"
+        assert msg.kind == "image"
+        assert [f.file_id for f in msg.files] == ["big"]
+        assert msg.files[0].mime_type == "image/jpeg"
+
+    def test_document_keeps_name_and_mime(self):
+        update = _message(
+            {
+                "document": {
+                    "file_id": "doc1",
+                    "file_name": "report.pdf",
+                    "mime_type": "application/pdf",
+                    "file_size": 1234,
+                }
+            }
+        )
+        msg = parse(update, bot_username=BOT)
+        assert msg.kind == "document"
+        ref = msg.files[0]
+        assert (ref.filename, ref.mime_type, ref.size) == ("report.pdf", "application/pdf", 1234)
+        assert ref.url == "doc1"
+
+    def test_voice_message(self):
+        update = _message({"voice": {"file_id": "v1", "mime_type": "audio/ogg", "file_size": 10}})
+        msg = parse(update, bot_username=BOT)
+        assert msg.kind == "audio"
+        assert msg.files[0].filename == "voice.ogg"
+
+    def test_message_id_recorded_in_source(self):
+        msg = parse(_message({}, text="hello"), bot_username=BOT)
+        assert msg.source["message_id"] == 42
+
+
+# ---------------------------------------------------------------------------
+# download_file
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadFile:
+    @respx.mock
+    async def test_downloads_via_getfile(self):
+        respx.post(f"{API}/bottok/getFile").mock(
+            return_value=httpx.Response(200, json={
+                "ok": True, "result": {"file_path": "photos/x.jpg", "file_size": 5},
+            })
+        )
+        respx.get(f"{API}/file/bottok/photos/x.jpg").mock(
+            return_value=httpx.Response(200, content=b"bytes")
+        )
+        p = TelegramPlatform()
+        data = await p.download_file(creds={"bot_token": "tok"}, url="fid", max_bytes=100)
+        assert data == b"bytes"
+
+    @respx.mock
+    async def test_rejects_oversize_declared(self):
+        respx.post(f"{API}/bottok/getFile").mock(
+            return_value=httpx.Response(200, json={
+                "ok": True, "result": {"file_path": "p", "file_size": 999},
+            })
+        )
+        p = TelegramPlatform()
+        assert await p.download_file(creds={"bot_token": "tok"}, url="fid", max_bytes=10) is None
+
+    @respx.mock
+    async def test_none_on_api_error(self):
+        respx.post(f"{API}/bottok/getFile").mock(
+            return_value=httpx.Response(200, json={"ok": False, "description": "not found"})
+        )
+        p = TelegramPlatform()
+        assert await p.download_file(creds={"bot_token": "tok"}, url="fid", max_bytes=10) is None
+
+    async def test_none_without_token(self):
+        p = TelegramPlatform()
+        assert await p.download_file(creds={}, url="fid", max_bytes=10) is None
+
+
+# ---------------------------------------------------------------------------
+# send — HTML, chunking, reply threading
+# ---------------------------------------------------------------------------
+
+
+def _capture_send(route):
+    return [json.loads(call.request.content) for call in route.calls]
+
+
+class TestSend:
+    @respx.mock
+    async def test_sends_html(self):
+        route = respx.post(f"{API}/bottok/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True, "result": {"message_id": 5}})
+        )
+        p = TelegramPlatform()
+        result = await p.send(_item("**bold** move"), creds={"bot_token": "tok"})
+        assert result.success and result.message_id == "5"
+        sent = _capture_send(route)[0]
+        assert sent["text"] == "<b>bold</b> move"
+        assert sent["parse_mode"] == "HTML"
+
+    @respx.mock
+    async def test_parse_error_retries_plain(self):
+        route = respx.post(f"{API}/bottok/sendMessage")
+        route.side_effect = [
+            httpx.Response(200, json={"ok": False, "description": "Bad Request: can't parse entities"}),
+            httpx.Response(200, json={"ok": True, "result": {"message_id": 6}}),
+        ]
+        p = TelegramPlatform()
+        result = await p.send(_item("**x**"), creds={"bot_token": "tok"})
+        assert result.success and result.message_id == "6"
+        calls = _capture_send(route)
+        assert "parse_mode" in calls[0] and "parse_mode" not in calls[1]
+        assert calls[1]["text"] == "x"
+
+    @respx.mock
+    async def test_long_text_chunked_under_limit(self):
+        route = respx.post(f"{API}/bottok/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True, "result": {"message_id": 9}})
+        )
+        p = TelegramPlatform()
+        text = "para. " * 2000  # ~12k chars
+        result = await p.send(_item(text), creds={"bot_token": "tok"})
+        assert result.success
+        calls = _capture_send(route)
+        assert len(calls) >= 3
+        for sent in calls:
+            assert len(sent["text"]) <= p._MAX_MESSAGE_CHARS
+
+    @respx.mock
+    async def test_reply_parameters_on_first_chunk_only(self):
+        route = respx.post(f"{API}/bottok/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True, "result": {"message_id": 9}})
+        )
+        p = TelegramPlatform()
+        text = "para. " * 2000
+        await p.send(
+            _item(text, destination={"reply_to_message_id": 42}),
+            creds={"bot_token": "tok"},
+        )
+        calls = _capture_send(route)
+        assert calls[0]["reply_parameters"] == {"message_id": 42}
+        assert all("reply_parameters" not in c for c in calls[1:])
+
+    @respx.mock
+    async def test_thread_id_propagates(self):
+        route = respx.post(f"{API}/bottok/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True, "result": {"message_id": 9}})
+        )
+        p = TelegramPlatform()
+        await p.send(
+            _item("hi", destination={"message_thread_id": 77}),
+            creds={"bot_token": "tok"},
+        )
+        assert _capture_send(route)[0]["message_thread_id"] == 77
+
+
+# ---------------------------------------------------------------------------
+# ack_received (reaction)
+# ---------------------------------------------------------------------------
+
+
+class TestAckReceived:
+    @respx.mock
+    async def test_reacts_when_enabled(self):
+        route = respx.post(f"{API}/bottok/setMessageReaction").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        p = TelegramPlatform()
+        msg = parse(_message({}, text="hello"), bot_username=BOT)
+        await p.ack_received(msg, creds={"bot_token": "tok"}, config={"reactions_enabled": True})
+        assert route.called
+        sent = json.loads(route.calls[0].request.content)
+        assert sent["message_id"] == 42 and sent["chat_id"] == "111"
+
+    async def test_noop_when_disabled(self):
+        p = TelegramPlatform()
+        p._http = AsyncMock()
+        msg = parse(_message({}, text="hello"), bot_username=BOT)
+        await p.ack_received(msg, creds={"bot_token": "tok"}, config={})
+        p._http.post.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Interactive input
+# ---------------------------------------------------------------------------
+
+
+QUESTIONS = [{"prompt": "Deploy to prod?", "choices": [{"label": "Yes"}, {"label": "No"}], "allow_other": False}]
+
+
+class TestInteractive:
+    def test_build_prompt_single_choice_question(self):
+        html_text, plain_text, markup = build_input_prompt(
+            session_id="s-1", questions=QUESTIONS, context="Release 1.2 ready.",
+        )
+        assert "Deploy to prod?" in html_text and "Release 1.2" in plain_text
+        rows = markup["inline_keyboard"]
+        assert [r[0]["text"] for r in rows] == ["Yes", "No"]
+        assert rows[0][0]["callback_data"] == "si:s-1:0:0"
+
+    def test_callback_data_fits_telegram_cap(self):
+        _, _, markup = build_input_prompt(
+            session_id="11111111-2222-3333-4444-555555555555",
+            questions=QUESTIONS,
+        )
+        for row in markup["inline_keyboard"]:
+            assert len(row[0]["callback_data"].encode()) <= 64
+
+    def test_free_text_prompt_has_no_keyboard(self):
+        _, _, markup = build_input_prompt(
+            session_id="s-1", questions=[{"prompt": "Name?"}],
+        )
+        assert markup is None
+
+    def test_parse_callback_roundtrip(self):
+        assert parse_callback_data("si:abc:0:1") == ("abc", 0, 1)
+        assert parse_callback_data("nope") is None
+        assert parse_callback_data("si:abc:x:1") is None
+
+    def test_resolve_text_answer_matches_choice(self):
+        responses = resolve_text_answer(QUESTIONS, "yes")
+        assert responses[0]["answer"] == "Yes" and responses[0]["is_other"] is False
+
+    def test_resolve_text_answer_other(self):
+        responses = resolve_text_answer(QUESTIONS, "maybe later")
+        assert responses[0]["answer"] == "maybe later" and responses[0]["is_other"] is True
+
+    @respx.mock
+    async def test_send_input_prompt_includes_keyboard(self):
+        route = respx.post(f"{API}/bottok/sendMessage").mock(
+            return_value=httpx.Response(200, json={"ok": True, "result": {"message_id": 3}})
+        )
+        p = TelegramPlatform()
+        item = _item(
+            "", payload={"input_prompt": True, "questions": QUESTIONS, "context": "ctx"},
+        )
+        result = await p.send(item, creds={"bot_token": "tok"})
+        assert result.success and result.message_id == "3"
+        sent = _capture_send(route)[0]
+        assert sent["reply_markup"]["inline_keyboard"][0][0]["callback_data"].startswith("si:")
+
+
+class TestCallbackResolution:
+    def _deps(self, session_config: dict | None = None):
+        session = SimpleNamespace(config=session_config or {"telegram_channel_id": "111"})
+        store = SimpleNamespace(get_session=AsyncMock(return_value=session))
+        return SimpleNamespace(session_store=store), store
+
+    def _callback_body(self, data: str, chat_id: int = 111):
+        return {
+            "update_id": 9,
+            "callback_query": {
+                "id": "cbq-1",
+                "data": data,
+                "from": {"id": 1},
+                "message": {"message_id": 3, "chat": {"id": chat_id}},
+            },
+        }
+
+    @respx.mock
+    async def test_resolves_pending_input(self, monkeypatch):
+        answer_route = respx.post(f"{API}/bottok/answerCallbackQuery").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        edit_route = respx.post(f"{API}/bottok/editMessageText").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        deps, store = self._deps()
+        pending = {"tool_call_id": "tc-1", "questions": QUESTIONS, "context": ""}
+        monkeypatch.setattr(
+            "surogates.session.interactive_input.pending_input_for_session",
+            AsyncMock(return_value=pending),
+        )
+        resolve = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            "surogates.session.interactive_input.resolve_input_response", resolve,
+        )
+
+        p = TelegramPlatform()
+        body = self._callback_body("si:11111111-2222-3333-4444-555555555555:0:1")
+        handled = await p.handle_non_message_update(
+            body, routing=None, creds={"bot_token": "tok"}, deps=deps,
+        )
+        assert handled is True
+        resolve.assert_awaited_once()
+        kwargs = resolve.await_args.kwargs
+        assert kwargs["tool_call_id"] == "tc-1"
+        assert kwargs["responses"][0]["answer"] == "No"
+        assert edit_route.called and answer_route.called
+
+    @respx.mock
+    async def test_chat_mismatch_is_rejected(self, monkeypatch):
+        respx.post(f"{API}/bottok/answerCallbackQuery").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        deps, _ = self._deps({"telegram_channel_id": "999"})
+        resolve = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            "surogates.session.interactive_input.resolve_input_response", resolve,
+        )
+        p = TelegramPlatform()
+        body = self._callback_body("si:11111111-2222-3333-4444-555555555555:0:1")
+        handled = await p.handle_non_message_update(
+            body, routing=None, creds={"bot_token": "tok"}, deps=deps,
+        )
+        assert handled is True
+        resolve.assert_not_awaited()
+
+    @respx.mock
+    async def test_non_input_callback_still_acked(self):
+        route = respx.post(f"{API}/bottok/answerCallbackQuery").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        p = TelegramPlatform()
+        body = self._callback_body("something-else")
+        handled = await p.handle_non_message_update(
+            body, routing=None, creds={"bot_token": "tok"}, deps=SimpleNamespace(session_store=None),
+        )
+        assert handled is True and route.called

--- a/tests/test_text_split.py
+++ b/tests/test_text_split.py
@@ -1,0 +1,58 @@
+"""Unit tests for the shared outbound message splitter."""
+
+import pytest
+
+from surogates.channels.text_split import split_text
+
+
+def test_short_text_unchanged():
+    assert split_text("hello", 100) == ["hello"]
+
+
+def test_empty_text_yields_no_chunks():
+    assert split_text("", 100) == []
+
+
+def test_invalid_limit_raises():
+    with pytest.raises(ValueError):
+        split_text("x", 0)
+
+
+def test_every_chunk_within_limit():
+    text = ("word " * 500).strip()
+    for chunk in split_text(text, 80):
+        assert 0 < len(chunk) <= 80
+
+
+def test_prefers_paragraph_boundary():
+    text = "para one is here.\n\npara two follows and is fairly long too."
+    chunks = split_text(text, 40)
+    assert chunks[0] == "para one is here."
+
+
+def test_prefers_line_boundary_over_word():
+    text = "line one goes here\nline two follows here"
+    chunks = split_text(text, 25)
+    assert chunks[0] == "line one goes here"
+    assert chunks[1] == "line two follows here"
+
+
+def test_hard_cut_for_unbroken_run():
+    text = "a" * 250
+    chunks = split_text(text, 100)
+    assert chunks == ["a" * 100, "a" * 100, "a" * 50]
+
+
+def test_no_content_lost():
+    text = "The quick brown fox jumps over the lazy dog. " * 40
+    chunks = split_text(text.strip(), 90)
+    reassembled = " ".join(chunks).split()
+    assert reassembled == text.strip().split()
+
+
+def test_no_empty_chunks_on_whitespace_runs():
+    text = ("x" * 50) + "\n\n\n\n" + ("y" * 50)
+    chunks = split_text(text, 52)
+    assert all(c.strip() for c in chunks)
+    assert "".join(chunks).count("x") == 50
+    assert "".join(chunks).count("y") == 50

--- a/tests/test_website_routing_config.py
+++ b/tests/test_website_routing_config.py
@@ -1,0 +1,69 @@
+"""Per-agent website routing config: origins/cap helpers and the
+``channel_identifier`` cookie claim."""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+os.environ.setdefault("SUROGATES_AUTH_JWT_SECRET", "test-secret-key-for-tests-0123456789")
+
+from surogates.api.routes.website import (
+    _agent_allowed_origins,
+    _routing_channel_config,
+)
+from surogates.channels.website_session import (
+    create_website_session_token,
+    decode_website_session_token,
+)
+
+
+class TestRoutingChannelConfig:
+    def test_none_routing_is_empty(self):
+        assert _routing_channel_config(None) == {}
+
+    def test_non_dict_config_is_empty(self):
+        assert _routing_channel_config({"config": "oops"}) == {}
+
+    def test_dict_config_passes_through(self):
+        assert _routing_channel_config({"config": {"a": 1}}) == {"a": 1}
+
+
+class TestAgentAllowedOrigins:
+    def test_absent_returns_none_for_global_fallback(self):
+        assert _agent_allowed_origins({}) is None
+
+    def test_list_is_normalized(self):
+        origins = _agent_allowed_origins(
+            {"allowed_origins": ["HTTPS://Customer.com/", "https://b.io"]}
+        )
+        assert origins == ("https://customer.com", "https://b.io")
+
+    def test_csv_string_accepted(self):
+        origins = _agent_allowed_origins({"allowed_origins": "https://a.com, https://b.io"})
+        assert origins == ("https://a.com", "https://b.io")
+
+    def test_empty_list_returns_none(self):
+        assert _agent_allowed_origins({"allowed_origins": []}) is None
+
+
+class TestChannelIdentifierClaim:
+    def test_roundtrip(self):
+        sid, org = uuid.uuid4(), uuid.uuid4()
+        token = create_website_session_token(
+            session_id=sid,
+            org_id=org,
+            origin="https://a.com",
+            csrf_token="csrf",
+            channel_identifier="surg_wk_abc",
+        )
+        claims = decode_website_session_token(token)
+        assert claims.channel_identifier == "surg_wk_abc"
+
+    def test_legacy_token_without_claim_decodes_empty(self):
+        sid, org = uuid.uuid4(), uuid.uuid4()
+        token = create_website_session_token(
+            session_id=sid, org_id=org, origin="https://a.com", csrf_token="c",
+        )
+        claims = decode_website_session_token(token)
+        assert claims.channel_identifier == ""


### PR DESCRIPTION
## Summary

Brings the Telegram channel to feature parity with Slack, makes the website channel's origin allow-list and message cap per-agent, and fixes outbox pollution. Companion PR: invergent-ai/surogate-ops#230 carries the control-plane side: website config projection, Slack save-time validation, Studio connect-flow honesty, and prod enablement.

## Telegram

- **Inbound media**: photos, documents, voice, audio, video, and video notes parse into file refs and are downloaded via `getFile` (20 MB / 10-file caps, host-pinned) into the session workspace; captions become the message text; caption-less attachments count as a message body.
- **Outbound formatting**: markdown renders to Telegram HTML (`telegram_format.py`) with an automatic plain-text retry on parse rejection; messages split at natural boundaries under the 4096-char cap (`text_split.py`, shared with Slack).
- **Interactive input**: `ask_user_question` renders an inline keyboard for choice questions. Callback data carries `si:<session>:<q>:<c>:<digest>` — the tool-call digest stops a stale button from resolving a newer question, and callbacks are bound to the session's chat. Free-text answers are plain replies; a reply that loses the race against a button tap falls through as a normal turn instead of vanishing. Acks (`✅ Got it`, `/stop`) post via the new `post_input_nudge`.
- **Reply threading** (`reply_to_mode`: `first`/`all`, groups only) with `allow_sending_without_reply` so a deleted target degrades gracefully; **reaction ack** (👀 via `setMessageReaction`) fired off the webhook hot path; **`mention_patterns`** wake-words matched on word boundaries with a cached compiled regex.
- All Bot API calls go through a single best-effort `_api` transport primitive.

## Cross-channel

- **Outbox allowlist**: only adapter-backed channels (`ADAPTER_CHANNELS` in the new `channels/constants.py`) get outbox rows — previously `api`/`website`/`task`/`delegation`/`worker` rows accumulated as pending forever (~15k rows in prod).
- **Interactive prompt delivery** is now gated by `INTERACTIVE_PROMPT_CHANNELS` instead of a slack-only literal — the previous gate silently made the whole Telegram interactive flow undeliverable.
- **Slack**: over-limit replies split and post sequentially instead of failing with `msg_too_long`; mid-sequence failures report the delivered prefix so retries cannot duplicate.
- Attachment ingest in the shared pipeline is platform-agnostic (was Slack-only).

## Website

- Per-agent `allowed_origins` and `session_message_cap` are read from the `channel_routing` config (projected by ops) with deployment-global fallback.
- The session cookie records its publishable key (`channel_identifier` claim, backward compatible); every request re-resolves the routing row, so turning the channel off in Studio cuts live visitor sessions with 403 and origin-list changes apply to in-flight sessions.

## Docs

`docs/channels/slack.md` and `docs/channels/telegram.md` rewritten — both described the retired Socket-Mode/long-polling architecture that `tests/test_channels_retired.py` forbids.

## Testing

- 82 new tests (splitter, formatter, media parse/download, send chunking/reply/interactive, callback resolution incl. stale-button and chat-forgery rejection, pipeline gates, outbox allowlist, website routing config, cookie claim roundtrip).
- Full unit suite: 4432 passed; the 35 failures on this branch are identical to `master` (verified against a clean master worktree) and unrelated (harness-loop/env tests).

## Deploy notes

- Requires the companion ops deploy for the runtime configmap (`channels.telegram.enabled: true`) and a `runtime-channels` rollout.
- Existing pending outbox rows for adapter-less channels are stopped at the source but not deleted; a one-off cleanup is: `DELETE FROM delivery_outbox WHERE status='pending' AND channel NOT IN ('slack','telegram');`