### PR TITLE
fix(advisor): classify hard tasks via the session client, and stop hiding failures

### DIFF
--- a/surogates/harness/expert_routing.py
+++ b/surogates/harness/expert_routing.py
@@ -27,7 +27,10 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from surogates.config import load_settings
-from surogates.harness.auxiliary_client import build_base_auxiliary_llm
+from surogates.harness.auxiliary_client import (
+    AuxiliaryLLM,
+    build_base_auxiliary_llm,
+)
 from surogates.harness.structured_output import generate_structured
 
 logger = logging.getLogger(__name__)
@@ -359,6 +362,7 @@ async def classify_hard_task_async(
     messages: list[dict[str, Any]],
     *,
     tenant: Any | None = None,
+    aux: AuxiliaryLLM | None = None,
 ) -> HardTaskClassification:
     """Classify the latest user message using recent conversation context.
 
@@ -368,12 +372,13 @@ async def classify_hard_task_async(
     regex :func:`classify_hard_task` on the latest user text when the
     base LLM is unconfigured, the call fails, or Outlines is missing.
 
-    The auxiliary client targets ``settings.llm.model`` (the same model
-    that handles the main iteration loop) via
-    :func:`build_base_auxiliary_llm`. Reusing the base endpoint keeps
-    the classifier on the upstream that's already warm for the session,
-    instead of paying a separate cold-prefix penalty against the
-    summary endpoint.
+    Callers that already hold a per-session client should pass it as
+    ``aux``; that client is resolved from the agent's runtime config and
+    therefore points at a billed, per-agent proxy route. The
+    :func:`build_base_auxiliary_llm` fallback builds a client from
+    ``settings.llm``, whose ``base_url`` is deployment config and is not
+    guaranteed to serve chat completions — when it does not, the call
+    fails and this degrades to the regex path.
     """
     if not messages:
         return HardTaskClassification(False)
