### PR TITLE
fix(web): declare thinking-orbs so the SPA bundles agent-chat-react's orb components

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -78,6 +78,7 @@
         "streamdown": "^2.5.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.1",
+        "thinking-orbs": "^0.1.1",
         "tokenlens": "^1.3.1",
         "tw-animate-css": "^1.4.0",
         "tw-shimmer": "^0.4.6",
@@ -139,6 +140,7 @@
         "shiki": "^4.0.2",
         "streamdown": "2.5.0",
         "tailwind-merge": "^3.5.0",
+        "thinking-orbs": "^0.1.1",
         "tokenlens": "^1.3.1",
         "tw-shimmer": "^0.4.6",
         "use-stick-to-bottom": "^1.1.3"
@@ -17441,6 +17443,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/thinking-orbs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/thinking-orbs/-/thinking-orbs-0.1.1.tgz",
+      "integrity": "sha512-nLvLTGJtk74K13MmP7XiRdzFiQx7UsoZAIyBZNgXyl7Q3h2mdz0r3eKn9LCsuzb3DGOVjwDvMhtnAkIqJJRVQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/tiny-invariant": {

--- a/web/package.json
+++ b/web/package.json
@@ -87,6 +87,7 @@
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.1",
+    "thinking-orbs": "^0.1.1",
     "tokenlens": "^1.3.1",
     "tw-animate-css": "^1.4.0",
     "tw-shimmer": "^0.4.6",


### PR DESCRIPTION
## Summary
The v2.11.1 release failed in the api image's `web-build` stage: Rolldown could not resolve the bare import `"thinking-orbs"` from `sdk/agent-chat-react`.

PR #152 added `thinking-orbs` as a dependency of `sdk/agent-chat-react`, but the Docker stage installs only from `web/package-lock.json` and symlinks `/build/node_modules` in as the SDK's `node_modules` — so every runtime dep of the SDK must also be declared in `web/`. Same failure mode previously fixed for `@novnc/novnc` in f975c60d.

## Changes
- Declare `thinking-orbs@^0.1.1` in `web/package.json` and refresh `web/package-lock.json`.

## Verification
- `npx vite build` in `web/` passes locally.
- `docker build --target web-build -f images/api/Dockerfile .` (the exact stage that failed) now completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)