### PR TITLE
feat(advisor): bias guidance toward carried work over method-only advice

### DIFF
--- a/surogates/harness/loop_advisor.py
+++ b/surogates/harness/loop_advisor.py
@@ -239,12 +239,24 @@ class AdvisorMixin:
         task: str,
     ) -> list[dict[str, str]]:
         transcript = self._build_advisor_context(messages)
+        # "Carry the work" wording, A/B-tested against a "do not solve
+        # outright" instruction: method-only advice failed to rescue the
+        # executor on arithmetic/bookkeeping-heavy tasks, while guidance
+        # carrying concrete intermediates and a proposed answer flipped
+        # them to passes without degrading tasks the executor already
+        # solved on its own.
         prompt = (
             "You are a strategic advisor for an agent harness. The executor "
             "model is cheaper and will continue the task after reading your "
             "guidance. Give concise, high-leverage advice under "
-            f"{self._advisor_max_tokens} tokens. Do not solve by writing the "
-            "entire final answer unless that is the only useful guidance.\n\n"
+            f"{self._advisor_max_tokens} tokens.\n"
+            "Work the problem as far as you can yourself: state the key "
+            "intermediate results, the pitfalls, and — when you are "
+            "confident — your own answer, plus how the executor should "
+            "verify it. Method-only advice does not rescue a weaker model "
+            "from error-prone arithmetic or bookkeeping; concrete numbers, "
+            "enumerations, and near-code do. If the task needs tools you "
+            "don't have, say exactly what to run and what output to expect.\n\n"
             f"Hard-task category: {category}\n\n"
             f"Current task or tool intent:\n{task}\n\n"
             f"Recent transcript:\n{transcript}"

--- a/tests/test_steer_loop.py
+++ b/tests/test_steer_loop.py
@@ -42,6 +42,8 @@ def _make_loop_harness(*, session_store: Any, budget: IterationBudget | None = N
     harness._advisor_model = ""
     harness._advisor_max_calls_per_turn = 0
     harness._advisor_max_tokens = 0
+    harness._pending_advisor_messages = []
+    harness._slash_commands = SimpleNamespace(commands=set())
     harness._checkpoints_enabled = False
     harness._saga_enabled = False
     harness._saga_settings = None


### PR DESCRIPTION
## What

Replaces the advisor prompt's "do not solve by writing the entire final answer" instruction with a **carry-the-work** instruction: state key intermediates, pitfalls, a proposed answer when confident, and how the executor should verify it.

## Why

A/B evaluation on computed-gold tasks (executor = the base tier, advisor = the pro tier, both through yunwu):

- Method-only advice produced **zero lift** on arithmetic/bookkeeping-heavy tasks — the executor acknowledged the strategy and still made the same slips.
- Guidance carrying concrete numbers/enumerations flipped previously-failing tasks to passes (e.g. digit-sum enumeration: advisor hand-carried the subset enumeration, caught its own miscount mid-guidance, proposed 360 + a brute-force verification — executor passed).
- Controls the executor already passed stayed passing under the new wording (no degradation observed in any round).
- Validated at the default `advisor_max_tokens=700`; even guidance truncated mid-sentence at that budget lifted the executor.

## Also

Revives the five `test_steer_loop.py` tests broken on master by the same fixture rot repaired earlier in `test_loop_turn_id.py` (hand-built harness missing `_slash_commands` / `_pending_advisor_messages`).

## Tests

- `tests/test_expert_routing.py`, `tests/test_loop_turn_id.py`, `tests/test_advisor_replay_ordering.py`, `tests/test_browser_base.py`, `tests/test_steer_loop.py` — all pass.
- Full suite (minus e2e/integration): 4505 passed; 26 failures are pre-existing on master in unrelated files (missing `reportlab`, browser-storage signature drift).