### PR TITLE
feat: operator-only user_reports tool

### DIFF
--- a/surogates/db/ops_engine.py
+++ b/surogates/db/ops_engine.py
@@ -90,3 +90,30 @@ def get_ops_session_factory() -> Optional[async_sessionmaker[AsyncSession]]:
     KB-related work entirely rather than fail at session-open time.
     """
     return _session_factory
+
+
+def ensure_ops_session_factory() -> Optional[async_sessionmaker[AsyncSession]]:
+    """Session factory with a lazy-init fallback for tool handlers.
+
+    Worker startup calls init_ops_engine(), but in some concurrency
+    configurations a tool handler may run in a context where the
+    module-global _session_factory was not yet set (e.g. import-order
+    timing in the asyncio task pool). Falling back to a fresh init
+    from Settings() makes handlers robust — at worst we pay a one-time
+    engine setup cost. None still means "ops DB not configured".
+    """
+    factory = get_ops_session_factory()
+    if factory is not None:
+        return factory
+
+    from surogates.config import Settings
+
+    settings = Settings()
+    if not settings.ops_db.url:
+        return None
+
+    return init_ops_engine(
+        settings.ops_db.url,
+        pool_size=settings.ops_db.pool_size,
+        pool_overflow=settings.ops_db.pool_overflow,
+    )

--- a/surogates/db/ops_models.py
+++ b/surogates/db/ops_models.py
@@ -27,6 +27,20 @@ class OpsBase(DeclarativeBase):
     pass
 
 
+class OpsAgent(OpsBase):
+    """Mirror of surogate-ops ``agents`` table.
+
+    Stripped to what the user_reports tool needs: identity plus the
+    cached cross-user overview report the ops Users page maintains.
+    """
+    __tablename__ = "agents"
+
+    id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
+    cohort_report: Mapped[Optional[dict]] = mapped_column(
+        sa.JSON, nullable=True,
+    )
+
+
 class OpsKnowledgeBase(OpsBase):
     """Mirror of surogate-ops ``knowledge_bases`` table.
 

