### PR TITLE
feat(sessions): Multi Session agent capability — canonical single-session conversations

### DIFF
--- a/surogates/api/routes/artifacts.py
+++ b/surogates/api/routes/artifacts.py
@@ -25,6 +25,7 @@ from surogates.artifacts.store import (
     ArtifactStore,
 )
 from surogates.session.events import EventType
+from surogates.api.session_guards import require_session_visible
 from surogates.session.store import SessionNotFoundError, SessionStore
 from surogates.storage.backend import StorageBackend
 from surogates.session.attachment_ingest import workspace_root_id
@@ -89,6 +90,7 @@ def _require_service_account_api_route(
 
 
 async def _resolve_storage_bucket(
+    request: Request,
     store: SessionStore,
     session_id: UUID,
     tenant: TenantContext,
@@ -106,6 +108,7 @@ async def _resolve_storage_bucket(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session {session_id} not found.",
         )
+    await require_session_visible(request, session)
     bucket = session.config.get("storage_bucket")
     if not bucket:
         raise HTTPException(
@@ -131,7 +134,7 @@ async def list_artifacts(
 ) -> ArtifactListResponse:
     """List every artifact that belongs to the session, oldest first."""
     store = _get_session_store(request)
-    session, bucket = await _resolve_storage_bucket(store, session_id, tenant)
+    session, bucket = await _resolve_storage_bucket(request, store, session_id, tenant)
     artifact_store = ArtifactStore(
         _get_storage(request),
         session_id=session_id,
@@ -161,7 +164,7 @@ async def get_artifact(
     """Fetch a single artifact's metadata and full payload."""
     _require_service_account_api_route(request, tenant)
     store = _get_session_store(request)
-    session, bucket = await _resolve_storage_bucket(store, session_id, tenant)
+    session, bucket = await _resolve_storage_bucket(request, store, session_id, tenant)
     artifact_store = ArtifactStore(
         _get_storage(request),
         session_id=session_id,
@@ -204,7 +207,7 @@ async def create_artifact(
     bucket and is fetched by the UI via :func:`get_artifact`.
     """
     store = _get_session_store(request)
-    session, bucket = await _resolve_storage_bucket(store, session_id, tenant)
+    session, bucket = await _resolve_storage_bucket(request, store, session_id, tenant)
 
     try:
         body.validate_spec()

--- a/surogates/api/routes/ask_user_question.py
+++ b/surogates/api/routes/ask_user_question.py
@@ -15,7 +15,10 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import func, update
 
-from surogates.api.session_guards import require_user_writable_session
+from surogates.api.session_guards import (
+    require_session_visible,
+    require_user_writable_session,
+)
 from surogates.db.models import InboxItem
 from surogates.session.events import EventType
 from surogates.session.store import SessionNotFoundError, SessionStore
@@ -120,6 +123,7 @@ async def respond_to_ask_user_question(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session {session_id} not found.",
         )
+    await require_session_visible(request, session)
     require_user_writable_session(session)
 
     # Sanity-check the tool_call_id format -- short, printable, no newlines.

--- a/surogates/api/routes/auth.py
+++ b/surogates/api/routes/auth.py
@@ -89,6 +89,9 @@ class AuthConfigResponse(BaseModel):
     # disabled commands from the composer menu + navbar.  "clear" has no
     # flag and is always present.
     slash_commands: list[str] = Field(default_factory=list)
+    # "Multi session" capability.  When False each user keeps one session
+    # per channel; the SPA hides "New chat" and pins the conversation.
+    multi_session: bool = True
 
 
 class FirebaseExchangeRequest(BaseModel):
@@ -122,6 +125,7 @@ async def auth_config(
             self_registration_enabled=False,
             firebase=None,
             slash_commands=slash_commands,
+            multi_session=agent_runtime.multi_session,
         )
     try:
         fb = await cache.get(project_id)
@@ -131,11 +135,13 @@ async def auth_config(
             self_registration_enabled=False,
             firebase=None,
             slash_commands=slash_commands,
+            multi_session=agent_runtime.multi_session,
         )
     return AuthConfigResponse(
         agent_id=agent_runtime.agent_id,
         self_registration_enabled=True,
         slash_commands=slash_commands,
+        multi_session=agent_runtime.multi_session,
         firebase=FirebaseWebConfig(
             api_key=fb.api_key,
             auth_domain=fb.auth_domain,

--- a/surogates/api/routes/board.py
+++ b/surogates/api/routes/board.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from surogates.board.render import render_board
 from surogates.board.store import BoardStore
 from surogates.config import get_board_settings
+from surogates.api.session_guards import require_session_visible
 from surogates.session.store import SessionNotFoundError, SessionStore
 from surogates.tenant.auth.middleware import get_current_tenant
 from surogates.tenant.context import TenantContext
@@ -75,6 +76,7 @@ async def get_session_board(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session {session_id} not found.",
         )
+    await require_session_visible(request, session)
     raw_group = (session.config or {}).get("context_group_id")
     if not raw_group:
         raise HTTPException(

--- a/surogates/api/routes/channel_files.py
+++ b/surogates/api/routes/channel_files.py
@@ -29,6 +29,7 @@ from surogates.channels.file_fetch import (
 from surogates.channels.message_fetch import fetch_channel_messages
 from surogates.channels.platform_resolve import effective_channel_platform
 from surogates.channels.registry import registry
+from surogates.api.session_guards import require_session_visible
 from surogates.session.store import SessionNotFoundError, SessionStore
 from surogates.tenant.auth.middleware import get_current_tenant
 from surogates.tenant.context import TenantContext
@@ -49,7 +50,7 @@ def _get_session_store(request: Request) -> SessionStore:
 
 
 async def _resolve_session(
-    store: SessionStore, session_id: UUID, tenant: TenantContext,
+    request: Request, store: SessionStore, session_id: UUID, tenant: TenantContext,
 ) -> Any:
     try:
         session = await store.get_session(session_id)
@@ -63,13 +64,14 @@ async def _resolve_session(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session {session_id} not found.",
         )
+    await require_session_visible(request, session)
     return session
 
 
 async def _resolve_session_bucket(
-    store: SessionStore, session_id: UUID, tenant: TenantContext,
+    request: Request, store: SessionStore, session_id: UUID, tenant: TenantContext,
 ) -> tuple[Any, str]:
-    session = await _resolve_session(store, session_id, tenant)
+    session = await _resolve_session(request, store, session_id, tenant)
     bucket = session.config.get("storage_bucket")
     if not bucket:
         raise HTTPException(
@@ -88,7 +90,7 @@ async def fetch_channel_file_route(
 ) -> dict:
     """Download a file shared in this session's channel into the workspace."""
     store = _get_session_store(request)
-    session, bucket = await _resolve_session_bucket(store, session_id, tenant)
+    session, bucket = await _resolve_session_bucket(request, store, session_id, tenant)
 
     # Ambient sessions carry a slack channel_id but channel="ambient".
     channel = effective_channel_platform(session)
@@ -145,7 +147,7 @@ async def fetch_channel_messages_route(
 ) -> dict:
     """Read recent messages from this session's Slack channel."""
     store = _get_session_store(request)
-    session = await _resolve_session(store, session_id, tenant)
+    session = await _resolve_session(request, store, session_id, tenant)
 
     # Ambient sessions carry a slack channel_id but channel="ambient".
     channel = effective_channel_platform(session)

--- a/surogates/api/routes/events.py
+++ b/surogates/api/routes/events.py
@@ -11,7 +11,10 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
-from surogates.api.session_guards import require_user_writable_session
+from surogates.api.session_guards import (
+    require_session_visible,
+    require_user_writable_session,
+)
 from surogates.config import enqueue_session, load_settings
 from surogates.harness.outcomes import build_defined_outcome_from_event
 from surogates.session.events import EventType
@@ -112,13 +115,14 @@ def _require_service_account_api_route(
 
 
 async def _verify_session_access(
-    store: SessionStore, session_id: UUID, tenant: TenantContext
+    request: Request, store: SessionStore, session_id: UUID, tenant: TenantContext
 ) -> None:
     """Raise 404 if the session does not exist or does not belong to the tenant.
 
     Session-scoped service-account JWTs are additionally restricted to
     the single session they were minted for — see
-    :meth:`TenantContext.covers_session`.
+    :meth:`TenantContext.covers_session`.  Hidden multi-era web sessions
+    ("multi session" capability off) 404 too.
     """
     try:
         session = await store.get_session(session_id)
@@ -132,6 +136,7 @@ async def _verify_session_access(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session {session_id} not found.",
         )
+    await require_session_visible(request, session)
 
 
 def _rubric_text_or_422(rubric: DefineOutcomeRubric | None) -> str:
@@ -176,7 +181,7 @@ async def send_session_events(
     """
     _require_service_account_api_route(request, tenant)
     store = _get_session_store(request)
-    await _verify_session_access(store, session_id, tenant)
+    await _verify_session_access(request, store, session_id, tenant)
     session = await store.get_session(session_id)
     require_user_writable_session(session)
 
@@ -282,6 +287,7 @@ async def stream_events(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found.")
     if not tenant.owns_session(session_check.org_id, session_id):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found.")
+    await require_session_visible(request, session_check)
 
     # Pre-loop fast-close for terminal sessions used to live here, but it
     # raced with concurrent POST /messages: a message landing between the
@@ -500,7 +506,7 @@ async def poll_events(
 ) -> PollEventsResponse:
     """Fetch events in a single request (non-streaming alternative to SSE)."""
     store = _get_session_store(request)
-    await _verify_session_access(store, session_id, tenant)
+    await _verify_session_access(request, store, session_id, tenant)
 
     if limit < 1:
         limit = 1

--- a/surogates/api/routes/feedback.py
+++ b/surogates/api/routes/feedback.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
 from surogates.session.events import EventType
+from surogates.api.session_guards import require_session_visible
 from surogates.session.store import SessionNotFoundError, SessionStore
 from surogates.tenant.auth.middleware import get_current_tenant
 from surogates.tenant.context import PrincipalKind, TenantContext
@@ -150,6 +151,7 @@ async def submit_feedback(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session {session_id} not found.",
         )
+    await require_session_visible(request, session)
 
     if target is None:
         raise HTTPException(

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -11,7 +11,15 @@ from pathlib import Path
 from typing import Any, Literal
 from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Request,
+    Response,
+    status,
+)
 from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import text as _sql_text
 
@@ -433,11 +441,28 @@ async def _create_session(
 async def create_session(
     body: CreateSessionRequest,
     request: Request,
+    response: Response,
     tenant: TenantContext = Depends(get_current_tenant),
     agent_runtime: AgentRuntimeContext = Depends(agent_runtime_context_dep),
     _rate: None = Depends(rate_limit_dep),
 ) -> Session:
-    """Create a new session for the authenticated user."""
+    """Create a new session for the authenticated user.
+
+    With the agent's "multi session" capability off, each user keeps one
+    web session: the newest reusable one is returned (200 instead of
+    201) rather than creating another.  Archived/failed sessions don't
+    count, so archiving is how a user deliberately starts over.
+    """
+    if not agent_runtime.multi_session and tenant.user_id is not None:
+        existing = await _get_session_store(request).get_reusable_channel_session(
+            org_id=tenant.org_id,
+            user_id=tenant.user_id,
+            agent_id=agent_runtime.agent_id,
+            channel="web",
+        )
+        if existing is not None:
+            response.status_code = status.HTTP_200_OK
+            return existing
     return await _create_session(
         body,
         request,

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -344,6 +344,8 @@ async def _get_session_for_tenant(
     session_id: UUID,
     tenant: TenantContext,
     agent_id: str,
+    *,
+    multi_session: bool = True,
 ) -> Session:
     """Fetch a session and verify it belongs to the tenant's org and this agent.
 
@@ -356,6 +358,13 @@ async def _get_session_for_tenant(
 
     ``agent_id`` is supplied by the caller (typically from
     :func:`surogates.runtime.agent_runtime_context_dep`).
+
+    With ``multi_session=False`` (the agent capability turned off),
+    top-level web-channel sessions that are NOT the canonical
+    single-session conversation (``config.single_session``) 404 too:
+    multi-era chats are hidden AND unreachable — deep links included —
+    until the capability is re-enabled.  Children (delegation subtree of
+    the canonical session) and non-web channels are unaffected.
     """
     store = _get_session_store(request)
     try:
@@ -368,6 +377,17 @@ async def _get_session_for_tenant(
 
     if session.agent_id != agent_id or not tenant.owns_session(
         session.org_id, session_id
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Session {session_id} not found.",
+        )
+
+    if (
+        not multi_session
+        and session.channel == "web"
+        and session.parent_id is None
+        and (session.config or {}).get("single_session") is not True
     ):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -449,9 +469,12 @@ async def create_session(
     """Create a new session for the authenticated user.
 
     With the agent's "multi session" capability off, each user keeps one
-    web session: the newest reusable one is returned (200 instead of
-    201) rather than creating another.  Archived/failed sessions don't
-    count, so archiving is how a user deliberately starts over.
+    dedicated web conversation: the canonical session (stamped
+    ``config.single_session`` at creation) is returned (200 instead of
+    201) rather than creating another.  Multi-era sessions are never
+    adopted — they stay hidden until the capability is re-enabled.
+    Archiving the dedicated session is how a user deliberately starts
+    over.
     """
     if not agent_runtime.multi_session and tenant.user_id is not None:
         existing = await _get_session_store(request).get_reusable_channel_session(
@@ -463,6 +486,9 @@ async def create_session(
         if existing is not None:
             response.status_code = status.HTTP_200_OK
             return existing
+        # First contact in single-session mode: the fresh session becomes
+        # the canonical conversation every later create resolves to.
+        body.config = {**body.config, "single_session": True}
     return await _create_session(
         body,
         request,
@@ -531,6 +557,7 @@ async def send_message(
     store = _get_session_store(request)
     session = await _get_session_for_tenant(
         request, session_id, tenant, agent_runtime.agent_id,
+        multi_session=agent_runtime.multi_session,
     )
     require_user_writable_session(session)
 
@@ -822,7 +849,10 @@ async def confirm_disclosure(
     enforcement is enabled.  Typically called by the frontend after
     showing the AI disclosure notice to the user.
     """
-    await _get_session_for_tenant(request, session_id, tenant, agent_runtime.agent_id)
+    await _get_session_for_tenant(
+        request, session_id, tenant, agent_runtime.agent_id,
+        multi_session=agent_runtime.multi_session,
+    )
 
     governance = getattr(request.app.state, "governance_gate", None)
     if governance is not None:
@@ -839,7 +869,10 @@ async def get_session(
 ) -> Session:
     """Retrieve metadata for a single session."""
     _require_service_account_api_route(request, tenant)
-    return await _get_session_for_tenant(request, session_id, tenant, agent_runtime.agent_id)
+    return await _get_session_for_tenant(
+        request, session_id, tenant, agent_runtime.agent_id,
+        multi_session=agent_runtime.multi_session,
+    )
 
 
 def _tree_node_from_row(row: dict) -> SessionTreeNode:
@@ -906,7 +939,10 @@ async def get_session_tree(
     ``session.config.agent_type``) so the frontend can display badges
     for sub-agent types without extra lookups.
     """
-    await _get_session_for_tenant(request, session_id, tenant, agent_runtime.agent_id)
+    await _get_session_for_tenant(
+        request, session_id, tenant, agent_runtime.agent_id,
+        multi_session=agent_runtime.multi_session,
+    )
 
     session_factory = request.app.state.session_factory
     agent_id = agent_runtime.agent_id
@@ -973,7 +1009,10 @@ async def get_session_children(
     Authorization: the parent session must belong to this tenant and
     agent; child rows inherit tenancy.
     """
-    await _get_session_for_tenant(request, session_id, tenant, agent_runtime.agent_id)
+    await _get_session_for_tenant(
+        request, session_id, tenant, agent_runtime.agent_id,
+        multi_session=agent_runtime.multi_session,
+    )
 
     session_factory = request.app.state.session_factory
     agent_id = agent_runtime.agent_id
@@ -1032,6 +1071,10 @@ async def list_sessions(
         limit=limit,
         offset=offset,
         include_descendants=include_descendants,
+        # Multi session off: only the canonical single-session
+        # conversation (and its subtree) is listed — multi-era chats
+        # stay hidden until the capability is re-enabled.
+        single_session_only=not agent_runtime.multi_session,
     )
 
     # Pagination is over roots; any descendants ride along with their root, so
@@ -1052,7 +1095,10 @@ async def pause_session(
     """Pause an active session."""
     _require_service_account_api_route(request, tenant)
     store = _get_session_store(request)
-    session = await _get_session_for_tenant(request, session_id, tenant, agent_runtime.agent_id)
+    session = await _get_session_for_tenant(
+        request, session_id, tenant, agent_runtime.agent_id,
+        multi_session=agent_runtime.multi_session,
+    )
 
     if session.status not in ("active", "processing", "paused"):
         raise HTTPException(
@@ -1088,7 +1134,10 @@ async def resume_session(
 ) -> Session:
     """Resume a paused session."""
     store = _get_session_store(request)
-    session = await _get_session_for_tenant(request, session_id, tenant, agent_runtime.agent_id)
+    session = await _get_session_for_tenant(
+        request, session_id, tenant, agent_runtime.agent_id,
+        multi_session=agent_runtime.multi_session,
+    )
     require_user_writable_session(session)
 
     if session.status != "paused":
@@ -1130,7 +1179,10 @@ async def retry_session(
     """
     _require_service_account_api_route(request, tenant)
     store = _get_session_store(request)
-    session = await _get_session_for_tenant(request, session_id, tenant, agent_runtime.agent_id)
+    session = await _get_session_for_tenant(
+        request, session_id, tenant, agent_runtime.agent_id,
+        multi_session=agent_runtime.multi_session,
+    )
     require_user_writable_session(session)
 
     if session.status not in ("failed", "paused"):
@@ -1265,7 +1317,10 @@ async def update_session(
     """
     _require_service_account_api_route(request, tenant)
     store = _get_session_store(request)
-    session = await _get_session_for_tenant(request, session_id, tenant, agent_runtime.agent_id)
+    session = await _get_session_for_tenant(
+        request, session_id, tenant, agent_runtime.agent_id,
+        multi_session=agent_runtime.multi_session,
+    )
     require_user_writable_session(session)
 
     await store.update_session_title(session_id, body.title)
@@ -1290,7 +1345,10 @@ async def delete_session(
     """Archive (soft-delete) a session and delete its workspace storage."""
     _require_service_account_api_route(request, tenant)
     store = _get_session_store(request)
-    session = await _get_session_for_tenant(request, session_id, tenant, agent_runtime.agent_id)
+    session = await _get_session_for_tenant(
+        request, session_id, tenant, agent_runtime.agent_id,
+        multi_session=agent_runtime.multi_session,
+    )
     require_user_writable_session(session)
 
     archived_sessions = await store.archive_session_tree_and_delete_schedules(

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -33,7 +33,7 @@ from surogates.session.attachment_ingest import (  # re-exported for back-compat
     _apply_inline_total_budget,
 )
 from surogates.api.session_guards import (
-    is_multi_era_web_session,
+    require_session_visible,
     require_user_writable_session,
 )
 from surogates.coding_agents.command import is_code_command
@@ -346,9 +346,7 @@ async def _get_session_for_tenant(
     request: Request,
     session_id: UUID,
     tenant: TenantContext,
-    agent_id: str,
-    *,
-    multi_session: bool = True,
+    agent_runtime: AgentRuntimeContext,
 ) -> Session:
     """Fetch a session and verify it belongs to the tenant's org and this agent.
 
@@ -359,15 +357,10 @@ async def _get_session_for_tenant(
     into the same 404 so callers cannot probe session existence across
     scopes.
 
-    ``agent_id`` is supplied by the caller (typically from
-    :func:`surogates.runtime.agent_runtime_context_dep`).
-
-    With ``multi_session=False`` (the agent capability turned off),
-    top-level web-channel sessions that are NOT the canonical
-    single-session conversation (``config.single_session``) 404 too:
-    multi-era chats are hidden AND unreachable — deep links included —
-    until the capability is re-enabled.  Children (delegation subtree of
-    the canonical session) and non-web channels are unaffected.
+    ``agent_runtime`` is the per-request context from
+    :func:`surogates.runtime.agent_runtime_context_dep`; its resolved
+    ``multi_session`` feeds :func:`require_session_visible`, which owns
+    the hidden-multi-era-session 404 contract.
     """
     store = _get_session_store(request)
     try:
@@ -378,7 +371,7 @@ async def _get_session_for_tenant(
             detail=f"Session {session_id} not found.",
         )
 
-    if session.agent_id != agent_id or not tenant.owns_session(
+    if session.agent_id != agent_runtime.agent_id or not tenant.owns_session(
         session.org_id, session_id
     ):
         raise HTTPException(
@@ -386,11 +379,9 @@ async def _get_session_for_tenant(
             detail=f"Session {session_id} not found.",
         )
 
-    if not multi_session and is_multi_era_web_session(session):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Session {session_id} not found.",
-        )
+    await require_session_visible(
+        request, session, multi_session=agent_runtime.multi_session,
+    )
 
     return session
 
@@ -557,10 +548,7 @@ async def send_message(
     """Send a user message to a session, triggering agent processing."""
     _require_service_account_api_route(request, tenant)
     store = _get_session_store(request)
-    session = await _get_session_for_tenant(
-        request, session_id, tenant, agent_runtime.agent_id,
-        multi_session=agent_runtime.multi_session,
-    )
+    session = await _get_session_for_tenant(request, session_id, tenant, agent_runtime)
     require_user_writable_session(session)
 
     if session.status not in ("active", "idle", "failed", "paused", "completed"):
@@ -851,10 +839,7 @@ async def confirm_disclosure(
     enforcement is enabled.  Typically called by the frontend after
     showing the AI disclosure notice to the user.
     """
-    await _get_session_for_tenant(
-        request, session_id, tenant, agent_runtime.agent_id,
-        multi_session=agent_runtime.multi_session,
-    )
+    await _get_session_for_tenant(request, session_id, tenant, agent_runtime)
 
     governance = getattr(request.app.state, "governance_gate", None)
     if governance is not None:
@@ -871,10 +856,7 @@ async def get_session(
 ) -> Session:
     """Retrieve metadata for a single session."""
     _require_service_account_api_route(request, tenant)
-    return await _get_session_for_tenant(
-        request, session_id, tenant, agent_runtime.agent_id,
-        multi_session=agent_runtime.multi_session,
-    )
+    return await _get_session_for_tenant(request, session_id, tenant, agent_runtime)
 
 
 def _tree_node_from_row(row: dict) -> SessionTreeNode:
@@ -941,10 +923,7 @@ async def get_session_tree(
     ``session.config.agent_type``) so the frontend can display badges
     for sub-agent types without extra lookups.
     """
-    await _get_session_for_tenant(
-        request, session_id, tenant, agent_runtime.agent_id,
-        multi_session=agent_runtime.multi_session,
-    )
+    await _get_session_for_tenant(request, session_id, tenant, agent_runtime)
 
     session_factory = request.app.state.session_factory
     agent_id = agent_runtime.agent_id
@@ -1011,10 +990,7 @@ async def get_session_children(
     Authorization: the parent session must belong to this tenant and
     agent; child rows inherit tenancy.
     """
-    await _get_session_for_tenant(
-        request, session_id, tenant, agent_runtime.agent_id,
-        multi_session=agent_runtime.multi_session,
-    )
+    await _get_session_for_tenant(request, session_id, tenant, agent_runtime)
 
     session_factory = request.app.state.session_factory
     agent_id = agent_runtime.agent_id
@@ -1097,10 +1073,7 @@ async def pause_session(
     """Pause an active session."""
     _require_service_account_api_route(request, tenant)
     store = _get_session_store(request)
-    session = await _get_session_for_tenant(
-        request, session_id, tenant, agent_runtime.agent_id,
-        multi_session=agent_runtime.multi_session,
-    )
+    session = await _get_session_for_tenant(request, session_id, tenant, agent_runtime)
 
     if session.status not in ("active", "processing", "paused"):
         raise HTTPException(
@@ -1136,10 +1109,7 @@ async def resume_session(
 ) -> Session:
     """Resume a paused session."""
     store = _get_session_store(request)
-    session = await _get_session_for_tenant(
-        request, session_id, tenant, agent_runtime.agent_id,
-        multi_session=agent_runtime.multi_session,
-    )
+    session = await _get_session_for_tenant(request, session_id, tenant, agent_runtime)
     require_user_writable_session(session)
 
     if session.status != "paused":
@@ -1181,10 +1151,7 @@ async def retry_session(
     """
     _require_service_account_api_route(request, tenant)
     store = _get_session_store(request)
-    session = await _get_session_for_tenant(
-        request, session_id, tenant, agent_runtime.agent_id,
-        multi_session=agent_runtime.multi_session,
-    )
+    session = await _get_session_for_tenant(request, session_id, tenant, agent_runtime)
     require_user_writable_session(session)
 
     if session.status not in ("failed", "paused"):
@@ -1319,10 +1286,7 @@ async def update_session(
     """
     _require_service_account_api_route(request, tenant)
     store = _get_session_store(request)
-    session = await _get_session_for_tenant(
-        request, session_id, tenant, agent_runtime.agent_id,
-        multi_session=agent_runtime.multi_session,
-    )
+    session = await _get_session_for_tenant(request, session_id, tenant, agent_runtime)
     require_user_writable_session(session)
 
     await store.update_session_title(session_id, body.title)
@@ -1347,10 +1311,7 @@ async def delete_session(
     """Archive (soft-delete) a session and delete its workspace storage."""
     _require_service_account_api_route(request, tenant)
     store = _get_session_store(request)
-    session = await _get_session_for_tenant(
-        request, session_id, tenant, agent_runtime.agent_id,
-        multi_session=agent_runtime.multi_session,
-    )
+    session = await _get_session_for_tenant(request, session_id, tenant, agent_runtime)
     require_user_writable_session(session)
 
     archived_sessions = await store.archive_session_tree_and_delete_schedules(

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -32,7 +32,10 @@ from surogates.session.attachment_ingest import (  # re-exported for back-compat
     _inline_extension_kind, _materialize_for_cache, _try_inline_attachment,
     _apply_inline_total_budget,
 )
-from surogates.api.session_guards import require_user_writable_session
+from surogates.api.session_guards import (
+    is_multi_era_web_session,
+    require_user_writable_session,
+)
 from surogates.coding_agents.command import is_code_command
 from surogates.config import INTERRUPT_CHANNEL_PREFIX, enqueue_session
 from surogates.session.events import EventType
@@ -383,12 +386,7 @@ async def _get_session_for_tenant(
             detail=f"Session {session_id} not found.",
         )
 
-    if (
-        not multi_session
-        and session.channel == "web"
-        and session.parent_id is None
-        and (session.config or {}).get("single_session") is not True
-    ):
+    if not multi_session and is_multi_era_web_session(session):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session {session_id} not found.",
@@ -476,6 +474,10 @@ async def create_session(
     Archiving the dedicated session is how a user deliberately starts
     over.
     """
+    # The canonical-conversation stamp is server-owned: a client-supplied
+    # value would let users pre-stamp sessions while multi-session is on
+    # and keep them past a later lockdown.
+    body.config.pop("single_session", None)
     if not agent_runtime.multi_session and tenant.user_id is not None:
         existing = await _get_session_store(request).get_reusable_channel_session(
             org_id=tenant.org_id,
@@ -620,7 +622,7 @@ async def send_message(
                 )
 
         session, bucket, root_id = await _get_workspace_session_bucket_and_root(
-            store, session_id, tenant,
+            request, store, session_id, tenant,
         )
         storage = _get_storage(request)
 

--- a/surogates/api/routes/skills.py
+++ b/surogates/api/routes/skills.py
@@ -240,15 +240,12 @@ async def _authorize_session_for_staging(
     from surogates.api.routes.sessions import _get_session_for_tenant
     from surogates.runtime import agent_runtime_context_dep
 
-    # ``_get_session_for_tenant`` requires ``agent_id`` to gate
+    # ``_get_session_for_tenant`` requires the runtime context to gate
     # cross-agent session reads.  Resolve it via
     # ``agent_runtime_context_dep`` so the staging helper stays in
     # lock-step with every other session-scoped route.
     agent_runtime = await agent_runtime_context_dep(request)
-    return await _get_session_for_tenant(
-        request, session_id, tenant, agent_runtime.agent_id,
-        multi_session=agent_runtime.multi_session,
-    )
+    return await _get_session_for_tenant(request, session_id, tenant, agent_runtime)
 
 
 async def _stage_skill_for_session(

--- a/surogates/api/routes/skills.py
+++ b/surogates/api/routes/skills.py
@@ -247,6 +247,7 @@ async def _authorize_session_for_staging(
     agent_runtime = await agent_runtime_context_dep(request)
     return await _get_session_for_tenant(
         request, session_id, tenant, agent_runtime.agent_id,
+        multi_session=agent_runtime.multi_session,
     )
 
 

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -70,7 +70,9 @@ from surogates.runtime.platform_client import (
     CommercePaymentRequiredError,
     PlatformAuthError,
 )
+from surogates.channels.constants import multi_session_disabled
 from surogates.session.events import EventType
+from surogates.session.models import REUSABLE_SESSION_STATUSES
 from surogates.session.store import SessionNotFoundError, SessionStore
 from surogates.storage.tenant import agent_session_bucket
 from surogates.tenant.auth.firebase import (
@@ -244,8 +246,14 @@ def _clear_session_cookie(response: Response) -> None:
 
 async def _resolve_claims_from_cookie(
     request: Request,
-) -> WebsiteSessionClaims:
+    *,
+    optional: bool = False,
+) -> WebsiteSessionClaims | None:
     """Decode the session cookie from *request* or raise 401.
+
+    With ``optional`` a missing/invalid cookie returns ``None`` instead
+    (the single-session bootstrap probes the cookie without failing the
+    request).
 
     The decoded claims are the authority for session ownership on
     messages/events — the cookie carries the session id, org, origin,
@@ -255,6 +263,8 @@ async def _resolve_claims_from_cookie(
     """
     raw = request.cookies.get(COOKIE_NAME)
     if not raw:
+        if optional:
+            return None
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing website session cookie; call POST /v1/website/sessions first.",
@@ -262,6 +272,8 @@ async def _resolve_claims_from_cookie(
     try:
         return decode_website_session_token(raw)
     except InvalidTokenError as exc:
+        if optional:
+            return None
         logger.debug("Invalid website session cookie: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -315,16 +327,6 @@ def _agent_allowed_origins(routing_config: dict) -> tuple[str, ...] | None:
     return parse_allowed_origins(csv) or None
 
 
-# Statuses a single-session bootstrap may funnel the visitor back into.
-# ``completed`` counts: an idle-completed conversation is still "their
-# session" and the worker resumes it on the next message.  ``failed``
-# and ``archived`` don't — never trap a visitor in a broken session, and
-# the explicit end-of-visit hook clears the cookie anyway.
-_REUSABLE_WEBSITE_STATUSES = frozenset(
-    {"active", "processing", "paused", "completed"}
-)
-
-
 async def _reusable_cookie_session(
     request: Request,
     *,
@@ -343,12 +345,8 @@ async def _reusable_cookie_session(
     missing/invalid cookie, any claim mismatch, or a session that is
     gone or not reusable, the caller falls through to a fresh create.
     """
-    raw = request.cookies.get(COOKIE_NAME)
-    if not raw:
-        return None
-    try:
-        claims = decode_website_session_token(raw)
-    except InvalidTokenError:
+    claims = await _resolve_claims_from_cookie(request, optional=True)
+    if claims is None:
         return None
     if (
         claims.channel_identifier != publishable_key
@@ -365,7 +363,7 @@ async def _reusable_cookie_session(
     if (
         session.agent_id != agent_id
         or session.channel != WEBSITE_CHANNEL
-        or session.status not in _REUSABLE_WEBSITE_STATUSES
+        or session.status not in REUSABLE_SESSION_STATUSES
         # Only the canonical single-session conversation qualifies — a
         # cookie left over from a multi-session era is not adopted.
         or config.get("single_session") is not True
@@ -649,6 +647,40 @@ async def _authorize_commerce_turn(
         )
 
 
+def _issue_bootstrap_response(
+    response: Response,
+    *,
+    session_id: UUID,
+    org_uuid: UUID,
+    origin: str,
+    publishable_key: str,
+    agent_id: str,
+) -> BootstrapResponse:
+    """Mint the CSRF token + session cookie and build the bootstrap body.
+
+    The cookie-mint contract (TTL, claim set, response shape) has one
+    home — both the fresh-create and single-session reuse paths return
+    through here.
+    """
+    csrf_token = generate_csrf_token()
+    cookie_token = create_website_session_token(
+        session_id=session_id,
+        org_id=org_uuid,
+        origin=origin,
+        csrf_token=csrf_token,
+        channel_identifier=publishable_key,
+    )
+    _set_session_cookie(
+        response, token=cookie_token, expires_seconds=DEFAULT_SESSION_TTL_SECONDS,
+    )
+    return BootstrapResponse(
+        session_id=session_id,
+        csrf_token=csrf_token,
+        expires_at=int(time.time()) + DEFAULT_SESSION_TTL_SECONDS,
+        agent_name=agent_id,
+    )
+
+
 @router.post(
     "/website/sessions",
     response_model=BootstrapResponse,
@@ -714,7 +746,7 @@ async def bootstrap_website_session(
 
     publishable_key = _extract_bearer(request) or ""
 
-    single_session = routing_config.get("multi_session") is False
+    single_session = multi_session_disabled(routing_config)
     if single_session:
         existing = await _reusable_cookie_session(
             request,
@@ -733,29 +765,20 @@ async def bootstrap_website_session(
                 buyer = await _resolve_commerce_buyer(
                     request, agent_id, body.firebase_id_token,
                 )
-                if buyer is not None:
-                    await _get_session_store(request).update_session_config_key(
+                if buyer is not None and (
+                    (existing.config or {}).get("commerce_buyer") != buyer
+                ):
+                    await store.update_session_config_key(
                         existing.id, "commerce_buyer", buyer,
                     )
-            csrf_token = generate_csrf_token()
-            cookie_token = create_website_session_token(
-                session_id=existing.id,
-                org_id=org_uuid,
-                origin=normalized_origin,
-                csrf_token=csrf_token,
-                channel_identifier=publishable_key,
-            )
-            _set_session_cookie(
-                response,
-                token=cookie_token,
-                expires_seconds=DEFAULT_SESSION_TTL_SECONDS,
-            )
             response.status_code = status.HTTP_200_OK
-            return BootstrapResponse(
+            return _issue_bootstrap_response(
+                response,
                 session_id=existing.id,
-                csrf_token=csrf_token,
-                expires_at=int(time.time()) + DEFAULT_SESSION_TTL_SECONDS,
-                agent_name=agent_id,
+                org_uuid=org_uuid,
+                origin=normalized_origin,
+                publishable_key=publishable_key,
+                agent_id=agent_id,
             )
 
     config: dict = {
@@ -819,23 +842,13 @@ async def bootstrap_website_session(
             detail="Failed to provision session workspace; try again.",
         )
 
-    csrf_token = generate_csrf_token()
-    cookie_token = create_website_session_token(
+    return _issue_bootstrap_response(
+        response,
         session_id=session.id,
-        org_id=org_uuid,
+        org_uuid=org_uuid,
         origin=normalized_origin,
-        csrf_token=csrf_token,
-        channel_identifier=publishable_key,
-    )
-    _set_session_cookie(
-        response, token=cookie_token, expires_seconds=DEFAULT_SESSION_TTL_SECONDS,
-    )
-
-    return BootstrapResponse(
-        session_id=session.id,
-        csrf_token=csrf_token,
-        expires_at=int(time.time()) + DEFAULT_SESSION_TTL_SECONDS,
-        agent_name=agent_id,
+        publishable_key=publishable_key,
+        agent_id=agent_id,
     )
 
 

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -365,6 +365,9 @@ async def _reusable_cookie_session(
         session.agent_id != agent_id
         or session.channel != WEBSITE_CHANNEL
         or session.status not in _REUSABLE_WEBSITE_STATUSES
+        # Only the canonical single-session conversation qualifies — a
+        # cookie left over from a multi-session era is not adopted.
+        or (session.config or {}).get("single_session") is not True
     ):
         return None
     return session
@@ -703,7 +706,8 @@ async def bootstrap_website_session(
 
     publishable_key = _extract_bearer(request) or ""
 
-    if routing_config.get("multi_session") is False:
+    single_session = routing_config.get("multi_session") is False
+    if single_session:
         existing = await _reusable_cookie_session(
             request,
             agent_id=agent_id,
@@ -739,6 +743,10 @@ async def bootstrap_website_session(
         "website_origin": normalized_origin,
         "channel_identifier": publishable_key,
     }
+    if single_session:
+        # The fresh session becomes the visitor's canonical conversation
+        # that every later re-bootstrap resolves to.
+        config["single_session"] = True
     # Materialise the message cap onto session.config so the route's
     # 429 enforcement is decoupled from settings — the cookie-bound
     # cap stays stable for the visitor even if ops adjusts the channel

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -361,14 +361,22 @@ async def _reusable_cookie_session(
         session = await store.get_session(claims.session_id)
     except SessionNotFoundError:
         return None
+    config = session.config or {}
     if (
         session.agent_id != agent_id
         or session.channel != WEBSITE_CHANNEL
         or session.status not in _REUSABLE_WEBSITE_STATUSES
         # Only the canonical single-session conversation qualifies — a
         # cookie left over from a multi-session era is not adopted.
-        or (session.config or {}).get("single_session") is not True
+        or config.get("single_session") is not True
     ):
+        return None
+    # A capped-out session must not be reused: the 429 on send tells the
+    # visitor to bootstrap a new session, so the bootstrap has to
+    # actually deliver one (message_count never resets and the cap is
+    # pinned at creation).
+    cap = config.get("session_message_cap") or 0
+    if cap and (session.message_count or 0) >= cap:
         return None
     return session
 
@@ -716,6 +724,19 @@ async def bootstrap_website_session(
             publishable_key=publishable_key,
         )
         if existing is not None:
+            # Buyer identity pins at bootstrap (see the fresh-create path
+            # below), and the sign-in recovery flow re-bootstraps with a
+            # Firebase token expecting exactly that — so a reused session
+            # must absorb the token too, or a signed-in buyer would 402
+            # forever against their buyer-less canonical session.
+            if body is not None and body.firebase_id_token:
+                buyer = await _resolve_commerce_buyer(
+                    request, agent_id, body.firebase_id_token,
+                )
+                if buyer is not None:
+                    await _get_session_store(request).update_session_config_key(
+                        existing.id, "commerce_buyer", buyer,
+                    )
             csrf_token = generate_csrf_token()
             cookie_token = create_website_session_token(
                 session_id=existing.id,

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -315,6 +315,61 @@ def _agent_allowed_origins(routing_config: dict) -> tuple[str, ...] | None:
     return parse_allowed_origins(csv) or None
 
 
+# Statuses a single-session bootstrap may funnel the visitor back into.
+# ``completed`` counts: an idle-completed conversation is still "their
+# session" and the worker resumes it on the next message.  ``failed``
+# and ``archived`` don't — never trap a visitor in a broken session, and
+# the explicit end-of-visit hook clears the cookie anyway.
+_REUSABLE_WEBSITE_STATUSES = frozenset(
+    {"active", "processing", "paused", "completed"}
+)
+
+
+async def _reusable_cookie_session(
+    request: Request,
+    *,
+    agent_id: str,
+    org_uuid: UUID,
+    normalized_origin: str,
+    publishable_key: str,
+):
+    """The visitor's cookie-bound session, for single-session bootstraps.
+
+    With the agent's "multi session" capability off, a re-bootstrap from
+    a browser still holding a valid session cookie must return the
+    visitor to their existing conversation instead of minting a new
+    session.  The cookie is trusted only when its claims bind to the
+    same publishable key, org and origin this bootstrap resolved; on a
+    missing/invalid cookie, any claim mismatch, or a session that is
+    gone or not reusable, the caller falls through to a fresh create.
+    """
+    raw = request.cookies.get(COOKIE_NAME)
+    if not raw:
+        return None
+    try:
+        claims = decode_website_session_token(raw)
+    except InvalidTokenError:
+        return None
+    if (
+        claims.channel_identifier != publishable_key
+        or claims.origin != normalized_origin
+        or claims.org_id != org_uuid
+    ):
+        return None
+    store = _get_session_store(request)
+    try:
+        session = await store.get_session(claims.session_id)
+    except SessionNotFoundError:
+        return None
+    if (
+        session.agent_id != agent_id
+        or session.channel != WEBSITE_CHANNEL
+        or session.status not in _REUSABLE_WEBSITE_STATUSES
+    ):
+        return None
+    return session
+
+
 async def _load_and_authorize_session(
     request: Request,
     path_session_id: UUID,
@@ -647,6 +702,37 @@ async def bootstrap_website_session(
     normalized_origin = normalize_origin(request_origin)
 
     publishable_key = _extract_bearer(request) or ""
+
+    if routing_config.get("multi_session") is False:
+        existing = await _reusable_cookie_session(
+            request,
+            agent_id=agent_id,
+            org_uuid=org_uuid,
+            normalized_origin=normalized_origin,
+            publishable_key=publishable_key,
+        )
+        if existing is not None:
+            csrf_token = generate_csrf_token()
+            cookie_token = create_website_session_token(
+                session_id=existing.id,
+                org_id=org_uuid,
+                origin=normalized_origin,
+                csrf_token=csrf_token,
+                channel_identifier=publishable_key,
+            )
+            _set_session_cookie(
+                response,
+                token=cookie_token,
+                expires_seconds=DEFAULT_SESSION_TTL_SECONDS,
+            )
+            response.status_code = status.HTTP_200_OK
+            return BootstrapResponse(
+                session_id=existing.id,
+                csrf_token=csrf_token,
+                expires_at=int(time.time()) + DEFAULT_SESSION_TTL_SECONDS,
+                agent_name=agent_id,
+            )
+
     config: dict = {
         "storage_bucket": bucket,
         "workspace_path": storage.resolve_workspace_path(bucket, session_id),

--- a/surogates/api/routes/workspace.py
+++ b/surogates/api/routes/workspace.py
@@ -20,7 +20,10 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, UploadFil
 from fastapi.responses import Response
 from pydantic import BaseModel
 
-from surogates.api.session_guards import require_user_writable_session
+from surogates.api.session_guards import (
+    require_session_visible,
+    require_user_writable_session,
+)
 from surogates.session.models import Session
 from surogates.session.store import SessionNotFoundError, SessionStore
 from surogates.storage.backend import StorageBackend
@@ -211,7 +214,7 @@ def _require_service_account_api_route(
 
 
 async def _get_workspace_session_bucket_and_root(
-    store: SessionStore, session_id: UUID, tenant: TenantContext,
+    request: Request, store: SessionStore, session_id: UUID, tenant: TenantContext,
 ) -> tuple[Session, str, str]:
     """Resolve session, bucket, and workspace-root id for storage access.
 
@@ -234,6 +237,7 @@ async def _get_workspace_session_bucket_and_root(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Session {session_id} not found.",
         )
+    await require_session_visible(request, session)
 
     bucket = session.config.get("storage_bucket")
     if not bucket:
@@ -380,7 +384,7 @@ async def get_workspace_tree(
     store = _get_session_store(request)
     storage = _get_storage(request)
     session, bucket, root_id = await _get_workspace_session_bucket_and_root(
-        store, session_id, tenant,
+        request, store, session_id, tenant,
     )
 
     prefix = boundary_workspace_prefix(session.config, session, root_id)
@@ -419,7 +423,7 @@ async def get_workspace_file(
     store = _get_session_store(request)
     storage = _get_storage(request)
     session, bucket, root_id = await _get_workspace_session_bucket_and_root(
-        store, session_id, tenant,
+        request, store, session_id, tenant,
     )
 
     is_text = _is_text_key(path)
@@ -500,7 +504,7 @@ async def upload_file(
     store = _get_session_store(request)
     storage = _get_storage(request)
     session, bucket, root_id = await _get_workspace_session_bucket_and_root(
-        store, session_id, tenant
+        request, store, session_id, tenant
     )
     require_user_writable_session(session)
 
@@ -544,7 +548,7 @@ async def download_file(
     store = _get_session_store(request)
     storage = _get_storage(request)
     session, bucket, root_id = await _get_workspace_session_bucket_and_root(
-        store, session_id, tenant,
+        request, store, session_id, tenant,
     )
 
     storage_key = boundary_workspace_key(session.config, session, root_id, path)
@@ -593,7 +597,7 @@ async def delete_file(
     store = _get_session_store(request)
     storage = _get_storage(request)
     session, bucket, root_id = await _get_workspace_session_bucket_and_root(
-        store, session_id, tenant
+        request, store, session_id, tenant
     )
     require_user_writable_session(session)
 

--- a/surogates/api/session_guards.py
+++ b/surogates/api/session_guards.py
@@ -2,12 +2,23 @@
 
 from __future__ import annotations
 
+import time
+
 from fastapi import HTTPException, Request, status
 
 from surogates.session.models import Session
 
 
 SCHEDULED_RUN_READ_ONLY_DETAIL = "Scheduled run sessions are read-only."
+
+# Bounded-staleness memo of agent_id → multi_session.  The guard sits on
+# high-frequency read routes (event polling, workspace tree) and must not
+# ride the runtime-config cache's 1-second TTL into an upstream fetch per
+# poll.  A capability flip reaching these secondary surfaces within the
+# memo TTL is acceptable — the primary create/list/access gates in the
+# sessions routes resolve the capability fresh per request.
+_MULTI_SESSION_MEMO_TTL = 30.0
+_multi_session_memo: dict[str, tuple[float, bool]] = {}
 
 
 def is_multi_era_web_session(session: Session) -> bool:
@@ -26,33 +37,54 @@ def is_multi_era_web_session(session: Session) -> bool:
     )
 
 
-async def require_session_visible(request: Request, session: Session) -> None:
+async def require_session_visible(
+    request: Request,
+    session: Session,
+    *,
+    multi_session: bool | None = None,
+) -> None:
     """404 hidden multi-era web sessions while "multi session" is off.
 
     The capability's contract is that non-canonical conversations are
     unreachable — deep links included — so every session-scoped read
     surface (events stream, workspace, artifacts, board, files,
     feedback, input answers) funnels through this guard, not just the
-    sessions CRUD.  The capability is resolved by the session's OWN
-    agent id straight from the runtime-config cache, so the check
-    cannot be steered by request parameters; an unresolvable config
-    fails open — the primary gate in the sessions routes still applies.
+    sessions CRUD.  Callers holding a resolved ``AgentRuntimeContext``
+    pass ``multi_session`` directly; otherwise the capability is
+    resolved (memoized) by the session's OWN agent id from the
+    runtime-config cache, so the check cannot be steered by request
+    parameters.  An unresolvable config fails open — the primary gate
+    in the sessions routes still applies.
     """
     if not is_multi_era_web_session(session):
         return
-    cache = getattr(request.app.state, "runtime_config_cache", None)
-    if cache is None:
-        return
-    try:
-        payload = await cache.get(session.agent_id)
-    except Exception:
-        return
-    if bool(payload.get("multi_session", True)):
+    if multi_session is None:
+        multi_session = await _resolve_multi_session(request, session.agent_id)
+    if multi_session:
         return
     raise HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,
         detail=f"Session {session.id} not found.",
     )
+
+
+async def _resolve_multi_session(request: Request, agent_id: str) -> bool:
+    now = time.monotonic()
+    memoized = _multi_session_memo.get(agent_id)
+    if memoized is not None and (now - memoized[0]) < _MULTI_SESSION_MEMO_TTL:
+        return memoized[1]
+    cache = getattr(request.app.state, "runtime_config_cache", None)
+    if cache is None:
+        return True
+    try:
+        payload = await cache.get(agent_id)
+    except Exception:
+        return True
+    from surogates.runtime.resolver import multi_session_from_payload
+
+    value = multi_session_from_payload(payload)
+    _multi_session_memo[agent_id] = (now, value)
+    return value
 
 
 def is_scheduled_run_session(session: Session) -> bool:

--- a/surogates/api/session_guards.py
+++ b/surogates/api/session_guards.py
@@ -1,13 +1,58 @@
-"""Shared API guards for session mutability."""
+"""Shared API guards for session mutability and visibility."""
 
 from __future__ import annotations
 
-from fastapi import HTTPException, status
+from fastapi import HTTPException, Request, status
 
 from surogates.session.models import Session
 
 
 SCHEDULED_RUN_READ_ONLY_DETAIL = "Scheduled run sessions are read-only."
+
+
+def is_multi_era_web_session(session: Session) -> bool:
+    """A top-level web conversation that is NOT the canonical single-session one.
+
+    These are the sessions the "multi session" capability hides while
+    off: children (delegation subtrees) and non-web channels are never
+    hidden, and the canonical conversation carries the
+    ``config.single_session`` stamp.
+    """
+    return (
+        getattr(session, "channel", None) == "web"
+        and getattr(session, "parent_id", None) is None
+        and (getattr(session, "config", None) or {}).get("single_session")
+        is not True
+    )
+
+
+async def require_session_visible(request: Request, session: Session) -> None:
+    """404 hidden multi-era web sessions while "multi session" is off.
+
+    The capability's contract is that non-canonical conversations are
+    unreachable — deep links included — so every session-scoped read
+    surface (events stream, workspace, artifacts, board, files,
+    feedback, input answers) funnels through this guard, not just the
+    sessions CRUD.  The capability is resolved by the session's OWN
+    agent id straight from the runtime-config cache, so the check
+    cannot be steered by request parameters; an unresolvable config
+    fails open — the primary gate in the sessions routes still applies.
+    """
+    if not is_multi_era_web_session(session):
+        return
+    cache = getattr(request.app.state, "runtime_config_cache", None)
+    if cache is None:
+        return
+    try:
+        payload = await cache.get(session.agent_id)
+    except Exception:
+        return
+    if bool(payload.get("multi_session", True)):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"Session {session.id} not found.",
+    )
 
 
 def is_scheduled_run_session(session: Session) -> bool:

--- a/surogates/channels/constants.py
+++ b/surogates/channels/constants.py
@@ -11,7 +11,21 @@ of literals scattered per file.
 
 from __future__ import annotations
 
-__all__ = ["ADAPTER_CHANNELS", "INTERACTIVE_PROMPT_CHANNELS"]
+__all__ = [
+    "ADAPTER_CHANNELS",
+    "INTERACTIVE_PROMPT_CHANNELS",
+    "multi_session_disabled",
+]
+
+
+def multi_session_disabled(config: dict) -> bool:
+    """Whether a routing/channel config turns the "multi session" capability off.
+
+    Only an explicit ``False`` counts — an absent key means the capability
+    is on (the default), so this must never be "simplified" to
+    ``not config.get(...)``.
+    """
+    return config.get("multi_session") is False
 
 #: Channels with a registered outbound delivery adapter (a delivery loop
 #: that claims their outbox rows).  Must match the platforms registered in

--- a/surogates/channels/identity.py
+++ b/surogates/channels/identity.py
@@ -17,6 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from surogates.session.models import REUSABLE_SESSION_STATUSES
 from surogates.channels.memory_boundary import MANAGED_CHANNELS
 from surogates.db.models import ChannelIdentity as ChannelIdentityRow
 from surogates.db.models import Session as SessionRow
@@ -302,7 +303,7 @@ def make_cached_identity_resolver(
 # Statuses whose session is reused for a routing key. completed/paused are
 # idle-but-resumable (re-activated on reuse); active/processing are in flight.
 # Any other status (failed, archived, …) starts a fresh session.
-_RESUMABLE_STATUSES = ("active", "processing", "paused", "completed")
+_RESUMABLE_STATUSES = REUSABLE_SESSION_STATUSES
 
 
 async def get_or_create_channel_session(
@@ -379,10 +380,35 @@ async def get_or_create_channel_session(
         # existed (or under a path that never set it). The flag is stable for a
         # given routing key, so this fires at most once per such session.
         _incoming_multi_party = bool(config.get("multi_party"))
-        _existing_multi_party = bool((getattr(existing, "config", None) or {}).get("multi_party"))
+        _existing_config = getattr(existing, "config", None) or {}
+        _existing_multi_party = bool(_existing_config.get("multi_party"))
         if _existing_multi_party != _incoming_multi_party:
             await session_store.update_session_config_key(
                 existing_id, "multi_party", _incoming_multi_party
+            )
+        # Single-session sync.  A collapsed conversation spans every
+        # thread of its chat, but delivery destinations come from session
+        # config — stamped once at creation, they would pin every reply
+        # to the first-ever thread.  Track the latest inbound thread here
+        # (the store re-reads it fresh at enqueue, the same remedy as
+        # ``telegram_reply_to_message_id``), skipping the write when
+        # unchanged.  The marker itself is synced both ways because DM
+        # routing keys are identical in both capability modes, so one
+        # session can straddle a flip.
+        _incoming_single = bool(config.get("single_session"))
+        _marker_changed = (
+            bool(_existing_config.get("single_session")) != _incoming_single
+        )
+        if _marker_changed:
+            await session_store.update_session_config_key(
+                existing_id, "single_session", _incoming_single,
+            )
+        _thread_field = f"{channel}_thread_key"
+        if (_incoming_single or _marker_changed) and (
+            _existing_config.get(_thread_field) != config.get(_thread_field)
+        ):
+            await session_store.update_session_config_key(
+                existing_id, _thread_field, config.get(_thread_field),
             )
         # Backfill boundary partitioning onto sessions created before the
         # thread's boundary was known (or before workspace partitioning

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -37,7 +37,11 @@ from uuid import UUID
 from sqlalchemy.exc import InterfaceError, OperationalError
 
 from surogates.channels.dedup import MessageDeduplicator
-from surogates.channels.source import SessionSource, build_session_key
+from surogates.channels.constants import multi_session_disabled
+from surogates.channels.source import (
+    SessionSource,
+    build_session_key_for_config,
+)
 from surogates.session.events import EventType
 
 logger = logging.getLogger(__name__)
@@ -565,15 +569,10 @@ class ChannelInboundPipeline:
             chat_name=msg.identifier,
         )
         # "multi session" off (ops projects the agent capability into the
-        # routing config) collapses the key to one session per chat:
-        # threads fold into the parent conversation and per_user_groups
-        # is overridden.  Absent key = capability on (default).
-        single_session = config.get("multi_session") is False
-        session_key = build_session_key(
-            source,
-            per_user_groups=bool(config.get("per_user_groups", False)),
-            single_session=single_session,
-        )
+        # routing config) folds thread suffixes so every thread continues
+        # the same conversation; see build_session_key_for_config.
+        single_session = multi_session_disabled(config)
+        session_key = build_session_key_for_config(source, config)
 
         from surogates.channels.memory_boundary import boundary_token
 
@@ -606,27 +605,6 @@ class ChannelInboundPipeline:
             },
             session_factory=deps.session_factory,
         )
-
-        if single_session:
-            # The collapsed session spans every thread of the chat, but
-            # delivery destinations come from session config — stamped at
-            # creation, they would pin every reply to the first-ever
-            # thread.  Track the latest inbound thread instead; the store
-            # re-reads it fresh at enqueue (same remedy as
-            # ``telegram_reply_to_message_id``).  Best-effort: a failed
-            # write falls back to the previous thread, never drops the
-            # message.
-            try:
-                await deps.session_store.update_session_config_key(
-                    session_id,
-                    f"{routing.platform}_thread_key",
-                    msg.thread_key,
-                )
-            except Exception:
-                logger.warning(
-                    "[channels] recording single-session thread key failed",
-                    exc_info=True,
-                )
 
         # Remember in Redis-backed state for thread-gate lookups.
         await deps.state.remember_session(session_key, str(session_id))
@@ -936,9 +914,5 @@ class ChannelInboundPipeline:
             user_id=msg.platform_user_id,
             thread_id=thread_key,
         )
-        key = build_session_key(
-            source,
-            per_user_groups=bool(config.get("per_user_groups", False)),
-            single_session=config.get("multi_session") is False,
-        )
+        key = build_session_key_for_config(source, config)
         return await deps.state.get_session(key) is not None

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -564,7 +564,16 @@ class ChannelInboundPipeline:
             thread_id=msg.thread_key,
             chat_name=msg.identifier,
         )
-        session_key = build_session_key(source, per_user_groups=bool(config.get("per_user_groups", False)))
+        # "multi session" off (ops projects the agent capability into the
+        # routing config) collapses the key to one session per chat:
+        # threads fold into the parent conversation and per_user_groups
+        # is overridden.  Absent key = capability on (default).
+        single_session = config.get("multi_session") is False
+        session_key = build_session_key(
+            source,
+            per_user_groups=bool(config.get("per_user_groups", False)),
+            single_session=single_session,
+        )
 
         from surogates.channels.memory_boundary import boundary_token
 
@@ -902,5 +911,9 @@ class ChannelInboundPipeline:
             user_id=msg.platform_user_id,
             thread_id=thread_key,
         )
-        key = build_session_key(source, per_user_groups=bool(config.get("per_user_groups", False)))
+        key = build_session_key(
+            source,
+            per_user_groups=bool(config.get("per_user_groups", False)),
+            single_session=config.get("multi_session") is False,
+        )
         return await deps.state.get_session(key) is not None

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -599,9 +599,34 @@ class ChannelInboundPipeline:
                 "channel_identifier": routing.identifier,
                 "memory_boundary": memory_boundary,
                 "multi_party": chat_type in ("group", "channel"),
+                # Marks the session as a collapsed single-session
+                # conversation; delivery reads the thread key fresh for
+                # these (see the outbox enqueue in the session store).
+                **({"single_session": True} if single_session else {}),
             },
             session_factory=deps.session_factory,
         )
+
+        if single_session:
+            # The collapsed session spans every thread of the chat, but
+            # delivery destinations come from session config — stamped at
+            # creation, they would pin every reply to the first-ever
+            # thread.  Track the latest inbound thread instead; the store
+            # re-reads it fresh at enqueue (same remedy as
+            # ``telegram_reply_to_message_id``).  Best-effort: a failed
+            # write falls back to the previous thread, never drops the
+            # message.
+            try:
+                await deps.session_store.update_session_config_key(
+                    session_id,
+                    f"{routing.platform}_thread_key",
+                    msg.thread_key,
+                )
+            except Exception:
+                logger.warning(
+                    "[channels] recording single-session thread key failed",
+                    exc_info=True,
+                )
 
         # Remember in Redis-backed state for thread-gate lookups.
         await deps.state.remember_session(session_key, str(session_id))

--- a/surogates/channels/source.py
+++ b/surogates/channels/source.py
@@ -71,11 +71,11 @@ def build_session_key(
       to its own session.
 
     *single_session* implements the agent's "multi session" capability
-    being off: the key collapses to one session per chat — thread
-    suffixes are dropped (every thread continues the same conversation)
-    and *per_user_groups* is ignored (a per-user split inside a group
-    would mint extra sessions).  DMs already map one-to-one to the user,
-    so their key shape is unchanged.
+    being off: thread suffixes are dropped so every thread continues the
+    same conversation.  *per_user_groups* still applies — collapsing the
+    per-user split would merge different users' conversation state into
+    one shared context, the opposite of "one session per user".  DMs
+    already map one-to-one to the user, so their key shape is unchanged.
 
     Returns a colon-separated string suitable for use as a Redis key or
     database lookup value, e.g.::
@@ -86,7 +86,7 @@ def build_session_key(
     """
     parts: list[str] = ["agent", source.platform, source.chat_type, source.chat_id]
 
-    if source.chat_type in ("group", "channel") and per_user_groups and not single_session:
+    if source.chat_type in ("group", "channel") and per_user_groups:
         parts.append(source.user_id)
 
     if source.thread_id and not single_session:

--- a/surogates/channels/source.py
+++ b/surogates/channels/source.py
@@ -56,6 +56,7 @@ def build_session_key(
     source: SessionSource,
     *,
     per_user_groups: bool = False,
+    single_session: bool = False,
 ) -> str:
     """Derive a deterministic routing key from a :class:`SessionSource`.
 
@@ -69,6 +70,13 @@ def build_session_key(
     * **Threads** -- appended to the parent key so that each thread maps
       to its own session.
 
+    *single_session* implements the agent's "multi session" capability
+    being off: the key collapses to one session per chat — thread
+    suffixes are dropped (every thread continues the same conversation)
+    and *per_user_groups* is ignored (a per-user split inside a group
+    would mint extra sessions).  DMs already map one-to-one to the user,
+    so their key shape is unchanged.
+
     Returns a colon-separated string suitable for use as a Redis key or
     database lookup value, e.g.::
 
@@ -78,10 +86,10 @@ def build_session_key(
     """
     parts: list[str] = ["agent", source.platform, source.chat_type, source.chat_id]
 
-    if source.chat_type in ("group", "channel") and per_user_groups:
+    if source.chat_type in ("group", "channel") and per_user_groups and not single_session:
         parts.append(source.user_id)
 
-    if source.thread_id:
+    if source.thread_id and not single_session:
         parts.append(source.thread_id)
 
     return ":".join(parts)

--- a/surogates/channels/source.py
+++ b/surogates/channels/source.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 __all__ = [
     "SessionSource",
     "build_session_key",
+    "build_session_key_for_config",
 ]
 
 
@@ -93,3 +94,20 @@ def build_session_key(
         parts.append(source.thread_id)
 
     return ":".join(parts)
+
+
+def build_session_key_for_config(source: SessionSource, config: dict) -> str:
+    """Derive the routing key from a channel routing config.
+
+    The config→flags convention lives here, once: ``per_user_groups`` is
+    truthy-on, while ``multi_session`` is explicit-``False``-off (absent =
+    on).  Both inbound call sites (session resolution and the thread-gate
+    existence check) must derive identically or routing forks.
+    """
+    from surogates.channels.constants import multi_session_disabled
+
+    return build_session_key(
+        source,
+        per_user_groups=bool(config.get("per_user_groups", False)),
+        single_session=multi_session_disabled(config),
+    )

--- a/surogates/runtime/context.py
+++ b/surogates/runtime/context.py
@@ -169,6 +169,13 @@ class AgentRuntimeContext:
     # Defaults True (browser tools have always been available).
     browser_enabled: bool = True
 
+    # "Multi session" capability.  When False each end-user gets exactly
+    # one session per channel — the create routes reuse the latest
+    # reusable session instead of creating another.  Defaults True so a
+    # runtime-config payload that predates this field keeps unlimited
+    # sessions.
+    multi_session: bool = True
+
     # File-bundle reference.  Both optional so agents that haven't
     # been onboarded to Hub-backed bundles yet still work.
     # ``bundle_hub_ref`` is the Hub repository in ``<owner>/<repo>``

--- a/surogates/runtime/resolver.py
+++ b/surogates/runtime/resolver.py
@@ -104,6 +104,7 @@ def build_agent_runtime_context(payload: dict) -> AgentRuntimeContext:
         slash_commands=_slash_commands(payload.get("slash_commands")),
         brainstorming_gate=bool(payload.get("brainstorming_gate", True)),
         browser_enabled=bool(payload.get("browser_enabled", True)),
+        multi_session=bool(payload.get("multi_session", True)),
         # bundle reference.  Empty strings → None
         # (a misconfigured payload that ships "" must not turn into
         # a Hub fetch against an empty ref).

--- a/surogates/runtime/resolver.py
+++ b/surogates/runtime/resolver.py
@@ -70,6 +70,15 @@ def _slash_commands(blob: dict | None) -> SlashCommandConfig:
     return SlashCommandConfig(commands=frozenset(ids))
 
 
+def multi_session_from_payload(payload: dict) -> bool:
+    """The "multi session" capability from a runtime-config payload.
+
+    Absent key = capability on.  Shared with the session-visibility
+    guard so the default is encoded exactly once.
+    """
+    return bool(payload.get("multi_session", True))
+
+
 def build_agent_runtime_context(payload: dict) -> AgentRuntimeContext:
     """Project the platform runtime-config payload into a context.
 
@@ -104,7 +113,7 @@ def build_agent_runtime_context(payload: dict) -> AgentRuntimeContext:
         slash_commands=_slash_commands(payload.get("slash_commands")),
         brainstorming_gate=bool(payload.get("brainstorming_gate", True)),
         browser_enabled=bool(payload.get("browser_enabled", True)),
-        multi_session=bool(payload.get("multi_session", True)),
+        multi_session=multi_session_from_payload(payload),
         # bundle reference.  Empty strings → None
         # (a misconfigured payload that ships "" must not turn into
         # a Hub fetch against an empty ref).

--- a/surogates/session/models.py
+++ b/surogates/session/models.py
@@ -14,6 +14,17 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 
+# Statuses a conversation may be resumed/reused in.  ``completed`` counts
+# (the worker resumes it on the next message); ``failed`` and ``archived``
+# never do — a broken session is not funneled back to, and archiving is
+# the deliberate fresh start.  Shared by the channel get-or-create
+# (channels/identity), the single-session reuse lookups (session/store),
+# and the website bootstrap (api/routes/website).
+REUSABLE_SESSION_STATUSES: tuple[str, ...] = (
+    "active", "processing", "paused", "completed",
+)
+
+
 class Session(BaseModel):
     """Snapshot of a session's metadata and aggregate counters."""
 

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -1088,21 +1088,41 @@ class SessionStore:
             dedupe_key = f"{channel}:{event_id}"
 
             async with self._sf() as db:
-                if channel == "telegram" and "telegram_reply_to_message_id" in config:
-                    # Reply threading tracks the latest inbound message id in
-                    # session config (written by the channels process), so it
-                    # must be read fresh — the per-session config cache above
-                    # is primed once and would pin every reply to the first
-                    # message.  Gated on the cached config carrying the key at
-                    # all, so sessions that never use reply threading pay no
-                    # extra query.  Best-effort: a read failure falls back to
-                    # the cached value rather than dropping the delivery.
+                # Two destination fields track the *latest* inbound message in
+                # session config (written by the channels process) and must be
+                # read fresh — the per-session config cache above is primed
+                # once and would pin every reply to the first message:
+                # ``telegram_reply_to_message_id`` (reply threading) and, for
+                # collapsed single-session conversations that span every
+                # thread of a chat, the ``*_thread_key`` reply destination.
+                # Gated on the cached config carrying the marker/key at all,
+                # so ordinary sessions pay no extra query.  Best-effort: a
+                # read failure falls back to the cached values rather than
+                # dropping the delivery.
+                needs_fresh_reply = (
+                    channel == "telegram"
+                    and "telegram_reply_to_message_id" in config
+                )
+                needs_fresh_thread = bool(config.get("single_session"))
+                if needs_fresh_reply or needs_fresh_thread:
                     try:
                         fresh = await db.get(SessionRow, session_id)
-                        if fresh is not None:
+                        fresh_config = (
+                            fresh.config or {} if fresh is not None else config
+                        )
+                        if needs_fresh_reply:
                             destination["reply_to_message_id"] = (
-                                fresh.config or {}
-                            ).get("telegram_reply_to_message_id")
+                                fresh_config.get("telegram_reply_to_message_id")
+                            )
+                        if needs_fresh_thread:
+                            if channel == "slack":
+                                destination["thread_ts"] = fresh_config.get(
+                                    "slack_thread_key"
+                                )
+                            elif channel == "telegram":
+                                destination["message_thread_id"] = (
+                                    fresh_config.get("telegram_thread_key")
+                                )
                     except Exception:
                         pass
                 outbox = DeliveryOutbox(

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -47,7 +47,12 @@ from surogates.session.inbox_payload import (
     ACKNOWLEDGE_ONLY_KINDS,
     build_inbox_row,
 )
-from surogates.session.models import Event, Session, SessionLease
+from surogates.session.models import (
+    REUSABLE_SESSION_STATUSES,
+    Event,
+    Session,
+    SessionLease,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +138,19 @@ def _build_channel_payload(event_type: EventType, data: dict, channel: str) -> d
                 "context": strip_next_action_blocks(data.get("context", "") or ""),
             }
     return payload
+
+
+# The canonical-conversation stamp, as a SQL predicate.  The stamp is a
+# JSON boolean, so ``astext`` compares against the string form.
+_SINGLE_SESSION_MARKER = SessionRow.config["single_session"].astext == "true"
+
+# Delivery-destination field per adapter channel and the session-config
+# key it is read from.  Used by both the cached destination build and
+# the single-session fresh re-read at enqueue — keep them in lockstep.
+_THREAD_DEST_FIELDS = {
+    "slack": ("thread_ts", "slack_thread_key"),
+    "telegram": ("message_thread_id", "telegram_thread_key"),
+}
 
 
 class SessionStore:
@@ -263,7 +281,6 @@ class SessionStore:
         callers treat this as get-before-create and accept the benign
         race of two near-simultaneous first messages.
         """
-        reusable = ("active", "processing", "paused", "completed")
         async with self._sf() as db:
             result = await db.execute(
                 select(SessionRow)
@@ -273,8 +290,8 @@ class SessionStore:
                     SessionRow.agent_id == agent_id,
                     SessionRow.channel == channel,
                     SessionRow.parent_id.is_(None),
-                    SessionRow.status.in_(reusable),
-                    SessionRow.config["single_session"].astext == "true",
+                    SessionRow.status.in_(REUSABLE_SESSION_STATUSES),
+                    _SINGLE_SESSION_MARKER,
                 )
                 .order_by(SessionRow.created_at.desc())
                 .limit(1)
@@ -811,11 +828,7 @@ class SessionStore:
                 if service_account_id is not None
                 else SessionRow.user_id == user_id
             )
-        marker_filter = (
-            SessionRow.config["single_session"].astext == "true"
-            if single_session_only
-            else true()
-        )
+        marker_filter = _SINGLE_SESSION_MARKER if single_session_only else true()
         async with self._sf() as db:
             result = await db.execute(
                 select(SessionRow)
@@ -1064,16 +1077,17 @@ class SessionStore:
 
             # Build channel-specific destination from session config.
             destination: dict[str, Any] = {}
+            thread_dest, thread_key = _THREAD_DEST_FIELDS.get(channel, (None, None))
             if channel == "slack":
                 destination = {
                     "channel_id": config.get("slack_channel_id", ""),
-                    "thread_ts": config.get("slack_thread_key"),
+                    thread_dest: config.get(thread_key),
                     "channel_identifier": config.get("channel_identifier", ""),
                 }
             elif channel == "telegram":
                 destination = {
                     "chat_id": config.get("telegram_channel_id", ""),
-                    "message_thread_id": config.get("telegram_thread_key"),
+                    thread_dest: config.get(thread_key),
                     "reply_to_message_id": config.get("telegram_reply_to_message_id"),
                     "channel_identifier": config.get("channel_identifier", ""),
                 }
@@ -1114,15 +1128,8 @@ class SessionStore:
                             destination["reply_to_message_id"] = (
                                 fresh_config.get("telegram_reply_to_message_id")
                             )
-                        if needs_fresh_thread:
-                            if channel == "slack":
-                                destination["thread_ts"] = fresh_config.get(
-                                    "slack_thread_key"
-                                )
-                            elif channel == "telegram":
-                                destination["message_thread_id"] = (
-                                    fresh_config.get("telegram_thread_key")
-                                )
+                        if needs_fresh_thread and thread_dest is not None:
+                            destination[thread_dest] = fresh_config.get(thread_key)
                     except Exception:
                         pass
                 outbox = DeliveryOutbox(

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -250,15 +250,18 @@ class SessionStore:
         agent_id: str,
         channel: str,
     ) -> Session | None:
-        """Return the user's newest reusable session on *channel*, if any.
+        """Return the user's canonical single-session conversation, if any.
 
         The lookup behind the single-session ("multi session" off)
-        capability: top-level sessions only, newest first, skipping
-        ``archived`` (a deliberate close unlocks a fresh session) and
-        ``failed`` (never funnel a user back into a broken session).
-        There is no unique constraint enforcing one row — callers treat
-        this as get-before-create and accept the benign race of two
-        near-simultaneous first messages.
+        capability.  Only sessions stamped ``config.single_session``
+        qualify — the dedicated conversation created while the
+        capability was off.  Sessions from a multi-session era are never
+        adopted; they stay hidden until the capability is re-enabled.
+        Skips ``archived`` (a deliberate close unlocks a fresh dedicated
+        session) and ``failed`` (never funnel a user back into a broken
+        session).  There is no unique constraint enforcing one row —
+        callers treat this as get-before-create and accept the benign
+        race of two near-simultaneous first messages.
         """
         reusable = ("active", "processing", "paused", "completed")
         async with self._sf() as db:
@@ -271,6 +274,7 @@ class SessionStore:
                     SessionRow.channel == channel,
                     SessionRow.parent_id.is_(None),
                     SessionRow.status.in_(reusable),
+                    SessionRow.config["single_session"].astext == "true",
                 )
                 .order_by(SessionRow.created_at.desc())
                 .limit(1)
@@ -771,8 +775,13 @@ class SessionStore:
         offset: int = 0,
         include_descendants: bool = False,
         any_principal: bool = False,
+        single_session_only: bool = False,
     ) -> list[Session]:
         """Return top-level sessions for a principal within an org, newest first.
+
+        With *single_session_only* the page is restricted to roots stamped
+        ``config.single_session`` — the "multi session off" listing, where
+        multi-era conversations stay hidden.
 
         Delegation children (``parent_id IS NOT NULL``) are excluded from the
         page itself -- they belong under their parent in the session tree, not
@@ -802,6 +811,11 @@ class SessionStore:
                 if service_account_id is not None
                 else SessionRow.user_id == user_id
             )
+        marker_filter = (
+            SessionRow.config["single_session"].astext == "true"
+            if single_session_only
+            else true()
+        )
         async with self._sf() as db:
             result = await db.execute(
                 select(SessionRow)
@@ -811,6 +825,7 @@ class SessionStore:
                     SessionRow.agent_id == agent_id,
                     SessionRow.status != "archived",
                     SessionRow.parent_id.is_(None),
+                    marker_filter,
                 )
                 .order_by(SessionRow.created_at.desc())
                 .limit(limit)

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -242,6 +242,44 @@ class SessionStore:
             return None
         return Session.model_validate(row)
 
+    async def get_reusable_channel_session(
+        self,
+        *,
+        org_id: UUID,
+        user_id: UUID,
+        agent_id: str,
+        channel: str,
+    ) -> Session | None:
+        """Return the user's newest reusable session on *channel*, if any.
+
+        The lookup behind the single-session ("multi session" off)
+        capability: top-level sessions only, newest first, skipping
+        ``archived`` (a deliberate close unlocks a fresh session) and
+        ``failed`` (never funnel a user back into a broken session).
+        There is no unique constraint enforcing one row — callers treat
+        this as get-before-create and accept the benign race of two
+        near-simultaneous first messages.
+        """
+        reusable = ("active", "processing", "paused", "completed")
+        async with self._sf() as db:
+            result = await db.execute(
+                select(SessionRow)
+                .where(
+                    SessionRow.org_id == org_id,
+                    SessionRow.user_id == user_id,
+                    SessionRow.agent_id == agent_id,
+                    SessionRow.channel == channel,
+                    SessionRow.parent_id.is_(None),
+                    SessionRow.status.in_(reusable),
+                )
+                .order_by(SessionRow.created_at.desc())
+                .limit(1)
+            )
+            row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return Session.model_validate(row)
+
     async def get_session(self, session_id: UUID) -> Session:
         """Fetch a single session by ID.  Raises ``SessionNotFoundError``."""
         async with self._sf() as db:

--- a/tests/api/test_auth_config_multi_session.py
+++ b/tests/api/test_auth_config_multi_session.py
@@ -1,0 +1,43 @@
+"""``GET /v1/auth/config`` exposes the agent's "multi session" capability
+so the web SPA can hide "New chat" and pin the single conversation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from surogates.api.routes.auth import auth_config
+from surogates.runtime import AgentRuntimeContext
+
+
+def _ctx(**overrides) -> AgentRuntimeContext:
+    return AgentRuntimeContext(
+        agent_id="a-1",
+        org_id="o-1",
+        project_id="p-1",
+        enabled=True,
+        config_version=1,
+        storage_key_prefix="p-1/a-1",
+        **overrides,
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_config_defaults_multi_session_on():
+    request = MagicMock()
+    request.app.state.firebase_config_cache = None
+
+    resp = await auth_config(request, agent_runtime=_ctx())
+
+    assert resp.multi_session is True
+
+
+@pytest.mark.asyncio
+async def test_auth_config_projects_multi_session_off():
+    request = MagicMock()
+    request.app.state.firebase_config_cache = None
+
+    resp = await auth_config(request, agent_runtime=_ctx(multi_session=False))
+
+    assert resp.multi_session is False

--- a/tests/api/test_session_visibility_guard.py
+++ b/tests/api/test_session_visibility_guard.py
@@ -1,0 +1,85 @@
+"""``require_session_visible`` — the shared guard that makes hidden
+multi-era web sessions unreachable on every session-scoped read surface
+(events stream, workspace, artifacts, …), not just the sessions CRUD."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from surogates.api.session_guards import (
+    is_multi_era_web_session,
+    require_session_visible,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Cache:
+    def __init__(self, payload=None, error=None):
+        self.payload = payload
+        self.error = error
+
+    async def get(self, agent_id):
+        if self.error is not None:
+            raise self.error
+        return self.payload
+
+
+def _session(channel="web", *, parent_id=None, config=None):
+    return SimpleNamespace(
+        id=uuid4(),
+        agent_id="support-bot",
+        channel=channel,
+        parent_id=parent_id,
+        config=config or {},
+    )
+
+
+def _request(cache):
+    state = SimpleNamespace()
+    if cache is not None:
+        state.runtime_config_cache = cache
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+def test_multi_era_predicate():
+    assert is_multi_era_web_session(_session("web"))
+    assert not is_multi_era_web_session(
+        _session("web", config={"single_session": True})
+    )
+    assert not is_multi_era_web_session(_session("web", parent_id=uuid4()))
+    assert not is_multi_era_web_session(_session("api"))
+    assert not is_multi_era_web_session(_session("website"))
+
+
+async def test_hides_multi_era_session_when_capability_off():
+    request = _request(_Cache(payload={"multi_session": False}))
+    with pytest.raises(HTTPException) as exc:
+        await require_session_visible(request, _session("web"))
+    assert exc.value.status_code == 404
+
+
+async def test_allows_canonical_child_and_other_channels():
+    request = _request(_Cache(payload={"multi_session": False}))
+    for session in (
+        _session("web", config={"single_session": True}),
+        _session("web", parent_id=uuid4()),
+        _session("api"),
+    ):
+        await require_session_visible(request, session)
+
+
+async def test_allows_when_capability_on_or_absent():
+    for payload in ({"multi_session": True}, {}):
+        request = _request(_Cache(payload=payload))
+        await require_session_visible(request, _session("web"))
+
+
+async def test_fails_open_without_cache_or_on_resolution_error():
+    await require_session_visible(_request(None), _session("web"))
+    request = _request(_Cache(error=LookupError("agent gone")))
+    await require_session_visible(request, _session("web"))

--- a/tests/api/test_session_visibility_guard.py
+++ b/tests/api/test_session_visibility_guard.py
@@ -18,6 +18,15 @@ from surogates.api.session_guards import (
 pytestmark = pytest.mark.asyncio
 
 
+@pytest.fixture(autouse=True)
+def _clear_multi_session_memo():
+    from surogates.api import session_guards
+
+    session_guards._multi_session_memo.clear()
+    yield
+    session_guards._multi_session_memo.clear()
+
+
 class _Cache:
     def __init__(self, payload=None, error=None):
         self.payload = payload

--- a/tests/api/test_website_multi_session.py
+++ b/tests/api/test_website_multi_session.py
@@ -121,13 +121,19 @@ def _cookie(session_id, org_id, *, origin=_ORIGIN, key=_KEY):
     )
 
 
-def _live_session(session_id, *, status="active", agent_id="hero-agent"):
+def _live_session(
+    session_id,
+    *,
+    status="active",
+    agent_id="hero-agent",
+    marked=True,
+):
     return SimpleNamespace(
         id=session_id,
         agent_id=agent_id,
         channel="website",
         status=status,
-        config={},
+        config={"single_session": True} if marked else {},
     )
 
 
@@ -158,7 +164,7 @@ async def test_single_session_reuses_cookie_bound_session():
     assert r.json()["csrf_token"]
 
 
-async def test_single_session_without_cookie_creates():
+async def test_single_session_without_cookie_creates_marked():
     org_id = uuid.uuid4()
     store = _Store()
     app = _app(org_id, store, multi_session=False)
@@ -167,6 +173,23 @@ async def test_single_session_without_cookie_creates():
 
     assert r.status_code == 201
     assert len(store.created) == 1
+    # The fresh session is stamped as the visitor's canonical
+    # conversation for later re-bootstraps.
+    assert store.created[0]["config"]["single_session"] is True
+
+
+async def test_single_session_ignores_multi_era_cookie():
+    org_id, session_id = uuid.uuid4(), uuid.uuid4()
+    store = _Store({session_id: _live_session(session_id, marked=False)})
+    app = _app(org_id, store, multi_session=False)
+
+    r = await _post(app, cookie=_cookie(session_id, org_id))
+
+    # The cookie points at an unmarked (multi-era) session — never
+    # adopted; a fresh canonical session is minted instead.
+    assert r.status_code == 201
+    assert len(store.created) == 1
+    assert r.json()["session_id"] != str(session_id)
 
 
 async def test_single_session_ignores_cookie_from_other_key():

--- a/tests/api/test_website_multi_session.py
+++ b/tests/api/test_website_multi_session.py
@@ -18,6 +18,8 @@ os.environ.setdefault(
     "SUROGATES_AUTH_JWT_SECRET", "test-secret-key-for-tests-0123456789"
 )
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -56,12 +58,16 @@ class _Store:
     def __init__(self, sessions=None):
         self.sessions = sessions or {}
         self.created: list[dict] = []
+        self.config_writes: list[tuple] = []
 
     async def get_session(self, session_id):
         try:
             return self.sessions[session_id]
         except KeyError:
             raise SessionNotFoundError(f"session {session_id} not found")
+
+    async def update_session_config_key(self, session_id, key, value):
+        self.config_writes.append((session_id, key, value))
 
     async def create_session(self, **kwargs):
         self.created.append(kwargs)
@@ -127,13 +133,18 @@ def _live_session(
     status="active",
     agent_id="hero-agent",
     marked=True,
+    config=None,
+    message_count=0,
 ):
+    base_config = {"single_session": True} if marked else {}
+    base_config.update(config or {})
     return SimpleNamespace(
         id=session_id,
         agent_id=agent_id,
         channel="website",
         status=status,
-        config={"single_session": True} if marked else {},
+        config=base_config,
+        message_count=message_count,
     )
 
 
@@ -228,6 +239,59 @@ async def test_single_session_reuses_completed_session():
     assert r.status_code == 200
     assert r.json()["session_id"] == str(session_id)
     assert store.created == []
+
+
+async def test_single_session_capped_session_not_reused():
+    org_id, session_id = uuid.uuid4(), uuid.uuid4()
+    store = _Store({
+        session_id: _live_session(
+            session_id,
+            config={"session_message_cap": 5},
+            message_count=5,
+        ),
+    })
+    app = _app(org_id, store, multi_session=False)
+
+    r = await _post(app, cookie=_cookie(session_id, org_id))
+
+    # The 429 on send tells the visitor to bootstrap a new session; the
+    # bootstrap must actually deliver one instead of the capped session.
+    assert r.status_code == 201
+    assert len(store.created) == 1
+    assert r.json()["session_id"] != str(session_id)
+
+
+async def test_single_session_reuse_pins_buyer_from_token():
+    org_id, session_id = uuid.uuid4(), uuid.uuid4()
+    store = _Store({session_id: _live_session(session_id)})
+    app = _app(org_id, store, multi_session=False)
+    buyer = {"firebase_uid": "fb-1", "email": "buyer@acme.com"}
+
+    with patch.object(
+        website, "_resolve_commerce_buyer",
+        new=AsyncMock(return_value=buyer),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport,
+            base_url="https://widget",
+            cookies={COOKIE_NAME: _cookie(session_id, org_id)},
+        ) as c:
+            r = await c.post(
+                "/v1/website/sessions",
+                headers={
+                    "Authorization": f"Bearer {_KEY}",
+                    "Origin": _ORIGIN,
+                    "Content-Type": "application/json",
+                },
+                json={"firebase_id_token": "tok-123"},
+            )
+
+    # Reuse must absorb the sign-in token — the paywall recovery flow
+    # re-bootstraps expecting the buyer to pin onto the session.
+    assert r.status_code == 200
+    assert r.json()["session_id"] == str(session_id)
+    assert store.config_writes == [(session_id, "commerce_buyer", buyer)]
 
 
 async def test_multi_session_on_always_creates():

--- a/tests/api/test_website_multi_session.py
+++ b/tests/api/test_website_multi_session.py
@@ -1,0 +1,218 @@
+"""Website bootstrap under the "multi session" capability.
+
+With ``multi_session: false`` projected into the routing config, a
+re-bootstrap from a browser still holding a valid session cookie
+returns the visitor's existing session (HTTP 200, fresh CSRF + cookie)
+instead of minting a new one.  A missing/foreign cookie, a dead
+session, or the capability left on all fall through to today's
+fresh-create behavior.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from types import SimpleNamespace
+
+os.environ.setdefault(
+    "SUROGATES_AUTH_JWT_SECRET", "test-secret-key-for-tests-0123456789"
+)
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from surogates.api.routes import website
+from surogates.channels.website_session import (
+    COOKIE_NAME,
+    create_website_session_token,
+    generate_csrf_token,
+)
+from surogates.session.store import SessionNotFoundError
+
+pytestmark = pytest.mark.asyncio
+
+_KEY = "surg_wk_test0000000000000000"
+_ORIGIN = "https://acme.com"
+
+
+class _FakeCache:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def get(self, key):
+        return self._rows.get(key)
+
+
+class _Storage:
+    async def create_bucket(self, bucket):
+        return None
+
+    def resolve_workspace_path(self, bucket, session_id):
+        return f"/bucket-root/{bucket}/{session_id}"
+
+
+class _Store:
+    def __init__(self, sessions=None):
+        self.sessions = sessions or {}
+        self.created: list[dict] = []
+
+    async def get_session(self, session_id):
+        try:
+            return self.sessions[session_id]
+        except KeyError:
+            raise SessionNotFoundError(f"session {session_id} not found")
+
+    async def create_session(self, **kwargs):
+        self.created.append(kwargs)
+        return SimpleNamespace(
+            id=kwargs["session_id"],
+            agent_id=kwargs["agent_id"],
+            channel=kwargs["channel"],
+            status="active",
+            config=kwargs["config"],
+        )
+
+    async def update_session_status(self, session_id, status):
+        return None
+
+
+def _settings():
+    return SimpleNamespace(
+        website=SimpleNamespace(
+            enabled=True,
+            allowed_origins=_ORIGIN,
+            publishable_key="",
+            session_message_cap=0,
+        ),
+        storage=SimpleNamespace(bucket="bkt"),
+        llm=SimpleNamespace(model="m"),
+    )
+
+
+def _app(org_id, store, *, multi_session):
+    config = {}
+    if multi_session is not None:
+        config["multi_session"] = multi_session
+    rows = {
+        f"website:{_KEY}": {
+            "agent_id": "hero-agent",
+            "org_id": str(org_id),
+            "api_web_url": _ORIGIN,
+            "config": config,
+        }
+    }
+    app = FastAPI()
+    app.include_router(website.router, prefix="/v1")
+    app.state.settings = _settings()
+    app.state.channel_routing_cache = _FakeCache(rows)
+    app.state.session_store = store
+    app.state.storage = _Storage()
+    return app
+
+
+def _cookie(session_id, org_id, *, origin=_ORIGIN, key=_KEY):
+    return create_website_session_token(
+        session_id=session_id,
+        org_id=org_id,
+        origin=origin,
+        csrf_token=generate_csrf_token(),
+        channel_identifier=key,
+    )
+
+
+def _live_session(session_id, *, status="active", agent_id="hero-agent"):
+    return SimpleNamespace(
+        id=session_id,
+        agent_id=agent_id,
+        channel="website",
+        status=status,
+        config={},
+    )
+
+
+async def _post(app, *, cookie=None):
+    transport = ASGITransport(app=app)
+    cookies = {COOKIE_NAME: cookie} if cookie else None
+    async with AsyncClient(
+        transport=transport, base_url="https://widget", cookies=cookies,
+    ) as c:
+        return await c.post(
+            "/v1/website/sessions",
+            headers={"Authorization": f"Bearer {_KEY}", "Origin": _ORIGIN},
+        )
+
+
+async def test_single_session_reuses_cookie_bound_session():
+    org_id, session_id = uuid.uuid4(), uuid.uuid4()
+    store = _Store({session_id: _live_session(session_id)})
+    app = _app(org_id, store, multi_session=False)
+
+    r = await _post(app, cookie=_cookie(session_id, org_id))
+
+    assert r.status_code == 200
+    assert r.json()["session_id"] == str(session_id)
+    assert store.created == []
+    # A fresh cookie + CSRF token are minted for the reused session.
+    assert COOKIE_NAME in r.cookies
+    assert r.json()["csrf_token"]
+
+
+async def test_single_session_without_cookie_creates():
+    org_id = uuid.uuid4()
+    store = _Store()
+    app = _app(org_id, store, multi_session=False)
+
+    r = await _post(app)
+
+    assert r.status_code == 201
+    assert len(store.created) == 1
+
+
+async def test_single_session_ignores_cookie_from_other_key():
+    org_id, session_id = uuid.uuid4(), uuid.uuid4()
+    store = _Store({session_id: _live_session(session_id)})
+    app = _app(org_id, store, multi_session=False)
+
+    r = await _post(
+        app,
+        cookie=_cookie(session_id, org_id, key="surg_wk_other000000000000000"),
+    )
+
+    assert r.status_code == 201
+    assert len(store.created) == 1
+    assert r.json()["session_id"] != str(session_id)
+
+
+async def test_single_session_skips_dead_session():
+    org_id, session_id = uuid.uuid4(), uuid.uuid4()
+    store = _Store({session_id: _live_session(session_id, status="failed")})
+    app = _app(org_id, store, multi_session=False)
+
+    r = await _post(app, cookie=_cookie(session_id, org_id))
+
+    assert r.status_code == 201
+    assert len(store.created) == 1
+
+
+async def test_single_session_reuses_completed_session():
+    org_id, session_id = uuid.uuid4(), uuid.uuid4()
+    store = _Store({session_id: _live_session(session_id, status="completed")})
+    app = _app(org_id, store, multi_session=False)
+
+    r = await _post(app, cookie=_cookie(session_id, org_id))
+
+    assert r.status_code == 200
+    assert r.json()["session_id"] == str(session_id)
+    assert store.created == []
+
+
+async def test_multi_session_on_always_creates():
+    org_id, session_id = uuid.uuid4(), uuid.uuid4()
+    store = _Store({session_id: _live_session(session_id)})
+    app = _app(org_id, store, multi_session=None)
+
+    r = await _post(app, cookie=_cookie(session_id, org_id))
+
+    assert r.status_code == 201
+    assert len(store.created) == 1

--- a/tests/runtime/test_resolver_projection.py
+++ b/tests/runtime/test_resolver_projection.py
@@ -197,3 +197,19 @@ def test_commerce_empty_strings_normalise_to_safe_defaults():
     ctx = build_agent_runtime_context(payload)
     assert ctx.commerce_mode == "free"
     assert ctx.commerce_buy_url is None
+
+
+def test_multi_session_defaults_true_when_absent():
+    from surogates.runtime import build_agent_runtime_context
+
+    ctx = build_agent_runtime_context(_minimum_payload())
+    assert ctx.multi_session is True
+
+
+def test_multi_session_projects_false():
+    from surogates.runtime import build_agent_runtime_context
+
+    payload = _minimum_payload()
+    payload["multi_session"] = False
+    ctx = build_agent_runtime_context(payload)
+    assert ctx.multi_session is False

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -97,6 +97,45 @@ class TestBuildSessionKey:
         # Threads are always appended.
         assert key == "agent:slack:dm:C1:T1"
 
+    def test_single_session_collapses_thread(self):
+        source = SessionSource(
+            platform="slack",
+            chat_id="C1",
+            chat_type="dm",
+            user_id="U1",
+            thread_id="T1",
+        )
+        key = build_session_key(source, single_session=True)
+        # "multi session" off: every thread continues the same conversation.
+        assert key == "agent:slack:dm:C1"
+
+    def test_single_session_overrides_per_user_groups(self):
+        source = SessionSource(
+            platform="telegram",
+            chat_id="CHAT_ID",
+            chat_type="group",
+            user_id="USER1",
+            thread_id="THREAD_99",
+        )
+        key = build_session_key(
+            source, per_user_groups=True, single_session=True,
+        )
+        # One shared session per chat: no user split, no thread suffix.
+        assert key == "agent:telegram:group:CHAT_ID"
+
+    def test_single_session_keeps_dm_shape(self):
+        source = SessionSource(
+            platform="slack",
+            chat_id="C123",
+            chat_type="dm",
+            user_id="U456",
+        )
+        assert (
+            build_session_key(source, single_session=True)
+            == build_session_key(source)
+            == "agent:slack:dm:C123"
+        )
+
 
 class TestSessionSourceImmutability:
     """SessionSource is frozen."""

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -109,7 +109,7 @@ class TestBuildSessionKey:
         # "multi session" off: every thread continues the same conversation.
         assert key == "agent:slack:dm:C1"
 
-    def test_single_session_overrides_per_user_groups(self):
+    def test_single_session_keeps_per_user_groups_split(self):
         source = SessionSource(
             platform="telegram",
             chat_id="CHAT_ID",
@@ -120,8 +120,9 @@ class TestBuildSessionKey:
         key = build_session_key(
             source, per_user_groups=True, single_session=True,
         )
-        # One shared session per chat: no user split, no thread suffix.
-        assert key == "agent:telegram:group:CHAT_ID"
+        # Thread suffix folds, but the per-user split survives — merging
+        # users would share one conversation context across people.
+        assert key == "agent:telegram:group:CHAT_ID:USER1"
 
     def test_single_session_keeps_dm_shape(self):
         source = SessionSource(

--- a/tests/test_chat_attachments.py
+++ b/tests/test_chat_attachments.py
@@ -307,7 +307,7 @@ def patched_send_message(monkeypatch):
             lambda _req: _FakeStorage(workspace_files),
         )
 
-        async def _get_bucket_and_root(_store, _sid, _tenant):
+        async def _get_bucket_and_root(_request, _store, _sid, _tenant):
             return session, "test-bucket", "root/"
 
         monkeypatch.setattr(

--- a/tests/test_session_multi_session.py
+++ b/tests/test_session_multi_session.py
@@ -38,10 +38,15 @@ class _Store:
         self.created: list[dict] = []
         self.reusable = reusable
         self.reusable_lookups: list[dict] = []
+        self.list_calls: list[dict] = []
 
     async def get_reusable_channel_session(self, **kwargs):
         self.reusable_lookups.append(kwargs)
         return self.reusable
+
+    async def list_sessions(self, **kwargs):
+        self.list_calls.append(kwargs)
+        return []
 
     async def create_session(self, **kwargs):
         self.created.append(kwargs)
@@ -137,7 +142,7 @@ async def test_single_session_returns_existing_web_session_with_200():
     ]
 
 
-async def test_single_session_creates_when_none_reusable():
+async def test_single_session_creates_canonical_marked_session():
     org_id, user_id = uuid4(), uuid4()
     store = _Store(reusable=None)
 
@@ -151,6 +156,9 @@ async def test_single_session_creates_when_none_reusable():
 
     assert len(store.created) == 1
     assert store.created[0]["channel"] == "web"
+    # The fresh session is stamped as the canonical single-session
+    # conversation so every later create/list/access resolves to it.
+    assert store.created[0]["config"]["single_session"] is True
     assert session.channel == "web"
 
 
@@ -172,4 +180,94 @@ async def test_multi_session_on_always_creates():
 
     assert store.reusable_lookups == []
     assert len(store.created) == 1
+    # No marker on multi-session creates.
+    assert "single_session" not in store.created[0]["config"]
     assert session.id != existing.id
+
+
+async def test_list_hides_multi_era_sessions_when_capability_off():
+    org_id, user_id = uuid4(), uuid4()
+    store = _Store()
+
+    await sessions_route.list_sessions(
+        _request(store, _Storage()),
+        _tenant(org_id, user_id),
+        _runtime("support-bot", org_id, multi_session=False),
+    )
+    await sessions_route.list_sessions(
+        _request(store, _Storage()),
+        _tenant(org_id, user_id),
+        _runtime("support-bot", org_id, multi_session=True),
+    )
+
+    assert store.list_calls[0]["single_session_only"] is True
+    assert store.list_calls[1]["single_session_only"] is False
+
+
+def _session(channel="web", *, parent_id=None, config=None):
+    return SimpleNamespace(
+        id=uuid4(),
+        org_id=uuid4(),
+        agent_id="support-bot",
+        status="active",
+        channel=channel,
+        parent_id=parent_id,
+        config=config or {},
+    )
+
+
+class _GetStore:
+    def __init__(self, session):
+        self._session = session
+
+    async def get_session(self, session_id):
+        return self._session
+
+
+def _owning_tenant(session):
+    tenant = SimpleNamespace(org_id=session.org_id)
+    tenant.owns_session = lambda org_id, session_id: True
+    return tenant
+
+
+def _get_request(store):
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(session_store=store)),
+    )
+
+
+async def test_access_block_hides_unmarked_web_session_when_off():
+    from fastapi import HTTPException
+
+    session = _session("web")
+    with __import__("pytest").raises(HTTPException) as exc:
+        await sessions_route._get_session_for_tenant(
+            _get_request(_GetStore(session)), session.id,
+            _owning_tenant(session), "support-bot",
+            multi_session=False,
+        )
+    assert exc.value.status_code == 404
+
+
+async def test_access_allows_canonical_and_children_and_other_channels():
+    canonical = _session("web", config={"single_session": True})
+    child = _session("web", parent_id=uuid4())
+    api_session = _session("api")
+
+    for session in (canonical, child, api_session):
+        got = await sessions_route._get_session_for_tenant(
+            _get_request(_GetStore(session)), session.id,
+            _owning_tenant(session), "support-bot",
+            multi_session=False,
+        )
+        assert got is session
+
+
+async def test_access_unrestricted_when_capability_on():
+    session = _session("web")  # unmarked multi-era session
+    got = await sessions_route._get_session_for_tenant(
+        _get_request(_GetStore(session)), session.id,
+        _owning_tenant(session), "support-bot",
+        multi_session=True,
+    )
+    assert got is session

--- a/tests/test_session_multi_session.py
+++ b/tests/test_session_multi_session.py
@@ -162,6 +162,23 @@ async def test_single_session_creates_canonical_marked_session():
     assert session.channel == "web"
 
 
+async def test_client_supplied_marker_is_stripped():
+    org_id, user_id = uuid4(), uuid4()
+    store = _Store(reusable=None)
+
+    await sessions_route.create_session(
+        sessions_route.CreateSessionRequest(config={"single_session": True}),
+        _request(store, _Storage()),
+        Response(),
+        _tenant(org_id, user_id),
+        _runtime("support-bot", org_id, multi_session=True),
+    )
+
+    # The canonical stamp is server-owned: a pre-stamped session created
+    # while multi-session is on would bypass a later lockdown.
+    assert "single_session" not in store.created[0]["config"]
+
+
 async def test_multi_session_on_always_creates():
     org_id, user_id = uuid4(), uuid4()
     existing = SimpleNamespace(

--- a/tests/test_session_multi_session.py
+++ b/tests/test_session_multi_session.py
@@ -253,15 +253,18 @@ def _get_request(store):
     )
 
 
+def _fake_runtime(multi_session):
+    return SimpleNamespace(agent_id="support-bot", multi_session=multi_session)
+
+
 async def test_access_block_hides_unmarked_web_session_when_off():
     from fastapi import HTTPException
 
     session = _session("web")
-    with __import__("pytest").raises(HTTPException) as exc:
+    with pytest.raises(HTTPException) as exc:
         await sessions_route._get_session_for_tenant(
             _get_request(_GetStore(session)), session.id,
-            _owning_tenant(session), "support-bot",
-            multi_session=False,
+            _owning_tenant(session), _fake_runtime(multi_session=False),
         )
     assert exc.value.status_code == 404
 
@@ -274,8 +277,7 @@ async def test_access_allows_canonical_and_children_and_other_channels():
     for session in (canonical, child, api_session):
         got = await sessions_route._get_session_for_tenant(
             _get_request(_GetStore(session)), session.id,
-            _owning_tenant(session), "support-bot",
-            multi_session=False,
+            _owning_tenant(session), _fake_runtime(multi_session=False),
         )
         assert got is session
 
@@ -284,7 +286,6 @@ async def test_access_unrestricted_when_capability_on():
     session = _session("web")  # unmarked multi-era session
     got = await sessions_route._get_session_for_tenant(
         _get_request(_GetStore(session)), session.id,
-        _owning_tenant(session), "support-bot",
-        multi_session=True,
+        _owning_tenant(session), _fake_runtime(multi_session=True),
     )
     assert got is session

--- a/tests/test_session_multi_session.py
+++ b/tests/test_session_multi_session.py
@@ -1,0 +1,175 @@
+"""Web-channel single-session enforcement.
+
+With the agent's "multi session" capability off, ``POST /v1/sessions``
+returns the user's newest reusable web session (HTTP 200) instead of
+creating another; a user with no reusable session still gets a fresh
+one.  The api channel and the capability-on default keep today's
+always-create behavior.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import Response
+
+from surogates.api.routes import sessions as sessions_route
+from surogates.config import Settings
+from surogates.tenant.context import TenantContext
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Storage:
+    def __init__(self) -> None:
+        self.created_buckets: list[str] = []
+
+    async def create_bucket(self, bucket: str) -> None:
+        self.created_buckets.append(bucket)
+
+    def resolve_workspace_path(self, bucket: str, session_id: UUID | str) -> str:
+        return f"/bucket-root/{bucket}/{session_id}"
+
+
+class _Store:
+    def __init__(self, *, reusable=None) -> None:
+        self.created: list[dict] = []
+        self.reusable = reusable
+        self.reusable_lookups: list[dict] = []
+
+    async def get_reusable_channel_session(self, **kwargs):
+        self.reusable_lookups.append(kwargs)
+        return self.reusable
+
+    async def create_session(self, **kwargs):
+        self.created.append(kwargs)
+        return SimpleNamespace(
+            id=kwargs["session_id"],
+            org_id=kwargs["org_id"],
+            agent_id=kwargs["agent_id"],
+            status="active",
+            channel=kwargs["channel"],
+            model=kwargs["model"],
+            config=kwargs["config"],
+        )
+
+    async def emit_event(self, session_id, event_type, data):
+        return 1
+
+    async def update_session_status(self, session_id, status):
+        return None
+
+
+def _runtime(agent_id: str, org_id: UUID, *, multi_session: bool):
+    from surogates.runtime import build_agent_runtime_context
+
+    return build_agent_runtime_context(
+        {
+            "agent_id": agent_id,
+            "org_id": str(org_id),
+            "project_id": "test-project",
+            "enabled": True,
+            "version": 1,
+            "storage_key_prefix": "",
+            "multi_session": multi_session,
+        }
+    )
+
+
+def _tenant(org_id: UUID, user_id: UUID | None) -> TenantContext:
+    return TenantContext(
+        org_id=org_id,
+        user_id=user_id,
+        org_config={},
+        user_preferences={},
+        permissions=frozenset({"sessions:read", "sessions:write"}),
+        asset_root="/tmp/assets",
+        service_account_id=None if user_id is not None else uuid4(),
+    )
+
+
+def _request(store: _Store, storage: _Storage):
+    settings = Settings()
+    settings.llm.model = "gpt-test"
+    settings.storage.bucket = "ops-agent-bucket"
+    return SimpleNamespace(
+        url=SimpleNamespace(path="/v1/sessions"),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                settings=settings,
+                session_store=store,
+                storage=storage,
+                redis=None,
+            ),
+        ),
+    )
+
+
+async def test_single_session_returns_existing_web_session_with_200():
+    org_id, user_id = uuid4(), uuid4()
+    existing = SimpleNamespace(
+        id=uuid4(), org_id=org_id, agent_id="support-bot",
+        status="active", channel="web", model="gpt-test", config={},
+    )
+    store = _Store(reusable=existing)
+    response = Response()
+
+    session = await sessions_route.create_session(
+        sessions_route.CreateSessionRequest(),
+        _request(store, _Storage()),
+        response,
+        _tenant(org_id, user_id),
+        _runtime("support-bot", org_id, multi_session=False),
+    )
+
+    assert session.id == existing.id
+    assert store.created == []
+    assert response.status_code == 200
+    assert store.reusable_lookups == [
+        {
+            "org_id": org_id,
+            "user_id": user_id,
+            "agent_id": "support-bot",
+            "channel": "web",
+        }
+    ]
+
+
+async def test_single_session_creates_when_none_reusable():
+    org_id, user_id = uuid4(), uuid4()
+    store = _Store(reusable=None)
+
+    session = await sessions_route.create_session(
+        sessions_route.CreateSessionRequest(),
+        _request(store, _Storage()),
+        Response(),
+        _tenant(org_id, user_id),
+        _runtime("support-bot", org_id, multi_session=False),
+    )
+
+    assert len(store.created) == 1
+    assert store.created[0]["channel"] == "web"
+    assert session.channel == "web"
+
+
+async def test_multi_session_on_always_creates():
+    org_id, user_id = uuid4(), uuid4()
+    existing = SimpleNamespace(
+        id=uuid4(), org_id=org_id, agent_id="support-bot",
+        status="active", channel="web", model="gpt-test", config={},
+    )
+    store = _Store(reusable=existing)
+
+    session = await sessions_route.create_session(
+        sessions_route.CreateSessionRequest(),
+        _request(store, _Storage()),
+        Response(),
+        _tenant(org_id, user_id),
+        _runtime("support-bot", org_id, multi_session=True),
+    )
+
+    assert store.reusable_lookups == []
+    assert len(store.created) == 1
+    assert session.id != existing.id

--- a/tests/test_session_rename.py
+++ b/tests/test_session_rename.py
@@ -119,7 +119,9 @@ def patched_update_session(monkeypatch):
             service_account_id=None,
             session_scope_id=None,
         )
-        agent_runtime = SimpleNamespace(agent_id=target.agent_id)
+        agent_runtime = SimpleNamespace(
+            agent_id=target.agent_id, multi_session=True,
+        )
 
         response = await update_session(
             session_id=target.id,

--- a/tests/test_session_workspace_storage.py
+++ b/tests/test_session_workspace_storage.py
@@ -7,7 +7,7 @@ from io import BytesIO
 from uuid import UUID, uuid4
 
 import pytest
-from fastapi import BackgroundTasks, UploadFile
+from fastapi import BackgroundTasks, Response, UploadFile
 
 from surogates.api.routes import workspace as workspace_route
 from surogates.api.routes import prompts as prompts_route
@@ -243,6 +243,7 @@ async def test_create_web_session_uses_agent_bucket_and_session_path():
     response = await sessions_route.create_session(
         sessions_route.CreateSessionRequest(),
         request,
+        Response(),
         _tenant(org_id, user_id),
         _runtime(store.agent_id, org_id),
     )

--- a/tests/test_user_message_metadata.py
+++ b/tests/test_user_message_metadata.py
@@ -136,7 +136,9 @@ def patched_send_message(monkeypatch):
             service_account_id=None,
             session_scope_id=None,
         )
-        agent_runtime = SimpleNamespace(agent_id=session.agent_id)
+        agent_runtime = SimpleNamespace(
+            agent_id=session.agent_id, multi_session=True,
+        )
 
         response = await send_message(
             session_id=session.id,

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -170,6 +170,10 @@ export interface AuthConfigResponse {
   // The agent this deployment serves, echoed from the runtime config.
   // Absent on older backends — consumers treat "absent" as null.
   agent_id?: string;
+  // "Multi session" capability. False pins each user to one session per
+  // channel (no "New chat"). Absent on a fetch error or an older backend
+  // — consumers treat "absent" as "unknown" and fail open (multi on).
+  multi_session?: boolean;
 }
 
 /** Fetch the runtime auth config. Falls back to "disabled" on any error

--- a/web/src/components/navbar.tsx
+++ b/web/src/components/navbar.tsx
@@ -54,6 +54,9 @@ export function SessionSidebar() {
   const sessionsLoading = useAppStore((s) => s.sessionsLoading);
   const user = useAppStore((s) => s.user);
   const slashCommands = useAppStore((s) => s.slashCommands);
+  // "Multi session" off pins each user to one conversation: no "New
+  // chat", no session picker.  ``null`` (unknown) fails open.
+  const singleSession = useAppStore((s) => s.multiSession) === false;
   const { theme, setTheme } = useTheme();
   const { unreadCount } = useInboxUnreadCount(surogatesWebChatAdapter);
   const viewMode = useChatViewMode();
@@ -120,18 +123,20 @@ export function SessionSidebar() {
           "p-1.5 lg:p-3 group-data-[mode=sheet]:p-3",
         )}
       >
-        <Button
-          variant="outline"
-          onClick={handleNewSession}
-          className={cn(
-            "w-full gap-2 min-h-11 lg:min-h-9 group-data-[mode=sheet]:min-h-11",
-            "justify-center px-0 lg:justify-start lg:px-3",
-            "group-data-[mode=sheet]:justify-start group-data-[mode=sheet]:px-3",
-          )}
-        >
-          <PlusIcon className="w-4 h-4" />
-          <span className={showExpandedInline}>New chat</span>
-        </Button>
+        {!singleSession && (
+          <Button
+            variant="outline"
+            onClick={handleNewSession}
+            className={cn(
+              "w-full gap-2 min-h-11 lg:min-h-9 group-data-[mode=sheet]:min-h-11",
+              "justify-center px-0 lg:justify-start lg:px-3",
+              "group-data-[mode=sheet]:justify-start group-data-[mode=sheet]:px-3",
+            )}
+          >
+            <PlusIcon className="w-4 h-4" />
+            <span className={showExpandedInline}>New chat</span>
+          </Button>
+        )}
         {!isSimpleMode && (
           <Button
             variant="ghost"
@@ -186,8 +191,11 @@ export function SessionSidebar() {
         </Button>
       </div>
 
-      {/* Sessions list */}
+      {/* Sessions list — hidden entirely in single-session mode: the one
+          conversation is always active, so a picker only invites hopping
+          back into pre-restriction sessions. */}
       <div className="min-h-0 flex-1 flex flex-col">
+        {!singleSession && (
         <div className="min-h-0 flex-1 overflow-y-auto py-1">
           {/* Compact (md only, not sheet): icon-only list */}
           <div className={hideOnExpanded}>
@@ -230,6 +238,7 @@ export function SessionSidebar() {
             )}
           </div>
         </div>
+        )}
 
         {/* Missions + Scheduled work — expanded only */}
         <div

--- a/web/src/components/navbar.tsx
+++ b/web/src/components/navbar.tsx
@@ -35,14 +35,10 @@ import { slashCommandEnabled } from "@/stores/capabilities-slice";
 //   - phone sheet   : `data-mode="sheet"` always renders expanded.
 // We use Tailwind v4's `group-data-[mode=sheet]:*` variants together with
 // `lg:*` to flip between compact (icons only) and expanded (full content).
-const showExpanded =
-  "hidden lg:flex group-data-[mode=sheet]:flex";
-const showExpandedInline =
-  "hidden lg:inline group-data-[mode=sheet]:inline";
-const showExpandedBlock =
-  "hidden lg:block group-data-[mode=sheet]:block";
-const hideOnExpanded =
-  "block lg:hidden group-data-[mode=sheet]:hidden";
+const showExpanded = "hidden lg:flex group-data-[mode=sheet]:flex";
+const showExpandedInline = "hidden lg:inline group-data-[mode=sheet]:inline";
+const showExpandedBlock = "hidden lg:block group-data-[mode=sheet]:block";
+const hideOnExpanded = "block lg:hidden group-data-[mode=sheet]:hidden";
 
 export function SessionSidebar() {
   const navigate = useNavigate();
@@ -196,48 +192,48 @@ export function SessionSidebar() {
           back into pre-restriction sessions. */}
       <div className="min-h-0 flex-1 flex flex-col">
         {!singleSession && (
-        <div className="min-h-0 flex-1 overflow-y-auto py-1">
-          {/* Compact (md only, not sheet): icon-only list */}
-          <div className={hideOnExpanded}>
-            {sessions.map((session) => {
-              const isActive = session.id === activeSessionId;
-              return (
-                <button
-                  key={session.id}
-                  type="button"
-                  onClick={() => handleSelectSession(session.id)}
-                  aria-label={session.title ?? "New session"}
-                  className={cn(
-                    "flex items-center justify-center w-full py-2 transition-colors border-l-2",
-                    isActive
-                      ? "bg-line text-foreground border-l-primary"
-                      : "bg-transparent text-subtle hover:bg-input hover:text-foreground border-l-transparent",
-                  )}
-                >
-                  <MessageSquareIcon className="w-4 h-4 shrink-0" />
-                </button>
-              );
-            })}
-          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto py-1">
+            {/* Compact (md only, not sheet): icon-only list */}
+            <div className={hideOnExpanded}>
+              {sessions.map((session) => {
+                const isActive = session.id === activeSessionId;
+                return (
+                  <button
+                    key={session.id}
+                    type="button"
+                    onClick={() => handleSelectSession(session.id)}
+                    aria-label={session.title ?? "New session"}
+                    className={cn(
+                      "flex items-center justify-center w-full py-2 transition-colors border-l-2",
+                      isActive
+                        ? "bg-line text-foreground border-l-primary"
+                        : "bg-transparent text-subtle hover:bg-input hover:text-foreground border-l-transparent",
+                    )}
+                  >
+                    <MessageSquareIcon className="w-4 h-4 shrink-0" />
+                  </button>
+                );
+              })}
+            </div>
 
-          {/* Expanded (lg+ or sheet): SessionTreePanel */}
-          <div className={showExpandedBlock}>
-            <SessionTreePanel
-              adapter={surogatesWebChatAdapter}
-              loadList
-              sessionId={activeSessionId ?? undefined}
-              activeSessionId={activeSessionId ?? undefined}
-              hideHeader
-              onSessionSelect={handleSelectSession}
-              onSessionDelete={handleSessionDeleted}
-            />
-            {!sessionsLoading && sessions.length === 0 && (
-              <div className="px-4 py-8 text-center text-sm text-faint">
-                No sessions yet
-              </div>
-            )}
+            {/* Expanded (lg+ or sheet): SessionTreePanel */}
+            <div className={showExpandedBlock}>
+              <SessionTreePanel
+                adapter={surogatesWebChatAdapter}
+                loadList
+                sessionId={activeSessionId ?? undefined}
+                activeSessionId={activeSessionId ?? undefined}
+                hideHeader
+                onSessionSelect={handleSelectSession}
+                onSessionDelete={handleSessionDeleted}
+              />
+              {!sessionsLoading && sessions.length === 0 && (
+                <div className="px-4 py-8 text-center text-sm text-faint">
+                  No sessions yet
+                </div>
+              )}
+            </div>
           </div>
-        </div>
         )}
 
         {/* Missions + Scheduled work — expanded only */}

--- a/web/src/features/chat/chat-page.tsx
+++ b/web/src/features/chat/chat-page.tsx
@@ -80,6 +80,9 @@ export function ChatPage() {
   useEffect(() => {
     if (multiSession !== false || sessionsLoading) return;
     if (activeSessionId || params.sessionId) return;
+    // The list is already server-filtered to canonical roots (archived
+    // and children excluded); only "failed" needs re-excluding to
+    // mirror the server's create-time reuse pick.
     const pinned = sessions.find((s) => s.status !== "failed");
     if (pinned) {
       setActiveSession(pinned.id);

--- a/web/src/features/chat/chat-page.tsx
+++ b/web/src/features/chat/chat-page.tsx
@@ -37,6 +37,8 @@ export function ChatPage() {
   const upsertSession = useAppStore((s) => s.upsertSession);
   const fetchCapabilities = useAppStore((s) => s.fetchCapabilities);
   const slashCommands = useAppStore((s) => s.slashCommands);
+  const multiSession = useAppStore((s) => s.multiSession);
+  const sessions = useAppStore((s) => s.sessions);
 
   // Load initial data on mount
   useEffect(() => {
@@ -67,6 +69,32 @@ export function ChatPage() {
     chatRouteState.nextActiveSessionId,
     chatRouteState.redirectTo,
     activeSessionId,
+    setActiveSession,
+    navigate,
+  ]);
+
+  // "Multi session" off pins the user to their single conversation: when
+  // nothing is selected, adopt the newest usable session so a reload or a
+  // bare /chat lands back in it instead of an empty composer.  The list is
+  // newest-first, matching the server's reuse pick on create.
+  useEffect(() => {
+    if (multiSession !== false || sessionsLoading) return;
+    if (activeSessionId || params.sessionId) return;
+    const pinned = sessions.find((s) => s.status !== "failed");
+    if (pinned) {
+      setActiveSession(pinned.id);
+      void navigate({
+        to: "/chat/$sessionId",
+        params: { sessionId: pinned.id },
+        replace: true,
+      });
+    }
+  }, [
+    multiSession,
+    sessionsLoading,
+    activeSessionId,
+    params.sessionId,
+    sessions,
     setActiveSession,
     navigate,
   ]);

--- a/web/src/stores/capabilities-slice.ts
+++ b/web/src/stores/capabilities-slice.ts
@@ -16,6 +16,9 @@ import { fetchAuthConfig } from "@/api/auth";
 export type CapabilitiesSlice = {
   slashCommands: string[] | null;
   agentId: string | null;
+  // "Multi session" capability. ``null`` = unknown (fail open — multi on);
+  // ``false`` pins each user to one session per channel.
+  multiSession: boolean | null;
 
   fetchCapabilities: () => Promise<void>;
 };
@@ -28,12 +31,17 @@ export const createCapabilitiesSlice: StateCreator<
 > = (set) => ({
   slashCommands: null,
   agentId: null,
+  multiSession: null,
 
   fetchCapabilities: async () => {
     // ``fetchAuthConfig`` already degrades to a safe fallback on error
     // (no ``slash_commands`` / ``agent_id`` fields), which map to ``null``.
     const config = await fetchAuthConfig();
-    set({ slashCommands: config.slash_commands ?? null, agentId: config.agent_id ?? null });
+    set({
+      slashCommands: config.slash_commands ?? null,
+      agentId: config.agent_id ?? null,
+      multiSession: config.multi_session ?? null,
+    });
   },
 });
 


### PR DESCRIPTION
## Summary

Runtime side of the new **Multi Session** agent capability (Studio → Configuration → Capabilities, ops PR: invergent-ai/surogate-ops — feat/multi-session-capability). Default **on** (today's behavior everywhere). When switched **off**, every end-user gets exactly one dedicated conversation per channel:

- **Web**: `POST /v1/sessions` returns the user's canonical session (200) instead of creating; the first message after the flip creates it, stamped `config.single_session` (server-owned — client-supplied stamps are stripped). Listings show only the canonical root + its subtree; every session-scoped surface (CRUD, events SSE/poll, workspace, artifacts, board, channel files, feedback, input answers) 404s hidden multi-era sessions via a shared `require_session_visible` guard. Turning the capability back on restores everything untouched; off again returns to the same conversation.
- **Website widget**: re-bootstrap reuses the visitor's cookie-bound canonical session (fresh CSRF + cookie), absorbs a `firebase_id_token` so paid-agent sign-in still pins the buyer, and refuses capped-out or multi-era sessions (fresh create instead).
- **Slack/Telegram**: thread suffixes fold into one conversation per chat (`per_user_groups` still splits per user — merging users would share context across people). Reply destinations track the latest inbound thread via the channel get-or-create's conditional backfill + a fresh read at outbox enqueue, so replies follow the conversation instead of pinning to the first-ever thread.
- **API/service accounts**: exempt by design (programmatic integrations); Studio chat is gated ops-side.

The SPA reads the flag from `/auth/config`: "New chat" and the session picker disappear, and a bare `/chat` auto-pins the canonical conversation. Unknown/absent flag fails open.

## Notes

- No DB migration — marker and capability ride existing JSONB config and the runtime-config payload; all wire fields are default-tolerant in both directions (old↔new ops/runtime mixes fail open to multi-session on).
- The visibility guard resolves the capability by the session's own agent id with a bounded 30s memo (polling routes stay off the 1s runtime-config TTL); the primary create/list/access gates resolve fresh per request.

## Testing

`pytest tests/ --ignore=tests/integration`: 4462 passed, 35 pre-existing failures (identical set on master — browser_image/browser_tool_storage/code_command_*/expert_routing/iteration_summary/loop_turn_id/steer_loop/title_generator/worker_channel_token). New coverage: create/reuse/marker semantics, listing filter, visibility guard + access block, website reuse (cookie binding, commerce token, message cap, multi-era rejection), session-key folding, auth-config projection, resolver defaults. `web/` tsc clean.