### PR TITLE
feat: per-agent end-user bindings (agent_users)

### DIFF
--- a/surogates/api/routes/auth.py
+++ b/surogates/api/routes/auth.py
@@ -418,8 +418,11 @@ async def login(
     user_id = UUID(result.user_id)
 
     # Successful auth through THIS agent's web channel is assignment
-    # intent — enroll the user on the serving agent.
-    if agent_runtime.agent_id:
+    # intent — enroll the user on the serving agent. Only when the
+    # authenticated org IS the serving agent's org: the body may carry
+    # a different org_id, and a binding pairing org X with org Y's
+    # agent would corrupt both tenants' rosters.
+    if agent_runtime.agent_id and str(org_id) == str(agent_runtime.org_id):
         async with session_factory() as enroll_session:
             await ensure_agent_user(
                 enroll_session,

--- a/surogates/api/routes/auth.py
+++ b/surogates/api/routes/auth.py
@@ -17,6 +17,7 @@ from surogates.audit import (
     auth_login_event,
     client_ip,
 )
+from surogates.db.agent_users import SOURCE_LOGIN, ensure_agent_user
 from surogates.db.models import ChannelIdentity, User
 from surogates.runtime import AgentRuntimeContext, agent_runtime_context_dep
 from surogates.tenant.auth.database import DatabaseAuthProvider
@@ -331,6 +332,18 @@ async def firebase_exchange(
             await session.commit()
             await session.refresh(user)
 
+        # Successful auth through THIS agent's web channel is
+        # assignment intent — enroll the user on the serving agent.
+        if agent_runtime.agent_id:
+            await ensure_agent_user(
+                session,
+                org_id=org_id,
+                agent_id=agent_runtime.agent_id,
+                user_id=user.id,
+                source=SOURCE_LOGIN,
+            )
+            await session.commit()
+
     permissions: set[str] = {"sessions:read", "sessions:write", "tools:read"}
     access_token = create_access_token(
         org_id=org_id, user_id=user.id, permissions=permissions,
@@ -403,6 +416,20 @@ async def login(
         )
 
     user_id = UUID(result.user_id)
+
+    # Successful auth through THIS agent's web channel is assignment
+    # intent — enroll the user on the serving agent.
+    if agent_runtime.agent_id:
+        async with session_factory() as enroll_session:
+            await ensure_agent_user(
+                enroll_session,
+                org_id=org_id,
+                agent_id=agent_runtime.agent_id,
+                user_id=user_id,
+                source=SOURCE_LOGIN,
+            )
+            await enroll_session.commit()
+
     # Default permissions for authenticated users.
     permissions: set[str] = {"sessions:read", "sessions:write", "tools:read"}
 

--- a/surogates/channels/constants.py
+++ b/surogates/channels/constants.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 __all__ = [
     "ADAPTER_CHANNELS",
+    "END_USER_CHANNELS",
     "INTERACTIVE_PROMPT_CHANNELS",
     "multi_session_disabled",
 ]
@@ -38,3 +39,13 @@ ADAPTER_CHANNELS = frozenset({"slack", "telegram"})
 #: outside this set must not receive content-less ``input_prompt`` outbox
 #: rows — their ``send`` would post an empty message.
 INTERACTIVE_PROMPT_CHANNELS = frozenset({"slack", "telegram"})
+
+#: Channels whose sessions represent a real end-user talking to the
+#: agent — the set that drives agent-user enrollment (``agent_users``)
+#: and, via the ops control plane, the Users-page activity stats.
+#: Everything else (api, task, delegation, worker, scheduled, ambient,
+#: browser_setup) must never mint a binding or count as end-user
+#: activity.  ``teams`` is pre-registered for the Phase-2 adapter
+#: (``channels/teams.py`` already pins ``channel='teams'``) so shipping
+#: it cannot silently split the roster from its stats.
+END_USER_CHANNELS = frozenset({"web", "website", "slack", "telegram", "teams"})

--- a/surogates/db/agent_users.py
+++ b/surogates/db/agent_users.py
@@ -1,0 +1,70 @@
+"""Enrollment writes for the ``agent_users`` binding table.
+
+One tiny module so every writer — session creation, the web-channel
+login paths, and the ops management client — shares the same
+idempotent INSERT instead of three hand-rolled variants.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from uuid import UUID
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from surogates.db.models import AgentUser
+
+logger = logging.getLogger(__name__)
+
+# Where a binding came from. Kept as plain strings (not an enum) so a
+# future writer can add a source without a schema migration.
+SOURCE_MANUAL = "manual"
+SOURCE_LOGIN = "login"
+SOURCE_SESSION = "session"
+SOURCE_BACKFILL = "backfill"
+
+# Idempotent backfill from historical sessions — safe to run on every
+# migrate. Interactive channels only: api/service-account traffic has
+# no end-user, and subagent rows inherit the parent's attribution.
+BACKFILL_SQL = """
+INSERT INTO agent_users (id, org_id, agent_id, user_id, source, created_at)
+SELECT gen_random_uuid(), s.org_id, s.agent_id, s.user_id,
+       'backfill', MIN(s.created_at)
+FROM sessions s
+WHERE s.user_id IS NOT NULL
+  AND s.agent_id IS NOT NULL
+  AND s.agent_id <> ''
+GROUP BY s.org_id, s.agent_id, s.user_id
+ON CONFLICT (org_id, agent_id, user_id) DO NOTHING
+"""
+
+
+async def ensure_agent_user(
+    db: AsyncSession,
+    *,
+    org_id: UUID,
+    agent_id: str,
+    user_id: UUID,
+    source: str,
+) -> None:
+    """Record that *user_id* belongs to *agent_id* (idempotent).
+
+    First write wins — an existing binding keeps its original source
+    and timestamp. Callers commit; this only stages the INSERT so it
+    rides in the caller's transaction.
+    """
+    await db.execute(
+        pg_insert(AgentUser)
+        .values(
+            id=uuid.uuid4(),
+            org_id=org_id,
+            agent_id=agent_id,
+            user_id=user_id,
+            source=source,
+        )
+        .on_conflict_do_nothing(
+            constraint="uq_agent_users_org_agent_user",
+        )
+    )

--- a/surogates/db/agent_users.py
+++ b/surogates/db/agent_users.py
@@ -15,17 +15,25 @@ manual attach path reactivates the tombstoned row.
 
 from __future__ import annotations
 
-import logging
 import uuid
 from uuid import UUID
 
-from sqlalchemy import select, text
+from sqlalchemy import delete, exists, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import func
 
-from surogates.db.models import AgentUser
-
-logger = logging.getLogger(__name__)
+from surogates.channels.constants import END_USER_CHANNELS
+from surogates.db.models import (
+    AgentUser,
+    AuditLog,
+    ChannelIdentity,
+    Event,
+    InboxItem,
+    Mission,
+    Session,
+    User,
+)
 
 # Where a binding came from. Kept as plain strings (not an enum) so a
 # future writer can add a source without a schema migration.
@@ -34,29 +42,41 @@ SOURCE_LOGIN = "login"
 SOURCE_SESSION = "session"
 SOURCE_BACKFILL = "backfill"
 
-# Channels whose sessions represent a real end-user talking to the
-# agent. Everything else (api, task, delegation, worker, scheduled,
-# ambient, browser_setup — which even uses the phantom agent id
-# "browser-setup") must never mint a binding. Mirrors the ops-side
-# USER_STATS_INTERACTIVE_CHANNELS so the roster and its stats agree.
-ENROLLMENT_CHANNELS = frozenset({"web", "website", "slack", "telegram"})
+# The channels that enroll users on agents — the canonical set lives in
+# channels/constants.py next to the adapter registry it must track.
+ENROLLMENT_CHANNELS = END_USER_CHANNELS
 
 # Idempotent backfill from historical sessions — safe to run on every
-# migrate. Interactive channels only (same set as ENROLLMENT_CHANNELS);
-# ON CONFLICT also guarantees a tombstoned (operator-removed) binding
-# is never resurrected by a re-run.
-BACKFILL_SQL = """
+# migrate. End-user channels only, generated from the same frozenset
+# the live enrollment uses so the two can never drift; ON CONFLICT
+# also guarantees a tombstoned (operator-removed) binding is never
+# resurrected by a re-run.
+BACKFILL_SQL = f"""
 INSERT INTO agent_users (id, org_id, agent_id, user_id, source, created_at)
 SELECT gen_random_uuid(), s.org_id, s.agent_id, s.user_id,
-       'backfill', MIN(s.created_at)
+       '{SOURCE_BACKFILL}', MIN(s.created_at)
 FROM sessions s
 WHERE s.user_id IS NOT NULL
   AND s.agent_id IS NOT NULL
   AND s.agent_id <> ''
-  AND s.channel IN ('web', 'website', 'slack', 'telegram')
+  AND s.channel IN ({", ".join(sorted(repr(c) for c in END_USER_CHANNELS))})
 GROUP BY s.org_id, s.agent_id, s.user_id
 ON CONFLICT (org_id, agent_id, user_id) DO NOTHING
 """
+
+
+def active_bound_user_ids(org_id: UUID, agent_ids: list[str]):
+    """Select of user ids actively bound (not tombstoned) to the agents.
+
+    The one definition of "this agent's users" — the Configure list,
+    the Users-page roster, and the assigned-flag reads all build on it
+    so removal semantics can never drift between surfaces.
+    """
+    return select(AgentUser.user_id).where(
+        AgentUser.org_id == org_id,
+        AgentUser.agent_id.in_(agent_ids),
+        AgentUser.removed_at.is_(None),
+    )
 
 
 def visible_users_filter(org_id: UUID, agent_id: str):
@@ -69,19 +89,13 @@ def visible_users_filter(org_id: UUID, agent_id: str):
     on this agent nor resurfaces everywhere as an orphan — re-adding
     them is the explicit attach path.
     """
-    from sqlalchemy import or_
-
-    from surogates.db.models import User
-
-    bound_here = select(AgentUser.user_id).where(
-        AgentUser.org_id == org_id,
-        AgentUser.agent_id == agent_id,
-        AgentUser.removed_at.is_(None),
-    )
     any_binding_row = select(AgentUser.user_id).where(
         AgentUser.org_id == org_id,
     )
-    return or_(User.id.in_(bound_here), User.id.not_in(any_binding_row))
+    return or_(
+        User.id.in_(active_bound_user_ids(org_id, [agent_id])),
+        User.id.not_in(any_binding_row),
+    )
 
 
 async def user_visibility(
@@ -97,55 +111,54 @@ async def user_visibility(
     exists in the org with no binding row at all (managed from any
     tab); ``None`` — nonexistent, another agent's user, or removed
     from this agent (re-add via the attach path, not edit-in-place).
+    One round trip: three EXISTS in a single SELECT.
     """
-    from surogates.db.models import User
-
-    user = (
-        await db.execute(
-            select(User.id).where(User.id == user_id, User.org_id == org_id)
-        )
-    ).scalar_one_or_none()
-    if user is None:
-        return None
-    bindings = (
-        (
-            await db.execute(
-                select(AgentUser.agent_id, AgentUser.removed_at).where(
-                    AgentUser.org_id == org_id,
-                    AgentUser.user_id == user_id,
-                )
-            )
-        )
-        .all()
+    user_rows = select(User.id).where(User.id == user_id, User.org_id == org_id)
+    any_binding = select(AgentUser.id).where(
+        AgentUser.org_id == org_id, AgentUser.user_id == user_id,
     )
-    if any(a == agent_id and removed is None for a, removed in bindings):
+    bound_here = any_binding.where(
+        AgentUser.agent_id == agent_id, AgentUser.removed_at.is_(None),
+    )
+    user_exists, has_bindings, is_bound = (
+        await db.execute(
+            select(exists(user_rows), exists(any_binding), exists(bound_here))
+        )
+    ).one()
+    if not user_exists:
+        return None
+    if is_bound:
         return "bound"
-    return "orphan" if not bindings else None
+    return "orphan" if not has_bindings else None
 
 
 async def purge_user_account(db: AsyncSession, *, org_id: UUID, user_id: UUID) -> None:
     """Hard-delete an account, detaching its history first.
 
-    Explicit raw-SQL cleanup (mirroring ops' ``delete_agent_data``
-    discipline) because the ORM relationships are ``lazy="raise"`` and
-    the ``user_id`` FKs carry no ``ondelete`` — a bare ORM delete
-    fails at flush for any user with sessions or channel identities.
-    Sessions/events/audit rows survive with ``user_id`` detached (they
-    are org history, not user property); identity rows and the user's
-    own inbox go with the account. Caller commits.
+    Explicit statement-per-table cleanup (mirroring ops'
+    ``delete_agent_data`` discipline) because the ORM relationships
+    are ``lazy="raise"`` and the ``user_id`` FKs carry no ``ondelete``
+    — a bare ORM instance delete fails at flush for any user with
+    sessions or channel identities. Sessions/events/audit rows survive
+    with ``user_id`` detached (they are org history, not user
+    property); identity rows and the user's own inbox go with the
+    account. The FK-coverage test in the integration suite pins this
+    list against the schema. Caller commits.
     """
-    params = {"uid": user_id, "org": org_id}
+    def scoped(model):
+        return (model.user_id == user_id, model.org_id == org_id)
+
     for stmt in (
-        "DELETE FROM channel_identities WHERE user_id = :uid AND org_id = :org",
-        "DELETE FROM inbox_items WHERE user_id = :uid AND org_id = :org",
-        "DELETE FROM agent_users WHERE user_id = :uid AND org_id = :org",
-        "UPDATE sessions SET user_id = NULL WHERE user_id = :uid AND org_id = :org",
-        "UPDATE events SET user_id = NULL WHERE user_id = :uid AND org_id = :org",
-        "UPDATE audit_log SET user_id = NULL WHERE user_id = :uid AND org_id = :org",
-        "UPDATE missions SET user_id = NULL WHERE user_id = :uid AND org_id = :org",
-        "DELETE FROM users WHERE id = :uid AND org_id = :org",
+        delete(ChannelIdentity).where(*scoped(ChannelIdentity)),
+        delete(InboxItem).where(*scoped(InboxItem)),
+        delete(AgentUser).where(*scoped(AgentUser)),
+        update(Session).where(*scoped(Session)).values(user_id=None),
+        update(Event).where(*scoped(Event)).values(user_id=None),
+        update(AuditLog).where(*scoped(AuditLog)).values(user_id=None),
+        update(Mission).where(*scoped(Mission)).values(user_id=None),
+        delete(User).where(User.id == user_id, User.org_id == org_id),
     ):
-        await db.execute(text(stmt), params)
+        await db.execute(stmt)
 
 
 async def remove_user_from_agent(
@@ -165,20 +178,25 @@ async def remove_user_from_agent(
     :func:`purge_user_account`. Returns False when the user isn't
     visible from this tab. Stages writes only — the caller commits.
     """
-    visibility = await user_visibility(
-        db, org_id=org_id, agent_id=agent_id, user_id=user_id,
-    )
-    if visibility == "bound":
-        await db.execute(
-            text(
-                "UPDATE agent_users SET removed_at = now() "
-                "WHERE org_id = :org AND agent_id = :agent "
-                "AND user_id = :uid AND removed_at IS NULL"
-            ),
-            {"org": org_id, "agent": agent_id, "uid": user_id},
+    # Tombstone-first: the common case is one UPDATE, no pre-reads.
+    result = await db.execute(
+        update(AgentUser)
+        .where(
+            AgentUser.org_id == org_id,
+            AgentUser.agent_id == agent_id,
+            AgentUser.user_id == user_id,
+            AgentUser.removed_at.is_(None),
         )
+        .values(removed_at=func.now())
+    )
+    if result.rowcount:
         return True
-    if visibility == "orphan":
+    if (
+        await user_visibility(
+            db, org_id=org_id, agent_id=agent_id, user_id=user_id,
+        )
+        == "orphan"
+    ):
         await purge_user_account(db, org_id=org_id, user_id=user_id)
         return True
     return False

--- a/surogates/db/agent_users.py
+++ b/surogates/db/agent_users.py
@@ -25,13 +25,19 @@ from sqlalchemy.sql import func
 
 from surogates.channels.constants import END_USER_CHANNELS
 from surogates.db.models import (
+    Agent,
     AgentUser,
     AuditLog,
+    BrowserProfile,
     ChannelIdentity,
+    Credential,
     Event,
     InboxItem,
+    McpServer,
     Mission,
+    ScheduledSession,
     Session,
+    Skill,
     User,
 )
 
@@ -139,26 +145,31 @@ async def purge_user_account(db: AsyncSession, *, org_id: UUID, user_id: UUID) -
     ``delete_agent_data`` discipline) because the ORM relationships
     are ``lazy="raise"`` and the ``user_id`` FKs carry no ``ondelete``
     — a bare ORM instance delete fails at flush for any user with
-    sessions or channel identities. Sessions/events/audit rows survive
-    with ``user_id`` detached (they are org history, not user
-    property); identity rows and the user's own inbox go with the
-    account. The FK-coverage test in the integration suite pins this
-    list against the schema. Caller commits.
+    sessions or channel identities. Rows the user owns outright
+    (identities, their inbox, private credentials — which must not be
+    promoted to org scope by NULLing) are deleted; everything else
+    references the user only for attribution and survives with
+    ``user_id`` detached (sessions and their history are org data, not
+    user property). The FK-coverage test in the integration suite pins
+    this list against the schema. Caller commits.
     """
     def scoped(model):
         return (model.user_id == user_id, model.org_id == org_id)
 
-    for stmt in (
-        delete(ChannelIdentity).where(*scoped(ChannelIdentity)),
-        delete(InboxItem).where(*scoped(InboxItem)),
-        delete(AgentUser).where(*scoped(AgentUser)),
-        update(Session).where(*scoped(Session)).values(user_id=None),
-        update(Event).where(*scoped(Event)).values(user_id=None),
-        update(AuditLog).where(*scoped(AuditLog)).values(user_id=None),
-        update(Mission).where(*scoped(Mission)).values(user_id=None),
-        delete(User).where(User.id == user_id, User.org_id == org_id),
-    ):
-        await db.execute(stmt)
+    owned = (ChannelIdentity, InboxItem, Credential, AgentUser)
+    attributed = (
+        Session, Event, AuditLog, Mission,
+        ScheduledSession, BrowserProfile, Skill, Agent, McpServer,
+    )
+    for model in owned:
+        await db.execute(delete(model).where(*scoped(model)))
+    for model in attributed:
+        await db.execute(
+            update(model).where(*scoped(model)).values(user_id=None)
+        )
+    await db.execute(
+        delete(User).where(User.id == user_id, User.org_id == org_id)
+    )
 
 
 async def remove_user_from_agent(

--- a/surogates/db/agent_users.py
+++ b/surogates/db/agent_users.py
@@ -1,8 +1,16 @@
-"""Enrollment writes for the ``agent_users`` binding table.
+"""Enrollment, visibility, and removal for the ``agent_users`` table.
 
-One tiny module so every writer — session creation, the web-channel
-login paths, and the ops management client — shares the same
-idempotent INSERT instead of three hand-rolled variants.
+One module so every writer — session creation, the web-channel login
+paths, and the ops management client — shares the same idempotent
+semantics instead of hand-rolled variants.
+
+Removal is a **tombstone** (``removed_at``), never a row delete. The
+tombstone is what makes three behaviors hold at once: the migrate-time
+backfill cannot resurrect a removed binding (the row still exists, so
+ON CONFLICT skips it), an automatic re-enroll at login/session cannot
+undo an operator's removal (same reason), and no destructive account
+delete is needed for users with history. Re-adding is explicit: the
+manual attach path reactivates the tombstoned row.
 """
 
 from __future__ import annotations
@@ -11,7 +19,7 @@ import logging
 import uuid
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -26,9 +34,17 @@ SOURCE_LOGIN = "login"
 SOURCE_SESSION = "session"
 SOURCE_BACKFILL = "backfill"
 
+# Channels whose sessions represent a real end-user talking to the
+# agent. Everything else (api, task, delegation, worker, scheduled,
+# ambient, browser_setup — which even uses the phantom agent id
+# "browser-setup") must never mint a binding. Mirrors the ops-side
+# USER_STATS_INTERACTIVE_CHANNELS so the roster and its stats agree.
+ENROLLMENT_CHANNELS = frozenset({"web", "website", "slack", "telegram"})
+
 # Idempotent backfill from historical sessions — safe to run on every
-# migrate. Interactive channels only: api/service-account traffic has
-# no end-user, and subagent rows inherit the parent's attribution.
+# migrate. Interactive channels only (same set as ENROLLMENT_CHANNELS);
+# ON CONFLICT also guarantees a tombstoned (operator-removed) binding
+# is never resurrected by a re-run.
 BACKFILL_SQL = """
 INSERT INTO agent_users (id, org_id, agent_id, user_id, source, created_at)
 SELECT gen_random_uuid(), s.org_id, s.agent_id, s.user_id,
@@ -37,6 +53,7 @@ FROM sessions s
 WHERE s.user_id IS NOT NULL
   AND s.agent_id IS NOT NULL
   AND s.agent_id <> ''
+  AND s.channel IN ('web', 'website', 'slack', 'telegram')
 GROUP BY s.org_id, s.agent_id, s.user_id
 ON CONFLICT (org_id, agent_id, user_id) DO NOTHING
 """
@@ -45,10 +62,12 @@ ON CONFLICT (org_id, agent_id, user_id) DO NOTHING
 def visible_users_filter(org_id: UUID, agent_id: str):
     """Filter for ``select(User)``: one agent's Configure → Users view.
 
-    The agent's bound users, plus org users bound to NO agent at all —
-    unbound accounts (legacy rows, pre-provisioned users whose agent
-    was deleted) must stay visible somewhere or they become
-    unmanageable orphans.
+    The agent's actively bound users, plus org users with no binding
+    row AT ALL — unbound accounts (legacy rows) must stay visible
+    somewhere or they become unmanageable orphans. A tombstoned
+    (removed) binding is deliberately neither: the user neither shows
+    on this agent nor resurfaces everywhere as an orphan — re-adding
+    them is the explicit attach path.
     """
     from sqlalchemy import or_
 
@@ -57,11 +76,12 @@ def visible_users_filter(org_id: UUID, agent_id: str):
     bound_here = select(AgentUser.user_id).where(
         AgentUser.org_id == org_id,
         AgentUser.agent_id == agent_id,
+        AgentUser.removed_at.is_(None),
     )
-    bound_anywhere = select(AgentUser.user_id).where(
+    any_binding_row = select(AgentUser.user_id).where(
         AgentUser.org_id == org_id,
     )
-    return or_(User.id.in_(bound_here), User.id.not_in(bound_anywhere))
+    return or_(User.id.in_(bound_here), User.id.not_in(any_binding_row))
 
 
 async def user_visibility(
@@ -73,9 +93,10 @@ async def user_visibility(
 ) -> str | None:
     """How one agent's Configure → Users tab may act on a user.
 
-    ``"bound"`` — enrolled on this agent; ``"orphan"`` — exists in the
-    org but bound to no agent at all (managed from any tab); ``None``
-    — nonexistent here, or another agent's user.
+    ``"bound"`` — actively enrolled on this agent; ``"orphan"`` —
+    exists in the org with no binding row at all (managed from any
+    tab); ``None`` — nonexistent, another agent's user, or removed
+    from this agent (re-add via the attach path, not edit-in-place).
     """
     from surogates.db.models import User
 
@@ -89,18 +110,42 @@ async def user_visibility(
     bindings = (
         (
             await db.execute(
-                select(AgentUser.agent_id).where(
+                select(AgentUser.agent_id, AgentUser.removed_at).where(
                     AgentUser.org_id == org_id,
                     AgentUser.user_id == user_id,
                 )
             )
         )
-        .scalars()
         .all()
     )
-    if agent_id in bindings:
+    if any(a == agent_id and removed is None for a, removed in bindings):
         return "bound"
     return "orphan" if not bindings else None
+
+
+async def purge_user_account(db: AsyncSession, *, org_id: UUID, user_id: UUID) -> None:
+    """Hard-delete an account, detaching its history first.
+
+    Explicit raw-SQL cleanup (mirroring ops' ``delete_agent_data``
+    discipline) because the ORM relationships are ``lazy="raise"`` and
+    the ``user_id`` FKs carry no ``ondelete`` — a bare ORM delete
+    fails at flush for any user with sessions or channel identities.
+    Sessions/events/audit rows survive with ``user_id`` detached (they
+    are org history, not user property); identity rows and the user's
+    own inbox go with the account. Caller commits.
+    """
+    params = {"uid": user_id, "org": org_id}
+    for stmt in (
+        "DELETE FROM channel_identities WHERE user_id = :uid AND org_id = :org",
+        "DELETE FROM inbox_items WHERE user_id = :uid AND org_id = :org",
+        "DELETE FROM agent_users WHERE user_id = :uid AND org_id = :org",
+        "UPDATE sessions SET user_id = NULL WHERE user_id = :uid AND org_id = :org",
+        "UPDATE events SET user_id = NULL WHERE user_id = :uid AND org_id = :org",
+        "UPDATE audit_log SET user_id = NULL WHERE user_id = :uid AND org_id = :org",
+        "UPDATE missions SET user_id = NULL WHERE user_id = :uid AND org_id = :org",
+        "DELETE FROM users WHERE id = :uid AND org_id = :org",
+    ):
+        await db.execute(text(stmt), params)
 
 
 async def remove_user_from_agent(
@@ -112,43 +157,31 @@ async def remove_user_from_agent(
 ) -> bool:
     """Remove a user from one agent's Configure → Users tab.
 
-    Bound user: drop this agent's binding; the ACCOUNT is deleted only
-    when no other agent still has the user — a shared account must
-    survive removal from one of its agents.  Orphan (no bindings
-    anywhere): plain account delete.  Returns False when the user
-    isn't visible from this tab.  Stages deletes only — the caller
-    commits.
+    Actively bound here: tombstone the binding (``removed_at``) — the
+    account and its history survive, other agents' bindings are
+    untouched, and neither the backfill nor an automatic login/session
+    re-enroll can bring the user back (ON CONFLICT hits the surviving
+    row). Orphan (no binding rows at all): hard account delete via
+    :func:`purge_user_account`. Returns False when the user isn't
+    visible from this tab. Stages writes only — the caller commits.
     """
-    from surogates.db.models import User
-
-    user = (
-        await db.execute(
-            select(User).where(User.id == user_id, User.org_id == org_id)
-        )
-    ).scalar_one_or_none()
-    if user is None:
-        return False
-    bindings = (
-        (
-            await db.execute(
-                select(AgentUser).where(
-                    AgentUser.org_id == org_id,
-                    AgentUser.user_id == user_id,
-                )
-            )
-        )
-        .scalars()
-        .all()
+    visibility = await user_visibility(
+        db, org_id=org_id, agent_id=agent_id, user_id=user_id,
     )
-    here = [b for b in bindings if b.agent_id == agent_id]
-    if bindings and not here:
-        return False
-    for binding in here:
-        await db.delete(binding)
-    if len(bindings) == len(here):
-        # Last (or only) home — remove the account itself.
-        await db.delete(user)
-    return True
+    if visibility == "bound":
+        await db.execute(
+            text(
+                "UPDATE agent_users SET removed_at = now() "
+                "WHERE org_id = :org AND agent_id = :agent "
+                "AND user_id = :uid AND removed_at IS NULL"
+            ),
+            {"org": org_id, "agent": agent_id, "uid": user_id},
+        )
+        return True
+    if visibility == "orphan":
+        await purge_user_account(db, org_id=org_id, user_id=user_id)
+        return True
+    return False
 
 
 async def ensure_agent_user(
@@ -158,23 +191,31 @@ async def ensure_agent_user(
     agent_id: str,
     user_id: UUID,
     source: str,
+    reactivate: bool = False,
 ) -> None:
     """Record that *user_id* belongs to *agent_id* (idempotent).
 
     First write wins — an existing binding keeps its original source
-    and timestamp. Callers commit; this only stages the INSERT so it
-    rides in the caller's transaction.
+    and timestamp, and a tombstoned binding stays removed, so the
+    automatic writers (login, first session, backfill) can never undo
+    an operator's removal. ``reactivate=True`` is the explicit re-add
+    (the manual attach path): it clears the tombstone. Callers commit;
+    this only stages the write so it rides in their transaction.
     """
-    await db.execute(
-        pg_insert(AgentUser)
-        .values(
-            id=uuid.uuid4(),
-            org_id=org_id,
-            agent_id=agent_id,
-            user_id=user_id,
-            source=source,
+    stmt = pg_insert(AgentUser).values(
+        id=uuid.uuid4(),
+        org_id=org_id,
+        agent_id=agent_id,
+        user_id=user_id,
+        source=source,
+    )
+    if reactivate:
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_agent_users_org_agent_user",
+            set_={"removed_at": None, "source": source},
         )
-        .on_conflict_do_nothing(
+    else:
+        stmt = stmt.on_conflict_do_nothing(
             constraint="uq_agent_users_org_agent_user",
         )
-    )
+    await db.execute(stmt)

--- a/surogates/db/agent_users.py
+++ b/surogates/db/agent_users.py
@@ -11,6 +11,7 @@ import logging
 import uuid
 from uuid import UUID
 
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,6 +40,115 @@ WHERE s.user_id IS NOT NULL
 GROUP BY s.org_id, s.agent_id, s.user_id
 ON CONFLICT (org_id, agent_id, user_id) DO NOTHING
 """
+
+
+def visible_users_filter(org_id: UUID, agent_id: str):
+    """Filter for ``select(User)``: one agent's Configure → Users view.
+
+    The agent's bound users, plus org users bound to NO agent at all —
+    unbound accounts (legacy rows, pre-provisioned users whose agent
+    was deleted) must stay visible somewhere or they become
+    unmanageable orphans.
+    """
+    from sqlalchemy import or_
+
+    from surogates.db.models import User
+
+    bound_here = select(AgentUser.user_id).where(
+        AgentUser.org_id == org_id,
+        AgentUser.agent_id == agent_id,
+    )
+    bound_anywhere = select(AgentUser.user_id).where(
+        AgentUser.org_id == org_id,
+    )
+    return or_(User.id.in_(bound_here), User.id.not_in(bound_anywhere))
+
+
+async def user_visibility(
+    db: AsyncSession,
+    *,
+    org_id: UUID,
+    agent_id: str,
+    user_id: UUID,
+) -> str | None:
+    """How one agent's Configure → Users tab may act on a user.
+
+    ``"bound"`` — enrolled on this agent; ``"orphan"`` — exists in the
+    org but bound to no agent at all (managed from any tab); ``None``
+    — nonexistent here, or another agent's user.
+    """
+    from surogates.db.models import User
+
+    user = (
+        await db.execute(
+            select(User.id).where(User.id == user_id, User.org_id == org_id)
+        )
+    ).scalar_one_or_none()
+    if user is None:
+        return None
+    bindings = (
+        (
+            await db.execute(
+                select(AgentUser.agent_id).where(
+                    AgentUser.org_id == org_id,
+                    AgentUser.user_id == user_id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if agent_id in bindings:
+        return "bound"
+    return "orphan" if not bindings else None
+
+
+async def remove_user_from_agent(
+    db: AsyncSession,
+    *,
+    org_id: UUID,
+    agent_id: str,
+    user_id: UUID,
+) -> bool:
+    """Remove a user from one agent's Configure → Users tab.
+
+    Bound user: drop this agent's binding; the ACCOUNT is deleted only
+    when no other agent still has the user — a shared account must
+    survive removal from one of its agents.  Orphan (no bindings
+    anywhere): plain account delete.  Returns False when the user
+    isn't visible from this tab.  Stages deletes only — the caller
+    commits.
+    """
+    from surogates.db.models import User
+
+    user = (
+        await db.execute(
+            select(User).where(User.id == user_id, User.org_id == org_id)
+        )
+    ).scalar_one_or_none()
+    if user is None:
+        return False
+    bindings = (
+        (
+            await db.execute(
+                select(AgentUser).where(
+                    AgentUser.org_id == org_id,
+                    AgentUser.user_id == user_id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    here = [b for b in bindings if b.agent_id == agent_id]
+    if bindings and not here:
+        return False
+    for binding in here:
+        await db.delete(binding)
+    if len(bindings) == len(here):
+        # Last (or only) home — remove the account itself.
+        await db.delete(user)
+    return True
 
 
 async def ensure_agent_user(

--- a/surogates/db/engine.py
+++ b/surogates/db/engine.py
@@ -108,11 +108,16 @@ def run_migrations(db_settings: DatabaseSettings) -> None:
     from surogates.db.models import Base
 
     async def _create_all() -> None:
+        from surogates.db.agent_users import BACKFILL_SQL
+
         engine = async_engine_from_settings(db_settings)
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
             await apply_observability_ddl(conn)
             await _execute_sql_script(conn, INBOX_PRINCIPAL_SQL_PATH)
+            # Derive agent-user bindings from historical sessions once
+            # the table exists; ON CONFLICT keeps re-runs free.
+            await conn.exec_driver_sql(BACKFILL_SQL)
         await engine.dispose()
 
     asyncio.run(_create_all())

--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -273,6 +273,11 @@ class AgentUser(Base):
     created_at: Mapped[datetime] = mapped_column(
         nullable=False, server_default=func.now()
     )
+    # Tombstone, not delete: a removed binding must keep existing so
+    # the backfill and the automatic login/session enrollment (both
+    # ON CONFLICT DO NOTHING) can never resurrect it. Cleared only by
+    # the explicit manual re-attach.
+    removed_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
 
 
 # ---------------------------------------------------------------------------

--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -214,6 +214,68 @@ class ChannelIdentity(Base):
 
 
 # ---------------------------------------------------------------------------
+# Agent-user bindings
+# ---------------------------------------------------------------------------
+
+
+class AgentUser(Base):
+    """Membership of an end-user on one agent of the org.
+
+    User accounts are org-scoped (one account works against every
+    agent in the project); this table records which agents a user
+    actually belongs to, so per-agent surfaces (the Users page, its
+    reports) can show *that agent's* users instead of the whole org
+    roster.  A user of two agents has two rows — correct, since
+    memory and reports are already per-agent per-user.
+
+    Rows are written wherever assignment intent exists:
+
+    * ``manual``   — operator created the account on a specific agent
+      (Configure → Users, via the ops client).
+    * ``login``    — the user authenticated through an agent's web
+      channel (password or Firebase; the serving agent comes from the
+      runtime context).
+    * ``session``  — first interactive session with the agent (covers
+      Slack/Telegram shadow users, which never log in).
+    * ``backfill`` — derived from historical ``sessions`` rows by the
+      migrate-time backfill.
+
+    Enrollment is append-only and idempotent (INSERT .. ON CONFLICT DO
+    NOTHING on the unique triple); the binding does NOT gate
+    authentication — any org user can still log into any agent of the
+    org, gaining a ``login`` row in the process.
+    """
+
+    __tablename__ = "agent_users"
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id", "agent_id", "user_id", name="uq_agent_users_org_agent_user"
+        ),
+        Index("idx_agent_users_org_agent", "org_id", "agent_id"),
+        Index("idx_agent_users_user", "user_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("orgs.id"), nullable=False
+    )
+    # Text, no FK — agents are management-plane entities mirrored into
+    # this database only as ids (same convention as sessions.agent_id).
+    agent_id: Mapped[str] = mapped_column(Text, nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    source: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        nullable=False, server_default=func.now()
+    )
+
+
+# ---------------------------------------------------------------------------
 # Sessions
 # ---------------------------------------------------------------------------
 

--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -172,6 +172,17 @@ class User(Base):
             unique=True,
             postgresql_where=text("external_id IS NOT NULL"),
         ),
+        # One account per (org, email), case-insensitive — email is the
+        # login key and the Configure→Users attach-by-email guard
+        # assumes it. Fresh databases get this from create_all; legacy
+        # databases get it from the guarded observability.sql retrofit,
+        # which skips (with a NOTICE) while old duplicates exist.
+        Index(
+            "uq_users_org_lower_email",
+            "org_id",
+            text("lower(email)"),
+            unique=True,
+        ),
     )
 
 

--- a/surogates/db/observability.sql
+++ b/surogates/db/observability.sql
@@ -838,3 +838,26 @@ SELECT
           AND e.data->>'rating' = 'up'
     ) AS had_response_thumbs_up
 FROM sessions s;
+
+-- ── agent_users retrofits ────────────────────────────────────────────
+-- Tombstone column for operator removals (create_all never alters
+-- existing tables, so the retrofit lives here).
+ALTER TABLE agent_users ADD COLUMN IF NOT EXISTS removed_at timestamp;
+
+-- One account per (org, email): the login key and the Configure→Users
+-- attach-by-email guard both assume it. Guarded — legacy databases may
+-- already carry duplicates, and failing every migrate over old data
+-- would be worse than the (rare) race the index closes; the NOTICE
+-- makes the skip visible so the duplicates get cleaned deliberately.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM users
+        GROUP BY org_id, lower(email) HAVING count(*) > 1
+    ) THEN
+        RAISE NOTICE 'skipping uq_users_org_lower_email: duplicate emails exist';
+    ELSE
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_users_org_lower_email
+            ON users (org_id, lower(email));
+    END IF;
+END $$;

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -23,6 +23,11 @@ from surogates.channels.constants import (
     ADAPTER_CHANNELS,
     INTERACTIVE_PROMPT_CHANNELS,
 )
+from surogates.db.agent_users import (
+    ENROLLMENT_CHANNELS,
+    SOURCE_SESSION,
+    ensure_agent_user,
+)
 from surogates.db.models import (
     Event as EventRow,
     IdeaNode,
@@ -234,8 +239,6 @@ class SessionStore:
             db.add(row)
             # Initialise the cursor row so get_harness_cursor never 404s.
             db.add(SessionCursor(session_id=row.id, harness_cursor=0))
-            from surogates.db.agent_users import ENROLLMENT_CHANNELS
-
             if user_id is not None and agent_id and channel in ENROLLMENT_CHANNELS:
                 # First user-attributed contact with an agent enrolls the
                 # user on it (idempotent) — this is what makes shadow
@@ -244,11 +247,6 @@ class SessionStore:
                 # browser_setup/task/api sessions carry user_id too but
                 # must never mint a binding (browser_setup even runs
                 # under the phantom agent id "browser-setup").
-                from surogates.db.agent_users import (
-                    SOURCE_SESSION,
-                    ensure_agent_user,
-                )
-
                 await ensure_agent_user(
                     db,
                     org_id=org_id,

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -234,6 +234,23 @@ class SessionStore:
             db.add(row)
             # Initialise the cursor row so get_harness_cursor never 404s.
             db.add(SessionCursor(session_id=row.id, harness_cursor=0))
+            if user_id is not None and agent_id:
+                # First user-attributed contact with an agent enrolls the
+                # user on it (idempotent) — this is what makes shadow
+                # users from Slack/Telegram, who never log in, appear on
+                # that agent's Users page.
+                from surogates.db.agent_users import (
+                    SOURCE_SESSION,
+                    ensure_agent_user,
+                )
+
+                await ensure_agent_user(
+                    db,
+                    org_id=org_id,
+                    agent_id=agent_id,
+                    user_id=user_id,
+                    source=SOURCE_SESSION,
+                )
             await db.commit()
             await db.refresh(row)
         return Session.model_validate(row)

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -234,11 +234,16 @@ class SessionStore:
             db.add(row)
             # Initialise the cursor row so get_harness_cursor never 404s.
             db.add(SessionCursor(session_id=row.id, harness_cursor=0))
-            if user_id is not None and agent_id:
+            from surogates.db.agent_users import ENROLLMENT_CHANNELS
+
+            if user_id is not None and agent_id and channel in ENROLLMENT_CHANNELS:
                 # First user-attributed contact with an agent enrolls the
                 # user on it (idempotent) — this is what makes shadow
                 # users from Slack/Telegram, who never log in, appear on
-                # that agent's Users page.
+                # that agent's Users page. Gated to end-user channels:
+                # browser_setup/task/api sessions carry user_id too but
+                # must never mint a binding (browser_setup even runs
+                # under the phantom agent id "browser-setup").
                 from surogates.db.agent_users import (
                     SOURCE_SESSION,
                     ensure_agent_user,

--- a/tests/integration/test_agent_user_bindings.py
+++ b/tests/integration/test_agent_user_bindings.py
@@ -15,7 +15,7 @@ from sqlalchemy import text
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
-from sqlalchemy import select, text as sa_text
+from sqlalchemy import select
 
 from surogates.db.agent_users import (
     BACKFILL_SQL,
@@ -31,6 +31,17 @@ from surogates.db.models import User
 
 from .conftest import create_org, create_user
 from .test_api import TEST_AGENT_ID, _create_test_tenant, app, client  # noqa: F401
+
+
+async def _enroll(
+    session_factory, org_id, agent_id, user_id, source, reactivate=False,
+):
+    async with session_factory() as db:
+        await ensure_agent_user(
+            db, org_id=org_id, agent_id=agent_id, user_id=user_id,
+            source=source, reactivate=reactivate,
+        )
+        await db.commit()
 
 
 async def _bindings(
@@ -55,12 +66,7 @@ async def test_ensure_agent_user_idempotent_first_source_wins(session_factory):
     org_id = await create_org(session_factory)
     user_id = await create_user(session_factory, org_id)
 
-    async with session_factory() as db:
-        await ensure_agent_user(
-            db, org_id=org_id, agent_id="agent-a",
-            user_id=user_id, source=SOURCE_MANUAL,
-        )
-        await db.commit()
+    await _enroll(session_factory, org_id, "agent-a", user_id, SOURCE_MANUAL)
     async with session_factory() as db:
         await ensure_agent_user(
             db, org_id=org_id, agent_id="agent-a",
@@ -255,12 +261,7 @@ async def test_user_visibility_states(session_factory):
     bound = await create_user(session_factory, org_id)
     orphan = await create_user(session_factory, org_id)
 
-    async with session_factory() as db:
-        await ensure_agent_user(
-            db, org_id=org_id, agent_id="agent-a",
-            user_id=bound, source=SOURCE_MANUAL,
-        )
-        await db.commit()
+    await _enroll(session_factory, org_id, "agent-a", bound, SOURCE_MANUAL)
 
     async with session_factory() as db:
         assert await user_visibility(
@@ -363,7 +364,7 @@ async def test_orphan_purge_handles_history(session_store, session_factory):
     )
     async with session_factory() as db:
         await db.execute(
-            sa_text(
+            text(
                 "INSERT INTO channel_identities (id, org_id, user_id, "
                 "platform, platform_user_id, platform_meta) VALUES "
                 "(:id, :org, :uid, 'slack', 'U123', '{}')"
@@ -371,7 +372,7 @@ async def test_orphan_purge_handles_history(session_store, session_factory):
             {"id": uuid.uuid4(), "org": org_id, "uid": user_id},
         )
         await db.execute(
-            sa_text(
+            text(
                 "INSERT INTO events (session_id, org_id, user_id, type, "
                 "data) VALUES (:sid, :org, :uid, 'user.message', '{}')"
             ),
@@ -392,7 +393,7 @@ async def test_orphan_purge_handles_history(session_store, session_factory):
         # The session survives, detached from the deleted account.
         detached = (
             await db.execute(
-                sa_text("SELECT user_id FROM sessions WHERE id = :sid"),
+                text("SELECT user_id FROM sessions WHERE id = :sid"),
                 {"sid": session.id},
             )
         ).scalar_one_or_none()
@@ -459,12 +460,7 @@ async def test_login_org_mismatch_does_not_enroll(
 async def test_user_delete_cascades_bindings(session_factory):
     org_id = await create_org(session_factory)
     user_id = await create_user(session_factory, org_id)
-    async with session_factory() as db:
-        await ensure_agent_user(
-            db, org_id=org_id, agent_id="agent-a",
-            user_id=user_id, source=SOURCE_MANUAL,
-        )
-        await db.commit()
+    await _enroll(session_factory, org_id, "agent-a", user_id, SOURCE_MANUAL)
 
     async with session_factory() as db:
         await db.execute(
@@ -473,3 +469,40 @@ async def test_user_delete_cascades_bindings(session_factory):
         await db.commit()
 
     assert await _bindings(session_factory, org_id) == []
+
+
+async def test_purge_covers_every_user_fk():
+    """purge_user_account hardcodes per-table statements; this walks the
+    schema so a future table with a users FK fails HERE, not at runtime
+    on the rarely-exercised orphan-purge path."""
+    from surogates.db import agent_users as module
+    from surogates.db.models import Base
+
+    import inspect
+
+    covered = {
+        "channel_identities", "inbox_items", "agent_users", "sessions",
+        "events", "audit_log", "missions", "users",
+    }
+    # Tables intentionally NOT purged: they belong to operator-side
+    # resources a deleted END-USER account must not take down.
+    exempt = {"agents", "browser_profiles", "credentials", "skills",
+              "mcp_servers", "tasks", "scheduled_sessions", "idea_nodes",
+              "research_runs"}
+    referencing = {
+        table.name
+        for table in Base.metadata.tables.values()
+        for fk in table.foreign_keys
+        if fk.column.table.name == "users"
+    }
+    unaccounted = referencing - covered - exempt
+    assert not unaccounted, (
+        f"tables with a users FK not handled by purge_user_account or "
+        f"explicitly exempted: {sorted(unaccounted)} — extend the purge "
+        f"statement list or the exemption list deliberately"
+    )
+    # And the covered list must actually appear in the implementation.
+    source = inspect.getsource(module.purge_user_account)
+    for name in ("ChannelIdentity", "InboxItem", "AgentUser", "Session",
+                 "Event", "AuditLog", "Mission", "User"):
+        assert name in source

--- a/tests/integration/test_agent_user_bindings.py
+++ b/tests/integration/test_agent_user_bindings.py
@@ -15,7 +15,7 @@ from sqlalchemy import text
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
-from sqlalchemy import select
+from sqlalchemy import select, text as sa_text
 
 from surogates.db.agent_users import (
     BACKFILL_SQL,
@@ -33,7 +33,9 @@ from .conftest import create_org, create_user
 from .test_api import TEST_AGENT_ID, _create_test_tenant, app, client  # noqa: F401
 
 
-async def _bindings(session_factory, org_id, agent_id=None):
+async def _bindings(
+    session_factory, org_id, agent_id=None, include_removed=False,
+):
     async with session_factory() as db:
         query = (
             "SELECT agent_id, user_id, source FROM agent_users "
@@ -43,6 +45,8 @@ async def _bindings(session_factory, org_id, agent_id=None):
         if agent_id is not None:
             query += " AND agent_id = :agent_id"
             params["agent_id"] = agent_id
+        if not include_removed:
+            query += " AND removed_at IS NULL"
         rows = await db.execute(text(query + " ORDER BY created_at"), params)
         return [tuple(r) for r in rows]
 
@@ -89,6 +93,15 @@ async def test_create_session_enrolls_interactive_user_only(
     await session_store.create_session(
         user_id=None, org_id=org_id, agent_id="agent-api", channel="api",
     )
+    # Non-end-user channels never enroll, even with a user attached —
+    # browser_setup notably runs under the phantom agent id below.
+    await session_store.create_session(
+        user_id=user_id, org_id=org_id, agent_id="browser-setup",
+        channel="browser_setup",
+    )
+    await session_store.create_session(
+        user_id=user_id, org_id=org_id, agent_id="agent-task", channel="task",
+    )
 
     rows = await _bindings(session_factory, org_id)
     assert rows == [("agent-web", user_id, SOURCE_SESSION)]
@@ -101,10 +114,28 @@ async def test_create_session_enrolls_interactive_user_only(
 
 
 async def test_login_enrolls_user_on_serving_agent(
-    client: AsyncClient, session_factory,
+    client: AsyncClient, app, session_factory,
 ):
     org_id, user_id, _, email = await _create_test_tenant(
         session_factory, password="bind-me-123",
+    )
+    # Enrollment requires the authenticated org to BE the serving
+    # agent's org — repin the test runtime context to this tenant.
+    from surogates.runtime import (
+        agent_runtime_context_dep,
+        build_agent_runtime_context,
+    )
+
+    previous = app.dependency_overrides[agent_runtime_context_dep]
+    app.dependency_overrides[agent_runtime_context_dep] = (
+        lambda: build_agent_runtime_context({
+            "agent_id": TEST_AGENT_ID,
+            "org_id": str(org_id),
+            "project_id": "test-project",
+            "enabled": True,
+            "version": 1,
+            "storage_key_prefix": "",
+        })
     )
 
     resp = await client.post(
@@ -123,6 +154,7 @@ async def test_login_enrolls_user_on_serving_agent(
     )
     assert resp.status_code == 200
     assert await _bindings(session_factory, org_id, agent_id=TEST_AGENT_ID) == rows
+    app.dependency_overrides[agent_runtime_context_dep] = previous
 
 
 async def test_backfill_derives_bindings_from_sessions(
@@ -159,6 +191,15 @@ async def test_backfill_derives_bindings_from_sessions(
                 "'api', 'completed')"
             ),
             {"id": uuid.uuid4(), "org": org_id},
+        )
+        # User-attributed but non-interactive channel — filtered out.
+        await db.execute(
+            text(
+                "INSERT INTO sessions (id, org_id, agent_id, user_id, "
+                "channel, status) VALUES (:id, :org, 'browser-setup', "
+                ":uid, 'browser_setup', 'completed')"
+            ),
+            {"id": uuid.uuid4(), "org": org_id, "uid": user_id},
         )
         await db.commit()
 
@@ -236,6 +277,20 @@ async def test_user_visibility_states(session_factory):
             db, org_id=org_id, agent_id="agent-a", user_id=uuid.uuid4(),
         ) is None
 
+    # Removed-from-here is invisible too — and NOT an orphan.
+    async with session_factory() as db:
+        assert await remove_user_from_agent(
+            db, org_id=org_id, agent_id="agent-a", user_id=bound,
+        )
+        await db.commit()
+    async with session_factory() as db:
+        assert await user_visibility(
+            db, org_id=org_id, agent_id="agent-a", user_id=bound,
+        ) is None
+        assert await user_visibility(
+            db, org_id=org_id, agent_id="agent-b", user_id=bound,
+        ) is None
+
 
 async def test_remove_user_from_agent_semantics(session_factory):
     org_id = await create_org(session_factory)
@@ -256,7 +311,8 @@ async def test_remove_user_from_agent_semantics(session_factory):
                 await db.execute(select(User.id).where(User.id == uid))
             ).scalar_one_or_none() is not None
 
-    # Removing from one agent unbinds but the shared account survives.
+    # Removing from one agent tombstones the binding; the account and
+    # the other agent's binding survive.
     async with session_factory() as db:
         assert await remove_user_from_agent(
             db, org_id=org_id, agent_id="agent-a", user_id=shared,
@@ -264,28 +320,140 @@ async def test_remove_user_from_agent_semantics(session_factory):
         await db.commit()
     assert await _user_exists(shared)
     assert await _bindings(session_factory, org_id, agent_id="agent-a") == []
+    removed_rows = await _bindings(
+        session_factory, org_id, agent_id="agent-a", include_removed=True,
+    )
+    assert len(removed_rows) == 1  # tombstoned, not deleted
 
-    # A tab the user isn't visible from cannot remove them.
+    # Already-removed user isn't visible from that tab anymore.
     async with session_factory() as db:
         assert not await remove_user_from_agent(
             db, org_id=org_id, agent_id="agent-a", user_id=shared,
         )
 
-    # Removing the last binding deletes the account.
+    # Removing the LAST active binding also tombstones — the account
+    # survives with its history (never a destructive delete for bound
+    # users).
     async with session_factory() as db:
         assert await remove_user_from_agent(
             db, org_id=org_id, agent_id="agent-b", user_id=shared,
         )
         await db.commit()
-    assert not await _user_exists(shared)
+    assert await _user_exists(shared)
 
-    # An orphan is removable from any tab — plain account delete.
+    # An orphan (no binding rows at all) is removable from any tab —
+    # that IS the account delete.
     async with session_factory() as db:
         assert await remove_user_from_agent(
             db, org_id=org_id, agent_id="agent-a", user_id=orphan,
         )
         await db.commit()
     assert not await _user_exists(orphan)
+
+
+async def test_orphan_purge_handles_history(session_store, session_factory):
+    """Account delete must survive sessions + channel identities —
+    the FKs carry no ondelete and the ORM relationships are
+    lazy="raise", so the purge detaches history explicitly."""
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+    # History in a NON-enrollment channel → user stays an orphan.
+    session = await session_store.create_session(
+        user_id=user_id, org_id=org_id, agent_id="agent-x", channel="api",
+    )
+    async with session_factory() as db:
+        await db.execute(
+            sa_text(
+                "INSERT INTO channel_identities (id, org_id, user_id, "
+                "platform, platform_user_id, platform_meta) VALUES "
+                "(:id, :org, :uid, 'slack', 'U123', '{}')"
+            ),
+            {"id": uuid.uuid4(), "org": org_id, "uid": user_id},
+        )
+        await db.execute(
+            sa_text(
+                "INSERT INTO events (session_id, org_id, user_id, type, "
+                "data) VALUES (:sid, :org, :uid, 'user.message', '{}')"
+            ),
+            {"sid": session.id, "org": org_id, "uid": user_id},
+        )
+        await db.commit()
+
+    async with session_factory() as db:
+        assert await remove_user_from_agent(
+            db, org_id=org_id, agent_id="agent-x", user_id=user_id,
+        )
+        await db.commit()
+
+    async with session_factory() as db:
+        assert (
+            await db.execute(select(User.id).where(User.id == user_id))
+        ).scalar_one_or_none() is None
+        # The session survives, detached from the deleted account.
+        detached = (
+            await db.execute(
+                sa_text("SELECT user_id FROM sessions WHERE id = :sid"),
+                {"sid": session.id},
+            )
+        ).scalar_one_or_none()
+        assert detached is None
+
+
+async def test_tombstone_blocks_backfill_and_auto_enroll(
+    session_store, session_factory,
+):
+    """An operator's removal must survive both the migrate-time
+    backfill and the automatic session/login enrollment."""
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+
+    await session_store.create_session(
+        user_id=user_id, org_id=org_id, agent_id="agent-a", channel="web",
+    )
+    async with session_factory() as db:
+        assert await remove_user_from_agent(
+            db, org_id=org_id, agent_id="agent-a", user_id=user_id,
+        )
+        await db.commit()
+
+    # Backfill re-derives from the surviving session rows…
+    async with session_factory() as db:
+        await db.execute(text(BACKFILL_SQL))
+        await db.commit()
+    # …and a new session re-fires the automatic enrollment…
+    await session_store.create_session(
+        user_id=user_id, org_id=org_id, agent_id="agent-a", channel="web",
+    )
+    # …but the tombstone holds.
+    assert await _bindings(session_factory, org_id, agent_id="agent-a") == []
+
+    # The explicit manual re-attach is what brings the user back.
+    async with session_factory() as db:
+        await ensure_agent_user(
+            db, org_id=org_id, agent_id="agent-a", user_id=user_id,
+            source=SOURCE_MANUAL, reactivate=True,
+        )
+        await db.commit()
+    assert await _bindings(session_factory, org_id, agent_id="agent-a") == [
+        ("agent-a", user_id, SOURCE_MANUAL),
+    ]
+
+
+async def test_login_org_mismatch_does_not_enroll(
+    client: AsyncClient, app, session_factory,
+):
+    """body.org_id different from the serving agent's org must not
+    mint a cross-tenant binding (the test app's runtime context is
+    pinned to the zero org, so any real org mismatches)."""
+    org_id, user_id, _, email = await _create_test_tenant(
+        session_factory, password="cross-org-1",
+    )
+    resp = await client.post(
+        "/v1/auth/login",
+        json={"email": email, "password": "cross-org-1", "org_id": str(org_id)},
+    )
+    assert resp.status_code == 200
+    assert await _bindings(session_factory, org_id) == []
 
 
 async def test_user_delete_cascades_bindings(session_factory):

--- a/tests/integration/test_agent_user_bindings.py
+++ b/tests/integration/test_agent_user_bindings.py
@@ -15,13 +15,19 @@ from sqlalchemy import text
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
+from sqlalchemy import select
+
 from surogates.db.agent_users import (
     BACKFILL_SQL,
     SOURCE_LOGIN,
     SOURCE_MANUAL,
     SOURCE_SESSION,
     ensure_agent_user,
+    remove_user_from_agent,
+    user_visibility,
+    visible_users_filter,
 )
+from surogates.db.models import User
 
 from .conftest import create_org, create_user
 from .test_api import TEST_AGENT_ID, _create_test_tenant, app, client  # noqa: F401
@@ -166,6 +172,120 @@ async def test_backfill_derives_bindings_from_sessions(
         ("agent-1", user_id, "backfill"),
         ("agent-2", other_user, "backfill"),
     ])
+
+
+async def test_visible_users_filter_bound_plus_orphans(session_factory):
+    org_id = await create_org(session_factory)
+    bound_a = await create_user(session_factory, org_id)
+    bound_b = await create_user(session_factory, org_id)
+    orphan = await create_user(session_factory, org_id)
+
+    async with session_factory() as db:
+        await ensure_agent_user(
+            db, org_id=org_id, agent_id="agent-a",
+            user_id=bound_a, source=SOURCE_MANUAL,
+        )
+        await ensure_agent_user(
+            db, org_id=org_id, agent_id="agent-b",
+            user_id=bound_b, source=SOURCE_MANUAL,
+        )
+        await db.commit()
+
+    async with session_factory() as db:
+        visible = (
+            (
+                await db.execute(
+                    select(User.id).where(
+                        User.org_id == org_id,
+                        visible_users_filter(org_id, "agent-a"),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    # Agent A sees its own user and the unassigned orphan — but never
+    # agent B's user.
+    assert sorted(map(str, visible)) == sorted(map(str, [bound_a, orphan]))
+
+
+async def test_user_visibility_states(session_factory):
+    org_id = await create_org(session_factory)
+    bound = await create_user(session_factory, org_id)
+    orphan = await create_user(session_factory, org_id)
+
+    async with session_factory() as db:
+        await ensure_agent_user(
+            db, org_id=org_id, agent_id="agent-a",
+            user_id=bound, source=SOURCE_MANUAL,
+        )
+        await db.commit()
+
+    async with session_factory() as db:
+        assert await user_visibility(
+            db, org_id=org_id, agent_id="agent-a", user_id=bound,
+        ) == "bound"
+        # Another agent's tab must not see agent A's user.
+        assert await user_visibility(
+            db, org_id=org_id, agent_id="agent-b", user_id=bound,
+        ) is None
+        assert await user_visibility(
+            db, org_id=org_id, agent_id="agent-a", user_id=orphan,
+        ) == "orphan"
+        assert await user_visibility(
+            db, org_id=org_id, agent_id="agent-a", user_id=uuid.uuid4(),
+        ) is None
+
+
+async def test_remove_user_from_agent_semantics(session_factory):
+    org_id = await create_org(session_factory)
+    shared = await create_user(session_factory, org_id)
+    orphan = await create_user(session_factory, org_id)
+
+    async with session_factory() as db:
+        for agent in ("agent-a", "agent-b"):
+            await ensure_agent_user(
+                db, org_id=org_id, agent_id=agent,
+                user_id=shared, source=SOURCE_MANUAL,
+            )
+        await db.commit()
+
+    async def _user_exists(uid):
+        async with session_factory() as db:
+            return (
+                await db.execute(select(User.id).where(User.id == uid))
+            ).scalar_one_or_none() is not None
+
+    # Removing from one agent unbinds but the shared account survives.
+    async with session_factory() as db:
+        assert await remove_user_from_agent(
+            db, org_id=org_id, agent_id="agent-a", user_id=shared,
+        )
+        await db.commit()
+    assert await _user_exists(shared)
+    assert await _bindings(session_factory, org_id, agent_id="agent-a") == []
+
+    # A tab the user isn't visible from cannot remove them.
+    async with session_factory() as db:
+        assert not await remove_user_from_agent(
+            db, org_id=org_id, agent_id="agent-a", user_id=shared,
+        )
+
+    # Removing the last binding deletes the account.
+    async with session_factory() as db:
+        assert await remove_user_from_agent(
+            db, org_id=org_id, agent_id="agent-b", user_id=shared,
+        )
+        await db.commit()
+    assert not await _user_exists(shared)
+
+    # An orphan is removable from any tab — plain account delete.
+    async with session_factory() as db:
+        assert await remove_user_from_agent(
+            db, org_id=org_id, agent_id="agent-a", user_id=orphan,
+        )
+        await db.commit()
+    assert not await _user_exists(orphan)
 
 
 async def test_user_delete_cascades_bindings(session_factory):

--- a/tests/integration/test_agent_user_bindings.py
+++ b/tests/integration/test_agent_user_bindings.py
@@ -481,14 +481,16 @@ async def test_purge_covers_every_user_fk():
     import inspect
 
     covered = {
-        "channel_identities", "inbox_items", "agent_users", "sessions",
-        "events", "audit_log", "missions", "users",
+        # Deleted with the account (owned outright)…
+        "channel_identities", "inbox_items", "credentials", "agent_users",
+        # …or de-attributed (org history/resources survive ownerless).
+        "sessions", "events", "audit_log", "missions",
+        "scheduled_sessions", "browser_profiles", "skills", "agents",
+        "mcp_servers", "users",
     }
-    # Tables intentionally NOT purged: they belong to operator-side
-    # resources a deleted END-USER account must not take down.
-    exempt = {"agents", "browser_profiles", "credentials", "skills",
-              "mcp_servers", "tasks", "scheduled_sessions", "idea_nodes",
-              "research_runs"}
+    # Every users FK must be covered — a new table joins this list (and
+    # the purge implementation) deliberately, never by omission.
+    exempt: set[str] = set()
     referencing = {
         table.name
         for table in Base.metadata.tables.values()
@@ -503,6 +505,8 @@ async def test_purge_covers_every_user_fk():
     )
     # And the covered list must actually appear in the implementation.
     source = inspect.getsource(module.purge_user_account)
-    for name in ("ChannelIdentity", "InboxItem", "AgentUser", "Session",
-                 "Event", "AuditLog", "Mission", "User"):
+    for name in ("ChannelIdentity", "InboxItem", "Credential", "AgentUser",
+                 "Session", "Event", "AuditLog", "Mission",
+                 "ScheduledSession", "BrowserProfile", "Skill", "Agent",
+                 "McpServer", "User"):
         assert name in source

--- a/tests/integration/test_agent_user_bindings.py
+++ b/tests/integration/test_agent_user_bindings.py
@@ -1,0 +1,187 @@
+"""Integration tests for the ``agent_users`` binding table.
+
+Covers the idempotent enrollment helper, the two runtime write points
+(session creation and web-channel login), the migrate-time backfill
+from historical sessions, and the delete cascade from ``users``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+from surogates.db.agent_users import (
+    BACKFILL_SQL,
+    SOURCE_LOGIN,
+    SOURCE_MANUAL,
+    SOURCE_SESSION,
+    ensure_agent_user,
+)
+
+from .conftest import create_org, create_user
+from .test_api import TEST_AGENT_ID, _create_test_tenant, app, client  # noqa: F401
+
+
+async def _bindings(session_factory, org_id, agent_id=None):
+    async with session_factory() as db:
+        query = (
+            "SELECT agent_id, user_id, source FROM agent_users "
+            "WHERE org_id = :org_id"
+        )
+        params: dict = {"org_id": org_id}
+        if agent_id is not None:
+            query += " AND agent_id = :agent_id"
+            params["agent_id"] = agent_id
+        rows = await db.execute(text(query + " ORDER BY created_at"), params)
+        return [tuple(r) for r in rows]
+
+
+async def test_ensure_agent_user_idempotent_first_source_wins(session_factory):
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+
+    async with session_factory() as db:
+        await ensure_agent_user(
+            db, org_id=org_id, agent_id="agent-a",
+            user_id=user_id, source=SOURCE_MANUAL,
+        )
+        await db.commit()
+    async with session_factory() as db:
+        await ensure_agent_user(
+            db, org_id=org_id, agent_id="agent-a",
+            user_id=user_id, source=SOURCE_SESSION,
+        )
+        # Same user on a second agent is a separate, legitimate binding.
+        await ensure_agent_user(
+            db, org_id=org_id, agent_id="agent-b",
+            user_id=user_id, source=SOURCE_SESSION,
+        )
+        await db.commit()
+
+    rows = await _bindings(session_factory, org_id)
+    assert rows == [
+        ("agent-a", user_id, SOURCE_MANUAL),
+        ("agent-b", user_id, SOURCE_SESSION),
+    ]
+
+
+async def test_create_session_enrolls_interactive_user_only(
+    session_store, session_factory,
+):
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+
+    await session_store.create_session(
+        user_id=user_id, org_id=org_id, agent_id="agent-web", channel="web",
+    )
+    # Service-account/api sessions carry no end-user — no binding.
+    await session_store.create_session(
+        user_id=None, org_id=org_id, agent_id="agent-api", channel="api",
+    )
+
+    rows = await _bindings(session_factory, org_id)
+    assert rows == [("agent-web", user_id, SOURCE_SESSION)]
+
+    # A second session on the same agent stays one binding.
+    await session_store.create_session(
+        user_id=user_id, org_id=org_id, agent_id="agent-web", channel="web",
+    )
+    assert await _bindings(session_factory, org_id) == rows
+
+
+async def test_login_enrolls_user_on_serving_agent(
+    client: AsyncClient, session_factory,
+):
+    org_id, user_id, _, email = await _create_test_tenant(
+        session_factory, password="bind-me-123",
+    )
+
+    resp = await client.post(
+        "/v1/auth/login",
+        json={"email": email, "password": "bind-me-123", "org_id": str(org_id)},
+    )
+    assert resp.status_code == 200
+
+    rows = await _bindings(session_factory, org_id, agent_id=TEST_AGENT_ID)
+    assert rows == [(TEST_AGENT_ID, user_id, SOURCE_LOGIN)]
+
+    # A repeat login stays idempotent.
+    resp = await client.post(
+        "/v1/auth/login",
+        json={"email": email, "password": "bind-me-123", "org_id": str(org_id)},
+    )
+    assert resp.status_code == 200
+    assert await _bindings(session_factory, org_id, agent_id=TEST_AGENT_ID) == rows
+
+
+async def test_backfill_derives_bindings_from_sessions(
+    session_store, session_factory,
+):
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+    other_user = await create_user(session_factory, org_id)
+
+    # Suppress live enrollment to simulate a pre-binding database, then
+    # let the backfill derive the rows from the session history alone.
+    async with session_factory() as db:
+        for agent_id, uid in [
+            ("agent-1", user_id),
+            ("agent-1", user_id),  # second session, same pair
+            ("agent-2", other_user),
+        ]:
+            await db.execute(
+                text(
+                    "INSERT INTO sessions (id, org_id, agent_id, user_id, "
+                    "channel, status) VALUES (:id, :org, :agent, :uid, "
+                    "'web', 'completed')"
+                ),
+                {
+                    "id": uuid.uuid4(), "org": org_id,
+                    "agent": agent_id, "uid": uid,
+                },
+            )
+        # Service-account style row — must not produce a binding.
+        await db.execute(
+            text(
+                "INSERT INTO sessions (id, org_id, agent_id, user_id, "
+                "channel, status) VALUES (:id, :org, 'agent-3', NULL, "
+                "'api', 'completed')"
+            ),
+            {"id": uuid.uuid4(), "org": org_id},
+        )
+        await db.commit()
+
+    async with session_factory() as db:
+        await db.execute(text(BACKFILL_SQL))
+        await db.execute(text(BACKFILL_SQL))  # idempotent re-run
+        await db.commit()
+
+    rows = await _bindings(session_factory, org_id)
+    assert sorted(rows) == sorted([
+        ("agent-1", user_id, "backfill"),
+        ("agent-2", other_user, "backfill"),
+    ])
+
+
+async def test_user_delete_cascades_bindings(session_factory):
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+    async with session_factory() as db:
+        await ensure_agent_user(
+            db, org_id=org_id, agent_id="agent-a",
+            user_id=user_id, source=SOURCE_MANUAL,
+        )
+        await db.commit()
+
+    async with session_factory() as db:
+        await db.execute(
+            text("DELETE FROM users WHERE id = :id"), {"id": user_id},
+        )
+        await db.commit()
+
+    assert await _bindings(session_factory, org_id) == []


### PR DESCRIPTION
## What

User accounts are org-scoped — one account works against every agent of the project — so per-agent surfaces (the ops Users page, Configure → Users) had no way to list *an agent's* users. This adds the `agent_users` binding table plus the visibility/removal semantics the ops control plane delegates to.

**Enrollment writes** (wherever assignment intent exists; idempotent, first write wins, never gates auth):
- `manual` — account created/attached from an agent's Configure → Users (via the ops client)
- `login` — successful password/Firebase auth through an agent's web channel (serving agent from the required `AgentRuntimeContext`)
- `session` — first user-attributed session (covers Slack/Telegram shadow users that never log in)
- `backfill` — idempotent migrate-time derivation from historical `sessions`

**Read/removal semantics** (in `surogates.db.agent_users`, integration-tested next to the schema):
- `visible_users_filter` — an agent's bound users plus org accounts bound to no agent at all (unassigned accounts stay manageable)
- `user_visibility` — bound / orphan / none (another agent's user)
- `remove_user_from_agent` — unbind; the account is deleted only at its last binding; orphans delete outright

Deleting a user cascades its bindings.

## Impact analysis

- **Commerce**: untouched — buyers are ops-side entities whose chats run as service-account sessions (no end-user rows).
- **Firebase**: BYO config is project-level; enrollment happens at token exchange using the serving agent.

## Tests

8 integration tests (testcontainers Postgres): helper idempotency + first-source-wins, session-creation enrollment (interactive only), login enrollment through the API app, backfill derivation + re-run idempotency, visibility states, removal semantics (shared account survives, last binding deletes, cross-agent guard), delete cascade.

Companion PR: invergent-ai/surogate-ops `feat/agent-user-bindings`.