--- a/surogates/db/ops_models.py
+++ b/surogates/db/ops_models.py
@@ -1,9 +1,10 @@
 """Minimal read-only models for ops DB tables we access at runtime.
 
 These mirror the writer-side schema in surogate-ops but expose only
-the columns the KB tools need. They're intentionally lightweight --
-no relationships, no event hooks, no validators -- because we just
-read rows and shape the output for the LLM.
+the columns runtime tools need (KB tools, user_reports). They're
+intentionally lightweight -- no relationships, no event hooks, no
+validators -- because we just read rows and shape the output for the
+LLM.
 
 Schema definitions of record live in surogate-ops; this module is
 purely an access pattern.

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -1610,7 +1610,13 @@ class AgentHarness(
             ):
                 if tool_filter is None:
                     tool_filter = set(self._tools.tool_names)
-                tool_filter = tool_filter - {"user_reports"}
+                # Gate by toolset (same mechanism as the worker's prompt
+                # fragments) so future tools in the group stay covered.
+                tool_filter = tool_filter - {
+                    e.name
+                    for e in self._tools.get_all()
+                    if e.toolset == "user_reports"
+                }
 
             tool_schemas = filter_schemas_for_tenant(
                 self._tools.get_schemas(names=tool_filter),

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -1598,6 +1598,20 @@ class AgentHarness(
             # - Sessions with explicit allowed_tools get exactly those.
             tool_filter = self._tool_filter_for_session(session)
 
+            # user_reports exposes other end-users' data — its schema is
+            # only offered to operator (Studio ops-chat) sessions.  The
+            # cheap config-only owner-scope check suffices here because
+            # the handler independently re-proves the full DB-backed
+            # predicate before returning anything.
+            from surogates.tools.owner_scope import owner_scope_config_ok
+
+            if not owner_scope_config_ok(
+                session.service_account_id, session.config,
+            ):
+                if tool_filter is None:
+                    tool_filter = set(self._tools.tool_names)
+                tool_filter = tool_filter - {"user_reports"}
+
             tool_schemas = filter_schemas_for_tenant(
                 self._tools.get_schemas(names=tool_filter),
                 has_agents=self._prompt.has_agents,

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -1380,12 +1380,12 @@ async def run_worker(settings: Settings) -> None:
                 for e in tool_registry.get_all()
                 if e.toolset == "browser"
             )
-        # user_reports exposes other end-users' data, so only operator
-        # (Studio ops-chat) sessions may even see its schema.  This is
-        # the cheap config-only approximation of owner scope — the
-        # handler re-proves it with the DB-backed predicate before
-        # returning anything (defense in depth, same rationale as the
-        # kb tools' handler-side checks).
+        # user_reports exposes other end-users' data, so non-operator
+        # sessions must not be primed with guidance about it.  This
+        # keeps the PROMPT fragments in sync; the LLM-visible schema is
+        # gated separately in the harness (loop.py's tool_filter, same
+        # config-only owner-scope check), and the handler re-proves the
+        # full DB-backed predicate before returning anything.
         from surogates.tools.owner_scope import owner_scope_config_ok
 
         if not owner_scope_config_ok(

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -1380,6 +1380,22 @@ async def run_worker(settings: Settings) -> None:
                 for e in tool_registry.get_all()
                 if e.toolset == "browser"
             )
+        # user_reports exposes other end-users' data, so only operator
+        # (Studio ops-chat) sessions may even see its schema.  This is
+        # the cheap config-only approximation of owner scope — the
+        # handler re-proves it with the DB-backed predicate before
+        # returning anything (defense in depth, same rationale as the
+        # kb tools' handler-side checks).
+        from surogates.tools.owner_scope import owner_scope_config_ok
+
+        if not owner_scope_config_ok(
+            getattr(tenant, "service_account_id", None), session.config,
+        ):
+            effective_tools.difference_update(
+                e.name
+                for e in tool_registry.get_all()
+                if e.toolset == "user_reports"
+            )
         # Principal-aware tool-set filtering: ``create_artifact``
         # requires the harness API client (so the session must have a
         # principal AND ``use_api_for_harness_tools`` must be on), and

--- a/surogates/tools/builtin/kb_tools.py
+++ b/surogates/tools/builtin/kb_tools.py
@@ -35,7 +35,7 @@ from typing import Any
 
 import sqlalchemy as sa
 
-from surogates.db.ops_engine import get_ops_session_factory, init_ops_engine
+from surogates.db.ops_engine import ensure_ops_session_factory
 from surogates.db.ops_models import (
     OpsKBWikiPage,
     OpsKnowledgeBase,
@@ -45,32 +45,6 @@ from surogates.storage.kb_hub import KBHubError, fetch_wiki_object
 from surogates.tools.registry import ToolRegistry, ToolSchema
 
 logger = logging.getLogger(__name__)
-
-
-def _ensure_ops_session_factory():
-    """Return the ops session factory, lazily initializing if needed.
-
-    Worker startup calls init_ops_engine(), but in some concurrency
-    configurations the tool handler may run in a context where the
-    module-global _session_factory was not yet set (e.g. import-order
-    timing in the asyncio task pool). Falling back to a fresh init
-    from Settings() makes the handler robust — at worst we pay a
-    one-time engine setup cost.
-    """
-    factory = get_ops_session_factory()
-    if factory is not None:
-        return factory
-
-    from surogates.config import Settings
-    settings = Settings()
-    if not settings.ops_db.url:
-        return None
-
-    return init_ops_engine(
-        settings.ops_db.url,
-        pool_size=settings.ops_db.pool_size,
-        pool_overflow=settings.ops_db.pool_overflow,
-    )
 
 
 # Wiki content sits in Hub under wiki/<path>. The DB stores the
@@ -173,7 +147,7 @@ async def _kb_list_pages_handler(
 
     agent_id = _agent_id_from_kwargs(kwargs)
 
-    factory = _ensure_ops_session_factory()
+    factory = ensure_ops_session_factory()
     if factory is None:
         return (
             "Error: KB tools are unavailable -- the worker was started "
@@ -231,7 +205,7 @@ async def _kb_read_page_handler(
 
     agent_id = _agent_id_from_kwargs(kwargs)
 
-    factory = _ensure_ops_session_factory()
+    factory = ensure_ops_session_factory()
     if factory is None:
         return (
             "Error: KB tools are unavailable -- the worker was started "

--- a/surogates/tools/builtin/session_search.py
+++ b/surogates/tools/builtin/session_search.py
@@ -26,6 +26,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
+from surogates.tools.owner_scope import is_owner_scoped as _is_owner_scoped
 from surogates.tools.registry import ToolRegistry, ToolSchema
 
 logger = logging.getLogger(__name__)
@@ -371,66 +372,13 @@ def _attach_session_user(
         entry["user_id"] = str(user_id) if user_id else None
 
 
-# Matches ops_chat_service_account_name in surogate-ops
-# (server/services/agent_forward.py): "ops-chat-{org_id}-{user_id}".
-# Only surogate-ops's live-chat forwarder authenticates with these
-# accounts; creating one with a matching name requires org-admin rights.
-_OPS_CHAT_SA_PREFIX = "ops-chat-"
-
-
-async def _is_owner_scoped(
-    session_store: Any,
-    service_account_id: UUID | None,
-    session_config: Any,
-) -> bool:
-    """Return ``True`` when the calling session is an ops console chat on a
-    managed (non-system) agent.
-
-    Owner scope widens search from "the caller's own sessions" to "every
-    principal's sessions for this org + agent" -- mirroring the ops
-    Sessions Explorer, where ``GET /api/sessions`` defaults to
-    ``scope="all"`` for managed agents but forces ``scope="mine"`` on
-    system agents (copilot chats are private per user).  All three
-    conditions are server-controlled:
-
-    - ``config.ops.user_id`` must be stamped (``create_live_session`` in
-      surogate-ops).  The public session API copies client config
-      verbatim, so this alone is forgeable -- hence the next check.
-      The same stamp is parsed in ``orchestrator/mcp_client.py`` and
-      ``tools/mcp/client.py``; keep all three in sync.
-    - the session principal must be a service account whose name carries
-      the ops live-chat prefix.  End-user surfaces (web SPA, website
-      widget, managed channels) never run under a service account, and an
-      org API token's own service account cannot match the prefix unless
-      an org admin deliberately named it so.
-    - ``config.agent_type`` must be absent: surogate-ops always stamps it
-      for system agents, and their sessions must stay private per user.
-    """
-    if service_account_id is None:
-        return False
-    if not isinstance(session_config, dict):
-        return False
-    ops = session_config.get("ops")
-    if not (isinstance(ops, dict) and ops.get("user_id")):
-        return False
-    if session_config.get("agent_type"):
-        return False
-    try:
-        from sqlalchemy import text as sa_text
-
-        async with session_store._sf() as db:
-            row = await db.execute(
-                sa_text("SELECT name FROM service_accounts WHERE id = :id"),
-                {"id": service_account_id},
-            )
-            name = row.scalar_one_or_none()
-    except Exception:
-        logger.warning(
-            "Owner-scope service-account lookup failed; staying principal-scoped",
-            exc_info=True,
-        )
-        return False
-    return bool(name) and name.startswith(_OPS_CHAT_SA_PREFIX)
+# Owner scope widens search from "the caller's own sessions" to "every
+# principal's sessions for this org + agent" — mirroring the ops
+# Sessions Explorer, where ``GET /api/sessions`` defaults to
+# ``scope="all"`` for managed agents but forces ``scope="mine"`` on
+# system agents (copilot chats are private per user).  The predicate
+# itself is shared with other operator-only tools — imported at the
+# top of this module from tools/owner_scope.py as ``_is_owner_scoped``.
 
 
 async def session_search(

--- a/surogates/tools/builtin/user_reports.py
+++ b/surogates/tools/builtin/user_reports.py
@@ -1,0 +1,272 @@
+"""Operator-only tool exposing the ops Users-page reports to the agent.
+
+Surogate-ops generates and automatically maintains two kinds of
+end-user intelligence for every agent: a per-user activity report
+(cached in ``users.memory_summary["reports"][<agent_id>]`` in THIS
+database) and a cross-user overview report (cached on the ops-side
+``agents.cohort_report`` column, read here via the read-only ops
+engine).  This tool lets the agent's OPERATOR ask for them in chat —
+"how's the cohort doing?", "status of Maria?" — without opening the
+Studio page.
+
+Privacy is the whole design: reports describe OTHER end-users, so the
+tool is owner-scoped exactly like session_search's cross-principal
+mode (see tools/owner_scope.py — ops-chat service-account principal +
+server-stamped config, never conversation-inferred).  The worker also
+hides the tool's schema from non-operator sessions, but the handler
+re-checks with the full database-backed predicate: a tool that
+trusted only schema visibility would be one prompt injection away
+from leaking every user's report.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from surogates.db.ops_engine import get_ops_session_factory, init_ops_engine
+from surogates.db.ops_models import OpsAgent
+from surogates.tools.owner_scope import is_owner_scoped
+from surogates.tools.registry import ToolRegistry, ToolSchema
+
+logger = logging.getLogger(__name__)
+
+_REFUSAL = (
+    "user_reports is only available to the agent's operator in the "
+    "Studio console; this session is not operator-scoped."
+)
+
+_PARAMS = {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": ["overview", "get", "list"],
+            "description": (
+                "'overview' returns the cross-user overview report; "
+                "'get' returns one end-user's report (requires 'user'); "
+                "'list' shows which end-users have a maintained report."
+            ),
+        },
+        "user": {
+            "type": "string",
+            "description": (
+                "For action='get': the end-user's display name, email "
+                "or id. A unique partial display-name match is accepted."
+            ),
+        },
+    },
+    "required": ["action"],
+}
+
+
+def _ensure_ops_session_factory():
+    """Ops session factory with the same lazy fallback as kb_tools."""
+    factory = get_ops_session_factory()
+    if factory is not None:
+        return factory
+
+    from surogates.config import Settings
+    settings = Settings()
+    if not settings.ops_db.url:
+        return None
+
+    return init_ops_engine(
+        settings.ops_db.url,
+        pool_size=settings.ops_db.pool_size,
+        pool_overflow=settings.ops_db.pool_overflow,
+    )
+
+
+async def _fetch_org_users(session_store: Any, org_id: UUID) -> list[Any]:
+    """All end-user rows of the org: (id, display_name, email,
+    memory_summary).  Raw SQL via the store's session factory — the
+    same access idiom session_search uses."""
+    async with session_store._sf() as db:
+        rows = await db.execute(
+            sa.text(
+                "SELECT id, display_name, email, memory_summary "
+                "FROM users WHERE org_id = :org_id",
+            ),
+            {"org_id": str(org_id)},
+        )
+        return list(rows)
+
+
+def _report_payload(memory_summary: Any, agent_id: str) -> dict | None:
+    if not isinstance(memory_summary, dict):
+        return None
+    payload = (memory_summary.get("reports") or {}).get(agent_id)
+    return payload if isinstance(payload, dict) else None
+
+
+def _match_user(rows: list[Any], needle: str) -> Any | None:
+    """Resolve by id, exact email, exact name, then unique partial name.
+
+    Ambiguity returns None rather than guessing — the LLM gets the
+    roster from action='list' to disambiguate.
+    """
+    lowered = needle.strip().lower()
+    for row in rows:
+        if str(row.id).lower() == lowered or row.email.lower() == lowered:
+            return row
+    exact = [r for r in rows if r.display_name.lower() == lowered]
+    if len(exact) == 1:
+        return exact[0]
+    partial = [r for r in rows if lowered in r.display_name.lower()]
+    return partial[0] if len(partial) == 1 else None
+
+
+async def _fetch_overview(agent_id: str) -> dict | None:
+    factory = _ensure_ops_session_factory()
+    if factory is None:
+        return None
+    async with factory() as db:
+        row = await db.execute(
+            sa.select(OpsAgent.cohort_report).where(OpsAgent.id == agent_id),
+        )
+        payload = row.scalar_one_or_none()
+    return payload if isinstance(payload, dict) else None
+
+
+async def _user_reports_handler(arguments: dict, **kwargs: Any) -> str:
+    session_store = kwargs.get("session_store")
+    tenant = kwargs.get("tenant")
+    agent_id = str(kwargs.get("agent_id") or "")
+    session_config = kwargs.get("session_config")
+
+    if session_store is None or tenant is None or not agent_id:
+        return json.dumps({"error": "user_reports is unavailable here"})
+
+    # Full owner-scope proof (service-account name lookup included) —
+    # defense in depth on top of the worker's schema-level hiding.
+    if not await is_owner_scoped(
+        session_store,
+        getattr(tenant, "service_account_id", None),
+        session_config,
+    ):
+        return json.dumps({"error": _REFUSAL})
+
+    org_id = getattr(tenant, "org_id", None)
+    if org_id is None:
+        return json.dumps({"error": "user_reports is unavailable here"})
+
+    action = str(arguments.get("action") or "").strip()
+    if action not in ("overview", "get", "list"):
+        return json.dumps(
+            {"error": "action must be one of: overview, get, list"},
+        )
+    if action == "overview":
+        overview = await _fetch_overview(agent_id)
+        if overview is None:
+            return json.dumps(
+                {
+                    "overview": None,
+                    "hint": (
+                        "No overview report exists yet — generate it once "
+                        "from the Users page in Studio; it then stays "
+                        "fresh automatically."
+                    ),
+                },
+            )
+        return json.dumps(
+            {
+                "overview": {
+                    "report_md": overview.get("report_md"),
+                    "updated_at": overview.get("generated_at"),
+                    "user_count": overview.get("user_count"),
+                },
+            },
+        )
+
+    rows = await _fetch_org_users(session_store, org_id)
+
+    if action == "list":
+        entries = []
+        for row in rows:
+            payload = _report_payload(row.memory_summary, agent_id)
+            if payload is not None:
+                entries.append(
+                    {
+                        "display_name": row.display_name,
+                        "email": row.email,
+                        "updated_at": payload.get("generated_at"),
+                    },
+                )
+        return json.dumps(
+            {
+                "users_with_reports": entries,
+                "hint": (
+                    "Use action='get' with user=<name or email> for one "
+                    "user's full report."
+                ),
+            },
+        )
+
+    needle = str(arguments.get("user") or "").strip()
+    if not needle:
+        return json.dumps(
+            {"error": "action='get' requires the 'user' argument"},
+        )
+    matched = _match_user(rows, needle)
+    if matched is None:
+        return json.dumps(
+            {
+                "error": (
+                    f"no end-user matching {needle!r} — use "
+                    "action='list' to see who has a report"
+                ),
+            },
+        )
+    payload = _report_payload(matched.memory_summary, agent_id)
+    if payload is None:
+        return json.dumps(
+            {
+                "display_name": matched.display_name,
+                "report": None,
+                "hint": (
+                    "No report exists for this user yet — generate it "
+                    "once from the Users page in Studio; it then "
+                    "stays fresh automatically."
+                ),
+            },
+        )
+    return json.dumps(
+        {
+            "display_name": matched.display_name,
+            "email": matched.email,
+            "report_md": payload.get("report_md"),
+            "updated_at": payload.get("generated_at"),
+        },
+    )
+
+
+def register(registry: ToolRegistry) -> None:
+    """Register the user_reports tool.
+
+    Always registered; the worker strips it from the LLM-visible
+    schema for non-operator sessions, and the handler independently
+    refuses without full owner scope.
+    """
+    registry.register(
+        name="user_reports",
+        schema=ToolSchema(
+            name="user_reports",
+            description=(
+                "Operator-only: read the maintained end-user reports of "
+                "this agent. action='overview' returns the cross-user "
+                "overview report; action='list' shows which end-users "
+                "have an individual report; action='get' with "
+                "user=<name, email or id> returns that user's full "
+                "activity report. Reports are markdown, generated from "
+                "the Studio Users page and kept fresh automatically."
+            ),
+            parameters=_PARAMS,
+        ),
+        handler=_user_reports_handler,
+        toolset="user_reports",
+    )

