### PR TITLE
fix(web): redirect plain-http dev requests to https

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,11 +2,12 @@
 // Copyright (c) 2026, Invergent SA, developed by Flavius Burca. See /studio/LICENSE.AGPL-3.0
 
 import fs from "node:fs";
+import type { Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig, loadEnv, type Plugin } from "vite";
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
@@ -47,8 +48,46 @@ export default defineConfig(({ mode }) => {
       ? { cert: fs.readFileSync(certFile), key: fs.readFileSync(keyFile) }
       : undefined;
 
+  // A TLS-only listener answers plain-http requests with an empty reply
+  // (Firefox: NS_ERROR_NET_EMPTY_RESPONSE), silently breaking http://
+  // bookmarks once the mkcert certs switch the dev server to https. Sniff
+  // the first byte of each connection (0x16 = TLS handshake) and redirect
+  // plain-http requests to the same URL on https.
+  const httpToHttpsRedirect = (): Plugin => ({
+    name: "http-to-https-redirect",
+    configureServer(server) {
+      const httpServer = server.httpServer;
+      if (!https || !httpServer) return;
+      const tlsListeners = httpServer
+        .listeners("connection")
+        .slice() as Array<(socket: Socket) => void>;
+      httpServer.removeAllListeners("connection");
+      httpServer.on("connection", (socket: Socket) => {
+        socket.once("data", (chunk: Buffer) => {
+          socket.pause();
+          socket.unshift(chunk);
+          if (chunk[0] === 0x16) {
+            for (const listener of tlsListeners) {
+              listener.call(httpServer, socket);
+            }
+            process.nextTick(() => socket.resume());
+            return;
+          }
+          const target = /^[A-Z]+ (\S+) HTTP/.exec(chunk.toString("latin1"));
+          const host = /\r\n[Hh]ost: *([^\r\n]+)/.exec(chunk.toString("latin1"));
+          socket.end(
+            "HTTP/1.1 307 Temporary Redirect\r\n" +
+              `Location: https://${host?.[1] ?? "localhost:5174"}${target?.[1] ?? "/"}\r\n` +
+              "Connection: close\r\n" +
+              "Content-Length: 0\r\n\r\n",
+          );
+        });
+      });
+    },
+  });
+
   return {
-    plugins: [react(), tailwindcss()],
+    plugins: [react(), tailwindcss(), httpToHttpsRedirect()],
     server: {
       host: "0.0.0.0",
       https,


### PR DESCRIPTION
Same fix as invergent-ai/surogate-ops#252, for the agent web app dev server on :5174.

Since the dev server went https-only (mkcert certs for the Firebase sign-in popups), plain `http://localhost:5174` requests got an empty reply (`NS_ERROR_NET_EMPTY_RESPONSE` in Firefox). Dev-only Vite plugin sniffs the first byte of each connection and 307-redirects plain-http to https. No effect on production builds.

Verified: `http://localhost:5174/chat` → 307 → https (path preserved), https serving unaffected.