### PR TITLE
refactor(session): record the model from the resolved bundle

### DIFF
--- a/surogates/ambient/materialize.py
+++ b/surogates/ambient/materialize.py
@@ -51,7 +51,7 @@ async def materialize_ambient_tick(
             org_id=schedule.org_id,
             agent_id=schedule.agent_id,
             channel="ambient",
-            model=settings.llm.model,
+            model=None,
             config={
                 "slack_channel_id": schedule.channel_id,
                 "slack_team_id": sched_config.get("slack_team_id", ""),

--- a/surogates/api/routes/browser_profiles.py
+++ b/surogates/api/routes/browser_profiles.py
@@ -205,7 +205,6 @@ async def create_setup_session(
         user_id=user_id,
         agent_id=body.agent_id or "browser-setup",
         channel="browser_setup",
-        model=settings.llm.model,
         config={
             "browser": {
                 "profile_id": str(profile_id),

--- a/surogates/api/routes/prompts.py
+++ b/surogates/api/routes/prompts.py
@@ -185,16 +185,6 @@ async def _submit_one(
                 deduplicated=True,
             )
 
-    # Validate config up front so a misconfigured deployment doesn't
-    # leak partial provisioning artefacts (Garage bucket created, then
-    # 503 returned, leaving an orphan bucket behind on every retry).
-    if not settings.llm.model:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="LLM model is not configured (settings.llm.model is empty).",
-        )
-    model = settings.llm.model
-
     config: dict = {
         "service_account_id": str(service_account_id),
     }
@@ -228,7 +218,6 @@ async def _submit_one(
             org_id=tenant.org_id,
             agent_id=agent_id,
             channel=API_CHANNEL,
-            model=model,
             config=config,
             service_account_id=service_account_id,
             idempotency_key=body.idempotency_key,

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -408,24 +408,15 @@ async def _create_session(
     helper is independent of process-wide ``settings.agent_id``.
     """
     store = _get_session_store(request)
-
-    # Model is always set from server config — not user-selectable.
-    # ``LLMSettings.model`` carries its own default; if the deployment
-    # actively cleared it, that's a misconfiguration we surface up
-    # front rather than silently substituting a model that may not
-    # exist on the configured provider.
     settings = request.app.state.settings
-    if not settings.llm.model:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="LLM model is not configured (settings.llm.model is empty).",
-        )
-    model = settings.llm.model
 
     config = body.config.copy()
     if body.system:
         config["system"] = body.system
 
+    # No model here: the agent's model is chosen by the management
+    # plane and only resolves when the worker builds the session's LLM
+    # bundle. The worker records it on the row at wake.
     session = await create_agent_session(
         store=store,
         storage=request.app.state.storage,
@@ -434,7 +425,6 @@ async def _create_session(
         org_id=tenant.org_id,
         agent_id=agent_id,
         channel=channel,
-        model=model,
         config=config,
         service_account_id=service_account_id,
     )

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -731,7 +731,7 @@ async def bootstrap_website_session(
         org_id=org_uuid,
         agent_id=agent_id,
         channel=WEBSITE_CHANNEL,
-        model=settings.llm.model,
+        model=None,
         config=config,
     )
     try:

--- a/surogates/channels/identity.py
+++ b/surogates/channels/identity.py
@@ -317,7 +317,6 @@ async def get_or_create_channel_session(
     channel: str,
     config: dict,
     session_factory: async_sessionmaker[AsyncSession],
-    model: str = "",
     storage: object = None,
     settings: object = None,
 ) -> UUID:
@@ -342,8 +341,6 @@ async def get_or_create_channel_session(
         Channel-specific session config (e.g. Slack channel_id, thread_ts).
     session_factory:
         SQLAlchemy async session factory for direct DB queries.
-    model:
-        LLM model override for this channel (empty = use global default).
 
     Returns
     -------
@@ -457,7 +454,6 @@ async def get_or_create_channel_session(
                 storage=storage,
                 settings=settings,
                 session_id=session_id,
-                model=model,
             )
         except Exception:
             logger.warning(
@@ -473,7 +469,7 @@ async def get_or_create_channel_session(
         org_id=org_id,
         agent_id=agent_id,
         channel=channel,
-        model=model,
+        model=None,
         config=merged_config,
     )
 

--- a/surogates/config.py
+++ b/surogates/config.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings
 
 
@@ -277,7 +277,32 @@ class LLMSettings(BaseSettings):
 
     model_config = {"env_prefix": "SUROGATES_LLM_"}
 
-    model: str = "gpt-4o"
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_deployment_level_model(cls, data: Any) -> Any:
+        """Fail with a fixable message when a config still sets ``model``.
+
+        ``extra="forbid"`` would already reject it, but with a generic
+        error that reads like a bug rather than a config to edit. This is
+        deliberately fatal rather than ignored: a stale model here used to
+        be recorded on every session row while the agent ran on something
+        else entirely, and silently dropping it would keep that
+        divergence invisible.
+        """
+        if isinstance(data, dict) and "model" in data:
+            raise ValueError(
+                "llm.model (SUROGATES_LLM_MODEL) is no longer supported — "
+                "remove it. Model selection now comes from the per-agent "
+                "runtime config the management plane writes (llm_main), "
+                "and the worker records the resolved model on the session.",
+            )
+        return data
+
+    # No ``model`` here on purpose: the management plane owns model
+    # selection. It reaches the runtime as the per-agent runtime
+    # config's ``llm_main`` slot, which the worker resolves into the
+    # session's LLM bundle and records on the session row. A second
+    # deployment-level model setting could only ever disagree with it.
     base_url: str = ""  # custom endpoint (e.g. vLLM, Ollama)
     api_key: str = ""  # provider API key
 

--- a/surogates/harness/auxiliary_client.py
+++ b/surogates/harness/auxiliary_client.py
@@ -69,6 +69,10 @@ def build_base_auxiliary_llm(
     the classifier benefits from the same upstream prefix cache and
     provider warmth as the iteration loop, instead of paying an extra
     round trip against a separately-tiered summary endpoint.
+
+    Only a tenant-level model override can drive this client: the
+    deployment does not carry a model of its own, and the session's
+    own model lives on the bundle the caller already holds.
     """
     llm = settings.llm
     org_llm = _mapping_get(getattr(tenant, "org_config", None), "llm")
@@ -77,7 +81,6 @@ def build_base_auxiliary_llm(
     model = (
         _mapping_get(user_llm, "model")
         or _mapping_get(org_llm, "model")
-        or llm.model
     )
     if not model:
         return None

--- a/surogates/harness/model_metadata.py
+++ b/surogates/harness/model_metadata.py
@@ -187,6 +187,17 @@ MODEL_CATALOG: dict[str, ModelInfo] = {
         output_cost_per_1k=0.0,
         supports_vision=True,
     ),
+    # The Pro tier is a distinct sentinel, so it needs its own entry —
+    # without one the compressor falls back to a default window for
+    # every Pro session and mis-sizes the context.
+    "surogate-pro": ModelInfo(
+        id="surogate-pro",
+        context_window=262_144,
+        max_output_tokens=32_768,
+        input_cost_per_1k=0.0,
+        output_cost_per_1k=0.0,
+        supports_vision=True,
+    ),
 }
 
 # Build alias lookup: allow matching by short prefix or common alias.

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -265,11 +265,21 @@ def _filter_effective_tools(
     return result
 
 
+_warned_missing_model_metadata: set[str] = set()
+
+
 def _warn_if_base_model_missing_from_metadata(model_id: str) -> None:
-    """Warn when the configured base model has no static metadata entry."""
+    """Warn when a session's resolved model has no static metadata entry.
+
+    Called per wake (the model is only known once the bundle resolves),
+    so warn once per distinct model rather than on every session.
+    """
     normalized = str(model_id or "").strip()
     if not normalized or get_model_info(normalized) is not None:
         return
+    if normalized in _warned_missing_model_metadata:
+        return
+    _warned_missing_model_metadata.add(normalized)
     logger.warning(
         "Base LLM model %r is not present in surogates.harness.model_metadata "
         "MODEL_CATALOG or aliases; add model metadata so context sizing and capability checks remain accurate.",
@@ -917,8 +927,8 @@ async def run_worker(settings: Settings) -> None:
     # SessionLLMClients bundle built by ``build_session_llm_clients``
     # from the per-agent runtime config + the credential vault.  No
     # process-wide AsyncOpenAI instance here — every session owns
-    # its own connection pool.
-    _warn_if_base_model_missing_from_metadata(settings.llm.model)
+    # its own connection pool.  Model metadata is checked per wake,
+    # once the bundle names the model.
 
     # Worker-side shared-runtime plumbing.  Wires the
     # RuntimeConfigCache + FileBundleCache + MemoryCache that
@@ -1119,6 +1129,12 @@ async def run_worker(settings: Settings) -> None:
             )
         model_id = llm_bundle.main.model
         llm_client = llm_bundle.main.client
+        # The session row is created before any bundle exists, so the
+        # model it ran on is only knowable here. Recording it from the
+        # bundle keeps one source of truth: the management plane picks
+        # the model, the worker reports what it picked.
+        _warn_if_base_model_missing_from_metadata(model_id)
+        await session_store.record_session_model(session.id, model_id)
         budget = IterationBudget(max_total=90)
         summary_slot = llm_bundle.summary
         vision_slot = llm_bundle.vision

--- a/surogates/scheduled/materialize.py
+++ b/surogates/scheduled/materialize.py
@@ -88,7 +88,6 @@ async def materialize_scheduled_run(
                 store=session_store,
                 parent=parent,
                 channel="scheduled",
-                model=settings.llm.model,
                 config=scheduled_config,
                 idempotency_key=idempotency_key,
             )
@@ -102,7 +101,6 @@ async def materialize_scheduled_run(
                 service_account_id=schedule.service_account_id,
                 agent_id=schedule.agent_id,
                 channel="scheduled",
-                model=settings.llm.model,
                 config=scheduled_config,
                 parent_id=None,
                 idempotency_key=idempotency_key,

--- a/surogates/session/provisioning.py
+++ b/surogates/session/provisioning.py
@@ -4,7 +4,6 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from surogates.channels.memory_boundary import MANAGED_CHANNELS
-from surogates.harness.model_metadata import get_model_info
 from surogates.sandbox.pool import sandbox_session_key
 from surogates.session.models import Session
 from surogates.session.store import SessionStore
@@ -18,7 +17,6 @@ _WORKSPACE_SHARING_FIELDS = (
     "storage_bucket",
     "storage_key_prefix",
     "workspace_path",
-    "supports_vision",
 )
 
 # Boundary fields a child session inherits verbatim from its parent so it
@@ -51,24 +49,24 @@ async def stamp_workspace_config(
     storage: Any,
     settings: Any,
     session_id: UUID,
-    model: str,
 ) -> dict:
     """Stamp the persistent-workspace fields into *config* and ensure the bucket exists.
 
-    Sets ``storage_bucket``, ``storage_key_prefix``, ``workspace_path`` and
-    ``supports_vision`` so the worker mounts a persistent S3 ``/workspace`` for
-    the session. Shared by API/web provisioning (:func:`create_agent_session`)
-    and channel-session provisioning so both yield an identical workspace.
+    Sets ``storage_bucket``, ``storage_key_prefix`` and ``workspace_path``
+    so the worker mounts a persistent S3 ``/workspace`` for the session.
+    Shared by API/web provisioning (:func:`create_agent_session`) and
+    channel-session provisioning so both yield an identical workspace.
+
+    Vision support is deliberately not stamped here: it depends on the
+    model, which is not known until the worker resolves the session's
+    LLM bundle. The harness re-derives it from the live model at the
+    point of use.
     """
     bucket = agent_session_bucket(settings.storage.bucket)
     await storage.create_bucket(bucket)
     config["storage_bucket"] = bucket
     config["storage_key_prefix"] = getattr(settings.storage, "key_prefix", "") or ""
     config["workspace_path"] = storage.resolve_workspace_path(bucket, session_id)
-    model_info = get_model_info(model)
-    config["supports_vision"] = (
-        model_info.supports_vision if model_info is not None else False
-    )
     return config
 
 
@@ -81,7 +79,6 @@ async def create_agent_session(
     user_id: UUID | None,
     agent_id: str,
     channel: str,
-    model: str,
     config: dict | None = None,
     service_account_id: UUID | None = None,
     parent_id: UUID | None = None,
@@ -98,18 +95,20 @@ async def create_agent_session(
     merged_config.setdefault("channel", channel)
     pin_workspace_boundary(merged_config, channel=channel)
     await stamp_workspace_config(
-        merged_config, storage=storage, settings=settings, session_id=sid, model=model,
+        merged_config, storage=storage, settings=settings, session_id=sid,
     )
     if service_account_id is not None:
         merged_config["service_account_id"] = str(service_account_id)
 
+    # ``model`` stays NULL until the worker resolves the LLM bundle and
+    # records what it actually ran on.
     return await store.create_session(
         session_id=sid,
         user_id=user_id,
         org_id=org_id,
         agent_id=agent_id,
         channel=channel,
-        model=model,
+        model=None,
         config=merged_config,
         parent_id=parent_id,
         service_account_id=service_account_id,
@@ -140,7 +139,9 @@ async def create_child_session(
     Identity is inherited from *parent*: ``agent_id``, ``org_id``,
     ``user_id``, and ``service_account_id`` (unless explicitly
     overridden via *service_account_id*).  ``model`` falls back to
-    ``parent.model`` when not supplied.
+    ``parent.model`` when not supplied — which is itself whatever the
+    worker recorded for the parent, or ``None`` if the parent has not
+    woken yet; the child's own wake stamps the authoritative value.
 
     *task_id* links the child to a ``tasks`` row when the spawn is a
     subagent task attempt.  Plain ``spawn_worker`` children pass

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -433,6 +433,26 @@ class SessionStore:
             )
             return {row.id: str(row.agent_id) for row in result.all()}
 
+    async def record_session_model(self, session_id: UUID, model: str) -> None:
+        """Record the model a session actually ran on.
+
+        The session row is created before any worker resolves the
+        agent's LLM bundle, so ``model`` starts out NULL. The worker
+        stamps it here at wake with ``llm_bundle.main.model`` — the same
+        value it calls — so the record can never drift from what ran.
+        No-ops when unchanged to keep the common path (every wake after
+        the first) off the write path.
+        """
+        if not model:
+            return
+        async with self._sf() as db:
+            await db.execute(
+                update(SessionRow)
+                .where(SessionRow.id == session_id, SessionRow.model.is_distinct_from(model))
+                .values(model=model)
+            )
+            await db.commit()
+
     async def update_session_status(self, session_id: UUID, status: str) -> None:
         """Set a session's status and touch ``updated_at``."""
         async with self._sf() as db:

--- a/tests/test_agent_type_spawn.py
+++ b/tests/test_agent_type_spawn.py
@@ -486,7 +486,6 @@ class TestSharedWorkspace:
         cfg = call["config"]
         assert cfg["storage_bucket"] == parent.config["storage_bucket"]
         assert cfg["workspace_path"] == parent.config["workspace_path"]
-        assert cfg["supports_vision"] is True
         # Parent is itself a root → root id is parent's own id.
         assert cfg["sandbox_root_session_id"] == str(parent.id)
         # Child identity inherits from parent, NOT from the caller tenant.

--- a/tests/test_session_model_recording.py
+++ b/tests/test_session_model_recording.py
@@ -1,0 +1,108 @@
+"""The session's model is recorded from the resolved bundle, not config.
+
+Model selection belongs to the management plane: it arrives as the
+per-agent runtime config's ``llm_main`` slot, the worker resolves it into
+the session's LLM bundle, and the row records what actually ran. A
+deployment-level ``llm.model`` setting could only ever disagree with that,
+so it must not exist — these tests pin both halves of that contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from surogates.config import LLMSettings
+
+
+def test_llm_settings_has_no_model_field():
+    """A deployment-level model would be a second source of truth."""
+    assert "model" not in LLMSettings.model_fields, (
+        "LLMSettings.model is back; model selection belongs to the "
+        "per-agent runtime config, and a settings-level model silently "
+        "disagrees with the model the session actually runs on"
+    )
+
+
+def test_a_config_still_setting_model_fails_with_a_fixable_message():
+    """A stale key must not be silently dropped — nor crash cryptically.
+
+    Deployments carrying ``llm.model`` (the PROD runtime configmap did)
+    have to be edited; the error has to say so.
+    """
+    with pytest.raises(Exception) as exc:
+        LLMSettings(model="qwen3.7-max")
+    message = str(exc.value)
+    assert "no longer supported" in message
+    assert "llm_main" in message
+
+
+def test_llm_settings_still_carries_the_shared_upstream():
+    """Endpoint/key stay: they serve model-metadata lookup and media roles."""
+    assert "base_url" in LLMSettings.model_fields
+    assert "api_key" in LLMSettings.model_fields
+
+
+@pytest.mark.asyncio
+async def test_record_session_model_writes_the_resolved_model():
+    from uuid import uuid4
+
+    from surogates.session.store import SessionStore
+
+    captured: list[object] = []
+
+    class _DB:
+        async def execute(self, stmt):
+            captured.append(stmt)
+
+        async def commit(self):
+            captured.append("commit")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    store = SessionStore.__new__(SessionStore)
+    store._sf = lambda: _DB()
+
+    await store.record_session_model(uuid4(), "surogate-pro")
+
+    assert "commit" in captured
+    compiled = str(captured[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "model" in compiled
+    assert "surogate-pro" in compiled
+
+
+@pytest.mark.asyncio
+async def test_record_session_model_ignores_an_empty_model():
+    """Nothing to record — must not issue a write that NULLs the column."""
+    from uuid import uuid4
+
+    from surogates.session.store import SessionStore
+
+    class _ExplodingDB:
+        async def __aenter__(self):
+            raise AssertionError("must not open a session for an empty model")
+
+        async def __aexit__(self, *exc):
+            return False
+
+    store = SessionStore.__new__(SessionStore)
+    store._sf = lambda: _ExplodingDB()
+
+    await store.record_session_model(uuid4(), "")
+
+
+def test_both_platform_tiers_have_model_metadata():
+    """Missing metadata makes the compressor mis-size the context window.
+
+    The tiers are sentinels rewritten upstream by the proxy, so they never
+    match a provider model name — each needs its own catalog entry.
+    """
+    from surogates.harness.model_metadata import get_model_info
+
+    for tier in ("surogate", "surogate-pro"):
+        info = get_model_info(tier)
+        assert info is not None, f"{tier} has no model metadata entry"
+        assert info.context_window > 0

--- a/tests/test_session_multi_session.py
+++ b/tests/test_session_multi_session.py
@@ -97,7 +97,6 @@ def _tenant(org_id: UUID, user_id: UUID | None) -> TenantContext:
 
 def _request(store: _Store, storage: _Storage):
     settings = Settings()
-    settings.llm.model = "gpt-test"
     settings.storage.bucket = "ops-agent-bucket"
     return SimpleNamespace(
         url=SimpleNamespace(path="/v1/sessions"),

--- a/tests/test_session_provisioning.py
+++ b/tests/test_session_provisioning.py
@@ -21,7 +21,6 @@ def _workspace_config() -> dict:
         "storage_bucket": "tenant-bucket",
         "storage_key_prefix": "",
         "workspace_path": "/workspace/tenant-bucket/parent",
-        "supports_vision": False,
     }
 
 
@@ -79,7 +78,6 @@ async def test_create_agent_session_populates_storage_and_model_metadata():
         user_id=user_id,
         agent_id="agent-a",
         channel="web",
-        model="gpt-5.5",
         config={"system": "be useful"},
         session_id=session_id,
     )
@@ -92,13 +90,15 @@ async def test_create_agent_session_populates_storage_and_model_metadata():
     assert call["user_id"] == user_id
     assert call["agent_id"] == "agent-a"
     assert call["channel"] == "web"
-    assert call["model"] == "gpt-5.5"
+    assert call["model"] is None
     assert call["config"]["system"] == "be useful"
     assert call["config"]["storage_bucket"] == "tenant-bucket"
     # storage_key_prefix is stamped (empty when settings.storage doesn't set it).
     assert call["config"]["storage_key_prefix"] == ""
     assert call["config"]["workspace_path"] == f"/workspace/tenant-bucket/{session_id}"
-    assert call["config"]["supports_vision"] is True
+    # Vision support is not stamped: it depends on the model, which is
+    # unknown until the worker resolves the bundle.
+    assert "supports_vision" not in call["config"]
 
 
 @pytest.mark.asyncio
@@ -108,7 +108,6 @@ async def test_create_child_session_inherits_workspace_from_root_parent():
             "storage_bucket": "tenant-bucket",
             "storage_key_prefix": "",
             "workspace_path": "/workspace/tenant-bucket/abc",
-            "supports_vision": True,
             "system": "parent-system",  # non-sharing field — not inherited
         },
     )
@@ -133,7 +132,6 @@ async def test_create_child_session_inherits_workspace_from_root_parent():
     cfg = call["config"]
     assert cfg["storage_bucket"] == "tenant-bucket"
     assert cfg["workspace_path"] == "/workspace/tenant-bucket/abc"
-    assert cfg["supports_vision"] is True
     assert cfg["sandbox_root_session_id"] == str(parent.id)
     assert cfg["max_iterations"] == 5
     assert cfg["streaming"] is False
@@ -149,7 +147,6 @@ async def test_create_child_session_grandchild_preserves_root():
             "storage_bucket": "b",
             "storage_key_prefix": "",
             "workspace_path": "/workspace/b/root",
-            "supports_vision": False,
             "sandbox_root_session_id": str(grandparent_id),
         },
         parent_id=grandparent_id,
@@ -196,7 +193,6 @@ async def test_create_child_session_caller_cannot_override_workspace_fields():
             "storage_bucket": "parent-bucket",
             "storage_key_prefix": "p-1/a-1",
             "workspace_path": "/workspace/parent",
-            "supports_vision": True,
         },
     )
     store = SimpleNamespace(create_session=AsyncMock(return_value=SimpleNamespace(id=uuid4())))
@@ -209,7 +205,6 @@ async def test_create_child_session_caller_cannot_override_workspace_fields():
             "storage_bucket": "attacker-bucket",
             "storage_key_prefix": "p-evil/a-evil",
             "workspace_path": "/elsewhere",
-            "supports_vision": False,
         },
     )
 
@@ -217,7 +212,6 @@ async def test_create_child_session_caller_cannot_override_workspace_fields():
     assert cfg["storage_bucket"] == "parent-bucket"
     assert cfg["storage_key_prefix"] == "p-1/a-1"
     assert cfg["workspace_path"] == "/workspace/parent"
-    assert cfg["supports_vision"] is True
 
 
 @pytest.mark.asyncio
@@ -230,7 +224,6 @@ async def test_create_child_session_inherits_service_account_from_parent():
             "storage_bucket": "b",
             "storage_key_prefix": "",
             "workspace_path": "/w",
-            "supports_vision": False,
             "service_account_id": str(sa_id),
         },
     )
@@ -313,7 +306,6 @@ async def test_create_child_session_does_not_touch_storage():
             "storage_bucket": "b",
             "storage_key_prefix": "",
             "workspace_path": "/w",
-            "supports_vision": False,
         },
     )
     store = SimpleNamespace(create_session=AsyncMock(return_value=SimpleNamespace(id=uuid4())))
@@ -356,8 +348,14 @@ async def test_create_child_session_propagates_idempotency_and_session_id():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_stamp_workspace_config_supports_vision_true_for_vision_model():
-    """A vision model has config['supports_vision'] = True after stamp."""
+async def test_stamp_workspace_config_does_not_stamp_vision_support():
+    """Vision support is model-dependent, so provisioning must not guess.
+
+    The session row exists before any worker resolves the agent's LLM
+    bundle, so the model is unknown here. Stamping a guess would freeze
+    a wrong value into the session config for its whole life; the
+    harness re-derives vision support from the live model instead.
+    """
     from surogates.session.provisioning import stamp_workspace_config
 
     class _FakeStorage:
@@ -369,40 +367,18 @@ async def test_stamp_workspace_config_supports_vision_true_for_vision_model():
             bucket = "test-bucket"
             key_prefix = ""
 
-    config = {}
+    config: dict = {}
+    session_id = uuid4()
     await stamp_workspace_config(
         config,
         storage=_FakeStorage(),
         settings=_FakeSettings(),
-        session_id=uuid4(),
-        model="gpt-5.5",
+        session_id=session_id,
     )
-    assert config["supports_vision"] is True
 
-
-@pytest.mark.asyncio
-async def test_stamp_workspace_config_supports_vision_false_for_text_model():
-    """A text-only model has config['supports_vision'] = False after stamp."""
-    from surogates.session.provisioning import stamp_workspace_config
-
-    class _FakeStorage:
-        async def create_bucket(self, bucket): pass
-        def resolve_workspace_path(self, bucket, session_id): return f"/ws/{session_id}"
-
-    class _FakeSettings:
-        class storage:
-            bucket = "test-bucket"
-            key_prefix = ""
-
-    config = {}
-    await stamp_workspace_config(
-        config,
-        storage=_FakeStorage(),
-        settings=_FakeSettings(),
-        session_id=uuid4(),
-        model="deepseek/deepseek-v4-pro",
-    )
-    assert config["supports_vision"] is False
+    assert "supports_vision" not in config
+    assert config["storage_bucket"] == "test-bucket"
+    assert config["workspace_path"] == f"/ws/{session_id}"
 
 
 @pytest.mark.asyncio
@@ -426,7 +402,6 @@ async def test_create_agent_session_pins_managed_channel_workspace_boundary():
         user_id=user_id,
         agent_id="agent-a",
         channel="slack",
-        model="gpt-4o",
         config={"memory_boundary": "slack:c:G1"},
         session_id=session_id,
     )
@@ -454,7 +429,6 @@ async def test_create_agent_session_does_not_pin_non_channel_memory_boundary():
         user_id=uuid4(),
         agent_id="agent-a",
         channel="web",
-        model="gpt-4o",
         config={"memory_boundary": "slack:c:G1"},
         session_id=session_id,
     )
@@ -471,7 +445,6 @@ async def test_create_child_session_inherits_boundary_fields_from_parent():
             "storage_bucket": "tenant-bucket",
             "storage_key_prefix": "project/agent",
             "workspace_path": "/workspace",
-            "supports_vision": True,
             "memory_boundary": "slack:c:G1",
             "workspace_boundary": "slack:c:G1",
         },

--- a/tests/test_session_provisioning_storage_prefix.py
+++ b/tests/test_session_provisioning_storage_prefix.py
@@ -27,27 +27,20 @@ class _Storage:
 
 @pytest.mark.asyncio
 async def test_create_agent_session_stamps_storage_key_prefix():
-    # get_model_info is consulted for vision support; stub it so tests
-    # don't depend on the model registry.
-    with mock.patch(
-        "surogates.session.provisioning.get_model_info",
-        return_value=SimpleNamespace(supports_vision=False),
-    ):
-        session = await create_agent_session(
-            store=_Store(),
-            storage=_Storage(),
-            settings=SimpleNamespace(
-                storage=SimpleNamespace(
-                    bucket="surogate-workspaces",
-                    key_prefix="p-1/a-1",
-                ),
+    session = await create_agent_session(
+        store=_Store(),
+        storage=_Storage(),
+        settings=SimpleNamespace(
+            storage=SimpleNamespace(
+                bucket="surogate-workspaces",
+                key_prefix="p-1/a-1",
             ),
-            org_id=uuid4(),
-            user_id=uuid4(),
-            agent_id="a-1",
-            channel="api",
-            model="gpt-4o",
-        )
+        ),
+        org_id=uuid4(),
+        user_id=uuid4(),
+        agent_id="a-1",
+        channel="api",
+    )
     assert session.config["storage_bucket"] == "surogate-workspaces"
     assert session.config["storage_key_prefix"] == "p-1/a-1"
 
@@ -55,22 +48,17 @@ async def test_create_agent_session_stamps_storage_key_prefix():
 @pytest.mark.asyncio
 async def test_create_agent_session_defaults_prefix_when_missing():
     """settings.storage with no key_prefix attribute → empty string."""
-    with mock.patch(
-        "surogates.session.provisioning.get_model_info",
-        return_value=SimpleNamespace(supports_vision=False),
-    ):
-        session = await create_agent_session(
-            store=_Store(),
-            storage=_Storage(),
-            settings=SimpleNamespace(
-                storage=SimpleNamespace(bucket="surogate-workspaces"),
-            ),
-            org_id=uuid4(),
-            user_id=uuid4(),
-            agent_id="a-1",
-            channel="api",
-            model="gpt-4o",
-        )
+    session = await create_agent_session(
+        store=_Store(),
+        storage=_Storage(),
+        settings=SimpleNamespace(
+            storage=SimpleNamespace(bucket="surogate-workspaces"),
+        ),
+        org_id=uuid4(),
+        user_id=uuid4(),
+        agent_id="a-1",
+        channel="api",
+    )
     assert session.config["storage_key_prefix"] == ""
 
 

--- a/tests/test_session_workspace_storage.py
+++ b/tests/test_session_workspace_storage.py
@@ -215,7 +215,6 @@ def _request(
     # ``Settings`` is no longer per-tenant — ``agent_id`` is resolved per
     # request via the runtime context, not from process-wide settings.
     settings = Settings()
-    settings.llm.model = "gpt-test"
     settings.storage.bucket = "ops-agent-bucket"
     return SimpleNamespace(
         url=SimpleNamespace(path=path),


### PR DESCRIPTION
## The problem

Two independent notions of an agent's model lived side by side:

| | source | used for |
|---|---|---|
| `ctx.llm_main.model` | per-agent runtime config (management plane) | the model actually called |
| `settings.llm.model` | deployment config / configmap | the value written to `sessions.model` at creation |

Nothing compared them, so they drifted freely. In PROD every session row was labelled `qwen3.7-max` while the agent ran on whatever the proxy resolved.

## The fix — the bundle is the source of truth

- **Sessions are created with `model=NULL`;** the worker stamps `sessions.model` from `llm_bundle.main.model` at wake (new `SessionStore.record_session_model`, a no-op write when unchanged). The recorded value is the model that ran, not a guess made before any model was known.
- **`LLMSettings.model` is removed.** A config that still sets it fails at load with a message naming the replacement — deliberately fatal rather than ignored, since silently dropping it would keep the divergence invisible, and better than the generic `extra=forbid` error.
- **`stamp_workspace_config` no longer stamps `supports_vision`.** It needed the model to derive it, nothing ever read the stamped value, and the harness already re-derives vision support from the live model at the point of use. Also dropped from `_WORKSPACE_SHARING_FIELDS` (it was a hard requirement for child sessions).
- **The model-metadata warning moves from worker startup to per-wake,** deduplicated per model id — it can only be checked once the bundle names a model.
- **Adds the missing `surogate-pro` metadata entry.** Pre-existing bug: without it, every Pro session fell back to a default context window and the compressor mis-sized the context.

## ⚠️ Deploy ordering (breaking config change)

The PROD runtime configmap sets `llm.model: "qwen3.7-max"`. Because the runtime now **rejects** that key, the configmap must be edited **before** this image rolls, or `runtime-*` pods crash-loop on startup.

The repo manifest is updated in a companion surogate-ops PR, but note the live configmap has drifted from it (it carries an SSH-egress block the repo file lacks) — patch the `model:` line surgically, do **not** apply the repo file wholesale.

## Tests

New `tests/test_session_model_recording.py` pins: no `model` field on `LLMSettings`; a stale key fails with a fixable message; `record_session_model` writes the resolved model and ignores an empty one; both tier sentinels have metadata.

Full suite: **4508 passed, 28 failed — byte-identical failure set to master** (missing `reportlab`, browser-storage signature drift, and 4 pre-existing `send_message` fixture failures). Verified by diffing failing-test names before/after. Ruff unchanged at 181 findings.