--- a/surogates/tools/builtin/user_reports.py
+++ b/surogates/tools/builtin/user_reports.py
@@ -12,8 +12,9 @@ Studio page.
 Privacy is the whole design: reports describe OTHER end-users, so the
 tool is owner-scoped exactly like session_search's cross-principal
 mode (see tools/owner_scope.py — ops-chat service-account principal +
-server-stamped config, never conversation-inferred).  The worker also
-hides the tool's schema from non-operator sessions, but the handler
+server-stamped config, never conversation-inferred).  The harness
+strips the tool's schema from non-operator sessions (loop.py's tool
+filter) and the worker strips its prompt guidance, but the handler
 re-checks with the full database-backed predicate: a tool that
 trusted only schema visibility would be one prompt injection away
 from leaking every user's report.
@@ -248,7 +249,7 @@ async def _user_reports_handler(arguments: dict, **kwargs: Any) -> str:
 def register(registry: ToolRegistry) -> None:
     """Register the user_reports tool.
 
-    Always registered; the worker strips it from the LLM-visible
+    Always registered; the harness strips it from the LLM-visible
     schema for non-operator sessions, and the handler independently
     refuses without full owner scope.
     """

--- a/surogates/tools/builtin/user_reports.py
+++ b/surogates/tools/builtin/user_reports.py
@@ -29,7 +29,7 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from surogates.db.ops_engine import get_ops_session_factory, init_ops_engine
+from surogates.db.ops_engine import ensure_ops_session_factory
 from surogates.db.ops_models import OpsAgent
 from surogates.tools.owner_scope import is_owner_scoped
 from surogates.tools.registry import ToolRegistry, ToolSchema
