### PR TITLE
ci: build releases on GitHub-hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   wheel:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,7 +33,7 @@ jobs:
 
   images:
     needs: npm
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -53,15 +53,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # GitHub-hosted runners start with ~14 GB free; the api and sandbox
+      # images add LibreOffice + Tesseract on top of the Python deps.
+      # Reclaim the preinstalled toolchains we never use (~25 GB).
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache/CodeQL}"
+          df -h /
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          # Persistent per-image builder on the self-hosted runner. Keeping
-          # the builder (cleanup: false) preserves its internal layer cache
-          # across runs, so we don't pay a slow local cache export each build.
-          name: surogates-builder-${{ matrix.dir }}
-          driver: docker-container
-          cleanup: false
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -83,17 +85,21 @@ jobs:
           tags: |
             ghcr.io/invergent-ai/${{ matrix.name }}:${{ steps.version.outputs.value }}
             ghcr.io/invergent-ai/${{ matrix.name }}:latest
-          # No cache-from/cache-to: the persistent builder above retains its
-          # layer cache between runs on the host, which is faster than
-          # serializing the whole cache to a local directory.
+          # The runner is ephemeral, so the layer cache lives in GHCR next to
+          # the image (mode=max keeps intermediate stages too). First build
+          # after this change is cold; subsequent ones reuse it.
+          cache-from: type=registry,ref=ghcr.io/invergent-ai/${{ matrix.name }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/invergent-ai/${{ matrix.name }}:buildcache,mode=max
 
   npm:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
-      # Self-hosted runners cannot produce npm provenance: npmjs.org only
-      # accepts provenance bundles built from "github-hosted" runners.
+      # Left off deliberately. Now that this job runs on a github-hosted
+      # runner, npm provenance (and OIDC trusted publishing) would be
+      # accepted — but that needs a trusted publisher configured on the
+      # npmjs side first, so enabling it here would break publishing.
       NPM_CONFIG_PROVENANCE: "false"
     steps:
       - uses: actions/checkout@v4
@@ -119,8 +125,9 @@ jobs:
 
       - name: Publish SDK packages
         env:
-          # OIDC trusted publishing requires github-hosted runners, so on
-          # self-hosted we authenticate with a long-lived npm automation token.
+          # Long-lived npm automation token. Switchable to OIDC trusted
+          # publishing now that the runner is github-hosted (see the
+          # NPM_CONFIG_PROVENANCE note above).
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: node scripts/publish-sdk-packages.mjs --version="${GITHUB_REF_NAME#v}"
 
@@ -128,7 +135,7 @@ jobs:
     needs:
       - wheel
       - images
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The self-hosted runner's disk keeps filling and apt fails mid-build (`exit code: 100`, while installing LibreOffice/Tesseract in the api + sandbox images). Moves the release jobs to `ubuntu-latest`.

## Changes
- `wheel`, `images`, `npm`, `release` → `runs-on: ubuntu-latest`
- **Layer cache**: the persistent named builder (`cleanup: false`) is meaningless on an ephemeral runner — replaced with a GHCR-backed cache (`type=registry,ref=…:buildcache,mode=max`)
- **Disk headroom**: each image job reclaims the preinstalled toolchains (~25 GB) and prints `df -h /`, so a disk failure shows up in the log instead of a bare exit 100

## npm publishing unchanged
Still the `NPM_TOKEN` automation token. Provenance and OIDC trusted publishing *are* now possible on a hosted runner, but they need a trusted publisher configured on npmjs first — enabling them here would break publishing. Only the stale "self-hosted can't do this" comments were corrected.

## Deliberately left on self-hosted
`update-images.yml` — SSHes to cluster nodes on port 22022; a GitHub-hosted runner is outside that network, so the deploy would fail.

## Expect
The **first release after this is a cold build** (no cache yet). Hosted runners are 2-core/7 GB, so image builds will be slower than on our own hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)