### PR TITLE
Agent end-user accounts and web-channel commerce enforcement

### DIFF
--- a/surogates/api/app.py
+++ b/surogates/api/app.py
@@ -713,12 +713,16 @@ def create_app() -> FastAPI:
         website,
         workspace,
     commerce,
+    firebase_auth_proxy,
 )
 
     app.include_router(health.router, tags=["health"])
     app.include_router(auth.router, prefix="/v1", tags=["auth"])
     app.include_router(sessions.router, prefix="/v1", tags=["sessions"])
     app.include_router(commerce.router, prefix="/v1", tags=["commerce"])
+    # Root-mounted: the Firebase SDK addresses /__/auth/* on the page
+    # origin directly.
+    app.include_router(firebase_auth_proxy.router, tags=["auth"])
     app.include_router(board.router, prefix="/v1", tags=["board"])
     app.include_router(events.router, prefix="/v1", tags=["events"])
     app.include_router(feedback.router, prefix="/v1", tags=["feedback"])

--- a/surogates/api/app.py
+++ b/surogates/api/app.py
@@ -712,11 +712,13 @@ def create_app() -> FastAPI:
         transparency,
         website,
         workspace,
-    )
+    commerce,
+)
 
     app.include_router(health.router, tags=["health"])
     app.include_router(auth.router, prefix="/v1", tags=["auth"])
     app.include_router(sessions.router, prefix="/v1", tags=["sessions"])
+    app.include_router(commerce.router, prefix="/v1", tags=["commerce"])
     app.include_router(board.router, prefix="/v1", tags=["board"])
     app.include_router(events.router, prefix="/v1", tags=["events"])
     app.include_router(feedback.router, prefix="/v1", tags=["feedback"])

--- a/surogates/api/routes/_commerce_turn.py
+++ b/surogates/api/routes/_commerce_turn.py
@@ -47,13 +47,7 @@ async def authorize_commerce_turn(
     turn.  402 details are structured (``{"code", "buy_url"}``) so the
     widget can render a paywall instead of a generic error.
     """
-    runtime_cache = getattr(request.app.state, "runtime_config_cache", None)
-    if runtime_cache is None:
-        return
-    try:
-        payload = await runtime_cache.get(str(session.agent_id)) or {}
-    except LookupError:
-        return
+    payload = await runtime_commerce_payload(request, str(session.agent_id))
     mode = str(payload.get("commerce_mode") or "free")
     if mode == "free":
         return
@@ -98,7 +92,7 @@ async def authorize_commerce_turn(
             detail="Access checks are temporarily unavailable; try again.",
         ) from exc
     if receipt.get("entitlement_id"):
-        store = _session_store(request)
+        store = get_session_store(request)
         # Appended, not overwritten: a second message can land while a
         # turn is still running, and each hold must survive until the
         # worker's settlement takes the whole list atomically.
@@ -113,8 +107,7 @@ async def authorize_commerce_turn(
         )
 
 
-
-def _session_store(request: Request) -> "SessionStore":
+def get_session_store(request: Request) -> "SessionStore":
     store = getattr(request.app.state, "session_store", None)
     if store is None:
         raise HTTPException(
@@ -122,3 +115,50 @@ def _session_store(request: Request) -> "SessionStore":
             detail="Session store not available.",
         )
     return store
+
+
+async def runtime_commerce_payload(request: Request, agent_id: str) -> dict:
+    """The agent's runtime-config payload, or ``{}`` when the cache is
+    absent or has no entry — reads as free mode either way. The single
+    cache-access point for commerce gating."""
+    runtime_cache = getattr(request.app.state, "runtime_config_cache", None)
+    if runtime_cache is None:
+        return {}
+    try:
+        return await runtime_cache.get(agent_id) or {}
+    except LookupError:
+        return {}
+
+
+async def firebase_buyer_identity(
+    request: Request, tenant,
+) -> dict | None:
+    """``{firebase_uid, email, name}`` for the signed-in user, or
+    ``None`` when the principal has no project-Firebase identity —
+    the one rule for "can this user be metered/charged", shared by
+    the web message gate and the Plan & tokens tab."""
+    if getattr(tenant, "user_id", None) is None:
+        return None
+    from sqlalchemy import select
+
+    from surogates.db.models import User
+
+    session_factory = request.app.state.session_factory
+    async with session_factory() as db:
+        user = await db.scalar(
+            select(User).where(
+                User.id == tenant.user_id,
+                User.org_id == tenant.org_id,
+            )
+        )
+    if (
+        user is None
+        or not (user.auth_provider or "").startswith("firebase:")
+        or not user.external_id
+    ):
+        return None
+    return {
+        "firebase_uid": user.external_id,
+        "email": user.email,
+        "name": user.display_name,
+    }

--- a/surogates/api/routes/_commerce_turn.py
+++ b/surogates/api/routes/_commerce_turn.py
@@ -1,0 +1,124 @@
+"""Per-turn commerce enforcement shared by every buyer-facing channel.
+
+The website widget binds the buyer identity onto the session at
+bootstrap; the web app derives it from the authenticated user at
+message time. Both feed the same authorize → reserve → (worker)
+settle pipeline: ops holds tokens before the turn runs and the
+worker settles the ``commerce_reservations`` list afterwards,
+regardless of channel.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException, Request, status
+
+from surogates.runtime.platform_client import (
+    CommercePaymentRequiredError,
+)
+from surogates.session.store import SessionStore
+
+logger = logging.getLogger(__name__)
+
+
+def estimate_turn_tokens(content: str) -> int:
+    """~4-chars/token heuristic — the same shape ops's
+    estimate_prompt_tokens computes for the hosted buy page
+    ((chars + 16) // 4 with the per-message framing overhead), so a
+    visitor's hold is the same through either surface."""
+    return (len(content) + 16) // 4
+
+
+async def authorize_commerce_turn(
+    request: Request,
+    session,
+    content: str,
+    *,
+    buyer: dict | None = None,
+) -> None:
+    """Gate one visitor message behind the agent's monetization mode.
+
+    Free agents (the default, and every agent while the platform's
+    commerce rollout flag is off — ops reports them as free) return
+    immediately.  Monetized agents require a session-bound buyer
+    identity and a successful ops-side token reservation; the receipt
+    is pinned on ``session.config`` for the worker to settle after the
+    turn.  402 details are structured (``{"code", "buy_url"}``) so the
+    widget can render a paywall instead of a generic error.
+    """
+    runtime_cache = getattr(request.app.state, "runtime_config_cache", None)
+    if runtime_cache is None:
+        return
+    try:
+        payload = await runtime_cache.get(str(session.agent_id)) or {}
+    except LookupError:
+        return
+    mode = str(payload.get("commerce_mode") or "free")
+    if mode == "free":
+        return
+    buy_url = payload.get("commerce_buy_url")
+    if buyer is None:
+        buyer = (session.config or {}).get("commerce_buyer") or {}
+    if not buyer.get("firebase_uid"):
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={"code": "sign_in_required", "buy_url": buy_url},
+        )
+    client = getattr(request.app.state, "platform_client", None)
+    if client is None:
+        logger.error("platform_client is not wired on app.state")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Access checks are temporarily unavailable; try again.",
+        )
+    try:
+        receipt = await client.commerce_authorize(
+            str(session.agent_id),
+            firebase_uid=buyer["firebase_uid"],
+            estimated_tokens=estimate_turn_tokens(content),
+            email=buyer.get("email"),
+            name=buyer.get("name"),
+        )
+    except CommercePaymentRequiredError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={"code": exc.detail, "buy_url": buy_url},
+        ) from exc
+    except Exception as exc:
+        # Fail closed: a paid agent must not serve free turns because
+        # the metering plane blinked.
+        logger.error(
+            "Commerce authorization failed for session %s: %s",
+            session.id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Access checks are temporarily unavailable; try again.",
+        ) from exc
+    if receipt.get("entitlement_id"):
+        store = _session_store(request)
+        # Appended, not overwritten: a second message can land while a
+        # turn is still running, and each hold must survive until the
+        # worker's settlement takes the whole list atomically.
+        await store.append_session_config_list(
+            session.id,
+            "commerce_reservations",
+            {
+                "entitlement_id": receipt["entitlement_id"],
+                "reserved_tokens": int(receipt.get("reserved_tokens") or 0),
+                "reservation_id": receipt.get("reservation_id") or "",
+            },
+        )
+
+
+
+def _session_store(request: Request) -> "SessionStore":
+    store = getattr(request.app.state, "session_store", None)
+    if store is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Session store not available.",
+        )
+    return store

--- a/surogates/api/routes/auth.py
+++ b/surogates/api/routes/auth.py
@@ -82,6 +82,9 @@ class FirebaseWebConfig(BaseModel):
     enabled_providers: list[str]
 
 
+USERNAME_PATTERN = r"^[a-z0-9][a-z0-9._-]{1,30}[a-z0-9]$"
+
+
 class AuthConfigResponse(BaseModel):
     """Runtime auth shape exposed by ``GET /v1/auth/config``."""
 
@@ -96,10 +99,22 @@ class AuthConfigResponse(BaseModel):
     # "Multi session" capability.  When False each user keeps one session
     # per channel; the SPA hides "New chat" and pins the conversation.
     multi_session: bool = True
+    # Username handle rule (source of truth: USERNAME_RE below). The
+    # sign-up form pre-validates with this so the client can never
+    # drift from the server.
+    username_pattern: str = USERNAME_PATTERN
 
 
 class FirebaseExchangeRequest(BaseModel):
     id_token: str
+    # Optional sign-up profile, applied atomically when this exchange
+    # auto-provisions a NEW user (the sign-up form collected them).
+    # Existing users are never overwritten here — profile edits go
+    # through PATCH /auth/me. Invalid or taken usernames are skipped
+    # rather than failing the sign-in.
+    display_name: str | None = None
+    username: str | None = None
+    phone: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -323,16 +338,45 @@ async def firebase_exchange(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Firebase token must include an email.",
                 )
+            requested_username = (
+                body.username.strip().lower() if body.username else None
+            )
+            if requested_username is not None and (
+                not USERNAME_RE.fullmatch(requested_username)
+                or await session.scalar(
+                    select(User.id).where(
+                        User.org_id == org_id,
+                        func.lower(User.username) == requested_username,
+                    )
+                )
+                is not None
+            ):
+                # Sign-in must not fail over the handle: skip it and
+                # let the user pick another via PATCH /auth/me.
+                requested_username = None
             user = User(
                 id=uuid.uuid4(),
                 org_id=org_id,
                 email=email,
-                display_name=_display_name_from_firebase_claims(claims, email),
+                display_name=(
+                    (body.display_name or "").strip()
+                    or _display_name_from_firebase_claims(claims, email)
+                ),
                 auth_provider=provider,
                 external_id=subject,
+                username=requested_username,
+                phone=(body.phone or "").strip() or None,
             )
             session.add(user)
-            await session.commit()
+            try:
+                await session.commit()
+            except IntegrityError:
+                # The username unique index caught a concurrent claim;
+                # retry once without it — account creation wins.
+                await session.rollback()
+                user.username = None
+                session.add(user)
+                await session.commit()
             await session.refresh(user)
 
         # Successful auth through THIS agent's web channel is