@@ -65,36 +65,23 @@ _PARAMS = {
 }
 
 
-def _ensure_ops_session_factory():
-    """Ops session factory with the same lazy fallback as kb_tools."""
-    factory = get_ops_session_factory()
-    if factory is not None:
-        return factory
-
-    from surogates.config import Settings
-    settings = Settings()
-    if not settings.ops_db.url:
-        return None
-
-    return init_ops_engine(
-        settings.ops_db.url,
-        pool_size=settings.ops_db.pool_size,
-        pool_overflow=settings.ops_db.pool_overflow,
-    )
-
-
-async def _fetch_org_users(session_store: Any, org_id: UUID) -> list[Any]:
-    """All end-user rows of the org: (id, display_name, email,
+async def _fetch_org_users(
+    session_store: Any, org_id: UUID, user_id: UUID | None = None,
+) -> list[Any]:
+    """End-user rows of the org: (id, display_name, email,
     memory_summary).  Raw SQL via the store's session factory — the
-    same access idiom session_search uses."""
+    same access idiom session_search uses.  ``user_id`` narrows the
+    query to one row (still org-pinned) for id lookups."""
+    query = (
+        "SELECT id, display_name, email, memory_summary "
+        "FROM users WHERE org_id = :org_id"
+    )
+    params: dict[str, str] = {"org_id": str(org_id)}
+    if user_id is not None:
+        query += " AND id = :user_id"
+        params["user_id"] = str(user_id)
     async with session_store._sf() as db:
-        rows = await db.execute(
-            sa.text(
-                "SELECT id, display_name, email, memory_summary "
-                "FROM users WHERE org_id = :org_id",
-            ),
-            {"org_id": str(org_id)},
-        )
+        rows = await db.execute(sa.text(query), params)
         return list(rows)
 
 
@@ -106,14 +93,15 @@ def _report_payload(memory_summary: Any, agent_id: str) -> dict | None:
 
 
 def _match_user(rows: list[Any], needle: str) -> Any | None:
-    """Resolve by id, exact email, exact name, then unique partial name.
+    """Resolve by exact email, exact name, then unique partial name.
 
-    Ambiguity returns None rather than guessing — the LLM gets the
-    roster from action='list' to disambiguate.
+    Id needles never reach this — the handler resolves them with a
+    targeted query.  Ambiguity returns None rather than guessing — the
+    LLM gets the roster from action='list' to disambiguate.
     """
     lowered = needle.strip().lower()
     for row in rows:
-        if str(row.id).lower() == lowered or row.email.lower() == lowered:
+        if row.email.lower() == lowered:
             return row
     exact = [r for r in rows if r.display_name.lower() == lowered]
     if len(exact) == 1:
@@ -123,7 +111,7 @@ def _match_user(rows: list[Any], needle: str) -> Any | None:
 
 
 async def _fetch_overview(agent_id: str) -> dict | None:
-    factory = _ensure_ops_session_factory()
+    factory = ensure_ops_session_factory()
     if factory is None:
         return None
     async with factory() as db:
@@ -184,9 +172,8 @@ async def _user_reports_handler(arguments: dict, **kwargs: Any) -> str:
             },
         )
 
-    rows = await _fetch_org_users(session_store, org_id)
-
     if action == "list":
+        rows = await _fetch_org_users(session_store, org_id)
         entries = []
         for row in rows:
             payload = _report_payload(row.memory_summary, agent_id)
@@ -213,7 +200,18 @@ async def _user_reports_handler(arguments: dict, **kwargs: Any) -> str:
         return json.dumps(
             {"error": "action='get' requires the 'user' argument"},
         )
-    matched = _match_user(rows, needle)
+    try:
+        uid = UUID(needle)
+    except ValueError:
+        uid = None
+    if uid is not None:
+        # Id lookup: one org-pinned row instead of the full roster.
+        targeted = await _fetch_org_users(session_store, org_id, uid)
+        matched = targeted[0] if targeted else None
+    else:
+        matched = _match_user(
+            await _fetch_org_users(session_store, org_id), needle,
+        )
     if matched is None:
         return json.dumps(
             {

--- a/surogates/tools/owner_scope.py
+++ b/surogates/tools/owner_scope.py
@@ -1,0 +1,83 @@
+"""Shared owner-scope predicate for operator-only tool behavior.
+
+"Owner scope" means the calling session is the ops console (Studio)
+live chat on a managed, non-system agent — the agent's operator, not
+one of its end-users.  Tools use it to unlock cross-user data
+(session_search widens to all principals; user_reports exists at all)
+without ever trusting conversation content.  All conditions are
+server-controlled:
+
+- ``config.ops.user_id`` must be stamped (``create_live_session`` in
+  surogate-ops).  The public session API copies client config
+  verbatim, so this alone is forgeable — hence the next check.  The
+  same stamp is parsed in ``orchestrator/mcp_client.py`` and
+  ``tools/mcp/client.py``; keep them in sync.
+- the session principal must be a service account whose name carries
+  the ops live-chat prefix.  End-user surfaces (web SPA, website
+  widget, managed channels) never run under a service account, and an
+  org API token's own service account cannot match the prefix unless
+  an org admin deliberately named it so.
+- ``config.agent_type`` must be absent: surogate-ops always stamps it
+  for system agents, and their sessions must stay private per user.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+# Matches ops_chat_service_account_name in surogate-ops
+# (core/ops_chat.py): "ops-chat-{org_id}-{user_id}".  Only
+# surogate-ops's live-chat forwarder authenticates with these
+# accounts; creating one with a matching name requires org-admin
+# rights.
+OPS_CHAT_SA_PREFIX = "ops-chat-"
+
+
+def owner_scope_config_ok(
+    service_account_id: UUID | None, session_config: Any,
+) -> bool:
+    """The cheap, DB-free subset of the owner-scope conditions.
+
+    Used where a database round-trip is unwelcome (per-session tool
+    visibility); NOT sufficient on its own — handlers must confirm
+    with :func:`is_owner_scoped` before returning cross-user data.
+    """
+    if service_account_id is None:
+        return False
+    if not isinstance(session_config, dict):
+        return False
+    ops = session_config.get("ops")
+    if not (isinstance(ops, dict) and ops.get("user_id")):
+        return False
+    return not session_config.get("agent_type")
+
+
+async def is_owner_scoped(
+    session_store: Any,
+    service_account_id: UUID | None,
+    session_config: Any,
+) -> bool:
+    """Full owner-scope check, including the service-account name proof."""
+    if not owner_scope_config_ok(service_account_id, session_config):
+        return False
+    try:
+        from sqlalchemy import text as sa_text
+
+        async with session_store._sf() as db:
+            row = await db.execute(
+                sa_text("SELECT name FROM service_accounts WHERE id = :id"),
+                {"id": service_account_id},
+            )
+            name = row.scalar_one_or_none()
+    except Exception:
+        logger.warning(
+            "Owner-scope service-account lookup failed; treating as "
+            "principal-scoped",
+            exc_info=True,
+        )
+        return False
+    return bool(name) and name.startswith(OPS_CHAT_SA_PREFIX)

