### PR TITLE
fix(harness): record cost for tier-sentinel sessions

### DIFF
--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -1925,14 +1925,29 @@ class AgentHarness(
             }
 
             # Compute cost estimate (cache reads billed at the discounted rate).
-            from surogates.harness.model_metadata import estimate_cost
+            from surogates.harness.model_metadata import estimate_call_cost
 
-            cost = estimate_cost(
-                model_id, input_tokens, output_tokens,
+            cost, priced_model = estimate_call_cost(
+                model_id,
+                usage_data.get("model"),
+                input_tokens,
+                output_tokens,
                 cache_read_tokens=cache_read_tokens,
             )
             if cost > 0:
                 response_data["cost_usd"] = cost
+            elif priced_model is None:
+                # No catalog rate for the model that served this call, so
+                # the session's estimated_cost_usd cannot move while its
+                # token counters do. Record the gap on the event instead of
+                # dropping it silently -- that silence is what let a
+                # 1.48M-token session read as costing nothing.
+                response_data["cost_unpriced_model"] = (
+                    usage_data.get("model") or model_id
+                )
+                self._warn_unpriced_model_once(
+                    usage_data.get("model") or model_id
+                )
 
             # Record in session cost tracker.
             if cost_tracker is not None:
@@ -2907,6 +2922,25 @@ class AgentHarness(
         self._fallback_activated = activated
         return True
 
+    def _warn_unpriced_model_once(self, model: str) -> None:
+        """Log a missing catalog rate once per model per session.
+
+        Per call would flood a long session; never would leave the operator
+        with silently-zero cost, which is the bug this guards.
+        """
+        seen = getattr(self, "_unpriced_models_warned", None)
+        if seen is None:
+            seen = set()
+            self._unpriced_models_warned = seen
+        if model in seen:
+            return
+        seen.add(model)
+        logger.warning(
+            "No catalog rate for model %r; sessions on it accrue tokens "
+            "with estimated_cost_usd staying at 0. Add it to MODEL_CATALOG.",
+            model,
+        )
+
     def _try_activate_pro_fallback(self) -> bool:
         """Escalate the session's model to the pro tier. True if activated."""
         new_client, new_model, used = try_activate_pro_fallback(
@@ -3760,10 +3794,13 @@ class AgentHarness(
             output_tokens = usage_data.get("output_tokens", 0)
             cache_read_tokens = usage_data.get("cache_read_tokens", 0)
 
-            from surogates.harness.model_metadata import estimate_cost
+            from surogates.harness.model_metadata import estimate_call_cost
 
-            cost = estimate_cost(
-                model_id, input_tokens, output_tokens,
+            cost, _priced_model = estimate_call_cost(
+                model_id,
+                usage_data.get("model"),
+                input_tokens,
+                output_tokens,
                 cache_read_tokens=cache_read_tokens,
             )
 

--- a/surogates/harness/model_metadata.py
+++ b/surogates/harness/model_metadata.py
@@ -178,6 +178,37 @@ MODEL_CATALOG: dict[str, ModelInfo] = {
         output_cost_per_1k=0.0,
         supports_vision=True,
     ),
+    # --- Anthropic (via the yunwu gateway) ---
+    # Rates from yunwu's public /api/pricing for the `default` group:
+    # price per 1M = model_ratio * group_ratio * $2, output = input *
+    # completion_ratio. sonnet-5 is ratio 1, opus-5 ratio 2.5, both with
+    # completion_ratio 5 and cache_ratio 0.1 (which matches
+    # _CACHE_READ_DISCOUNT). These are gateway rates, NOT Anthropic list
+    # prices -- re-derive from /api/pricing if the gateway or group changes.
+    # The tier sentinels below deliberately carry no rate; cost is priced
+    # against whichever of these actually served the call.
+    # Both are 1M context / 128k max output -- 1M is the default, with no
+    # smaller variant and no beta header required.
+    #
+    # NOTE: sonnet-5's $2/$10 is INTRODUCTORY pricing that ends 2026-08-31,
+    # after which list is $3/$15 per MTok. Re-derive from /api/pricing then.
+    # opus-5 at $5/$25 matches Anthropic list, so the gateway is at parity.
+    "claude-sonnet-5": ModelInfo(
+        id="claude-sonnet-5",
+        context_window=1_000_000,
+        max_output_tokens=128_000,
+        input_cost_per_1k=0.002,
+        output_cost_per_1k=0.010,
+        supports_vision=True,
+    ),
+    "claude-opus-5": ModelInfo(
+        id="claude-opus-5",
+        context_window=1_000_000,
+        max_output_tokens=128_000,
+        input_cost_per_1k=0.005,
+        output_cost_per_1k=0.025,
+        supports_vision=True,
+    ),
     # --- Surogate -----------------------
     "surogate": ModelInfo(
         id="surogate",

--- a/surogates/harness/model_metadata.py
+++ b/surogates/harness/model_metadata.py
@@ -390,6 +390,51 @@ def estimate_cost(
     return input_cost + cache_cost + output_cost
 
 
+def _has_rate(model_id: str) -> bool:
+    info = get_model_info(model_id)
+    return info is not None and (
+        info.input_cost_per_1k > 0 or info.output_cost_per_1k > 0
+    )
+
+
+def estimate_call_cost(
+    model_id: str,
+    usage_model: str | None,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+) -> tuple[float, str | None]:
+    """Price a call against the model that actually served it.
+
+    Sessions run under a tier sentinel (``surogate`` / ``surogate-pro``),
+    but the request is served by a concrete upstream model, reported back
+    in the usage payload. The sentinels are in the catalog deliberately --
+    the compressor needs their context window -- yet carry ``0.0`` prices,
+    so pricing the sentinel yields no cost while token counters keep
+    climbing. That is how a 1.48M-token session recorded
+    ``estimated_cost_usd = 0``.
+
+    Returns ``(cost, priced_model)``. ``priced_model`` is ``None`` when no
+    source had a rate, which callers should surface: silently returning
+    ``0.0`` is what hid the gap. Deliberately does NOT invent a rate -- a
+    confidently wrong cost is worse than an obviously missing one.
+    """
+    for candidate in (usage_model, model_id):
+        if candidate and _has_rate(candidate):
+            return (
+                estimate_cost(
+                    candidate, input_tokens, output_tokens,
+                    cache_read_tokens=cache_read_tokens,
+                ),
+                candidate,
+            )
+
+    # A call that consumed nothing is not a pricing gap.
+    if not input_tokens and not output_tokens:
+        return 0.0, (usage_model or model_id or None)
+    return 0.0, None
+
+
 # ---------------------------------------------------------------------------
 # Context probe tiers
 # ---------------------------------------------------------------------------

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -261,7 +261,7 @@ class TestEstimateCallCost:
         from surogates.harness.model_metadata import estimate_call_cost
 
         cost, priced = estimate_call_cost(
-            model_id="surogate", usage_model="claude-sonnet-5",
+            model_id="surogate", usage_model="some-unlisted-model-v9",
             input_tokens=1_000_000, output_tokens=10_000,
         )
         assert cost == 0.0
@@ -276,3 +276,62 @@ class TestEstimateCallCost:
         )
         assert cost == 0.0
         assert priced == "gpt-5.5"
+
+
+class TestClaudeCatalogRates:
+    """Rates derived from yunwu's public /api/pricing for the default group.
+
+    price per 1M = model_ratio * group_ratio * $2 (one-api convention);
+    output = input * completion_ratio. Cross-checked against the recorded
+    rate card: opus at ratio 2.5 gives $5/$25/$0.5/$6.25 per M for
+    in/out/cache-read/cache-write, matching on all four.
+    """
+
+    def test_sonnet_5_rates(self):
+        from surogates.harness.model_metadata import get_model_info
+
+        i = get_model_info("claude-sonnet-5")
+        assert i is not None
+        assert i.input_cost_per_1k == 0.002    # ratio 1 -> $2/M (introductory)
+        assert i.output_cost_per_1k == 0.010   # x5      -> $10/M
+
+    def test_opus_5_rates(self):
+        from surogates.harness.model_metadata import get_model_info
+
+        i = get_model_info("claude-opus-5")
+        assert i is not None
+        assert i.input_cost_per_1k == 0.005    # ratio 2.5 -> $5/M
+        assert i.output_cost_per_1k == 0.025   # x5        -> $25/M
+
+    def test_context_windows_are_1m_not_the_sentinel_default(self):
+        """Both ship a 1M window with 128k output.
+
+        Copying the sentinel's 262k would make the compressor compress at
+        a quarter of the real capacity.
+        """
+        from surogates.harness.model_metadata import get_model_info
+
+        for name in ("claude-sonnet-5", "claude-opus-5"):
+            i = get_model_info(name)
+            assert i.context_window == 1_000_000, name
+            assert i.max_output_tokens == 128_000, name
+
+    def test_sentinel_session_now_prices_via_the_served_model(self):
+        # The whole point: a session running as "surogate" served by
+        # claude-sonnet-5 must accrue cost instead of silently zero.
+        from surogates.harness.model_metadata import estimate_call_cost
+
+        cost, priced = estimate_call_cost(
+            "surogate", "claude-sonnet-5", 1_000_000, 10_000,
+        )
+        assert priced == "claude-sonnet-5"
+        assert cost == pytest.approx(2.10)  # 1M*0.002 + 10k*0.010
+
+    def test_cache_reads_are_discounted(self):
+        from surogates.harness.model_metadata import estimate_call_cost
+
+        cost, _ = estimate_call_cost(
+            "surogate", "claude-sonnet-5", 1_000_000, 0,
+            cache_read_tokens=1_000_000,
+        )
+        assert cost == pytest.approx(0.20)  # all cached: $2/M * 0.1

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -218,3 +218,61 @@ class TestOpus48Cost:
             cache_read_tokens=1000,
         )
         assert cost == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Pricing the model that actually served the request
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateCallCost:
+    """Sessions run under a tier sentinel ("surogate"), but the request is
+    served by a concrete upstream model reported back in usage.
+
+    The sentinel is in the catalog on purpose -- the compressor needs its
+    context window -- but carries 0.0 prices, so pricing the sentinel
+    silently yields no cost while token counters keep climbing. Observed in
+    PROD: 1.48M input tokens recorded against estimated_cost_usd = 0.
+    """
+
+    def test_prices_the_resolved_model_over_the_sentinel(self):
+        from surogates.harness.model_metadata import estimate_call_cost
+
+        cost, priced = estimate_call_cost(
+            model_id="surogate", usage_model="gpt-5.5",
+            input_tokens=1_000_000, output_tokens=10_000,
+        )
+        assert priced == "gpt-5.5"
+        assert cost > 0
+
+    def test_falls_back_to_the_sentinel_when_usage_model_is_absent(self):
+        from surogates.harness.model_metadata import estimate_call_cost
+
+        cost, priced = estimate_call_cost(
+            model_id="gpt-5.5", usage_model=None,
+            input_tokens=1_000, output_tokens=100,
+        )
+        assert priced == "gpt-5.5"
+        assert cost > 0
+
+    def test_reports_unpriced_when_no_source_has_a_rate(self):
+        # The gap must be visible. Returning 0.0 with no signal is why a
+        # 1.48M-token session showed zero cost and nobody noticed.
+        from surogates.harness.model_metadata import estimate_call_cost
+
+        cost, priced = estimate_call_cost(
+            model_id="surogate", usage_model="claude-sonnet-5",
+            input_tokens=1_000_000, output_tokens=10_000,
+        )
+        assert cost == 0.0
+        assert priced is None
+
+    def test_zero_token_call_is_not_reported_as_unpriced(self):
+        from surogates.harness.model_metadata import estimate_call_cost
+
+        cost, priced = estimate_call_cost(
+            model_id="gpt-5.5", usage_model="gpt-5.5",
+            input_tokens=0, output_tokens=0,
+        )
+        assert cost == 0.0
+        assert priced == "gpt-5.5"


### PR DESCRIPTION
## Problem

Sessions run under a tier sentinel (`surogate` / `surogate-pro`). Those sentinels are in `MODEL_CATALOG` deliberately — the compressor needs their context window — but they carry `0.0` rates.

Cost was estimated against the **sentinel** rather than the model that actually served the call, so `estimate_cost` returned `0.0`, `cost_usd` was never attached to `llm.response`, and the store's counter clause only adds cost when that key is present. Token counters climbed while `estimated_cost_usd` stayed at zero.

Observed in PROD: a session with **1,479,372 input tokens** recording **$0.00**. Cost dashboards could not have surfaced it.

## Changes

**`estimate_call_cost`** prices the usage-reported model first, falling back to the sentinel. It deliberately does **not** invent a rate — a confidently wrong cost is worse than an obviously missing one — and instead returns `priced_model=None` so the caller can surface the gap. The event then records `cost_unpriced_model` and the harness warns once per model, so the next unpriced model is loud rather than silently free.

**Catalog entries** for `claude-sonnet-5` and `claude-opus-5`, which were absent entirely.

| model | context | max output | $/M in | $/M out |
| --- | --- | --- | --- | --- |
| claude-sonnet-5 | 1,000,000 | 128,000 | $2 | $10 |
| claude-opus-5 | 1,000,000 | 128,000 | $5 | $25 |

## How the rates were derived

From yunwu's public `/api/pricing` for the `default` group: price per 1M = `model_ratio` × `group_ratio` × $2, output = input × `completion_ratio`. sonnet-5 is ratio 1, opus-5 ratio 2.5, both `completion_ratio` 5 and `cache_ratio` 0.1 — which matches the existing `_CACHE_READ_DISCOUNT`.

Independently confirmed: opus-5 at $5/$25 matches Anthropic list pricing exactly.

⚠️ **sonnet-5's $2/$10 is introductory pricing ending 2026-08-31**, after which list is $3/$15. Noted inline so it gets re-derived rather than silently drifting into a 50% under-report.

Context is 1M / 128k output for both per Anthropic's docs — **not** the sentinel's 262k/32k, which would have made the compressor compress at a quarter of real capacity.

## Effect

The PROD session above now prices at **~$3.14** uncached (~$0.80 if mostly cache-read) instead of $0.

## Testing

116 tests pass across `test_model_metadata`, `test_cost_tracker`, `test_worker_model_metadata_warning`, `test_harness_resilience`. New coverage: rate values, 1M context windows, sentinel-to-served-model pricing, cache-read discounting, and the unpriced-model signal.

Found while building a GAIA benchmark harness against the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