@@ -541,9 +585,9 @@ async def me(
 
 # Lowercase handle: 3-32 chars of [a-z0-9._-], starting and ending
 # alphanumeric. Validated after lowercasing, so any case is accepted
-# on the wire. Mirrored as an inline regex in the web sign-up form
-# (web/src/features/auth/login-page.tsx) — keep both in lockstep.
-USERNAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{1,30}[a-z0-9]$")
+# on the wire. Served to clients via /auth/config's username_pattern —
+# one source of truth, no frontend mirror to drift.
+USERNAME_RE = re.compile(USERNAME_PATTERN)
 
 
 class UserUpdateRequest(BaseModel):

--- a/surogates/api/routes/auth.py
+++ b/surogates/api/routes/auth.py
@@ -541,7 +541,8 @@ async def me(
 
 # Lowercase handle: 3-32 chars of [a-z0-9._-], starting and ending
 # alphanumeric. Validated after lowercasing, so any case is accepted
-# on the wire.
+# on the wire. Mirrored as an inline regex in the web sign-up form
+# (web/src/features/auth/login-page.tsx) — keep both in lockstep.
 USERNAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{1,30}[a-z0-9]$")
 
 

--- a/surogates/api/routes/auth.py
+++ b/surogates/api/routes/auth.py
@@ -8,7 +8,10 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
-from sqlalchemy import select
+import re
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 
 from surogates.audit import (
     AuditStore,
@@ -524,6 +527,8 @@ async def me(
         org_id=user.org_id,
         email=user.email,
         display_name=user.display_name,
+        username=user.username,
+        phone=user.phone,
         auth_provider=user.auth_provider,
         created_at=user.created_at,
     )
@@ -534,11 +539,19 @@ async def me(
 # ---------------------------------------------------------------------------
 
 
+# Lowercase handle: 3-32 chars of [a-z0-9._-], starting and ending
+# alphanumeric. Validated after lowercasing, so any case is accepted
+# on the wire.
+USERNAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{1,30}[a-z0-9]$")
+
+
 class UserUpdateRequest(BaseModel):
     """Payload for updating the current user's profile."""
 
     display_name: str | None = None
     email: str | None = None
+    username: str | None = None
+    phone: str | None = None
 
 
 @router.patch("/auth/me", response_model=UserResponse)
@@ -548,10 +561,26 @@ async def update_me(
     tenant: TenantContext = Depends(get_current_tenant),
 ) -> UserResponse:
     """Update profile fields for the currently authenticated user."""
-    if body.display_name is None and body.email is None:
+    if (
+        body.display_name is None
+        and body.email is None
+        and body.username is None
+        and body.phone is None
+    ):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="No fields to update.",
+        )
+
+    username = body.username.strip().lower() if body.username is not None else None
+    if username is not None and not USERNAME_RE.fullmatch(username):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "Username must be 3-32 characters (letters, digits, "
+                "dots, dashes, underscores) and start/end with a letter "
+                "or digit."
+            ),
         )
 
     session_factory = request.app.state.session_factory
@@ -581,8 +610,33 @@ async def update_me(
             user.display_name = stripped
         if body.email is not None:
             user.email = body.email
+        if username is not None:
+            taken = await session.scalar(
+                select(User.id).where(
+                    User.org_id == tenant.org_id,
+                    func.lower(User.username) == username,
+                    User.id != user.id,
+                )
+            )
+            if taken is not None:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="That username is already taken.",
+                )
+            user.username = username
+        if body.phone is not None:
+            # Optional field: an empty string clears it.
+            user.phone = body.phone.strip() or None
 
-        await session.commit()
+        try:
+            await session.commit()
+        except IntegrityError:
+            # The partial unique index caught a concurrent claim the
+            # pre-check raced with.
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="That username is already taken.",
+            )
         await session.refresh(user)
 
     return UserResponse(
@@ -590,6 +644,8 @@ async def update_me(
         org_id=user.org_id,
         email=user.email,
         display_name=user.display_name,
+        username=user.username,
+        phone=user.phone,
         auth_provider=user.auth_provider,
         created_at=user.created_at,
     )

--- a/surogates/api/routes/auth.py
+++ b/surogates/api/routes/auth.py
@@ -103,6 +103,12 @@ class AuthConfigResponse(BaseModel):
     # sign-up form pre-validates with this so the client can never
     # drift from the server.
     username_pattern: str = USERNAME_PATTERN
+    # Monetization projection: on paid agents the login page routes
+    # NEW users to the buy page (account creation happens inside the
+    # purchase flow, so they arrive entitled); free agents keep local
+    # self-registration. Public data — the buy page itself is public.
+    commerce_mode: str = "free"
+    commerce_buy_url: str | None = None
 
 
 class FirebaseExchangeRequest(BaseModel):
@@ -136,6 +142,13 @@ async def auth_config(
     local login.
     """
     slash_commands = sorted(agent_runtime.slash_commands.commands)
+    from surogates.api.routes._commerce_turn import runtime_commerce_payload
+
+    commerce = await runtime_commerce_payload(
+        request, str(agent_runtime.agent_id),
+    )
+    commerce_mode = str(commerce.get("commerce_mode") or "free")
+    commerce_buy_url = commerce.get("commerce_buy_url")
     cache = getattr(request.app.state, "firebase_config_cache", None)
     project_id = getattr(agent_runtime, "project_id", None)
     if cache is None or not project_id:
@@ -145,6 +158,8 @@ async def auth_config(
             firebase=None,
             slash_commands=slash_commands,
             multi_session=agent_runtime.multi_session,
+            commerce_mode=commerce_mode,
+            commerce_buy_url=commerce_buy_url,
         )
     try:
         fb = await cache.get(project_id)
@@ -155,12 +170,16 @@ async def auth_config(
             firebase=None,
             slash_commands=slash_commands,
             multi_session=agent_runtime.multi_session,
+            commerce_mode=commerce_mode,
+            commerce_buy_url=commerce_buy_url,
         )
     return AuthConfigResponse(
         agent_id=agent_runtime.agent_id,
         self_registration_enabled=True,
         slash_commands=slash_commands,
         multi_session=agent_runtime.multi_session,
+        commerce_mode=commerce_mode,
+        commerce_buy_url=commerce_buy_url,
         firebase=FirebaseWebConfig(
             api_key=fb.api_key,
             auth_domain=fb.auth_domain,

--- a/surogates/api/routes/auth.py
+++ b/surogates/api/routes/auth.py
@@ -630,9 +630,17 @@ async def update_me(
 
         try:
             await session.commit()
-        except IntegrityError:
-            # The partial unique index caught a concurrent claim the
-            # pre-check raced with.
+        except IntegrityError as exc:
+            # Two org-scoped unique indexes can fire here: the
+            # username handle and the login-key e-mail. Name the right
+            # one — a mislabeled conflict sends the user fixing the
+            # wrong field.
+            constraint = str(getattr(exc, "orig", exc))
+            if "uq_users_org_lower_email" in constraint:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="That email is already in use.",
+                )
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="That username is already taken.",

--- a/surogates/api/routes/commerce.py
+++ b/surogates/api/routes/commerce.py
@@ -19,8 +19,7 @@ import logging
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
-from sqlalchemy import select
-
+from surogates.api.routes._commerce_turn import firebase_buyer_identity
 from surogates.runtime import AgentRuntimeContext, agent_runtime_context_dep
 from surogates.runtime.platform_client import PlatformAuthError
 from surogates.tenant.auth.middleware import get_current_tenant
@@ -39,30 +38,6 @@ class CommerceCheckoutResponse(BaseModel):
     url: str
 
 
-async def _firebase_identity(
-    request: Request, tenant: TenantContext,
-) -> tuple[str, str | None, str | None] | None:
-    """(firebase_uid, email, name) for the signed-in user, or ``None``
-    when the principal has no project-Firebase identity."""
-    if tenant.user_id is None:
-        return None
-    from surogates.db.models import User
-
-    session_factory = request.app.state.session_factory
-    async with session_factory() as db:
-        user = await db.scalar(
-            select(User).where(
-                User.id == tenant.user_id,
-                User.org_id == tenant.org_id,
-            )
-        )
-    if (
-        user is None
-        or not (user.auth_provider or "").startswith("firebase:")
-        or not user.external_id
-    ):
-        return None
-    return user.external_id, user.email, user.display_name
 
 
 def _platform_client(request: Request):
@@ -86,31 +61,13 @@ async def commerce_overview(
     ``purchasable`` tells the tab whether Buy buttons can work for
     this principal (it requires a Firebase identity to meter against).
     """
-    identity = await _firebase_identity(request, tenant)
+    identity = await firebase_buyer_identity(request, tenant)
     client = _platform_client(request)
-    if identity is None:
-        # Still show what the agent sells — with buying disabled. No
-        # identity is sent, so ops mints no buyer/entitlement row.
-        try:
-            summary = await client.commerce_summary(
-                str(agent_runtime.agent_id),
-            )
-        except (PlatformAuthError, httpx.HTTPError):
-            logger.warning("commerce summary unavailable", exc_info=True)
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Plan information is temporarily unavailable.",
-            )
-        summary["entitlement"] = None
-        summary["purchasable"] = False
-        return summary
-    uid, email, name = identity
     try:
+        # Identity-less principals get the offer list only — no
+        # identity is sent, so ops mints no buyer/entitlement row.
         summary = await client.commerce_summary(
-            str(agent_runtime.agent_id),
-            firebase_uid=uid,
-            email=email,
-            name=name,
+            str(agent_runtime.agent_id), **(identity or {}),
         )
     except (PlatformAuthError, httpx.HTTPError):
         logger.warning("commerce summary unavailable", exc_info=True)
@@ -118,7 +75,11 @@ async def commerce_overview(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Plan information is temporarily unavailable.",
         )
-    summary["purchasable"] = summary.get("mode") != "free"
+    if identity is None:
+        summary["entitlement"] = None
+    summary["purchasable"] = (
+        identity is not None and summary.get("mode") != "free"
+    )
     return summary
 
 
@@ -129,7 +90,7 @@ async def commerce_checkout(
     tenant: TenantContext = Depends(get_current_tenant),
     agent_runtime: AgentRuntimeContext = Depends(agent_runtime_context_dep),
 ) -> CommerceCheckoutResponse:
-    identity = await _firebase_identity(request, tenant)
+    identity = await firebase_buyer_identity(request, tenant)
     if identity is None:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -139,15 +100,12 @@ async def commerce_checkout(
                 "operator)."
             ),
         )
-    uid, email, name = identity
     client = _platform_client(request)
     try:
         payload = await client.commerce_checkout(
             str(agent_runtime.agent_id),
-            firebase_uid=uid,
             offer_id=body.offer_id,
-            email=email,
-            name=name,
+            **identity,
         )
     except httpx.HTTPStatusError as exc:
         detail = "Checkout is unavailable for this offer."