@@ -386,15 +391,17 @@ async def classify_hard_task_async(
     if cached is not None:
         return cached
 
-    try:
-        aux = build_base_auxiliary_llm(load_settings(), tenant)
-    except Exception:
-        logger.debug(
-            "Base LLM client unavailable for hard-task classifier; "
-            "falling back to regex.",
-            exc_info=True,
-        )
-        aux = None
+    if aux is None:
+        try:
+            aux = build_base_auxiliary_llm(load_settings(), tenant)
+        except Exception:
+            logger.warning(
+                "Base LLM client unavailable for hard-task classifier; "
+                "falling back to the regex classifier, which reads only "
+                "the latest message and is weak on non-English input.",
+                exc_info=True,
+            )
+            aux = None
 
     if aux is None:
         result = classify_hard_task(latest_user)
@@ -419,8 +426,11 @@ async def classify_hard_task_async(
             temperature=0,
         )
     except Exception:
-        logger.debug(
-            "LLM hard-task classifier raised; falling back to regex.",
+        logger.warning(
+            "LLM hard-task classifier raised; falling back to the regex "
+            "classifier, which reads only the latest message and is weak "
+            "on non-English input. Check that the classifier endpoint "
+            "actually serves chat completions.",
             exc_info=True,
         )
 

--- a/surogates/harness/loop_advisor.py
+++ b/surogates/harness/loop_advisor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Literal
 
+from surogates.harness.auxiliary_client import AuxiliaryLLM
 from surogates.harness.expert_routing import classify_hard_task_async
 from surogates.harness.loop_vision import _collapse_text_parts, _extract_response_text
 from surogates.session.events import EventType
@@ -30,9 +31,21 @@ class AdvisorMixin:
             return False
 
         user_content = str(last_user.get("content") or "")
+        # Prefer the session's summary client: it is resolved from the
+        # agent's runtime config, so it points at a billed per-agent
+        # proxy route and runs on the cheap summary model. The
+        # settings-level fallback inside the classifier depends on
+        # ``llm.base_url`` serving chat completions, which it does not
+        # when that URL is the proxy root.
+        classifier_aux: AuxiliaryLLM | None = None
+        if self._summary_client is not None and self._summary_model:
+            classifier_aux = AuxiliaryLLM(
+                client=self._summary_client, model=self._summary_model,
+            )
         classification = await classify_hard_task_async(
             messages,
             tenant=self._tenant,
+            aux=classifier_aux,
         )
         if not classification.required or classification.category is None:
             return False

--- a/tests/test_expert_routing.py
+++ b/tests/test_expert_routing.py
@@ -243,3 +243,116 @@ class TestHarnessAdvisorPreflight:
         from surogates.harness.loop import AgentHarness
 
         assert not hasattr(AgentHarness, "_maybe_consult_for_tool_calls")
+
+
+class TestClassifierClientInjection:
+    """The classifier must use the caller's per-session client when given.
+
+    Its ``settings.llm``-derived fallback depends on ``llm.base_url``
+    serving chat completions. In the shared-runtime deployment that URL
+    is the proxy root, which serves only ``/proxy/services/...`` — so the
+    fallback 404s and the classifier silently degrades to regex. Passing
+    the session's summary client (a real, billed per-agent route) is what
+    keeps the LLM path working.
+    """
+
+    @pytest.mark.asyncio
+    async def test_injected_aux_is_used_and_settings_fallback_not_built(
+        self, monkeypatch,
+    ):
+        from surogates.harness import expert_routing
+        from surogates.harness.auxiliary_client import AuxiliaryLLM
+
+        expert_routing._classifier_cache._store.clear()
+
+        def _boom(*_a, **_kw):  # pragma: no cover - must not be reached
+            raise AssertionError(
+                "settings fallback was built despite an injected client",
+            )
+
+        monkeypatch.setattr(expert_routing, "build_base_auxiliary_llm", _boom)
+
+        captured: dict = {}
+
+        async def fake_generate(**kwargs):
+            captured.update(kwargs)
+            return expert_routing.HardTaskJudgment(
+                required=True, category="coding",
+            )
+
+        monkeypatch.setattr(
+            expert_routing, "generate_structured", fake_generate,
+        )
+
+        aux = AuxiliaryLLM(client=MagicMock(), model="cheap-summary-model")
+        result = await expert_routing.classify_hard_task_async(
+            [{"role": "user", "content": "refactor the auth module for aux test"}],
+            aux=aux,
+        )
+
+        assert result.required is True
+        assert captured["model"] == "cheap-summary-model"
+        assert captured["llm_client"] is aux.client
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_settings_client_when_none_injected(
+        self, monkeypatch,
+    ):
+        from surogates.harness import expert_routing
+        from surogates.harness.auxiliary_client import AuxiliaryLLM
+
+        expert_routing._classifier_cache._store.clear()
+        built = MagicMock()
+        monkeypatch.setattr(
+            expert_routing, "build_base_auxiliary_llm",
+            lambda *_a, **_kw: AuxiliaryLLM(client=built, model="base-model"),
+        )
+        monkeypatch.setattr(expert_routing, "load_settings", lambda: object())
+
+        captured: dict = {}
+
+        async def fake_generate(**kwargs):
+            captured.update(kwargs)
+            return expert_routing.HardTaskJudgment(required=False, category=None)
+
+        monkeypatch.setattr(
+            expert_routing, "generate_structured", fake_generate,
+        )
+
+        await expert_routing.classify_hard_task_async(
+            [{"role": "user", "content": "hello there fallback test"}],
+        )
+        assert captured["llm_client"] is built
+
+    @pytest.mark.asyncio
+    async def test_request_failure_is_logged_at_warning_not_debug(
+        self, monkeypatch, caplog,
+    ):
+        """A 404 from a misconfigured endpoint must not vanish."""
+        import logging
+
+        from surogates.harness import expert_routing
+        from surogates.harness.auxiliary_client import AuxiliaryLLM
+
+        expert_routing._classifier_cache._store.clear()
+
+        async def boom(**_kwargs):
+            raise RuntimeError("404 page not found")
+
+        monkeypatch.setattr(
+            expert_routing, "generate_structured", boom,
+        )
+
+        aux = AuxiliaryLLM(client=MagicMock(), model="m")
+        with caplog.at_level(logging.WARNING, logger="surogates.harness.expert_routing"):
+            result = await expert_routing.classify_hard_task_async(
+                [{"role": "user", "content": "do something hard warn test"}],
+                aux=aux,
+            )
+        # Still degrades gracefully...
+        assert result is not None
+        # ...but no longer silently.
+        assert any(
+            "falling back to the regex classifier" in r.message
+            for r in caplog.records
+        )


### PR DESCRIPTION
The hard-task classifier gates **every** advisor consult. It built its
client from `settings.llm`, whose `base_url` in the shared-runtime
deployment is the proxy *root*:

```
llm.base_url: http://surogate-proxy.surogate.svc:8889/v1
```

But the proxy mounts its routers only under `/proxy/services/...` (plus
`/healthz`), so `POST /v1/chat/completions` 404s. The failure was caught
and logged at **debug**, so the classifier silently degraded to the regex
path — latest message only, weak on non-English input — and nothing
surfaced that the LLM classifier had never run.

## Fix

`classify_hard_task_async` now accepts an already-resolved `aux` client,
and the advisor preflight passes the session's **summary** client. That one
is resolved from the agent's runtime config, so it targets a real billed
per-agent proxy route and runs on the cheap summary model — the right tier
for a classification. The `settings.llm`-derived client remains as a
fallback.

Both fallback paths now log at **warning** and say what was lost, so a
misconfigured endpoint is visible instead of silent.

## Why it matters now

This was latent while the advisor was disabled — `maybe_consult` returns
early on the availability check *before* classifying — but it decides when
to spend Pro-rate advisor calls the moment `advisor_enabled` is turned on.
(Ops-side counterpart: the advisor now runs on the Surogate Pro tier and
bills at the Pro rate.)

## Not affected

`ContextCompressor` reads the same `base_url`, but only for
context-window discovery via `resolve_model_info`, and it receives an
explicit `summary_client` for the actual work — so compression was never
broken by this, and that discovery path already warns loudly.

## Verification

`tests/test_expert_routing.py`: 12 passed, 4 failed — the 4 are
pre-existing `TestHarnessAdvisorPreflight` failures on `master`, confirmed
by stashing this change. Three new tests cover: the injected client being
used (and the settings fallback *not* built), the fallback still working
when no client is injected, and a request failure being logged at warning
rather than debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)