--- a/surogates/tools/router.py
+++ b/surogates/tools/router.py
@@ -48,6 +48,9 @@ TOOL_LOCATIONS: dict[str, ToolLocation] = {
     "skill_view": ToolLocation.HARNESS,
     "skill_manage": ToolLocation.HARNESS,
     "session_search": ToolLocation.HARNESS,
+    # Reads users.memory_summary + the ops DB cohort cache — needs the
+    # worker's DB access, never the sandbox.
+    "user_reports": ToolLocation.HARNESS,
     "web_search": ToolLocation.HARNESS,
     "web_extract": ToolLocation.HARNESS,
     "web_crawl": ToolLocation.HARNESS,

--- a/surogates/tools/runtime.py
+++ b/surogates/tools/runtime.py
@@ -70,6 +70,7 @@ class ToolRuntime:
             skills,
             terminal,
             todo,
+            user_reports,
             vision,
             web_search,
         )
@@ -94,6 +95,7 @@ class ToolRuntime:
             expert,
             terminal,  # also registers the 'process' tool
             session_search,
+            user_reports,  # operator-only Users-page reports (owner-scoped)
             todo,
             ask_user_question,
             cron,

--- a/tests/test_user_reports_tool.py
+++ b/tests/test_user_reports_tool.py
@@ -1,0 +1,246 @@
+"""Unit tests for the operator-only user_reports builtin tool.
+
+The ops-DB side (cohort overview) runs against in-memory SQLite via
+the OpsBase metadata (the kb_tools/ops_credits convention).  The
+surogates-DB side (org users + memory_summary) and the owner-scope
+DB lookup are monkeypatched — their SQL runs against Postgres-only
+JSONB in production and is exercised by the ops-side live checks.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool
+
+from surogates.db import ops_engine
+from surogates.db.ops_models import OpsAgent, OpsBase
+from surogates.tools import owner_scope
+from surogates.tools.builtin import user_reports as module
+
+_ORG = UUID("11111111-1111-1111-1111-111111111111")
+_AGENT = "agent-a"
+_SA_ID = uuid4()
+
+_OWNER_CONFIG = {"ops": {"user_id": "ops-user-1"}}
+
+
+def _tenant(service_account_id=_SA_ID, org_id=_ORG):
+    return SimpleNamespace(
+        org_id=org_id,
+        user_id=None,
+        service_account_id=service_account_id,
+    )
+
+
+def _user_row(name, email, reports=None):
+    return SimpleNamespace(
+        id=uuid4(),
+        display_name=name,
+        email=email,
+        memory_summary={"reports": reports} if reports is not None else {},
+    )
+
+
+@pytest.fixture
+def owner_scoped(monkeypatch):
+    monkeypatch.setattr(
+        module, "is_owner_scoped", AsyncMock(return_value=True),
+    )
+
+
+@pytest.fixture
+async def ops_sqlite(monkeypatch):
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(OpsBase.metadata.create_all)
+    factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False,
+    )
+    monkeypatch.setattr(ops_engine, "_session_factory", factory)
+    yield factory
+    await engine.dispose()
+
+
+async def _call(arguments, **overrides):
+    kwargs = {
+        "session_store": SimpleNamespace(_sf=None),
+        "tenant": _tenant(),
+        "agent_id": _AGENT,
+        "session_config": _OWNER_CONFIG,
+    }
+    kwargs.update(overrides)
+    return json.loads(await module._user_reports_handler(arguments, **kwargs))
+
+
+# ── owner-scope enforcement ────────────────────────────────────────
+
+
+async def test_refuses_without_owner_scope(monkeypatch):
+    monkeypatch.setattr(
+        module, "is_owner_scoped", AsyncMock(return_value=False),
+    )
+    result = await _call({"action": "overview"})
+    assert "operator" in result["error"]
+
+
+async def test_owner_scope_receives_principal_and_config(monkeypatch):
+    gate = AsyncMock(return_value=False)
+    monkeypatch.setattr(module, "is_owner_scoped", gate)
+    store = SimpleNamespace(_sf="factory-sentinel")
+    await _call({"action": "overview"}, session_store=store)
+    gate.assert_awaited_once_with(store, _SA_ID, _OWNER_CONFIG)
+
+
+# ── overview (ops DB) ──────────────────────────────────────────────
+
+
+async def test_overview_reads_ops_cohort_cache(owner_scoped, ops_sqlite):
+    async with ops_sqlite() as db:
+        db.add(
+            OpsAgent(
+                id=_AGENT,
+                cohort_report={
+                    "report_md": "## Cohort",
+                    "generated_at": "2026-07-22T00:00:00Z",
+                    "user_count": 5,
+                },
+            ),
+        )
+        await db.commit()
+    result = await _call({"action": "overview"})
+    assert result["overview"] == {
+        "report_md": "## Cohort",
+        "updated_at": "2026-07-22T00:00:00Z",
+        "user_count": 5,
+    }
+
+
+async def test_overview_absent_gives_hint(owner_scoped, ops_sqlite):
+    result = await _call({"action": "overview"})
+    assert result["overview"] is None
+    assert "Users page" in result["hint"]
+
+
+# ── list / get (surogates DB, patched fetch) ───────────────────────
+
+
+@pytest.fixture
+def org_users(monkeypatch):
+    maria = _user_row(
+        "Maria Dumitrescu",
+        "maria@example.com",
+        reports={
+            _AGENT: {
+                "report_md": "## Maria",
+                "generated_at": "2026-07-21T00:00:00Z",
+            },
+        },
+    )
+    tudor = _user_row("Tudor Enache", "tudor@example.com")
+    monkeypatch.setattr(
+        module, "_fetch_org_users", AsyncMock(return_value=[maria, tudor]),
+    )
+    return {"maria": maria, "tudor": tudor}
+
+
+async def test_list_shows_only_users_with_reports(owner_scoped, org_users):
+    result = await _call({"action": "list"})
+    assert result["users_with_reports"] == [
+        {
+            "display_name": "Maria Dumitrescu",
+            "email": "maria@example.com",
+            "updated_at": "2026-07-21T00:00:00Z",
+        },
+    ]
+
+
+async def test_get_by_partial_name(owner_scoped, org_users):
+    result = await _call({"action": "get", "user": "maria"})
+    assert result["display_name"] == "Maria Dumitrescu"
+    assert result["report_md"] == "## Maria"
+
+
+async def test_get_without_report_gives_hint(owner_scoped, org_users):
+    result = await _call({"action": "get", "user": "tudor@example.com"})
+    assert result["report"] is None
+    assert "Users page" in result["hint"]
+
+
+async def test_get_unknown_or_missing_user(owner_scoped, org_users):
+    result = await _call({"action": "get", "user": "nobody"})
+    assert "no end-user matching" in result["error"]
+    result = await _call({"action": "get"})
+    assert "requires the 'user' argument" in result["error"]
+
+
+async def test_unknown_action(owner_scoped):
+    result = await _call({"action": "bogus"})
+    assert "must be one of" in result["error"]
+
+
+# ── owner_scope module ─────────────────────────────────────────────
+
+
+def test_config_ok_conditions():
+    ok = owner_scope.owner_scope_config_ok
+    assert ok(_SA_ID, _OWNER_CONFIG)
+    assert not ok(None, _OWNER_CONFIG)
+    assert not ok(_SA_ID, None)
+    assert not ok(_SA_ID, {"ops": {}})
+    assert not ok(_SA_ID, {**_OWNER_CONFIG, "agent_type": "copilot"})
+
+
+class _FakeResult:
+    def __init__(self, name):
+        self._name = name
+
+    def scalar_one_or_none(self):
+        return self._name
+
+
+class _FakeDb:
+    def __init__(self, name):
+        self._name = name
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, *_args, **_kwargs):
+        return _FakeResult(self._name)
+
+
+def _store(sa_name):
+    return SimpleNamespace(_sf=lambda: _FakeDb(sa_name))
+
+
+async def test_is_owner_scoped_requires_ops_chat_prefix():
+    assert await owner_scope.is_owner_scoped(
+        _store("ops-chat-org-user"), _SA_ID, _OWNER_CONFIG,
+    )
+    assert not await owner_scope.is_owner_scoped(
+        _store("agent:some-agent"), _SA_ID, _OWNER_CONFIG,
+    )
+    assert not await owner_scope.is_owner_scoped(
+        _store(None), _SA_ID, _OWNER_CONFIG,
+    )
+    # Config short-circuit: no DB call path needed at all.
+    assert not await owner_scope.is_owner_scoped(
+        _store("ops-chat-org-user"), None, _OWNER_CONFIG,
+    )


### PR DESCRIPTION
## What

A new builtin tool, `user_reports`, that lets an agent's **operator** read the ops Users-page reports directly in chat ("how's the cohort doing?", "status of Maria?"):

- `action=overview` — the cross-user overview report, read from the ops DB `agents.cohort_report` cache via a new read-only `OpsAgent` mirror model (kb_tools ops-engine pattern).
- `action=get user=<name|email|id>` — one end-user's maintained report from `users.memory_summary["reports"][<agent_id>]`; unique partial name matches accepted, ambiguity refuses.
- `action=list` — which end-users have a maintained report.

## Privacy

Reports describe **other end-users**, so the tool is owner-scoped like `session_search`'s cross-principal mode, with two layers:
- the worker hides the tool's schema from non-operator sessions (cheap config-only check: SA principal + server-stamped `config.ops.user_id` + no `agent_type`);
- the handler independently re-proves full owner scope, including the `ops-chat-*` service-account name lookup, before returning anything — schema visibility alone is never trusted (prompt-injection defense in depth).

The owner-scope predicate moves out of `session_search` into shared `tools/owner_scope.py`; `session_search` now imports it (behavior unchanged).

## Verification

11 new unit tests (owner-scope enforcement incl. exact gate arguments, ops-SQLite cohort reads, list/get shaping, ambiguity refusal, the owner_scope module itself) plus the adjacent kb_tools/ops_credits suites — all green.

Pairs with surogate-ops PR #239 (which generates and auto-maintains the reports) and the copilot `get_user_reports` tool added there.