--- a/surogates/api/routes/commerce.py
+++ b/surogates/api/routes/commerce.py
@@ -1,0 +1,166 @@
+"""End-user commerce routes for the agent web app.
+
+The Plan & tokens tab in the web app's settings shows what the agent
+sells and what the signed-in user currently holds, and lets them buy.
+The harness fronts surogate-ops with its runtime token, keyed to the
+authenticated user's project-Firebase identity — the browser never
+handles ops credentials or cross-origin calls.
+
+Users without a Firebase identity (operator-provisioned database /
+external accounts) get the offer list with ``purchasable=false`` —
+they chat unmetered by the operator's choice and have no buyer
+identity a purchase could attach to.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from surogates.runtime import AgentRuntimeContext, agent_runtime_context_dep
+from surogates.runtime.platform_client import PlatformAuthError
+from surogates.tenant.auth.middleware import get_current_tenant
+from surogates.tenant.context import TenantContext
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class CommerceCheckoutRequest(BaseModel):
+    offer_id: str = Field(min_length=1, max_length=36)
+
+
+class CommerceCheckoutResponse(BaseModel):
+    url: str
+
+
+async def _firebase_identity(
+    request: Request, tenant: TenantContext,
+) -> tuple[str, str | None, str | None] | None:
+    """(firebase_uid, email, name) for the signed-in user, or ``None``
+    when the principal has no project-Firebase identity."""
+    if tenant.user_id is None:
+        return None
+    from surogates.db.models import User
+
+    session_factory = request.app.state.session_factory
+    async with session_factory() as db:
+        user = await db.scalar(
+            select(User).where(
+                User.id == tenant.user_id,
+                User.org_id == tenant.org_id,
+            )
+        )
+    if (
+        user is None
+        or not (user.auth_provider or "").startswith("firebase:")
+        or not user.external_id
+    ):
+        return None
+    return user.external_id, user.email, user.display_name
+
+
+def _platform_client(request: Request):
+    client = getattr(request.app.state, "platform_client", None)
+    if client is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Platform connection is not available.",
+        )
+    return client
+
+
+@router.get("/commerce/overview")
+async def commerce_overview(
+    request: Request,
+    tenant: TenantContext = Depends(get_current_tenant),
+    agent_runtime: AgentRuntimeContext = Depends(agent_runtime_context_dep),
+) -> dict:
+    """Offers + the caller's entitlement, shaped for the settings tab.
+
+    ``purchasable`` tells the tab whether Buy buttons can work for
+    this principal (it requires a Firebase identity to meter against).
+    """
+    identity = await _firebase_identity(request, tenant)
+    client = _platform_client(request)
+    if identity is None:
+        # Still show what the agent sells — with buying disabled.
+        try:
+            summary = await client.commerce_summary(
+                str(agent_runtime.agent_id),
+                firebase_uid="__none__",
+            )
+        except (PlatformAuthError, httpx.HTTPError):
+            logger.warning("commerce summary unavailable", exc_info=True)
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Plan information is temporarily unavailable.",
+            )
+        summary["entitlement"] = None
+        summary["purchasable"] = False
+        return summary
+    uid, email, name = identity
+    try:
+        summary = await client.commerce_summary(
+            str(agent_runtime.agent_id),
+            firebase_uid=uid,
+            email=email,
+            name=name,
+        )
+    except (PlatformAuthError, httpx.HTTPError):
+        logger.warning("commerce summary unavailable", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Plan information is temporarily unavailable.",
+        )
+    summary["purchasable"] = summary.get("mode") != "free"
+    return summary
+
+
+@router.post("/commerce/checkout", response_model=CommerceCheckoutResponse)
+async def commerce_checkout(
+    body: CommerceCheckoutRequest,
+    request: Request,
+    tenant: TenantContext = Depends(get_current_tenant),
+    agent_runtime: AgentRuntimeContext = Depends(agent_runtime_context_dep),
+) -> CommerceCheckoutResponse:
+    identity = await _firebase_identity(request, tenant)
+    if identity is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Purchases require an account created through the "
+                "agent's sign-in (your account was provisioned by the "
+                "operator)."
+            ),
+        )
+    uid, email, name = identity
+    client = _platform_client(request)
+    try:
+        payload = await client.commerce_checkout(
+            str(agent_runtime.agent_id),
+            firebase_uid=uid,
+            offer_id=body.offer_id,
+            email=email,
+            name=name,
+        )
+    except httpx.HTTPStatusError as exc:
+        detail = "Checkout is unavailable for this offer."
+        try:
+            detail = str(exc.response.json().get("detail") or detail)
+        except ValueError:
+            pass
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=detail,
+        ) from exc
+    except (PlatformAuthError, httpx.HTTPError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Checkout is temporarily unavailable; try again.",
+        ) from exc
+    return CommerceCheckoutResponse(url=payload["url"])

--- a/surogates/api/routes/commerce.py
+++ b/surogates/api/routes/commerce.py
@@ -89,11 +89,11 @@ async def commerce_overview(
     identity = await _firebase_identity(request, tenant)
     client = _platform_client(request)
     if identity is None:
-        # Still show what the agent sells — with buying disabled.
+        # Still show what the agent sells — with buying disabled. No
+        # identity is sent, so ops mints no buyer/entitlement row.
         try:
             summary = await client.commerce_summary(
                 str(agent_runtime.agent_id),
-                firebase_uid="__none__",
             )
         except (PlatformAuthError, httpx.HTTPError):
             logger.warning("commerce summary unavailable", exc_info=True)

--- a/surogates/api/routes/firebase_auth_proxy.py
+++ b/surogates/api/routes/firebase_auth_proxy.py
@@ -1,0 +1,128 @@
+"""Same-origin Firebase auth helpers for the agent web app.
+
+``signInWithPopup`` completes through helper pages served from the
+Firebase ``authDomain`` (``/__/auth/*``). When that domain differs
+from the page origin, browsers that partition third-party storage
+(Firefox ETP, Safari, Chrome's cookie phase-out) sever the popup's
+completion channel and sign-in hangs forever.
+
+In production every agent web app is served at
+``<slug>.<base-domain>`` by this API (wildcard ingress), so this
+route makes the app's own origin serve the helpers: it resolves the
+agent from the request (Host subdomain), looks up the project's
+Firebase config, and reverse-proxies to the project's real
+``firebaseapp.com`` domain. The SPA then uses ``location.host`` as
+``authDomain``, keeping the whole flow first-party. The agent's
+domain must be added to the Firebase project's authorized domains.
+
+Dev keeps the vite ``/__`` proxy (no Host slug to resolve there);
+this route is the production equivalent. The upstream host always
+comes from the stored project config — never from the request — so
+this is a pinned proxy, not an open one.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+
+from surogates.runtime import AgentRuntimeContext, agent_runtime_context_dep
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Only the Firebase helper namespaces are proxied.
+_ALLOWED_PREFIXES = ("auth/", "firebase/")
+
+# Hop-by-hop and origin-bound headers that must not be forwarded
+# either direction.
+_SKIP_REQUEST_HEADERS = {
+    "host",
+    "connection",
+    "content-length",
+    "accept-encoding",
+    "cookie",
+    "transfer-encoding",
+}
+_SKIP_RESPONSE_HEADERS = {
+    "connection",
+    "content-length",
+    "content-encoding",
+    "transfer-encoding",
+    "set-cookie",
+}
+
+_PROXY_TIMEOUT_SECONDS = 15.0
+
+
+def _proxy_client(request: Request) -> httpx.AsyncClient:
+    client = getattr(request.app.state, "firebase_helper_client", None)
+    if client is None:
+        client = httpx.AsyncClient(
+            timeout=_PROXY_TIMEOUT_SECONDS, follow_redirects=False,
+        )
+        request.app.state.firebase_helper_client = client
+    return client
+
+
+@router.api_route("/__/{helper_path:path}", methods=["GET", "POST"])
+async def firebase_auth_helpers(
+    helper_path: str,
+    request: Request,
+    agent_runtime: AgentRuntimeContext = Depends(agent_runtime_context_dep),
+) -> Response:
+    if not helper_path.startswith(_ALLOWED_PREFIXES):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Not found",
+        )
+
+    cache = getattr(request.app.state, "firebase_config_cache", None)
+    project_id = getattr(agent_runtime, "project_id", None)
+    fb = None
+    if cache is not None and project_id:
+        try:
+            fb = await cache.get(project_id)
+        except LookupError:
+            fb = None
+    if fb is None or not getattr(fb, "auth_domain", None):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Firebase auth is not configured.",
+        )
+
+    upstream = httpx.URL(
+        f"https://{fb.auth_domain}/__/{helper_path}",
+        query=request.url.query.encode() or None,
+    )
+    headers = {
+        k: v
+        for k, v in request.headers.items()
+        if k.lower() not in _SKIP_REQUEST_HEADERS
+    }
+    body = await request.body()
+    client = _proxy_client(request)
+    try:
+        proxied = await client.request(
+            request.method, upstream, headers=headers, content=body or None,
+        )
+    except httpx.HTTPError:
+        logger.warning(
+            "Firebase helper proxy failed for %s", upstream, exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Firebase auth helpers are unreachable.",
+        )
+    response_headers = {
+        k: v
+        for k, v in proxied.headers.items()
+        if k.lower() not in _SKIP_RESPONSE_HEADERS
+    }
+    return Response(
+        content=proxied.content,
+        status_code=proxied.status_code,
+        headers=response_headers,
+    )

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -38,6 +38,9 @@ from surogates.api.session_guards import (
 )
 from surogates.coding_agents.command import is_code_command
 from surogates.config import INTERRUPT_CHANNEL_PREFIX, enqueue_session
+from surogates.api.routes._commerce_turn import (
+    authorize_commerce_turn,
+)
 from surogates.session.events import EventType
 from surogates.session.models import Session
 from surogates.session.provisioning import create_agent_session
@@ -527,6 +530,22 @@ async def create_api_session(
     )
 
 
+async def _load_tenant_user(request: Request, tenant: TenantContext):
+    """The authenticated user row, or None for non-user principals."""
+    from sqlalchemy import select
+
+    from surogates.db.models import User
+
+    session_factory = request.app.state.session_factory
+    async with session_factory() as db:
+        return await db.scalar(
+            select(User).where(
+                User.id == tenant.user_id,
+                User.org_id == tenant.org_id,
+            )
+        )
+
+
 @router.post(
     "/api/sessions/{session_id}/messages",
     response_model=SendMessageResponse,
@@ -797,6 +816,31 @@ async def send_message(
         len(body.images) if body.images else 0,
         len(attachments_payload) if attachments_payload else 0,
     )
+    # ── Commerce enforcement (monetized agents, web channel) ──
+    # The authenticated web user's Firebase identity IS the buyer
+    # identity ops meters against (exchange stores the Firebase uid as
+    # external_id), so their paid subscription/token-pack balance
+    # applies here exactly as on the hosted buy page: reserve before
+    # the turn, worker settles ``commerce_reservations`` after it.
+    # Operator-provisioned accounts (database/external providers, no
+    # Firebase uid) are the builder's own people and pass unmetered —
+    # granting them access is the operator's explicit choice.
+    if session.channel == "web" and tenant.user_id is not None:
+        principal = await _load_tenant_user(request, tenant)
+        if principal is not None and (
+            principal.auth_provider or ""
+        ).startswith("firebase:") and principal.external_id:
+            await authorize_commerce_turn(
+                request,
+                session,
+                body.content,
+                buyer={
+                    "firebase_uid": principal.external_id,
+                    "email": principal.email,
+                    "name": principal.display_name,
+                },
+            )
+
     event_data: dict = {"content": body.content}
     if body.images:
         event_data["images"] = [

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -40,6 +40,8 @@ from surogates.coding_agents.command import is_code_command
 from surogates.config import INTERRUPT_CHANNEL_PREFIX, enqueue_session
 from surogates.api.routes._commerce_turn import (
     authorize_commerce_turn,
+    firebase_buyer_identity,
+    runtime_commerce_payload,
 )
 from surogates.session.events import EventType
 from surogates.session.models import Session
@@ -530,20 +532,6 @@ async def create_api_session(
     )
 
 
-async def _load_tenant_user(request: Request, tenant: TenantContext):
-    """The authenticated user row, or None for non-user principals."""
-    from sqlalchemy import select
-
-    from surogates.db.models import User
-
-    session_factory = request.app.state.session_factory
-    async with session_factory() as db:
-        return await db.scalar(
-            select(User).where(
-                User.id == tenant.user_id,
-                User.org_id == tenant.org_id,
-            )
-        )
 
 
 @router.post(
@@ -826,20 +814,18 @@ async def send_message(
     # Firebase uid) are the builder's own people and pass unmetered —
     # granting them access is the operator's explicit choice.
     if session.channel == "web" and tenant.user_id is not None:
-        principal = await _load_tenant_user(request, tenant)
-        if principal is not None and (
-            principal.auth_provider or ""
-        ).startswith("firebase:") and principal.external_id:
-            await authorize_commerce_turn(
-                request,
-                session,
-                body.content,
-                buyer={
-                    "firebase_uid": principal.external_id,
-                    "email": principal.email,
-                    "name": principal.display_name,
-                },
-            )
+        payload = await runtime_commerce_payload(
+            request, str(session.agent_id),
+        )
+        if str(payload.get("commerce_mode") or "free") != "free":
+            buyer = await firebase_buyer_identity(request, tenant)
+            if buyer is not None:
+                await authorize_commerce_turn(
+                    request,
+                    session,
+                    body.content,
+                    buyer=buyer,
+                )
 
     event_data: dict = {"content": body.content}
     if body.images:

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -66,6 +66,10 @@ from surogates.channels.website_session import (
     verify_csrf_token,
 )
 from surogates.config import Settings, enqueue_session
+from surogates.api.routes._commerce_turn import (
+    authorize_commerce_turn,
+    estimate_turn_tokens,
+)
 from surogates.runtime.platform_client import (
     CommercePaymentRequiredError,
     PlatformAuthError,
@@ -491,14 +495,6 @@ async def _enforce_website_rate_limit(
 # ---------------------------------------------------------------------------
 
 
-def _estimate_turn_tokens(content: str) -> int:
-    """~4-chars/token heuristic — the same shape ops's
-    estimate_prompt_tokens computes for the hosted buy page
-    ((chars + 16) // 4 with the per-message framing overhead), so a
-    visitor's hold is the same through either surface."""
-    return (len(content) + 16) // 4
-
-
 async def _resolve_commerce_buyer(
     request: Request, agent_id: str, firebase_id_token: str,
 ) -> dict | None:
@@ -567,84 +563,6 @@ async def _resolve_commerce_buyer(
         "email": email,
         "name": _display_name_from_firebase_claims(claims, email),
     }
-
-
-async def _authorize_commerce_turn(
-    request: Request, session, content: str,
-) -> None:
-    """Gate one visitor message behind the agent's monetization mode.
-
-    Free agents (the default, and every agent while the platform's
-    commerce rollout flag is off — ops reports them as free) return
-    immediately.  Monetized agents require a session-bound buyer
-    identity and a successful ops-side token reservation; the receipt
-    is pinned on ``session.config`` for the worker to settle after the
-    turn.  402 details are structured (``{"code", "buy_url"}``) so the
-    widget can render a paywall instead of a generic error.
-    """
-    runtime_cache = getattr(request.app.state, "runtime_config_cache", None)
-    if runtime_cache is None:
-        return
-    try:
-        payload = await runtime_cache.get(str(session.agent_id)) or {}
-    except LookupError:
-        return
-    mode = str(payload.get("commerce_mode") or "free")
-    if mode == "free":
-        return
-    buy_url = payload.get("commerce_buy_url")
-    buyer = (session.config or {}).get("commerce_buyer") or {}
-    if not buyer.get("firebase_uid"):
-        raise HTTPException(
-            status_code=status.HTTP_402_PAYMENT_REQUIRED,
-            detail={"code": "sign_in_required", "buy_url": buy_url},
-        )
-    client = getattr(request.app.state, "platform_client", None)
-    if client is None:
-        logger.error("platform_client is not wired on app.state")
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Access checks are temporarily unavailable; try again.",
-        )
-    try:
-        receipt = await client.commerce_authorize(
-            str(session.agent_id),
-            firebase_uid=buyer["firebase_uid"],
-            estimated_tokens=_estimate_turn_tokens(content),
-            email=buyer.get("email"),
-            name=buyer.get("name"),
-        )
-    except CommercePaymentRequiredError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_402_PAYMENT_REQUIRED,
-            detail={"code": exc.detail, "buy_url": buy_url},
-        ) from exc
-    except Exception as exc:
-        # Fail closed: a paid agent must not serve free turns because
-        # the metering plane blinked.
-        logger.error(
-            "Commerce authorization failed for session %s: %s",
-            session.id,
-            exc,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Access checks are temporarily unavailable; try again.",
-        ) from exc
-    if receipt.get("entitlement_id"):
-        store = _get_session_store(request)
-        # Appended, not overwritten: a second message can land while a
-        # turn is still running, and each hold must survive until the
-        # worker's settlement takes the whole list atomically.
-        await store.append_session_config_list(
-            session.id,
-            "commerce_reservations",
-            {
-                "entitlement_id": receipt["entitlement_id"],
-                "reserved_tokens": int(receipt.get("reserved_tokens") or 0),
-                "reservation_id": receipt.get("reservation_id") or "",
-            },
-        )
 
 
 def _issue_bootstrap_response(
@@ -914,7 +832,7 @@ async def send_website_message(
             ),
         )
 
-    await _authorize_commerce_turn(request, session, body.content)
+    await authorize_commerce_turn(request, session, body.content)
 
     if session.status in ("failed", "paused", "completed"):
         await store.update_session_status(session_id, "active")

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -69,6 +69,7 @@ from surogates.config import Settings, enqueue_session
 from surogates.api.routes._commerce_turn import (
     authorize_commerce_turn,
     estimate_turn_tokens,
+    get_session_store,
 )
 from surogates.runtime.platform_client import (
     CommercePaymentRequiredError,
@@ -158,14 +159,6 @@ def _get_settings(request: Request) -> Settings:
     return request.app.state.settings
 
 
-def _get_session_store(request: Request) -> SessionStore:
-    store: SessionStore | None = getattr(request.app.state, "session_store", None)
-    if store is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Session store not available.",
-        )
-    return store
 
 
 def _require_website_enabled(settings: Settings) -> None:
@@ -358,7 +351,7 @@ async def _reusable_cookie_session(
         or claims.org_id != org_uuid
     ):
         return None
-    store = _get_session_store(request)
+    store = get_session_store(request)
     try:
         session = await store.get_session(claims.session_id)
     except SessionNotFoundError:
@@ -655,7 +648,7 @@ async def bootstrap_website_session(
             detail="Storage bucket is not configured (settings.storage.bucket is empty).",
         )
 
-    store = _get_session_store(request)
+    store = get_session_store(request)
     storage = request.app.state.storage
 
     session_id = uuid.uuid4()
@@ -796,7 +789,7 @@ async def send_website_message(
             detail=f"Missing or mismatched {CSRF_HEADER_NAME} header.",
         )
 
-    store = _get_session_store(request)
+    store = get_session_store(request)
     try:
         session = await store.get_session(session_id)
     except SessionNotFoundError:
@@ -867,7 +860,7 @@ async def stream_website_events(
     origin and the deployment's live allow-list.
     """
     claims = await _load_and_authorize_session(request, session_id)
-    store = _get_session_store(request)
+    store = get_session_store(request)
 
     try:
         session_check = await asyncio.shield(store.get_session(session_id))
@@ -1066,7 +1059,7 @@ async def end_website_session(
             detail=f"Missing or mismatched {CSRF_HEADER_NAME} header.",
         )
 
-    store = _get_session_store(request)
+    store = get_session_store(request)
     await store.update_session_status(session_id, "completed")
     await store.emit_event(session_id, EventType.SESSION_COMPLETE, {})
     _clear_session_cookie(response)

--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -130,6 +130,10 @@ class User(Base):
     )
     external_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     password_hash: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # Self-registration profile: a lowercase handle (unique per org via
+    # the partial index in observability.sql) and an optional phone.
+    username: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    phone: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     memory_summary: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, server_default="{}"
     )

--- a/surogates/db/observability.sql
+++ b/surogates/db/observability.sql
@@ -861,3 +861,12 @@ BEGIN
             ON users (org_id, lower(email));
     END IF;
 END $$;
+
+-- ── users: self-registration profile fields ─────────────────────────
+-- Full name lives in display_name; username is a per-org unique
+-- lowercase handle, phone is optional free-form.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS username text;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS phone text;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_users_org_username
+    ON users (org_id, lower(username))
+    WHERE username IS NOT NULL;

--- a/surogates/runtime/platform_client.py
+++ b/surogates/runtime/platform_client.py
@@ -396,6 +396,64 @@ class PlatformClient:
         resp.raise_for_status()
         return resp.json()
 
+    async def commerce_summary(
+        self,
+        agent_id: str,
+        *,
+        firebase_uid: str,
+        email: str | None = None,
+        name: str | None = None,
+    ) -> dict:
+        """The agent's offers plus this end-user's entitlement — the
+        payload behind the web app's Plan & tokens tab. Raises
+        :class:`PlatformAuthError` on 401; other non-2xx propagate."""
+        body: dict = {"firebase_uid": firebase_uid}
+        if email is not None:
+            body["email"] = email
+        if name is not None:
+            body["name"] = name
+        resp = await self._client.post(
+            f"/api/agents/agents/{agent_id}/commerce/summary", json=body,
+        )
+        if resp.status_code == 401:
+            raise PlatformAuthError(
+                "surogate-ops rejected runtime token (401); "
+                "is the token revoked or missing the 'runtime' scope?",
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def commerce_checkout(
+        self,
+        agent_id: str,
+        *,
+        firebase_uid: str,
+        offer_id: str,
+        email: str | None = None,
+        name: str | None = None,
+    ) -> dict:
+        """Mint a Stripe Checkout URL for an in-app purchase.
+
+        Returns ``{"url": str}``. 4xx refusals (inactive offer, seller
+        account not ready, …) surface as ``httpx.HTTPStatusError`` for
+        the route to translate; 401 raises
+        :class:`PlatformAuthError`."""
+        body: dict = {"firebase_uid": firebase_uid, "offer_id": offer_id}
+        if email is not None:
+            body["email"] = email
+        if name is not None:
+            body["name"] = name
+        resp = await self._client.post(
+            f"/api/agents/agents/{agent_id}/commerce/checkout", json=body,
+        )
+        if resp.status_code == 401:
+            raise PlatformAuthError(
+                "surogate-ops rejected runtime token (401); "
+                "is the token revoked or missing the 'runtime' scope?",
+            )
+        resp.raise_for_status()
+        return resp.json()
+
     async def commerce_debit(
         self,
         agent_id: str,

--- a/surogates/runtime/platform_client.py
+++ b/surogates/runtime/platform_client.py
@@ -400,14 +400,16 @@ class PlatformClient:
         self,
         agent_id: str,
         *,
-        firebase_uid: str,
+        firebase_uid: str | None = None,
         email: str | None = None,
         name: str | None = None,
     ) -> dict:
         """The agent's offers plus this end-user's entitlement — the
         payload behind the web app's Plan & tokens tab. Raises
         :class:`PlatformAuthError` on 401; other non-2xx propagate."""
-        body: dict = {"firebase_uid": firebase_uid}
+        body: dict = {}
+        if firebase_uid is not None:
+            body["firebase_uid"] = firebase_uid
         if email is not None:
             body["email"] = email
         if name is not None:

--- a/surogates/runtime/platform_client.py
+++ b/surogates/runtime/platform_client.py
@@ -396,6 +396,18 @@ class PlatformClient:
         resp.raise_for_status()
         return resp.json()
 
+    async def _post_commerce(self, path: str, body: dict) -> dict:
+        """POST with the shared 401→PlatformAuthError translation the
+        commerce endpoints all need."""
+        resp = await self._client.post(path, json=body)
+        if resp.status_code == 401:
+            raise PlatformAuthError(
+                "surogate-ops rejected runtime token (401); "
+                "is the token revoked or missing the 'runtime' scope?",
+            )
+        resp.raise_for_status()
+        return resp.json()
+
     async def commerce_summary(
         self,
         agent_id: str,
@@ -414,16 +426,9 @@ class PlatformClient:
             body["email"] = email
         if name is not None:
             body["name"] = name
-        resp = await self._client.post(
-            f"/api/agents/agents/{agent_id}/commerce/summary", json=body,
+        return await self._post_commerce(
+            f"/api/agents/agents/{agent_id}/commerce/summary", body,
         )
-        if resp.status_code == 401:
-            raise PlatformAuthError(
-                "surogate-ops rejected runtime token (401); "
-                "is the token revoked or missing the 'runtime' scope?",
-            )
-        resp.raise_for_status()
-        return resp.json()
 
     async def commerce_checkout(
         self,
@@ -445,16 +450,9 @@ class PlatformClient:
             body["email"] = email
         if name is not None:
             body["name"] = name
-        resp = await self._client.post(
-            f"/api/agents/agents/{agent_id}/commerce/checkout", json=body,
+        return await self._post_commerce(
+            f"/api/agents/agents/{agent_id}/commerce/checkout", body,
         )
-        if resp.status_code == 401:
-            raise PlatformAuthError(
-                "surogate-ops rejected runtime token (401); "
-                "is the token revoked or missing the 'runtime' scope?",
-            )
-        resp.raise_for_status()
-        return resp.json()
 
     async def commerce_debit(
         self,

--- a/surogates/tenant/models.py
+++ b/surogates/tenant/models.py
@@ -73,6 +73,8 @@ class UserResponse(BaseModel):
     org_id: UUID
     email: str | None = None
     display_name: str | None = None
+    username: str | None = None
+    phone: str | None = None
     auth_provider: str
     created_at: datetime
 

--- a/tests/api/test_auth_config_multi_session.py
+++ b/tests/api/test_auth_config_multi_session.py
@@ -27,6 +27,7 @@ def _ctx(**overrides) -> AgentRuntimeContext:
 async def test_auth_config_defaults_multi_session_on():
     request = MagicMock()
     request.app.state.firebase_config_cache = None
+    request.app.state.runtime_config_cache = None
 
     resp = await auth_config(request, agent_runtime=_ctx())
 
@@ -37,6 +38,7 @@ async def test_auth_config_defaults_multi_session_on():
 async def test_auth_config_projects_multi_session_off():
     request = MagicMock()
     request.app.state.firebase_config_cache = None
+    request.app.state.runtime_config_cache = None
 
     resp = await auth_config(request, agent_runtime=_ctx(multi_session=False))
 

--- a/tests/api/test_auth_config_slash_commands.py
+++ b/tests/api/test_auth_config_slash_commands.py
@@ -29,6 +29,7 @@ async def test_auth_config_exposes_enabled_slash_commands():
     # No firebase cache → the early-return path; slash_commands must still
     # be populated.
     request.app.state.firebase_config_cache = None
+    request.app.state.runtime_config_cache = None
 
     resp = await auth_config(
         request, agent_runtime=_ctx(frozenset({"clear", "loop", "compress"}))
@@ -41,6 +42,7 @@ async def test_auth_config_exposes_enabled_slash_commands():
 async def test_auth_config_omits_disabled_slash_commands():
     request = MagicMock()
     request.app.state.firebase_config_cache = None
+    request.app.state.runtime_config_cache = None
 
     resp = await auth_config(request, agent_runtime=_ctx(frozenset({"clear"})))
 

--- a/tests/api/test_commerce_tab.py
+++ b/tests/api/test_commerce_tab.py
@@ -62,9 +62,9 @@ _SUMMARY = {
 @pytest.mark.asyncio
 async def test_overview_marks_purchasable_for_firebase_user(monkeypatch):
     async def ident(request, tenant):
-        return ("uid-1", "u@example.com", "U")
+        return {"firebase_uid": "uid-1", "email": "u@example.com", "name": "U"}
 
-    monkeypatch.setattr(commerce, "_firebase_identity", ident)
+    monkeypatch.setattr(commerce, "firebase_buyer_identity", ident)
     platform = _FakePlatform(summary=_SUMMARY)
     out = await commerce.commerce_overview(
         _request(platform), tenant=_TENANT, agent_runtime=_ctx(),
@@ -81,7 +81,7 @@ async def test_overview_disables_buying_without_firebase_identity(
     async def ident(request, tenant):
         return None
 
-    monkeypatch.setattr(commerce, "_firebase_identity", ident)
+    monkeypatch.setattr(commerce, "firebase_buyer_identity", ident)
     platform = _FakePlatform(summary=_SUMMARY)
     out = await commerce.commerce_overview(
         _request(platform), tenant=_TENANT, agent_runtime=_ctx(),
@@ -93,9 +93,9 @@ async def test_overview_disables_buying_without_firebase_identity(
 @pytest.mark.asyncio
 async def test_checkout_translates_ops_refusals(monkeypatch):
     async def ident(request, tenant):
-        return ("uid-1", None, None)
+        return {"firebase_uid": "uid-1", "email": None, "name": None}
 
-    monkeypatch.setattr(commerce, "_firebase_identity", ident)
+    monkeypatch.setattr(commerce, "firebase_buyer_identity", ident)
     refusal = httpx.HTTPStatusError(
         "400",
         request=httpx.Request("POST", "http://x"),
@@ -118,7 +118,7 @@ async def test_checkout_refuses_operator_accounts(monkeypatch):
     async def ident(request, tenant):
         return None
 
-    monkeypatch.setattr(commerce, "_firebase_identity", ident)
+    monkeypatch.setattr(commerce, "firebase_buyer_identity", ident)
     platform = _FakePlatform(checkout={"url": "x"})
     with pytest.raises(HTTPException) as err:
         await commerce.commerce_checkout(
@@ -133,9 +133,9 @@ async def test_checkout_refuses_operator_accounts(monkeypatch):
 @pytest.mark.asyncio
 async def test_checkout_returns_url(monkeypatch):
     async def ident(request, tenant):
-        return ("uid-1", "u@example.com", "U")
+        return {"firebase_uid": "uid-1", "email": "u@example.com", "name": "U"}
 
-    monkeypatch.setattr(commerce, "_firebase_identity", ident)
+    monkeypatch.setattr(commerce, "firebase_buyer_identity", ident)
     platform = _FakePlatform(checkout={"url": "https://stripe/xyz"})
     out = await commerce.commerce_checkout(
         commerce.CommerceCheckoutRequest(offer_id="off-1"),

--- a/tests/api/test_commerce_tab.py
+++ b/tests/api/test_commerce_tab.py
@@ -1,0 +1,146 @@
+"""Plan & tokens tab routes: the harness fronts ops for the signed-in
+web user, translating identities and failures."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from surogates.api.routes import commerce
+from surogates.runtime import AgentRuntimeContext
+
+
+def _ctx() -> AgentRuntimeContext:
+    return AgentRuntimeContext(
+        agent_id="a-1",
+        org_id="o-1",
+        project_id="p-1",
+        enabled=True,
+        config_version=1,
+        storage_key_prefix="p-1/a-1",
+    )
+
+
+class _FakePlatform:
+    def __init__(self, *, summary=None, checkout=None, error=None):
+        self._summary = summary
+        self._checkout = checkout
+        self._error = error
+        self.calls: list[tuple] = []
+
+    async def commerce_summary(self, agent_id, **kw):
+        self.calls.append(("summary", agent_id, kw))
+        if self._error:
+            raise self._error
+        return dict(self._summary)
+
+    async def commerce_checkout(self, agent_id, **kw):
+        self.calls.append(("checkout", agent_id, kw))
+        if self._error:
+            raise self._error
+        return dict(self._checkout)
+
+
+def _request(platform):
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(platform_client=platform)),
+    )
+
+
+_TENANT = SimpleNamespace(user_id="u-1", org_id="o-1")
+_SUMMARY = {
+    "mode": "subscription_required",
+    "buy_url": "https://buy",
+    "offers": [{"id": "off-1"}],
+    "entitlement": {"topup_token_remaining": 5},
+}
+
+
+@pytest.mark.asyncio
+async def test_overview_marks_purchasable_for_firebase_user(monkeypatch):
+    async def ident(request, tenant):
+        return ("uid-1", "u@example.com", "U")
+
+    monkeypatch.setattr(commerce, "_firebase_identity", ident)
+    platform = _FakePlatform(summary=_SUMMARY)
+    out = await commerce.commerce_overview(
+        _request(platform), tenant=_TENANT, agent_runtime=_ctx(),
+    )
+    assert out["purchasable"] is True
+    assert out["entitlement"]["topup_token_remaining"] == 5
+    assert platform.calls[0][2]["firebase_uid"] == "uid-1"
+
+
+@pytest.mark.asyncio
+async def test_overview_disables_buying_without_firebase_identity(
+    monkeypatch,
+):
+    async def ident(request, tenant):
+        return None
+
+    monkeypatch.setattr(commerce, "_firebase_identity", ident)
+    platform = _FakePlatform(summary=_SUMMARY)
+    out = await commerce.commerce_overview(
+        _request(platform), tenant=_TENANT, agent_runtime=_ctx(),
+    )
+    assert out["purchasable"] is False
+    assert out["entitlement"] is None
+
+
+@pytest.mark.asyncio
+async def test_checkout_translates_ops_refusals(monkeypatch):
+    async def ident(request, tenant):
+        return ("uid-1", None, None)
+
+    monkeypatch.setattr(commerce, "_firebase_identity", ident)
+    refusal = httpx.HTTPStatusError(
+        "400",
+        request=httpx.Request("POST", "http://x"),
+        response=httpx.Response(400, json={"detail": "Offer is not active"}),
+    )
+    platform = _FakePlatform(error=refusal)
+    with pytest.raises(HTTPException) as err:
+        await commerce.commerce_checkout(
+            commerce.CommerceCheckoutRequest(offer_id="off-1"),
+            _request(platform),
+            tenant=_TENANT,
+            agent_runtime=_ctx(),
+        )
+    assert err.value.status_code == 400
+    assert err.value.detail == "Offer is not active"
+
+
+@pytest.mark.asyncio
+async def test_checkout_refuses_operator_accounts(monkeypatch):
+    async def ident(request, tenant):
+        return None
+
+    monkeypatch.setattr(commerce, "_firebase_identity", ident)
+    platform = _FakePlatform(checkout={"url": "x"})
+    with pytest.raises(HTTPException) as err:
+        await commerce.commerce_checkout(
+            commerce.CommerceCheckoutRequest(offer_id="off-1"),
+            _request(platform),
+            tenant=_TENANT,
+            agent_runtime=_ctx(),
+        )
+    assert err.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_checkout_returns_url(monkeypatch):
+    async def ident(request, tenant):
+        return ("uid-1", "u@example.com", "U")
+
+    monkeypatch.setattr(commerce, "_firebase_identity", ident)
+    platform = _FakePlatform(checkout={"url": "https://stripe/xyz"})
+    out = await commerce.commerce_checkout(
+        commerce.CommerceCheckoutRequest(offer_id="off-1"),
+        _request(platform),
+        tenant=_TENANT,
+        agent_runtime=_ctx(),
+    )
+    assert out.url == "https://stripe/xyz"

--- a/tests/api/test_firebase_auth_proxy.py
+++ b/tests/api/test_firebase_auth_proxy.py
@@ -1,0 +1,110 @@
+"""Same-origin Firebase auth-helper proxy: pinned upstream, helper
+namespace only, graceful failures."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from surogates.api.routes import firebase_auth_proxy
+from surogates.runtime import AgentRuntimeContext, FirebaseConfig
+
+
+def _ctx() -> AgentRuntimeContext:
+    return AgentRuntimeContext(
+        agent_id="a-1",
+        org_id="o-1",
+        project_id="p-1",
+        enabled=True,
+        config_version=1,
+        storage_key_prefix="p-1/a-1",
+    )
+
+
+def _firebase() -> FirebaseConfig:
+    return FirebaseConfig(
+        project_id="p-1",
+        firebase_project_id="proj-x",
+        api_key="AIzaX",
+        auth_domain="proj-x.firebaseapp.com",
+        enabled_providers=("google",),
+    )
+
+
+class _FakeCache:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def get(self, key):
+        if key not in self._rows:
+            raise LookupError(key)
+        return self._rows[key]
+
+
+class _FakeUpstream:
+    def __init__(self):
+        self.requests = []
+
+    async def request(self, method, url, headers=None, content=None):
+        self.requests.append((method, str(url), headers))
+        return httpx.Response(
+            200,
+            content=b"<html>helper</html>",
+            headers={"content-type": "text/html", "set-cookie": "x=1"},
+        )
+
+
+def _request(*, firebase=None, upstream=None):
+    state = SimpleNamespace()
+    if firebase is not None:
+        state.firebase_config_cache = _FakeCache({"p-1": firebase})
+    if upstream is not None:
+        state.firebase_helper_client = upstream
+    async def body():
+        return b""
+    return SimpleNamespace(
+        app=SimpleNamespace(state=state),
+        headers={"host": "ludwig.cloud.surogate.ai", "cookie": "secret"},
+        method="GET",
+        url=SimpleNamespace(query="apiKey=AIzaX"),
+        body=body,
+    )
+
+
+@pytest.mark.asyncio
+async def test_proxies_helper_to_the_project_domain():
+    upstream = _FakeUpstream()
+    request = _request(firebase=_firebase(), upstream=upstream)
+    resp = await firebase_auth_proxy.firebase_auth_helpers(
+        "auth/iframe", request, agent_runtime=_ctx(),
+    )
+    assert resp.status_code == 200
+    method, url, headers = upstream.requests[0]
+    assert url.startswith("https://proj-x.firebaseapp.com/__/auth/iframe")
+    assert "apiKey=AIzaX" in url
+    # Origin-bound headers never cross the proxy, either direction.
+    assert "cookie" not in {k.lower() for k in headers}
+    assert "set-cookie" not in {k.lower() for k in resp.headers}
+
+
+@pytest.mark.asyncio
+async def test_rejects_paths_outside_the_helper_namespace():
+    request = _request(firebase=_firebase(), upstream=_FakeUpstream())
+    with pytest.raises(HTTPException) as err:
+        await firebase_auth_proxy.firebase_auth_helpers(
+            "not-a-helper", request, agent_runtime=_ctx(),
+        )
+    assert err.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_404_when_project_has_no_firebase():
+    request = _request(upstream=_FakeUpstream())
+    with pytest.raises(HTTPException) as err:
+        await firebase_auth_proxy.firebase_auth_helpers(
+            "auth/iframe", request, agent_runtime=_ctx(),
+        )
+    assert err.value.status_code == 404

--- a/tests/api/test_web_channel_commerce.py
+++ b/tests/api/test_web_channel_commerce.py
@@ -1,0 +1,146 @@
+"""Commerce enforcement on the authenticated web channel.
+
+The web app derives the buyer identity from the signed-in user's
+Firebase uid (``external_id``) at message time and feeds the same
+``authorize_commerce_turn`` gate the website widget uses — one
+pipeline, two channels.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from surogates.api.routes._commerce_turn import authorize_commerce_turn
+from surogates.runtime.platform_client import CommercePaymentRequiredError
+
+
+class _FakeCache:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def get(self, key):
+        if key not in self._rows:
+            raise LookupError(key)
+        return self._rows[key]
+
+
+class _FakeStore:
+    def __init__(self):
+        self.updates: list[tuple] = []
+
+    async def append_session_config_list(self, session_id, key, value):
+        self.updates.append((session_id, key, value))
+
+
+class _FakePlatformClient:
+    def __init__(self, *, receipt=None, error=None):
+        self.receipt = receipt
+        self.error = error
+        self.calls: list[dict] = []
+
+    async def commerce_authorize(self, agent_id, **kwargs):
+        self.calls.append({"agent_id": agent_id, **kwargs})
+        if self.error is not None:
+            raise self.error
+        return self.receipt
+
+
+def _request(*, runtime_payload=None, platform_client=None, store=None):
+    state = SimpleNamespace()
+    if runtime_payload is not None:
+        state.runtime_config_cache = _FakeCache({"a-1": runtime_payload})
+    if platform_client is not None:
+        state.platform_client = platform_client
+    if store is not None:
+        state.session_store = store
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+def _session():
+    return SimpleNamespace(id=uuid.uuid4(), agent_id="a-1", config={})
+
+
+_PAID = {
+    "commerce_mode": "subscription_required",
+    "commerce_buy_url": "https://studio.example/buy/a-1",
+}
+
+_BUYER = {
+    "firebase_uid": "uid-web-1",
+    "email": "web@example.com",
+    "name": "Web User",
+}
+
+
+@pytest.mark.asyncio
+async def test_explicit_buyer_reserves_and_pins_receipt():
+    store = _FakeStore()
+    client = _FakePlatformClient(
+        receipt={
+            "entitlement_id": "ent-1",
+            "reserved_tokens": 42,
+            "reservation_id": "res-1",
+        },
+    )
+    request = _request(
+        runtime_payload=_PAID, platform_client=client, store=store,
+    )
+    session = _session()
+    await authorize_commerce_turn(request, session, "hello", buyer=_BUYER)
+    assert client.calls and client.calls[0]["firebase_uid"] == "uid-web-1"
+    assert store.updates
+    _, key, value = store.updates[0]
+    assert key == "commerce_reservations"
+    assert value["entitlement_id"] == "ent-1"
+    assert value["reserved_tokens"] == 42
+
+
+@pytest.mark.asyncio
+async def test_explicit_buyer_out_of_tokens_402s_with_buy_url():
+    client = _FakePlatformClient(
+        error=CommercePaymentRequiredError("payment_required"),
+    )
+    request = _request(runtime_payload=_PAID, platform_client=client)
+    with pytest.raises(HTTPException) as err:
+        await authorize_commerce_turn(
+            request, _session(), "hello", buyer=_BUYER,
+        )
+    assert err.value.status_code == 402
+    assert err.value.detail["buy_url"] == "https://studio.example/buy/a-1"
+
+
+@pytest.mark.asyncio
+async def test_free_mode_ignores_explicit_buyer():
+    client = _FakePlatformClient()
+    request = _request(
+        runtime_payload={"commerce_mode": "free"}, platform_client=client,
+    )
+    await authorize_commerce_turn(
+        request, _session(), "hello", buyer=_BUYER,
+    )
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_explicit_buyer_overrides_session_config_binding():
+    """The web channel passes the tenant user's identity even when the
+    session config carries no widget-era binding."""
+    store = _FakeStore()
+    client = _FakePlatformClient(
+        receipt={
+            "entitlement_id": "ent-2",
+            "reserved_tokens": 7,
+            "reservation_id": "res-2",
+        },
+    )
+    request = _request(
+        runtime_payload=_PAID, platform_client=client, store=store,
+    )
+    session = _session()
+    session.config = {}
+    await authorize_commerce_turn(request, session, "hi", buyer=_BUYER)
+    assert client.calls[0]["email"] == "web@example.com"

--- a/tests/api/test_website_commerce.py
+++ b/tests/api/test_website_commerce.py
@@ -4,7 +4,7 @@ Covers the two route-level hooks:
 
 - ``_resolve_commerce_buyer`` — bootstrap-time Firebase verification
   that pins the buyer identity on the session config.
-- ``_authorize_commerce_turn`` — message-accept gate: free agents pass
+- ``authorize_commerce_turn`` — message-accept gate: free agents pass
   through untouched; monetized agents require a bound buyer and an
   ops-side reservation, with structured 402 details the widget maps to
   its paywall.
@@ -88,7 +88,7 @@ _PAID_PAYLOAD = {
 }
 
 
-# ── _authorize_commerce_turn ─────────────────────────────────────────
+# ── authorize_commerce_turn ─────────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -97,21 +97,21 @@ async def test_free_mode_passes_without_touching_the_platform():
     request = _request(
         runtime_payload={"commerce_mode": "free"}, platform_client=client,
     )
-    await website._authorize_commerce_turn(request, _session(), "hello")
+    await website.authorize_commerce_turn(request, _session(), "hello")
     assert client.calls == []
 
 
 @pytest.mark.asyncio
 async def test_missing_runtime_cache_passes_through():
     request = _request()
-    await website._authorize_commerce_turn(request, _session(), "hello")
+    await website.authorize_commerce_turn(request, _session(), "hello")
 
 
 @pytest.mark.asyncio
 async def test_paid_without_buyer_402_sign_in_required():
     request = _request(runtime_payload=_PAID_PAYLOAD)
     with pytest.raises(HTTPException) as exc_info:
-        await website._authorize_commerce_turn(request, _session(), "hello")
+        await website.authorize_commerce_turn(request, _session(), "hello")
     assert exc_info.value.status_code == 402
     assert exc_info.value.detail == {
         "code": "sign_in_required",
@@ -141,7 +141,7 @@ async def test_paid_with_buyer_reserves_and_pins_receipt():
             },
         },
     )
-    await website._authorize_commerce_turn(request, session, "x" * 100)
+    await website.authorize_commerce_turn(request, session, "x" * 100)
 
     assert client.calls == [
         {
@@ -175,7 +175,7 @@ async def test_paid_402_from_ops_maps_to_structured_detail():
     )
     session = _session(config={"commerce_buyer": {"firebase_uid": "fb-1"}})
     with pytest.raises(HTTPException) as exc_info:
-        await website._authorize_commerce_turn(request, session, "hello")
+        await website.authorize_commerce_turn(request, session, "hello")
     assert exc_info.value.status_code == 402
     assert exc_info.value.detail == {
         "code": "insufficient_tokens",
@@ -191,7 +191,7 @@ async def test_paid_platform_failure_fails_closed_503():
     )
     session = _session(config={"commerce_buyer": {"firebase_uid": "fb-1"}})
     with pytest.raises(HTTPException) as exc_info:
-        await website._authorize_commerce_turn(request, session, "hello")
+        await website.authorize_commerce_turn(request, session, "hello")
     assert exc_info.value.status_code == 503
 
 
@@ -200,7 +200,7 @@ async def test_paid_without_platform_client_fails_closed_503():
     request = _request(runtime_payload=_PAID_PAYLOAD)
     session = _session(config={"commerce_buyer": {"firebase_uid": "fb-1"}})
     with pytest.raises(HTTPException) as exc_info:
-        await website._authorize_commerce_turn(request, session, "hello")
+        await website.authorize_commerce_turn(request, session, "hello")
     assert exc_info.value.status_code == 503
 
 
@@ -218,7 +218,7 @@ async def test_free_receipt_is_not_pinned():
         runtime_payload=_PAID_PAYLOAD, platform_client=client, store=store,
     )
     session = _session(config={"commerce_buyer": {"firebase_uid": "fb-1"}})
-    await website._authorize_commerce_turn(request, session, "hello")
+    await website.authorize_commerce_turn(request, session, "hello")
     assert store.updates == []
 
 

--- a/tests/integration/test_auth_firebase_self_registration.py
+++ b/tests/integration/test_auth_firebase_self_registration.py
@@ -462,3 +462,27 @@ async def test_me_patch_rejects_malformed_username(
             headers={"Authorization": f"Bearer {token}"},
         )
         assert r.status_code == 422, bad
+
+
+async def test_me_patch_labels_email_conflict_correctly(
+    auth_client, auth_app, session_factory, monkeypatch,
+):
+    """An e-mail collision must not masquerade as a username conflict —
+    the org-scoped e-mail unique index fires on commit and the error
+    names the right field."""
+    org_id = await create_org(session_factory)
+    _set_org(auth_app, org_id)
+    _set_firebase(auth_app, enabled=True)
+    await _exchange_token(
+        auth_client, monkeypatch, uid="uid-mail-1", email="one@example.com",
+    )
+    token = await _exchange_token(
+        auth_client, monkeypatch, uid="uid-mail-2", email="two@example.com",
+    )
+    r = await auth_client.patch(
+        "/v1/auth/me",
+        json={"email": "one@example.com"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 409, r.text
+    assert r.json()["detail"] == "That email is already in use."

--- a/tests/integration/test_auth_firebase_self_registration.py
+++ b/tests/integration/test_auth_firebase_self_registration.py
@@ -359,3 +359,106 @@ async def test_cross_project_uid_collision_resolves_to_different_users(
     assert providers == ["firebase:project-a", "firebase:project-b"], providers
     emails = sorted(u.email for u in rows)
     assert emails == ["alice@example.com", "bob@example.com"]
+
+
+async def _exchange_token(auth_client, monkeypatch, *, uid, email):
+    async def fake_verify(token: str, project_id: str) -> dict:
+        return {"sub": uid, "email": email, "email_verified": True}
+
+    monkeypatch.setattr(auth_routes, "verify_firebase_id_token", fake_verify)
+    response = await auth_client.post(
+        "/v1/auth/firebase/exchange", json={"id_token": "t"},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+async def test_me_patch_persists_profile_fields(
+    auth_client, auth_app, session_factory, monkeypatch,
+):
+    """Sign-up captures full name, username, and an optional phone —
+    stored on the same org-scoped user row the exchange minted."""
+    org_id = await create_org(session_factory)
+    _set_org(auth_app, org_id)
+    _set_firebase(auth_app, enabled=True)
+    token = await _exchange_token(
+        auth_client, monkeypatch, uid="uid-prof", email="prof@example.com",
+    )
+
+    response = await auth_client.patch(
+        "/v1/auth/me",
+        json={
+            "display_name": "Ada Lovelace",
+            "username": "Ada.Lovelace",
+            "phone": "+40 712 345 678",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # Usernames are case-insensitive login-style handles — normalised
+    # to lowercase on write.
+    assert body["username"] == "ada.lovelace"
+    assert body["phone"] == "+40 712 345 678"
+    assert body["display_name"] == "Ada Lovelace"
+
+    async with session_factory() as session:
+        user = await session.scalar(
+            select(User).where(
+                User.org_id == org_id, User.email == "prof@example.com",
+            )
+        )
+    assert user.username == "ada.lovelace"
+    assert user.phone == "+40 712 345 678"
+
+
+async def test_me_patch_rejects_taken_username(
+    auth_client, auth_app, session_factory, monkeypatch,
+):
+    org_id = await create_org(session_factory)
+    _set_org(auth_app, org_id)
+    _set_firebase(auth_app, enabled=True)
+    first = await _exchange_token(
+        auth_client, monkeypatch, uid="uid-a", email="a@example.com",
+    )
+    r = await auth_client.patch(
+        "/v1/auth/me",
+        json={"username": "taken"},
+        headers={"Authorization": f"Bearer {first}"},
+    )
+    assert r.status_code == 200, r.text
+
+    second = await _exchange_token(
+        auth_client, monkeypatch, uid="uid-b", email="b@example.com",
+    )
+    r = await auth_client.patch(
+        "/v1/auth/me",
+        json={"username": "TAKEN"},
+        headers={"Authorization": f"Bearer {second}"},
+    )
+    assert r.status_code == 409
+    # ...but re-saving your OWN username is not a conflict.
+    r = await auth_client.patch(
+        "/v1/auth/me",
+        json={"username": "taken"},
+        headers={"Authorization": f"Bearer {first}"},
+    )
+    assert r.status_code == 200, r.text
+
+
+async def test_me_patch_rejects_malformed_username(
+    auth_client, auth_app, session_factory, monkeypatch,
+):
+    org_id = await create_org(session_factory)
+    _set_org(auth_app, org_id)
+    _set_firebase(auth_app, enabled=True)
+    token = await _exchange_token(
+        auth_client, monkeypatch, uid="uid-c", email="c@example.com",
+    )
+    for bad in ("ab", "has space", "x" * 33, "emoji🙂"):
+        r = await auth_client.patch(
+            "/v1/auth/me",
+            json={"username": bad},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 422, bad

--- a/tests/integration/test_auth_firebase_self_registration.py
+++ b/tests/integration/test_auth_firebase_self_registration.py
@@ -486,3 +486,80 @@ async def test_me_patch_labels_email_conflict_correctly(
     )
     assert r.status_code == 409, r.text
     assert r.json()["detail"] == "That email is already in use."
+
+
+async def test_exchange_applies_signup_profile_atomically(
+    auth_client, auth_app, session_factory, monkeypatch,
+):
+    """The sign-up form's profile rides the first exchange — the new
+    user row is born complete, no follow-up PATCH required."""
+    org_id = await create_org(session_factory)
+    _set_org(auth_app, org_id)
+    _set_firebase(auth_app, enabled=True)
+
+    async def fake_verify(token: str, project_id: str) -> dict:
+        return {
+            "sub": "uid-atomic",
+            "email": "atomic@example.com",
+            "email_verified": True,
+        }
+
+    monkeypatch.setattr(auth_routes, "verify_firebase_id_token", fake_verify)
+    r = await auth_client.post(
+        "/v1/auth/firebase/exchange",
+        json={
+            "id_token": "t",
+            "display_name": "Atomic User",
+            "username": "Atomic.User",
+            "phone": "+40 700 111 222",
+        },
+    )
+    assert r.status_code == 200, r.text
+    async with session_factory() as session:
+        user = await session.scalar(
+            select(User).where(
+                User.org_id == org_id, User.email == "atomic@example.com",
+            )
+        )
+    assert user.display_name == "Atomic User"
+    assert user.username == "atomic.user"
+    assert user.phone == "+40 700 111 222"
+
+
+async def test_exchange_skips_taken_username_without_failing(
+    auth_client, auth_app, session_factory, monkeypatch,
+):
+    org_id = await create_org(session_factory)
+    _set_org(auth_app, org_id)
+    _set_firebase(auth_app, enabled=True)
+    token = await _exchange_token(
+        auth_client, monkeypatch, uid="uid-h1", email="h1@example.com",
+    )
+    r = await auth_client.patch(
+        "/v1/auth/me",
+        json={"username": "wanted"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+
+    async def fake_verify(token: str, project_id: str) -> dict:
+        return {
+            "sub": "uid-h2",
+            "email": "h2@example.com",
+            "email_verified": True,
+        }
+
+    monkeypatch.setattr(auth_routes, "verify_firebase_id_token", fake_verify)
+    r = await auth_client.post(
+        "/v1/auth/firebase/exchange",
+        json={"id_token": "t", "username": "WANTED"},
+    )
+    assert r.status_code == 200, r.text
+    async with session_factory() as session:
+        user = await session.scalar(
+            select(User).where(
+                User.org_id == org_id, User.email == "h2@example.com",
+            )
+        )
+    assert user is not None
+    assert user.username is None

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -177,6 +177,10 @@ export interface AuthConfigResponse {
   // Username handle rule served by the backend (single source of
   // truth). Absent on older backends — callers fall back locally.
   username_pattern?: string;
+  // Monetization projection: paid agents route NEW users to the buy
+  // page (they arrive back entitled); free agents keep local sign-up.
+  commerce_mode?: string;
+  commerce_buy_url?: string | null;
 }
 
 /** Fetch the runtime auth config. Falls back to "disabled" on any error

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -174,6 +174,9 @@ export interface AuthConfigResponse {
   // channel (no "New chat"). Absent on a fetch error or an older backend
   // — consumers treat "absent" as "unknown" and fail open (multi on).
   multi_session?: boolean;
+  // Username handle rule served by the backend (single source of
+  // truth). Absent on older backends — callers fall back locally.
+  username_pattern?: string;
 }
 
 /** Fetch the runtime auth config. Falls back to "disabled" on any error
@@ -191,7 +194,16 @@ export async function fetchAuthConfig(): Promise<AuthConfigResponse> {
 }
 
 /** Exchange a Firebase ID token for Surogates access + refresh tokens. */
-export async function exchangeFirebaseToken(idToken: string): Promise<{
+export interface SignupProfile {
+  display_name?: string;
+  username?: string;
+  phone?: string;
+}
+
+export async function exchangeFirebaseToken(
+  idToken: string,
+  profile?: SignupProfile,
+): Promise<{
   access_token: string;
   refresh_token: string;
   token_type: string;
@@ -199,7 +211,7 @@ export async function exchangeFirebaseToken(idToken: string): Promise<{
   const response = await fetch("/api/v1/auth/firebase/exchange", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ id_token: idToken }),
+    body: JSON.stringify({ id_token: idToken, ...(profile ?? {}) }),
   });
   if (!response.ok) {
     const data = (await response.json().catch(() => null)) as

--- a/web/src/features/auth/firebase.ts
+++ b/web/src/features/auth/firebase.ts
@@ -16,6 +16,7 @@ import {
   createUserWithEmailAndPassword,
   getAuth,
   sendEmailVerification,
+  sendPasswordResetEmail,
   signInWithEmailAndPassword,
   signInWithPopup,
   type Auth,
@@ -163,4 +164,14 @@ export async function resendFirebaseEmailVerification(
   user: User,
 ): Promise<void> {
   await sendEmailVerification(user);
+}
+
+/** Send the Firebase password-reset email for a self-registered
+ * account. Callers surface a neutral notice either way so the form
+ * doesn't leak whether the address is registered. */
+export async function sendFirebasePasswordReset(
+  config: FirebaseRuntimeConfig,
+  email: string,
+): Promise<void> {
+  await sendPasswordResetEmail(getRuntimeFirebaseAuth(config), email.trim());
 }

--- a/web/src/features/auth/firebase.ts
+++ b/web/src/features/auth/firebase.ts
@@ -84,13 +84,14 @@ export function getRuntimeFirebaseAuth(config: FirebaseRuntimeConfig): Auth {
     app = initializeApp(
       {
         apiKey: config.api_key,
-        // Dev serves the Firebase auth helpers same-origin (vite
-        // proxies /__ to the project's firebaseapp.com), which keeps
-        // the popup result channel working under browser storage
-        // partitioning. Production keeps the project auth domain.
-        authDomain: import.meta.env.DEV
-          ? window.location.host
-          : config.auth_domain,
+        // The auth helpers are served same-origin on every surface:
+        // vite proxies /__ in dev, the harness API reverse-proxies it
+        // in production (see api/routes/firebase_auth_proxy.py).
+        // Using our own host as authDomain keeps the popup completion
+        // channel first-party, immune to third-party storage
+        // partitioning. The agent's domain must be in the Firebase
+        // project's authorized domains.
+        authDomain: window.location.host,
         projectId: config.project_id,
         appId: config.app_id ?? undefined,
         messagingSenderId: config.messaging_sender_id ?? undefined,

--- a/web/src/features/auth/firebase.ts
+++ b/web/src/features/auth/firebase.ts
@@ -83,7 +83,13 @@ export function getRuntimeFirebaseAuth(config: FirebaseRuntimeConfig): Auth {
     app = initializeApp(
       {
         apiKey: config.api_key,
-        authDomain: config.auth_domain,
+        // Dev serves the Firebase auth helpers same-origin (vite
+        // proxies /__ to the project's firebaseapp.com), which keeps
+        // the popup result channel working under browser storage
+        // partitioning. Production keeps the project auth domain.
+        authDomain: import.meta.env.DEV
+          ? window.location.host
+          : config.auth_domain,
         projectId: config.project_id,
         appId: config.app_id ?? undefined,
         messagingSenderId: config.messaging_sender_id ?? undefined,

--- a/web/src/features/auth/login-page.tsx
+++ b/web/src/features/auth/login-page.tsx
@@ -27,7 +27,7 @@ import {
   sendFirebasePasswordReset,
   signInWithGoogle,
 } from "./firebase";
-import { updateCurrentUser } from "@/api/auth";
+import { updateCurrentUser, type SignupProfile } from "@/api/auth";
 import { storeAuthTokens, getPostAuthRoute } from "./session";
 
 const TAGS = [
@@ -179,7 +179,16 @@ export function LoginPage() {
     // server-side state (notably ``email_verified`` after the user
     // returns from clicking the verification link).
     const idToken = await user.getIdToken(true);
-    const tokens = await exchangeFirebaseToken(idToken);
+    // New-user exchanges apply the sign-up profile atomically at
+    // creation; existing users are untouched by these fields and the
+    // PATCH relay below covers them instead.
+    const stashed = user.email
+      ? safeStorage.get(pendingProfileKey(user.email))
+      : null;
+    const tokens = await exchangeFirebaseToken(
+      idToken,
+      stashed ? (JSON.parse(stashed) as SignupProfile) : undefined,
+    );
     storeAuthTokens(tokens.access_token, tokens.refresh_token);
     // Best-effort: a failed profile write must not block sign-in; the
     // stash is cleared either way and the user can edit their profile
@@ -357,9 +366,12 @@ export function LoginPage() {
         setIsLoading(false);
         return;
       }
-      // Mirror of USERNAME_RE in surogates/api/routes/auth.py — keep
-      // both in lockstep.
-      if (!/^[a-z0-9][a-z0-9._-]{1,30}[a-z0-9]$/.test(username.trim().toLowerCase())) {
+      // The handle rule comes from the backend (/auth/config);
+      // the literal is only a fallback for older backends.
+      const usernamePattern = new RegExp(
+        authConfig.username_pattern ?? "^[a-z0-9][a-z0-9._-]{1,30}[a-z0-9]$",
+      );
+      if (!usernamePattern.test(username.trim().toLowerCase())) {
         setLoginError(
           "Username must be 3-32 characters: letters, digits, dots, dashes or underscores.",
         );

--- a/web/src/features/auth/login-page.tsx
+++ b/web/src/features/auth/login-page.tsx
@@ -24,6 +24,7 @@ import {
   resendFirebaseEmailVerification,
   signInWithFirebaseEmail,
   signInWithGithub,
+  sendFirebasePasswordReset,
   signInWithGoogle,
 } from "./firebase";
 import { storeAuthTokens, getPostAuthRoute } from "./session";
@@ -60,6 +61,9 @@ export function LoginPage() {
     self_registration_enabled: false,
     firebase: null,
   });
+  const [fullName, setFullName] = useState("");
+  const [username, setUsername] = useState("");
+  const [phone, setPhone] = useState("");
   const [firebaseMode, setFirebaseMode] = useState<"sign-in" | "create">(
     "sign-in",
   );
@@ -81,7 +85,88 @@ export function LoginPage() {
     };
   }, []);
 
+  // Sign-up collects full name / username / phone, but the account
+  // only becomes exchangeable after e-mail verification — so the
+  // profile waits in localStorage (keyed by e-mail) and is applied to
+  // /auth/me right after the first successful exchange.
+  const pendingProfileKey = (address: string) =>
+    `surogates.pendingProfile.${address.trim().toLowerCase()}`;
+
+  const stashPendingProfile = (address: string) => {
+    const profile = {
+      display_name: fullName.trim(),
+      username: username.trim().toLowerCase(),
+      phone: phone.trim(),
+    };
+    try {
+      localStorage.setItem(pendingProfileKey(address), JSON.stringify(profile));
+    } catch {
+      // Storage unavailable (private mode) — the user can still fill
+      // their profile later; sign-up must not fail over this.
+    }
+  };
+
+  const applyPendingProfile = async (
+    address: string | null | undefined,
+    accessToken: string,
+  ) => {
+    if (!address) return;
+    let raw: string | null = null;
+    try {
+      raw = localStorage.getItem(pendingProfileKey(address));
+    } catch {
+      return;
+    }
+    if (!raw) return;
+    try {
+      const profile = JSON.parse(raw) as {
+        display_name?: string;
+        username?: string;
+        phone?: string;
+      };
+      const body: Record<string, string> = {};
+      if (profile.display_name) body.display_name = profile.display_name;
+      if (profile.username) body.username = profile.username;
+      if (profile.phone) body.phone = profile.phone;
+      if (Object.keys(body).length > 0) {
+        await fetch("/api/v1/auth/me", {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify(body),
+        });
+      }
+    } finally {
+      try {
+        localStorage.removeItem(pendingProfileKey(address));
+      } catch {
+        // ignore
+      }
+    }
+  };
+
+  const handleForgotPassword = async () => {
+    if (!firebaseConfig) return;
+    if (!email.trim()) {
+      setLoginError("Enter your email above first.");
+      return;
+    }
+    setLoginError(null);
+    try {
+      await sendFirebasePasswordReset(firebaseConfig, email);
+    } catch {
+      // Fall through to the neutral notice — the form must not leak
+      // whether an address is registered.
+    }
+    setLoginNotice(
+      "If an account exists for that email, a password-reset link is on its way.",
+    );
+  };
+
   const finishFirebaseUser = async (user: {
+    email?: string | null;
     getIdToken: (forceRefresh?: boolean) => Promise<string>;
   }) => {
     // Force-refresh the ID token so claims reflect the current
@@ -90,6 +175,10 @@ export function LoginPage() {
     const idToken = await user.getIdToken(true);
     const tokens = await exchangeFirebaseToken(idToken);
     storeAuthTokens(tokens.access_token, tokens.refresh_token);
+    // Best-effort: a failed profile write must not block sign-in; the
+    // stash is cleared either way and the user can edit their profile
+    // later.
+    await applyPendingProfile(user.email, tokens.access_token).catch(() => {});
     void navigate({ to: getPostAuthRoute() });
   };
 
@@ -257,6 +346,19 @@ export function LoginPage() {
     // ── Create-account mode: sign up via Firebase email/password. ──
     const firebaseConfig = authConfig.firebase;
     if (firebaseMode === "create" && firebasePasswordEnabled && firebaseConfig) {
+      if (!fullName.trim()) {
+        setLoginError("Please enter your full name.");
+        setIsLoading(false);
+        return;
+      }
+      if (!/^[a-z0-9][a-z0-9._-]{1,30}[a-z0-9]$/.test(username.trim().toLowerCase())) {
+        setLoginError(
+          "Username must be 3-32 characters: letters, digits, dots, dashes or underscores.",
+        );
+        setIsLoading(false);
+        return;
+      }
+      stashPendingProfile(email);
       try {
         const { user, verificationSent, verificationError } =
           await createFirebaseEmailAccount(firebaseConfig, email, password);
@@ -432,6 +534,56 @@ export function LoginPage() {
 
         {/* form */}
         <form onSubmit={handleLogin}>
+          {firebaseMode === "create" && firebasePasswordEnabled && (
+            <>
+              <div className="mb-3.5">
+                <Label
+                  htmlFor="signup-full-name"
+                  className="mb-1.5 block text-subtle"
+                >
+                  Full name
+                </Label>
+                <Input
+                  id="signup-full-name"
+                  value={fullName}
+                  onChange={(e) => { setFullName(e.target.value); clearError(); }}
+                  placeholder="Ada Lovelace"
+                  autoComplete="name"
+                />
+              </div>
+              <div className="mb-3.5">
+                <Label
+                  htmlFor="signup-username"
+                  className="mb-1.5 block text-subtle"
+                >
+                  Username
+                </Label>
+                <Input
+                  id="signup-username"
+                  value={username}
+                  onChange={(e) => { setUsername(e.target.value); clearError(); }}
+                  placeholder="ada.lovelace"
+                  autoComplete="username"
+                />
+              </div>
+              <div className="mb-3.5">
+                <Label
+                  htmlFor="signup-phone"
+                  className="mb-1.5 block text-subtle"
+                >
+                  Phone <span className="text-faint">(optional)</span>
+                </Label>
+                <Input
+                  id="signup-phone"
+                  type="tel"
+                  value={phone}
+                  onChange={(e) => { setPhone(e.target.value); clearError(); }}
+                  placeholder="+40 712 345 678"
+                  autoComplete="tel"
+                />
+              </div>
+            </>
+          )}
           <div className="mb-3.5">
             <Label htmlFor="login-email" className="mb-1.5 block text-subtle">
               Email
@@ -469,6 +621,15 @@ export function LoginPage() {
                 {showPassword ? "Hide" : "Show"}
               </Button>
             </div>
+            {firebaseMode === "sign-in" && firebasePasswordEnabled && (
+              <button
+                type="button"
+                onClick={handleForgotPassword}
+                className="mt-1.5 text-xs text-faint hover:text-foreground hover:underline"
+              >
+                Forgot password?
+              </button>
+            )}
           </div>
 
           {loginError && (

--- a/web/src/features/auth/login-page.tsx
+++ b/web/src/features/auth/login-page.tsx
@@ -142,7 +142,9 @@ export function LoginPage() {
       try {
         localStorage.removeItem(pendingProfileKey(address));
       } catch {
-        // ignore
+        // Storage may be unavailable (private mode) — the stale stash
+        // is harmless; it is keyed by e-mail and overwritten on the
+        // next sign-up attempt.
       }
     }
   };

--- a/web/src/features/auth/login-page.tsx
+++ b/web/src/features/auth/login-page.tsx
@@ -27,6 +27,7 @@ import {
   sendFirebasePasswordReset,
   signInWithGoogle,
 } from "./firebase";
+import { updateCurrentUser } from "@/api/auth";
 import { storeAuthTokens, getPostAuthRoute } from "./session";
 
 const TAGS = [
@@ -88,35 +89,50 @@ export function LoginPage() {
   // Sign-up collects full name / username / phone, but the account
   // only becomes exchangeable after e-mail verification — so the
   // profile waits in localStorage (keyed by e-mail) and is applied to
-  // /auth/me right after the first successful exchange.
+  // /auth/me right after the first successful exchange. All storage
+  // access is best-effort: private-mode browsers may refuse it, and
+  // sign-up must never fail over a profile stash.
+  const safeStorage = {
+    get(key: string): string | null {
+      try {
+        return localStorage.getItem(key);
+      } catch {
+        return null;
+      }
+    },
+    set(key: string, value: string): void {
+      try {
+        localStorage.setItem(key, value);
+      } catch {
+        /* best-effort by design */
+      }
+    },
+    remove(key: string): void {
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        /* best-effort by design */
+      }
+    },
+  };
+
   const pendingProfileKey = (address: string) =>
     `surogates.pendingProfile.${address.trim().toLowerCase()}`;
 
   const stashPendingProfile = (address: string) => {
-    const profile = {
-      display_name: fullName.trim(),
-      username: username.trim().toLowerCase(),
-      phone: phone.trim(),
-    };
-    try {
-      localStorage.setItem(pendingProfileKey(address), JSON.stringify(profile));
-    } catch {
-      // Storage unavailable (private mode) — the user can still fill
-      // their profile later; sign-up must not fail over this.
-    }
+    safeStorage.set(
+      pendingProfileKey(address),
+      JSON.stringify({
+        display_name: fullName.trim(),
+        username: username.trim().toLowerCase(),
+        phone: phone.trim(),
+      }),
+    );
   };
 
-  const applyPendingProfile = async (
-    address: string | null | undefined,
-    accessToken: string,
-  ) => {
+  const applyPendingProfile = async (address: string | null | undefined) => {
     if (!address) return;
-    let raw: string | null = null;
-    try {
-      raw = localStorage.getItem(pendingProfileKey(address));
-    } catch {
-      return;
-    }
+    const raw = safeStorage.get(pendingProfileKey(address));
     if (!raw) return;
     try {
       const profile = JSON.parse(raw) as {
@@ -129,23 +145,11 @@ export function LoginPage() {
       if (profile.username) body.username = profile.username;
       if (profile.phone) body.phone = profile.phone;
       if (Object.keys(body).length > 0) {
-        await fetch("/api/v1/auth/me", {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${accessToken}`,
-          },
-          body: JSON.stringify(body),
-        });
+        // authFetch inside reads the freshly-stored access token.
+        await updateCurrentUser(body);
       }
     } finally {
-      try {
-        localStorage.removeItem(pendingProfileKey(address));
-      } catch {
-        // Storage may be unavailable (private mode) — the stale stash
-        // is harmless; it is keyed by e-mail and overwritten on the
-        // next sign-up attempt.
-      }
+      safeStorage.remove(pendingProfileKey(address));
     }
   };
 
@@ -180,7 +184,7 @@ export function LoginPage() {
     // Best-effort: a failed profile write must not block sign-in; the
     // stash is cleared either way and the user can edit their profile
     // later.
-    await applyPendingProfile(user.email, tokens.access_token).catch(() => {});
+    await applyPendingProfile(user.email).catch(() => {});
     void navigate({ to: getPostAuthRoute() });
   };
 
@@ -353,6 +357,8 @@ export function LoginPage() {
         setIsLoading(false);
         return;
       }
+      // Mirror of USERNAME_RE in surogates/api/routes/auth.py — keep
+      // both in lockstep.
       if (!/^[a-z0-9][a-z0-9._-]{1,30}[a-z0-9]$/.test(username.trim().toLowerCase())) {
         setLoginError(
           "Username must be 3-32 characters: letters, digits, dots, dashes or underscores.",

--- a/web/src/features/auth/login-page.tsx
+++ b/web/src/features/auth/login-page.tsx
@@ -702,20 +702,40 @@ export function LoginPage() {
             )}
           </Button>
 
-          {firebasePasswordEnabled && (
-            <button
-              type="button"
-              className="mt-3 block text-center text-[11px] text-faint hover:text-foreground transition-colors"
-              onClick={() => {
-                clearError();
-                setFirebaseMode((m) => (m === "create" ? "sign-in" : "create"));
-              }}
-            >
-              {firebaseMode === "create"
-                ? "Already have an account? Sign in"
-                : "New here? Create an account"}
-            </button>
-          )}
+          {(() => {
+            // Paid agents: new users belong on the buy page, where the
+            // account is created inside the purchase flow and they come
+            // back already entitled — local sign-up would only lead to
+            // the paywall. Free agents keep in-app self-registration.
+            const monetized =
+              (authConfig.commerce_mode ?? "free") !== "free" &&
+              !!authConfig.commerce_buy_url;
+            if (monetized) {
+              return (
+                <a
+                  href={authConfig.commerce_buy_url ?? "#"}
+                  className="mt-3 block text-center text-[11px] text-faint hover:text-foreground transition-colors"
+                >
+                  New here? Get access →
+                </a>
+              );
+            }
+            if (!firebasePasswordEnabled) return null;
+            return (
+              <button
+                type="button"
+                className="mt-3 block text-center text-[11px] text-faint hover:text-foreground transition-colors"
+                onClick={() => {
+                  clearError();
+                  setFirebaseMode((m) => (m === "create" ? "sign-in" : "create"));
+                }}
+              >
+                {firebaseMode === "create"
+                  ? "Already have an account? Sign in"
+                  : "New here? Create an account"}
+              </button>
+            );
+          })()}
         </form>
 
         {/* ── Firebase self-registration ── */}

--- a/web/src/features/settings/plan-tokens-tab.tsx
+++ b/web/src/features/settings/plan-tokens-tab.tsx
@@ -42,6 +42,9 @@ interface CommerceOverview {
 
 const ACTIVE_SUB = new Set(["active", "trialing"]);
 
+const errorMessage = (e: unknown, fallback: string): string =>
+  e instanceof Error ? e.message : fallback;
+
 function formatPrice(amountCents: number, currency: string): string {
   return new Intl.NumberFormat(undefined, {
     style: "currency",
@@ -69,9 +72,7 @@ export function PlanTokensTab() {
       setOverview((await r.json()) as CommerceOverview);
     } catch (e) {
       setError(
-        e instanceof Error
-          ? e.message
-          : "Plan information is temporarily unavailable.",
+        errorMessage(e, "Plan information is temporarily unavailable."),
       );
     }
   }, []);
@@ -98,9 +99,7 @@ export function PlanTokensTab() {
       }
       window.location.assign(body.url);
     } catch (e) {
-      setError(
-        e instanceof Error ? e.message : "Checkout is unavailable right now.",
-      );
+      setError(errorMessage(e, "Checkout is unavailable right now."));
       setBusyOfferId(null);
     }
   };

--- a/web/src/features/settings/plan-tokens-tab.tsx
+++ b/web/src/features/settings/plan-tokens-tab.tsx
@@ -1,0 +1,235 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Settings → Plan & tokens: what this agent sells and what the
+// signed-in user currently holds. Data comes from the harness's
+// /v1/commerce endpoints (which front surogate-ops with the runtime
+// token) — the browser never talks to ops directly.
+
+import { useCallback, useEffect, useState } from "react";
+import { authFetch } from "@/api/auth";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface CommerceOffer {
+  id: string;
+  kind: "subscription" | "token_pack";
+  name: string;
+  currency: string;
+  amount_cents: number;
+  billing_interval: string | null;
+  token_amount: number;
+}
+
+interface CommerceOverview {
+  mode: string;
+  buy_url: string | null;
+  offers: CommerceOffer[];
+  entitlement: {
+    subscription_status: string;
+    current_period_end: string | null;
+    period_token_remaining: number;
+    topup_token_remaining: number;
+  } | null;
+  purchasable: boolean;
+}
+
+const ACTIVE_SUB = new Set(["active", "trialing"]);
+
+function formatPrice(amountCents: number, currency: string): string {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: currency.toUpperCase(),
+    minimumFractionDigits: amountCents % 100 === 0 ? 0 : 2,
+  }).format(amountCents / 100);
+}
+
+function formatTokens(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+export function PlanTokensTab() {
+  const [overview, setOverview] = useState<CommerceOverview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyOfferId, setBusyOfferId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const r = await authFetch("/api/v1/commerce/overview");
+      if (!r.ok) {
+        throw new Error("Plan information is temporarily unavailable.");
+      }
+      setOverview((await r.json()) as CommerceOverview);
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? e.message
+          : "Plan information is temporarily unavailable.",
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const buy = async (offerId: string) => {
+    setBusyOfferId(offerId);
+    setError(null);
+    try {
+      const r = await authFetch("/api/v1/commerce/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ offer_id: offerId }),
+      });
+      const body = (await r.json().catch(() => null)) as {
+        url?: string;
+        detail?: string;
+      } | null;
+      if (!r.ok || !body?.url) {
+        throw new Error(body?.detail ?? "Checkout is unavailable right now.");
+      }
+      window.location.assign(body.url);
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : "Checkout is unavailable right now.",
+      );
+      setBusyOfferId(null);
+    }
+  };
+
+  if (error && overview === null) {
+    return (
+      <Alert variant="destructive" data-testid="plan-tab-error">
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+  if (overview === null) {
+    return (
+      <p className="text-sm text-muted-foreground" data-testid="plan-tab-loading">
+        Loading…
+      </p>
+    );
+  }
+  if (overview.mode === "free") {
+    return (
+      <p className="text-sm text-muted-foreground" data-testid="plan-tab-free">
+        This agent is free to use — there are no plans or token packs.
+      </p>
+    );
+  }
+
+  const ent = overview.entitlement;
+  const subscriptions = overview.offers.filter(
+    (o) => o.kind === "subscription",
+  );
+  const packs = overview.offers.filter((o) => o.kind === "token_pack");
+
+  return (
+    <div className="flex max-w-[680px] flex-col gap-6" data-testid="plan-tab">
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* ── Current balance ── */}
+      <Card data-testid="plan-tab-balance">
+        <CardHeader>
+          <CardTitle>Your access</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-2 text-sm">
+          {ent === null ? (
+            <p className="text-muted-foreground">
+              Purchases aren't available for this account — it was created
+              by the agent's operator, so your access is managed for you.
+            </p>
+          ) : (
+            <>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Subscription</span>
+                <span className="font-medium">
+                  {ACTIVE_SUB.has(ent.subscription_status)
+                    ? `Active${
+                        ent.current_period_end
+                          ? ` · renews ${new Date(
+                              ent.current_period_end,
+                            ).toLocaleDateString()}`
+                          : ""
+                      }`
+                    : "None"}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">
+                  Plan tokens this period
+                </span>
+                <span className="font-medium tabular-nums">
+                  {formatTokens(ent.period_token_remaining)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Top-up tokens</span>
+                <span className="font-medium tabular-nums">
+                  {formatTokens(ent.topup_token_remaining)}
+                </span>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ── Offers ── */}
+      {[
+        { label: "Plans", items: subscriptions, verb: "Subscribe" },
+        { label: "Token packs", items: packs, verb: "Buy" },
+      ]
+        .filter((s) => s.items.length > 0)
+        .map((section) => (
+          <div key={section.label} className="flex flex-col gap-2.5">
+            <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+              {section.label}
+            </p>
+            {section.items.map((offer) => (
+              <div
+                key={offer.id}
+                data-testid={`plan-offer-${offer.id}`}
+                className="flex items-center gap-4 rounded-lg border border-border bg-card px-4 py-3"
+              >
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <span className="text-sm font-medium">{offer.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {formatTokens(offer.token_amount)} tokens
+                    {offer.kind === "subscription"
+                      ? " every period"
+                      : " · one-time"}
+                  </span>
+                </div>
+                <span className="shrink-0 text-sm font-semibold tabular-nums">
+                  {formatPrice(offer.amount_cents, offer.currency)}
+                  {offer.kind === "subscription" && offer.billing_interval
+                    ? `/${offer.billing_interval}`
+                    : ""}
+                </span>
+                <Button
+                  size="sm"
+                  disabled={!overview.purchasable || busyOfferId !== null}
+                  onClick={() => void buy(offer.id)}
+                >
+                  {busyOfferId === offer.id ? "Redirecting…" : section.verb}
+                </Button>
+              </div>
+            ))}
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/web/src/features/settings/settings-page.tsx
+++ b/web/src/features/settings/settings-page.tsx
@@ -13,6 +13,7 @@ import { toast } from "sonner";
 import { CodingAgentsPanel } from "@invergent/agent-chat-react";
 import { surogatesWebChatAdapter } from "@/features/chat";
 import { BrowserProfilesTab } from "./browser-profiles-tab";
+import { PlanTokensTab } from "./plan-tokens-tab";
 import { useAppStore } from "@/stores/app-store";
 import {
   updateCurrentUser,
@@ -152,11 +153,17 @@ export function SettingsPage() {
               >
                 Connected Channels
               </TabsTrigger>
+              <TabsTrigger value="plan">Plan &amp; Tokens</TabsTrigger>
               <TabsTrigger value="coding-agents">Coding Agents</TabsTrigger>
               <TabsTrigger value="browser-profiles">
                 Browser Profiles
               </TabsTrigger>
             </TabsList>
+
+            {/* ── Plan & tokens ── */}
+            <TabsContent value="plan">
+              <PlanTokensTab />
+            </TabsContent>
 
             {/* ── Profile ── */}
             <TabsContent value="profile">

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) 2026, Invergent SA, developed by Flavius Burca. See /studio/LICENSE.AGPL-3.0
 
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
@@ -32,10 +34,24 @@ export default defineConfig(({ mode }) => {
     return `${stripped}${sep}agent_id=${devAgentId}`;
   };
 
+  // Firebase's popup helpers are always addressed as https://<authDomain>,
+  // and authDomain is this dev server's host — so the dev server must
+  // speak TLS. mkcert-minted localhost certs are picked up when present
+  // (see ~/.surogates/dev-tls); otherwise plain http still works for
+  // everything except Google/GitHub popup sign-in.
+  const tlsDir = path.join(os.homedir(), ".surogates", "dev-tls");
+  const certFile = path.join(tlsDir, "localhost.pem");
+  const keyFile = path.join(tlsDir, "localhost-key.pem");
+  const https =
+    fs.existsSync(certFile) && fs.existsSync(keyFile)
+      ? { cert: fs.readFileSync(certFile), key: fs.readFileSync(keyFile) }
+      : undefined;
+
   return {
     plugins: [react(), tailwindcss()],
     server: {
       host: "0.0.0.0",
+      https,
       allowedHosts: true,
       proxy: {
         // Firebase auth helpers, served same-origin so the sign-in

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -38,6 +38,17 @@ export default defineConfig(({ mode }) => {
       host: "0.0.0.0",
       allowedHosts: true,
       proxy: {
+        // Firebase auth helpers, served same-origin so the sign-in
+        // popup/iframe channel survives browser storage partitioning
+        // (Firefox ETP breaks the cross-origin firebaseapp.com flow).
+        // The SPA uses location.host as authDomain in dev to match.
+        "/__": {
+          target: `https://${
+            env.VITE_DEV_FIREBASE_AUTH_DOMAIN || "example.firebaseapp.com"
+          }`,
+          changeOrigin: true,
+          secure: true,
+        },
         "/api": {
           target: "http://127.0.0.1:8000",
           changeOrigin: true,


### PR DESCRIPTION
Full account lifecycle for agent end-users plus paid-access enforcement on the web channel, pairing with surogate-ops#248.

## Self-registration & auth
- Sign-up with email, password, full name, username, and optional phone; email confirmation gates the token exchange; forgot-password flow.
- Profile is applied atomically at first exchange (invalid or taken usernames are skipped rather than failing the sign-in; unique-violation retry).
- Username rule served from the API (`username_pattern` in auth config) so client and server can't drift; PATCH /auth/me supports username and phone with per-constraint 409 messages.
- New users of paid agents are routed to the buy page ("New here? Get access") instead of local account creation, so registration happens inside the purchase flow.
- Root-mounted `/__/{path}` reverse proxy for Firebase auth helpers (Host → agent → project config → pinned upstream; helper namespaces only, cookies stripped) — keeps Google sign-in same-origin behind wildcard ingress.
- mkcert TLS pickup on the web dev server.

## Web-channel commerce
- Paid agents enforce entitlements per turn: shared authorize → reserve → settle pipeline (`_commerce_turn.py`) used by both the website widget and the web app; structured 402 details (`sign_in_required`, `insufficient_tokens`) with the buy URL so the client renders a paywall.
- Fails closed: a paid agent never serves free turns when the metering plane is unavailable.
- `/v1/commerce/overview` + `/checkout`: signed-in users see owned entitlements and can buy top-ups from the new Plan & Tokens tab in web settings; identity-less requests get offers only — no phantom buyer rows.
- Runtime platform client gains commerce summary/checkout calls against ops.

## Schema
- `users.username` + `users.phone` with a partial unique index per org, applied as idempotent retrofit ALTERs in observability.sql.

Verified live against the running stack: registration → confirmation → exchange, unpaid 402 → paywall, paid turn reserving and settling real token holds, checkout URLs minted from the web app.