### PR TITLE
feat: capability- and provider-aware end-user web app

### DIFF
--- a/surogates/api/routes/auth.py
+++ b/surogates/api/routes/auth.py
@@ -215,6 +215,21 @@ def _email_from_firebase_claims(claims: dict) -> tuple[str | None, bool]:
     return email.strip().lower(), claims.get("email_verified") is True
 
 
+def _sign_in_provider_from_claims(claims: dict) -> str | None:
+    """The Firebase sign-in method from token claims.
+
+    Firebase nests it as ``firebase.sign_in_provider`` (e.g. "password",
+    "google.com", "github.com").  Returns ``None`` when absent so callers
+    leave the stored value untouched rather than clobbering it.
+    """
+    firebase = claims.get("firebase")
+    if isinstance(firebase, dict):
+        method = firebase.get("sign_in_provider")
+        if isinstance(method, str) and method:
+            return method
+    return None
+
+
 def _display_name_from_firebase_claims(
     claims: dict, email: str | None,
 ) -> str:
@@ -304,6 +319,7 @@ async def firebase_exchange(
         )
     email, email_verified = _email_from_firebase_claims(claims)
     provider = firebase_auth_provider_name(fb_project_id)
+    sign_in_method = _sign_in_provider_from_claims(claims)
 
     session_factory = request.app.state.session_factory
     async with session_factory() as session:
@@ -412,6 +428,13 @@ async def firebase_exchange(
                 session.add(user)
                 await session.commit()
             await session.refresh(user)
+
+        # Record how they signed in (only when the token carried it, so a
+        # malformed claim never clobbers a known value). Persisted even on
+        # the no-agent path below via its own commit.
+        if sign_in_method is not None and user.sign_in_provider != sign_in_method:
+            user.sign_in_provider = sign_in_method
+            await session.commit()
 
         # Successful auth through THIS agent's web channel is
         # assignment intent — enroll the user on the serving agent.
@@ -608,6 +631,7 @@ async def me(
         username=user.username,
         phone=user.phone,
         auth_provider=user.auth_provider,
+        sign_in_provider=user.sign_in_provider,
         created_at=user.created_at,
     )
 
@@ -734,6 +758,7 @@ async def update_me(
         username=user.username,
         phone=user.phone,
         auth_provider=user.auth_provider,
+        sign_in_provider=user.sign_in_provider,
         created_at=user.created_at,
     )
 

--- a/surogates/api/routes/auth.py
+++ b/surogates/api/routes/auth.py
@@ -156,45 +156,31 @@ async def auth_config(
     commerce = await runtime_commerce_payload(
         request, str(agent_runtime.agent_id),
     )
-    commerce_mode = str(commerce.get("commerce_mode") or "free")
-    commerce_buy_url = commerce.get("commerce_buy_url")
+    # Capability + monetization fields shared by every branch below; only
+    # self_registration_enabled and firebase differ per resolution outcome.
+    base = dict(
+        agent_id=agent_runtime.agent_id,
+        slash_commands=slash_commands,
+        multi_session=agent_runtime.multi_session,
+        browser_enabled=agent_runtime.browser_enabled,
+        linkable_channels=list(agent_runtime.linkable_channels),
+        commerce_mode=str(commerce.get("commerce_mode") or "free"),
+        commerce_buy_url=commerce.get("commerce_buy_url"),
+    )
     cache = getattr(request.app.state, "firebase_config_cache", None)
     project_id = getattr(agent_runtime, "project_id", None)
     if cache is None or not project_id:
         return AuthConfigResponse(
-            agent_id=agent_runtime.agent_id,
-            self_registration_enabled=False,
-            firebase=None,
-            slash_commands=slash_commands,
-            multi_session=agent_runtime.multi_session,
-            browser_enabled=agent_runtime.browser_enabled,
-            linkable_channels=list(agent_runtime.linkable_channels),
-            commerce_mode=commerce_mode,
-            commerce_buy_url=commerce_buy_url,
+            self_registration_enabled=False, firebase=None, **base,
         )
     try:
         fb = await cache.get(project_id)
     except LookupError:
         return AuthConfigResponse(
-            agent_id=agent_runtime.agent_id,
-            self_registration_enabled=False,
-            firebase=None,
-            slash_commands=slash_commands,
-            multi_session=agent_runtime.multi_session,
-            browser_enabled=agent_runtime.browser_enabled,
-            linkable_channels=list(agent_runtime.linkable_channels),
-            commerce_mode=commerce_mode,
-            commerce_buy_url=commerce_buy_url,
+            self_registration_enabled=False, firebase=None, **base,
         )
     return AuthConfigResponse(
-        agent_id=agent_runtime.agent_id,
         self_registration_enabled=True,
-        slash_commands=slash_commands,
-        multi_session=agent_runtime.multi_session,
-        browser_enabled=agent_runtime.browser_enabled,
-        linkable_channels=list(agent_runtime.linkable_channels),
-        commerce_mode=commerce_mode,
-        commerce_buy_url=commerce_buy_url,
         firebase=FirebaseWebConfig(
             api_key=fb.api_key,
             auth_domain=fb.auth_domain,
@@ -204,6 +190,7 @@ async def auth_config(
             measurement_id=fb.measurement_id or None,
             enabled_providers=list(fb.enabled_providers),
         ),
+        **base,
     )
 
 
@@ -416,6 +403,7 @@ async def firebase_exchange(
                 external_id=subject,
                 username=requested_username,
                 phone=(body.phone or "").strip() or None,
+                sign_in_provider=sign_in_method,
             )
             session.add(user)
             try:
@@ -788,8 +776,6 @@ async def change_password(
     identity provider — the web app offers them a reset-email flow
     instead — so this route refuses them with 409.
     """
-    import bcrypt
-
     if len(body.new_password) < 8:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -817,9 +803,8 @@ async def change_password(
                     "Password changes are managed by your sign-in provider."
                 ),
             )
-        if not bcrypt.checkpw(
-            body.current_password.encode("utf-8"),
-            user.password_hash.encode("utf-8"),
+        if not DatabaseAuthProvider.verify_password(
+            body.current_password, user.password_hash,
         ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/surogates/api/routes/auth.py
+++ b/surogates/api/routes/auth.py
@@ -99,6 +99,15 @@ class AuthConfigResponse(BaseModel):
     # "Multi session" capability.  When False each user keeps one session
     # per channel; the SPA hides "New chat" and pins the conversation.
     multi_session: bool = True
+    # "Live browser support" capability.  When False the SPA hides the
+    # Browser Profiles settings tab and the composer's browser-profile
+    # picker (the agent's browser_* tools are already removed server-side).
+    # Defaults True so an older backend keeps browser affordances visible.
+    browser_enabled: bool = True
+    # Active messaging channels an end-user can link their identity to
+    # (subset of slack/teams/telegram).  Empty means the agent has no
+    # such channel, so the SPA hides "Connected Channels" entirely.
+    linkable_channels: list[str] = Field(default_factory=list)
     # Username handle rule (source of truth: USERNAME_RE below). The
     # sign-up form pre-validates with this so the client can never
     # drift from the server.
@@ -158,6 +167,8 @@ async def auth_config(
             firebase=None,
             slash_commands=slash_commands,
             multi_session=agent_runtime.multi_session,
+            browser_enabled=agent_runtime.browser_enabled,
+            linkable_channels=list(agent_runtime.linkable_channels),
             commerce_mode=commerce_mode,
             commerce_buy_url=commerce_buy_url,
         )
@@ -170,6 +181,8 @@ async def auth_config(
             firebase=None,
             slash_commands=slash_commands,
             multi_session=agent_runtime.multi_session,
+            browser_enabled=agent_runtime.browser_enabled,
+            linkable_channels=list(agent_runtime.linkable_channels),
             commerce_mode=commerce_mode,
             commerce_buy_url=commerce_buy_url,
         )
@@ -178,6 +191,8 @@ async def auth_config(
         self_registration_enabled=True,
         slash_commands=slash_commands,
         multi_session=agent_runtime.multi_session,
+        browser_enabled=agent_runtime.browser_enabled,
+        linkable_channels=list(agent_runtime.linkable_channels),
         commerce_mode=commerce_mode,
         commerce_buy_url=commerce_buy_url,
         firebase=FirebaseWebConfig(
@@ -721,6 +736,74 @@ async def update_me(
         auth_provider=user.auth_provider,
         created_at=user.created_at,
     )
+
+
+# ---------------------------------------------------------------------------
+# Password
+# ---------------------------------------------------------------------------
+
+
+class ChangePasswordRequest(BaseModel):
+    """Payload for changing a local (database) account's password."""
+
+    current_password: str
+    new_password: str
+
+
+@router.post("/auth/me/password", status_code=status.HTTP_204_NO_CONTENT)
+async def change_password(
+    body: ChangePasswordRequest,
+    request: Request,
+    tenant: TenantContext = Depends(get_current_tenant),
+) -> None:
+    """Change the password of a local (``database``) account.
+
+    Only accounts with a stored bcrypt hash can change their password
+    here.  Firebase-backed users manage credentials through their
+    identity provider — the web app offers them a reset-email flow
+    instead — so this route refuses them with 409.
+    """
+    import bcrypt
+
+    if len(body.new_password) < 8:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="New password must be at least 8 characters.",
+        )
+
+    session_factory = request.app.state.session_factory
+    async with session_factory() as session:
+        result = await session.execute(
+            select(User).where(
+                User.id == tenant.user_id,
+                User.org_id == tenant.org_id,
+            )
+        )
+        user = result.scalar_one_or_none()
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="User not found.",
+            )
+        if user.auth_provider != "database" or not user.password_hash:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "Password changes are managed by your sign-in provider."
+                ),
+            )
+        if not bcrypt.checkpw(
+            body.current_password.encode("utf-8"),
+            user.password_hash.encode("utf-8"),
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Current password is incorrect.",
+            )
+        user.password_hash = DatabaseAuthProvider.hash_password(
+            body.new_password,
+        )
+        await session.commit()
 
 
 # ---------------------------------------------------------------------------

--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -130,10 +130,11 @@ class User(Base):
     )
     external_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     password_hash: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    # How the user most recently signed in. For Firebase users this is the
-    # token's ``firebase.sign_in_provider`` (e.g. "password", "google.com",
-    # "github.com"); local logins record "password". Drives whether the web
-    # app offers password reset — only "password" users have one to reset.
+    # How a Firebase user most recently signed in — the token's
+    # ``firebase.sign_in_provider`` (e.g. "password", "google.com",
+    # "github.com"). Drives whether the web app offers password reset:
+    # only "password" users have one to reset. Local (database) accounts
+    # leave this NULL; they are password-capable via ``auth_provider``.
     sign_in_provider: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     # Self-registration profile: a lowercase handle (unique per org via
     # the partial index in observability.sql) and an optional phone.

--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -130,6 +130,11 @@ class User(Base):
     )
     external_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     password_hash: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # How the user most recently signed in. For Firebase users this is the
+    # token's ``firebase.sign_in_provider`` (e.g. "password", "google.com",
+    # "github.com"); local logins record "password". Drives whether the web
+    # app offers password reset — only "password" users have one to reset.
+    sign_in_provider: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     # Self-registration profile: a lowercase handle (unique per org via
     # the partial index in observability.sql) and an optional phone.
     username: Mapped[Optional[str]] = mapped_column(Text, nullable=True)

--- a/surogates/db/observability.sql
+++ b/surogates/db/observability.sql
@@ -867,6 +867,9 @@ END $$;
 -- lowercase handle, phone is optional free-form.
 ALTER TABLE users ADD COLUMN IF NOT EXISTS username text;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS phone text;
+-- Most recent sign-in method (Firebase ``sign_in_provider`` / "password"
+-- for local logins). Drives the web app's password-reset affordance.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS sign_in_provider text;
 CREATE UNIQUE INDEX IF NOT EXISTS uq_users_org_username
     ON users (org_id, lower(username))
     WHERE username IS NOT NULL;

--- a/surogates/runtime/context.py
+++ b/surogates/runtime/context.py
@@ -176,6 +176,13 @@ class AgentRuntimeContext:
     # sessions.
     multi_session: bool = True
 
+    # Active messaging channels an end-user can link their identity to
+    # (subset of slack/teams/telegram).  Empty by default so a payload
+    # predating this field hides the web app's "Connected Channels"
+    # surface (nothing to pair against until the management plane
+    # reports a channel).
+    linkable_channels: tuple[str, ...] = ()
+
     # File-bundle reference.  Both optional so agents that haven't
     # been onboarded to Hub-backed bundles yet still work.
     # ``bundle_hub_ref`` is the Hub repository in ``<owner>/<repo>``

--- a/surogates/runtime/resolver.py
+++ b/surogates/runtime/resolver.py
@@ -114,6 +114,7 @@ def build_agent_runtime_context(payload: dict) -> AgentRuntimeContext:
         brainstorming_gate=bool(payload.get("brainstorming_gate", True)),
         browser_enabled=bool(payload.get("browser_enabled", True)),
         multi_session=multi_session_from_payload(payload),
+        linkable_channels=tuple(payload.get("linkable_channels") or ()),
         # bundle reference.  Empty strings → None
         # (a misconfigured payload that ships "" must not turn into
         # a Hub fetch against an empty ref).

--- a/surogates/tenant/auth/database.py
+++ b/surogates/tenant/auth/database.py
@@ -60,7 +60,7 @@ class DatabaseAuthProvider:
                 error="Account does not have a password configured.",
             )
 
-        if not _bcrypt.checkpw(password.encode("utf-8"), user.password_hash.encode("utf-8")):
+        if not self.verify_password(password, user.password_hash):
             return AuthResult(authenticated=False, error="Invalid credentials.")
 
         return AuthResult(
@@ -80,3 +80,8 @@ class DatabaseAuthProvider:
         return _bcrypt.hashpw(
             plain.encode("utf-8"), _bcrypt.gensalt(rounds=12)
         ).decode("utf-8")
+
+    @staticmethod
+    def verify_password(plain: str, hashed: str) -> bool:
+        """Return whether ``plain`` matches the stored bcrypt ``hashed``."""
+        return _bcrypt.checkpw(plain.encode("utf-8"), hashed.encode("utf-8"))

--- a/surogates/tenant/models.py
+++ b/surogates/tenant/models.py
@@ -76,6 +76,9 @@ class UserResponse(BaseModel):
     username: str | None = None
     phone: str | None = None
     auth_provider: str
+    # Most recent sign-in method (e.g. "password", "google.com"). Lets the
+    # web app show password reset only to email/password accounts.
+    sign_in_provider: str | None = None
     created_at: datetime
 
 

--- a/tests/api/test_auth_config_browser_enabled.py
+++ b/tests/api/test_auth_config_browser_enabled.py
@@ -1,0 +1,71 @@
+"""``GET /v1/auth/config`` exposes the agent's "live browser support"
+capability so the web SPA can hide the Browser Profiles tab and the
+composer's browser-profile picker when it is off."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from surogates.api.routes.auth import auth_config
+from surogates.runtime import AgentRuntimeContext
+
+
+def _ctx(**overrides) -> AgentRuntimeContext:
+    return AgentRuntimeContext(
+        agent_id="a-1",
+        org_id="o-1",
+        project_id="p-1",
+        enabled=True,
+        config_version=1,
+        storage_key_prefix="p-1/a-1",
+        **overrides,
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_config_defaults_browser_enabled_on():
+    request = MagicMock()
+    request.app.state.firebase_config_cache = None
+    request.app.state.runtime_config_cache = None
+
+    resp = await auth_config(request, agent_runtime=_ctx())
+
+    assert resp.browser_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_auth_config_projects_browser_enabled_off():
+    request = MagicMock()
+    request.app.state.firebase_config_cache = None
+    request.app.state.runtime_config_cache = None
+
+    resp = await auth_config(request, agent_runtime=_ctx(browser_enabled=False))
+
+    assert resp.browser_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_auth_config_linkable_channels_default_empty():
+    request = MagicMock()
+    request.app.state.firebase_config_cache = None
+    request.app.state.runtime_config_cache = None
+
+    resp = await auth_config(request, agent_runtime=_ctx())
+
+    assert resp.linkable_channels == []
+
+
+@pytest.mark.asyncio
+async def test_auth_config_projects_linkable_channels():
+    request = MagicMock()
+    request.app.state.firebase_config_cache = None
+    request.app.state.runtime_config_cache = None
+
+    resp = await auth_config(
+        request,
+        agent_runtime=_ctx(linkable_channels=("slack", "telegram")),
+    )
+
+    assert resp.linkable_channels == ["slack", "telegram"]

--- a/tests/api/test_change_password.py
+++ b/tests/api/test_change_password.py
@@ -1,0 +1,116 @@
+"""``POST /v1/auth/me/password`` lets a local (database) account change
+its password; Firebase-backed accounts are refused (they reset through
+their identity provider)."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import bcrypt
+import pytest
+from fastapi import HTTPException
+
+from surogates.api.routes.auth import ChangePasswordRequest, change_password
+
+
+def _db_user(password: str = "oldpassword", provider: str = "database"):
+    return SimpleNamespace(
+        id="u-1",
+        org_id="o-1",
+        auth_provider=provider,
+        password_hash=bcrypt.hashpw(
+            password.encode("utf-8"), bcrypt.gensalt(rounds=4)
+        ).decode("utf-8"),
+    )
+
+
+def _request_for(user) -> tuple[MagicMock, MagicMock]:
+    session = MagicMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = user
+    session.execute = AsyncMock(return_value=result)
+    session.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def factory():
+        yield session
+
+    request = MagicMock()
+    request.app.state.session_factory = factory
+    return request, session
+
+
+@pytest.mark.asyncio
+async def test_change_password_success_updates_hash_and_commits():
+    user = _db_user("oldpassword")
+    old_hash = user.password_hash
+    request, session = _request_for(user)
+
+    result = await change_password(
+        ChangePasswordRequest(
+            current_password="oldpassword", new_password="newpassword1"
+        ),
+        request,
+        tenant=MagicMock(),
+    )
+
+    assert result is None
+    assert user.password_hash != old_hash
+    assert bcrypt.checkpw(
+        b"newpassword1", user.password_hash.encode("utf-8")
+    )
+    session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_change_password_rejects_wrong_current():
+    user = _db_user("oldpassword")
+    request, session = _request_for(user)
+
+    with pytest.raises(HTTPException) as exc:
+        await change_password(
+            ChangePasswordRequest(
+                current_password="wrong", new_password="newpassword1"
+            ),
+            request,
+            tenant=MagicMock(),
+        )
+
+    assert exc.value.status_code == 403
+    session.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_change_password_rejects_short_new_password():
+    request, session = _request_for(_db_user("oldpassword"))
+
+    with pytest.raises(HTTPException) as exc:
+        await change_password(
+            ChangePasswordRequest(
+                current_password="oldpassword", new_password="short"
+            ),
+            request,
+            tenant=MagicMock(),
+        )
+
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_change_password_refuses_firebase_accounts():
+    user = _db_user("oldpassword", provider="firebase:proj-1")
+    request, session = _request_for(user)
+
+    with pytest.raises(HTTPException) as exc:
+        await change_password(
+            ChangePasswordRequest(
+                current_password="oldpassword", new_password="newpassword1"
+            ),
+            request,
+            tenant=MagicMock(),
+        )
+
+    assert exc.value.status_code == 409
+    session.commit.assert_not_awaited()

--- a/tests/api/test_sign_in_provider_claims.py
+++ b/tests/api/test_sign_in_provider_claims.py
@@ -1,0 +1,33 @@
+"""``_sign_in_provider_from_claims`` extracts the Firebase sign-in method
+(``firebase.sign_in_provider``) that the web app uses to decide whether to
+offer password reset."""
+
+from __future__ import annotations
+
+from surogates.api.routes.auth import _sign_in_provider_from_claims
+
+
+def test_extracts_password_provider():
+    claims = {"sub": "u", "firebase": {"sign_in_provider": "password"}}
+    assert _sign_in_provider_from_claims(claims) == "password"
+
+
+def test_extracts_federated_provider():
+    claims = {"firebase": {"sign_in_provider": "google.com"}}
+    assert _sign_in_provider_from_claims(claims) == "google.com"
+
+
+def test_missing_firebase_block_returns_none():
+    assert _sign_in_provider_from_claims({"sub": "u"}) is None
+
+
+def test_firebase_block_without_method_returns_none():
+    assert _sign_in_provider_from_claims({"firebase": {}}) is None
+
+
+def test_non_dict_firebase_block_returns_none():
+    assert _sign_in_provider_from_claims({"firebase": "nope"}) is None
+
+
+def test_empty_method_returns_none():
+    assert _sign_in_provider_from_claims({"firebase": {"sign_in_provider": ""}}) is None

--- a/tests/integration/test_auth_firebase_self_registration.py
+++ b/tests/integration/test_auth_firebase_self_registration.py
@@ -212,6 +212,76 @@ async def test_firebase_exchange_creates_user_when_enabled(
     assert user.external_id == "uid-123"
 
 
+async def test_firebase_exchange_records_password_sign_in_provider(
+    auth_client, auth_app, session_factory, monkeypatch,
+):
+    """A password-provider token stamps ``sign_in_provider='password'`` so
+    the web app can offer password reset to this user."""
+    org_id = await create_org(session_factory)
+    _set_org(auth_app, org_id)
+    _set_firebase(auth_app, enabled=True)
+
+    async def fake_verify(token: str, project_id: str) -> dict:
+        return {
+            "sub": "uid-pw",
+            "email": "pw-user@example.com",
+            "email_verified": True,
+            "firebase": {"sign_in_provider": "password"},
+        }
+
+    monkeypatch.setattr(auth_routes, "verify_firebase_id_token", fake_verify)
+
+    response = await auth_client.post(
+        "/v1/auth/firebase/exchange",
+        json={"id_token": "firebase-token"},
+    )
+    assert response.status_code == 200, response.text
+
+    async with session_factory() as session:
+        user = await session.scalar(
+            select(User).where(
+                User.org_id == org_id, User.email == "pw-user@example.com",
+            )
+        )
+    assert user is not None
+    assert user.sign_in_provider == "password"
+
+
+async def test_firebase_exchange_records_federated_sign_in_provider(
+    auth_client, auth_app, session_factory, monkeypatch,
+):
+    """A Google-provider token stamps ``sign_in_provider='google.com'`` so
+    the web app hides password reset (no password to reset)."""
+    org_id = await create_org(session_factory)
+    _set_org(auth_app, org_id)
+    _set_firebase(auth_app, enabled=True)
+
+    async def fake_verify(token: str, project_id: str) -> dict:
+        return {
+            "sub": "uid-goog",
+            "email": "goog-user@example.com",
+            "email_verified": True,
+            "firebase": {"sign_in_provider": "google.com"},
+        }
+
+    monkeypatch.setattr(auth_routes, "verify_firebase_id_token", fake_verify)
+
+    response = await auth_client.post(
+        "/v1/auth/firebase/exchange",
+        json={"id_token": "firebase-token"},
+    )
+    assert response.status_code == 200, response.text
+
+    async with session_factory() as session:
+        user = await session.scalar(
+            select(User).where(
+                User.org_id == org_id, User.email == "goog-user@example.com",
+            )
+        )
+    assert user is not None
+    assert user.sign_in_provider == "google.com"
+
+
 async def test_firebase_exchange_404_when_project_has_no_firebase(
     auth_client, auth_app, session_factory, monkeypatch,
 ):

--- a/tests/runtime/test_resolver_projection.py
+++ b/tests/runtime/test_resolver_projection.py
@@ -213,3 +213,29 @@ def test_multi_session_projects_false():
     payload["multi_session"] = False
     ctx = build_agent_runtime_context(payload)
     assert ctx.multi_session is False
+
+
+def test_linkable_channels_default_to_empty_tuple():
+    from surogates.runtime import build_agent_runtime_context
+
+    ctx = build_agent_runtime_context(_minimum_payload())
+    assert ctx.linkable_channels == ()
+
+
+def test_linkable_channels_project_as_tuple():
+    from surogates.runtime import build_agent_runtime_context
+
+    payload = _minimum_payload()
+    payload["linkable_channels"] = ["slack", "telegram"]
+    ctx = build_agent_runtime_context(payload)
+    assert isinstance(ctx.linkable_channels, tuple)
+    assert ctx.linkable_channels == ("slack", "telegram")
+
+
+def test_linkable_channels_null_normalises_to_empty():
+    from surogates.runtime import build_agent_runtime_context
+
+    payload = _minimum_payload()
+    payload["linkable_channels"] = None
+    ctx = build_agent_runtime_context(payload)
+    assert ctx.linkable_channels == ()

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -146,6 +146,25 @@ export async function unlinkChannel(identityId: string): Promise<void> {
   }
 }
 
+/** Change the password of a local (database) account. Firebase-backed
+ * users manage credentials through their provider and get a 409 here. */
+export async function changePassword(fields: {
+  current_password: string;
+  new_password: string;
+}): Promise<void> {
+  const response = await authFetch("/api/v1/auth/me/password", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(fields),
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => null);
+    throw new Error(
+      errorDetailMessage(data?.detail) ?? "Failed to change password.",
+    );
+  }
+}
+
 // ── BYO Firebase self-registration ──────────────────────────────────────
 
 export type FirebaseProvider = "google" | "github" | "password";
@@ -174,6 +193,14 @@ export interface AuthConfigResponse {
   // channel (no "New chat"). Absent on a fetch error or an older backend
   // — consumers treat "absent" as "unknown" and fail open (multi on).
   multi_session?: boolean;
+  // "Live browser support" capability. False hides the Browser Profiles
+  // settings tab and the composer's browser-profile picker. Absent on a
+  // fetch error or an older backend — treated as "unknown" (fail open).
+  browser_enabled?: boolean;
+  // Active messaging channels an end-user can link their identity to
+  // (subset of slack/teams/telegram). Empty/absent hides "Connected
+  // Channels" — there is nothing to pair against.
+  linkable_channels?: string[];
   // Username handle rule served by the backend (single source of
   // truth). Absent on older backends — callers fall back locally.
   username_pattern?: string;

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -93,6 +93,7 @@ export async function fetchCurrentUser(): Promise<{
   email: string;
   display_name: string | null;
   auth_provider: string;
+  sign_in_provider: string | null;
   created_at: string;
 }> {
   const response = await authFetch("/api/v1/auth/me");
@@ -109,6 +110,7 @@ export async function updateCurrentUser(fields: {
   email: string;
   display_name: string | null;
   auth_provider: string;
+  sign_in_provider: string | null;
   created_at: string;
 }> {
   const response = await authFetch("/api/v1/auth/me", {

--- a/web/src/app/routes/coding-agents.tsx
+++ b/web/src/app/routes/coding-agents.tsx
@@ -15,22 +15,20 @@ function CodingAgentsRoute() {
   const navigate = useNavigate();
   const fetchCapabilities = useAppStore((s) => s.fetchCapabilities);
   const slashCommands = useAppStore((s) => s.slashCommands);
-  const enabled = slashCommandEnabled(slashCommands, "code");
+  // Redirect only once capabilities have resolved (null = unknown, stay
+  // put and fail open) and coding agents are disabled for this agent.
+  const shouldRedirect =
+    slashCommands !== null && !slashCommandEnabled(slashCommands, "code");
 
   useEffect(() => {
     void fetchCapabilities();
   }, [fetchCapabilities]);
 
-  // Deep links must not reach the panel when the agent has coding agents
-  // disabled. Redirect once capabilities have resolved (null = unknown,
-  // stay put and fail open).
   useEffect(() => {
-    if (slashCommands !== null && !enabled) {
-      void navigate({ to: "/chat", replace: true });
-    }
-  }, [slashCommands, enabled, navigate]);
+    if (shouldRedirect) void navigate({ to: "/chat", replace: true });
+  }, [shouldRedirect, navigate]);
 
-  if (slashCommands !== null && !enabled) return null;
+  if (shouldRedirect) return null;
 
   return (
     <CodingAgentsPanel

--- a/web/src/app/routes/coding-agents.tsx
+++ b/web/src/app/routes/coding-agents.tsx
@@ -1,15 +1,37 @@
 // Copyright (c) 2026, Invergent SA, developed by Flavius Burca
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { useEffect } from "react";
 import { CodingAgentsPanel } from "@invergent/agent-chat-react";
 import { createRoute, useNavigate } from "@tanstack/react-router";
 
 import { surogatesWebChatAdapter } from "@/features/chat";
+import { useAppStore } from "@/stores/app-store";
+import { slashCommandEnabled } from "@/stores/capabilities-slice";
 import { requireAuth } from "../auth-guards";
 import { Route as rootRoute } from "./__root";
 
 function CodingAgentsRoute() {
   const navigate = useNavigate();
+  const fetchCapabilities = useAppStore((s) => s.fetchCapabilities);
+  const slashCommands = useAppStore((s) => s.slashCommands);
+  const enabled = slashCommandEnabled(slashCommands, "code");
+
+  useEffect(() => {
+    void fetchCapabilities();
+  }, [fetchCapabilities]);
+
+  // Deep links must not reach the panel when the agent has coding agents
+  // disabled. Redirect once capabilities have resolved (null = unknown,
+  // stay put and fail open).
+  useEffect(() => {
+    if (slashCommands !== null && !enabled) {
+      void navigate({ to: "/chat", replace: true });
+    }
+  }, [slashCommands, enabled, navigate]);
+
+  if (slashCommands !== null && !enabled) return null;
+
   return (
     <CodingAgentsPanel
       adapter={surogatesWebChatAdapter}

--- a/web/src/components/navbar.tsx
+++ b/web/src/components/navbar.tsx
@@ -63,6 +63,20 @@ export function SessionSidebar() {
     void navigate({ to: "/chat" });
   }
 
+  // Single-session return-to-chat: land on the pinned conversation if one is
+  // already selected, otherwise fall through to `/chat`, where the chat page
+  // adopts the newest usable session.
+  function handleOpenChat() {
+    if (activeSessionId) {
+      void navigate({
+        to: "/chat/$sessionId",
+        params: { sessionId: activeSessionId },
+      });
+    } else {
+      void navigate({ to: "/chat" });
+    }
+  }
+
   function handleSelectSession(sessionId: string) {
     setActiveSession(sessionId);
     void navigate({ to: "/chat/$sessionId", params: { sessionId } });
@@ -119,7 +133,22 @@ export function SessionSidebar() {
           "p-1.5 lg:p-3 group-data-[mode=sheet]:p-3",
         )}
       >
-        {!singleSession && (
+        {singleSession ? (
+          // One dedicated conversation per user: no "New chat", but the
+          // sidebar must still offer a way back into it from other pages.
+          <Button
+            variant="outline"
+            onClick={handleOpenChat}
+            className={cn(
+              "w-full gap-2 min-h-11 lg:min-h-9 group-data-[mode=sheet]:min-h-11",
+              "justify-center px-0 lg:justify-start lg:px-3",
+              "group-data-[mode=sheet]:justify-start group-data-[mode=sheet]:px-3",
+            )}
+          >
+            <MessageSquareIcon className="w-4 h-4" />
+            <span className={showExpandedInline}>Chat</span>
+          </Button>
+        ) : (
           <Button
             variant="outline"
             onClick={handleNewSession}

--- a/web/src/features/auth/firebase.ts
+++ b/web/src/features/auth/firebase.ts
@@ -15,6 +15,7 @@ import {
   GoogleAuthProvider,
   createUserWithEmailAndPassword,
   getAuth,
+  onAuthStateChanged,
   sendEmailVerification,
   sendPasswordResetEmail,
   signInWithEmailAndPassword,
@@ -175,4 +176,31 @@ export async function sendFirebasePasswordReset(
   email: string,
 ): Promise<void> {
   await sendPasswordResetEmail(getRuntimeFirebaseAuth(config), email.trim());
+}
+
+/** Resolve the persisted Firebase auth user, waiting for the SDK to
+ * restore it from storage on a cold load. Resolves ``null`` when no
+ * user is available (e.g. the Firebase session lapsed while the app's
+ * own JWT is still valid). */
+function currentFirebaseUser(config: FirebaseRuntimeConfig): Promise<User | null> {
+  const auth = getRuntimeFirebaseAuth(config);
+  if (auth.currentUser) return Promise.resolve(auth.currentUser);
+  return new Promise<User | null>((resolve) => {
+    const unsub = onAuthStateChanged(auth, (user) => {
+      unsub();
+      resolve(user);
+    });
+  });
+}
+
+/** Whether the signed-in Firebase user has an email/password credential,
+ * i.e. a "password" entry in ``providerData``. Only such users have a
+ * password to reset — Google/GitHub-only accounts do not. Resolves
+ * false when no Firebase user can be resolved (callers then hide the
+ * password UI; the sign-in page's own reset flow remains the fallback). */
+export async function firebaseUserHasPasswordProvider(
+  config: FirebaseRuntimeConfig,
+): Promise<boolean> {
+  const user = await currentFirebaseUser(config);
+  return !!user?.providerData.some((p) => p.providerId === "password");
 }

--- a/web/src/features/auth/firebase.ts
+++ b/web/src/features/auth/firebase.ts
@@ -15,7 +15,6 @@ import {
   GoogleAuthProvider,
   createUserWithEmailAndPassword,
   getAuth,
-  onAuthStateChanged,
   sendEmailVerification,
   sendPasswordResetEmail,
   signInWithEmailAndPassword,
@@ -176,31 +175,4 @@ export async function sendFirebasePasswordReset(
   email: string,
 ): Promise<void> {
   await sendPasswordResetEmail(getRuntimeFirebaseAuth(config), email.trim());
-}
-
-/** Resolve the persisted Firebase auth user, waiting for the SDK to
- * restore it from storage on a cold load. Resolves ``null`` when no
- * user is available (e.g. the Firebase session lapsed while the app's
- * own JWT is still valid). */
-function currentFirebaseUser(config: FirebaseRuntimeConfig): Promise<User | null> {
-  const auth = getRuntimeFirebaseAuth(config);
-  if (auth.currentUser) return Promise.resolve(auth.currentUser);
-  return new Promise<User | null>((resolve) => {
-    const unsub = onAuthStateChanged(auth, (user) => {
-      unsub();
-      resolve(user);
-    });
-  });
-}
-
-/** Whether the signed-in Firebase user has an email/password credential,
- * i.e. a "password" entry in ``providerData``. Only such users have a
- * password to reset — Google/GitHub-only accounts do not. Resolves
- * false when no Firebase user can be resolved (callers then hide the
- * password UI; the sign-in page's own reset flow remains the fallback). */
-export async function firebaseUserHasPasswordProvider(
-  config: FirebaseRuntimeConfig,
-): Promise<boolean> {
-  const user = await currentFirebaseUser(config);
-  return !!user?.providerData.some((p) => p.providerId === "password");
 }

--- a/web/src/features/auth/index.ts
+++ b/web/src/features/auth/index.ts
@@ -1,6 +1,10 @@
 export { LinkChannelPage } from "./link-channel-page";
 export { LoginPage } from "./login-page";
 export {
+  firebaseUserHasPasswordProvider,
+  sendFirebasePasswordReset,
+} from "./firebase";
+export {
   clearAuthTokens,
   getAuthToken,
   getPostAuthRoute,

--- a/web/src/features/auth/index.ts
+++ b/web/src/features/auth/index.ts
@@ -1,9 +1,6 @@
 export { LinkChannelPage } from "./link-channel-page";
 export { LoginPage } from "./login-page";
-export {
-  firebaseUserHasPasswordProvider,
-  sendFirebasePasswordReset,
-} from "./firebase";
+export { sendFirebasePasswordReset } from "./firebase";
 export {
   clearAuthTokens,
   getAuthToken,

--- a/web/src/features/auth/link-channel-page.tsx
+++ b/web/src/features/auth/link-channel-page.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 // Self-registration page for linking messaging platform accounts
-// (Slack, Teams, Telegram) to a Surogates user account.
+// (Slack, Telegram) to a Surogates user account.
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearch } from "@tanstack/react-router";
@@ -285,7 +285,7 @@ export function LinkChannelPage() {
           <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
             {status === "success"
               ? "You are all set."
-              : "Message this assistant on Slack, Teams, or Telegram and it replies with an 8-character code. Enter it below to link that chat to your account."}
+              : "Message this assistant on Slack or Telegram and it replies with an 8-character code. Enter it below to link that chat to your account."}
           </p>
         </div>
 

--- a/web/src/features/auth/link-channel-page.tsx
+++ b/web/src/features/auth/link-channel-page.tsx
@@ -31,13 +31,6 @@ const PLATFORM_LABELS: Record<string, string> = {
   telegram: "Telegram",
 };
 
-const TAGS = [
-  { label: "Managed Agents", icon: "⬡" },
-  { label: "MCP Integration", icon: "⚡" },
-  { label: "Tool Governance", icon: "◈" },
-  { label: "Multi-Tenant", icon: "◇" },
-] as const;
-
 export function LinkChannelPage() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { resolvedTheme, setTheme } = useTheme();
@@ -276,10 +269,10 @@ export function LinkChannelPage() {
           />
           <div>
             <div className="font-extrabold text-2xl text-foreground tracking-tight">
-              Surogates
+              Surogate
             </div>
             <div className="text-xs text-muted-foreground tracking-[0.14em] uppercase">
-              Managed Agents
+              Account linking
             </div>
           </div>
         </div>
@@ -287,10 +280,12 @@ export function LinkChannelPage() {
         {/* heading */}
         <div className="mb-8">
           <h3 className="text-2xl font-bold text-foreground tracking-tight">
-            Link your account
+            Link your chat account
           </h3>
-          <p className="text-sm text-muted-foreground">
-            connect your messaging platform
+          <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
+            {status === "success"
+              ? "You are all set."
+              : "Message this assistant on Slack, Teams, or Telegram and it replies with an 8-character code. Enter it below to link that chat to your account."}
           </p>
         </div>
 
@@ -301,7 +296,8 @@ export function LinkChannelPage() {
               {platformLabel} account linked successfully!
             </p>
             <p className="text-sm text-muted-foreground">
-              You can now send messages to the bot and it will recognize you.
+              You can now message the assistant on {platformLabel} and it will
+              recognize you as the same person.
             </p>
           </div>
         ) : (
@@ -389,24 +385,6 @@ export function LinkChannelPage() {
             )}
           </form>
         )}
-      </div>
-
-      {/* tags strip below card */}
-      <div
-        className={cn("relative z-10 mt-8 opacity-0", "animate-fade-in")}
-        style={{ animationDelay: "0.5s" }}
-      >
-        <div className="flex flex-wrap justify-center gap-2">
-          {TAGS.map((tag) => (
-            <div
-              key={tag.label}
-              className="flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-card/50 border border-line/50 backdrop-blur-sm"
-            >
-              <span className="text-sm text-primary">{tag.icon}</span>
-              <span className="text-sm text-faint">{tag.label}</span>
-            </div>
-          ))}
-        </div>
       </div>
 
       {/* footer */}

--- a/web/src/features/chat/chat-page.tsx
+++ b/web/src/features/chat/chat-page.tsx
@@ -12,10 +12,7 @@ import { AppShell } from "@/components/app-shell";
 import { SessionSidebar } from "@/components/navbar";
 import { TransparencyBanner } from "@/components/transparency-banner";
 import { useAppStore } from "@/stores/app-store";
-import {
-  browserCapabilityEnabled,
-  slashCommandEnabled,
-} from "@/stores/capabilities-slice";
+import { slashCommandEnabled } from "@/stores/capabilities-slice";
 import * as sessionsApi from "@/api/sessions";
 import {
   getTransparencyConfig,
@@ -248,10 +245,10 @@ export function ChatPage() {
               browserProfileId={browserProfileId}
               onSelectBrowserProfile={setBrowserProfileId}
               // Offer the browser-profile picker only when the agent has live
-              // browser support (``browser_enabled`` from /auth/config).
-              // Unknown (capabilities not yet loaded) fails open. Shown before
-              // the session starts and locked once active (SDK handles lock).
-              browserProfilesEnabled={browserCapabilityEnabled(browserEnabled)}
+              // browser support (``browser_enabled`` from /auth/config). Only
+              // an explicit false hides it; unknown (not yet loaded) fails
+              // open. Shown before the session starts and locked once active.
+              browserProfilesEnabled={browserEnabled !== false}
               // Hide built-in slash commands the agent has disabled. Unknown
               // (capabilities not yet loaded) fails open via the helper.
               compressEnabled={slashCommandEnabled(slashCommands, "compress")}

--- a/web/src/features/chat/chat-page.tsx
+++ b/web/src/features/chat/chat-page.tsx
@@ -12,7 +12,10 @@ import { AppShell } from "@/components/app-shell";
 import { SessionSidebar } from "@/components/navbar";
 import { TransparencyBanner } from "@/components/transparency-banner";
 import { useAppStore } from "@/stores/app-store";
-import { slashCommandEnabled } from "@/stores/capabilities-slice";
+import {
+  browserCapabilityEnabled,
+  slashCommandEnabled,
+} from "@/stores/capabilities-slice";
 import * as sessionsApi from "@/api/sessions";
 import {
   getTransparencyConfig,
@@ -38,6 +41,7 @@ export function ChatPage() {
   const fetchCapabilities = useAppStore((s) => s.fetchCapabilities);
   const slashCommands = useAppStore((s) => s.slashCommands);
   const multiSession = useAppStore((s) => s.multiSession);
+  const browserEnabled = useAppStore((s) => s.browserEnabled);
   const sessions = useAppStore((s) => s.sessions);
 
   // Load initial data on mount
@@ -243,11 +247,11 @@ export function ChatPage() {
               onOpenIntegrations={() => void navigate({ to: "/integrations" })}
               browserProfileId={browserProfileId}
               onSelectBrowserProfile={setBrowserProfileId}
-              // The web app has no per-agent browser-capability flag, so the
-              // picker is always offered; selecting a profile for a non-browser
-              // agent is a harmless no-op. Shown before the session starts and
-              // locked once it is active (the SDK handles the lock).
-              browserProfilesEnabled
+              // Offer the browser-profile picker only when the agent has live
+              // browser support (``browser_enabled`` from /auth/config).
+              // Unknown (capabilities not yet loaded) fails open. Shown before
+              // the session starts and locked once active (SDK handles lock).
+              browserProfilesEnabled={browserCapabilityEnabled(browserEnabled)}
               // Hide built-in slash commands the agent has disabled. Unknown
               // (capabilities not yet loaded) fails open via the helper.
               compressEnabled={slashCommandEnabled(slashCommands, "compress")}

--- a/web/src/features/settings/password-section.tsx
+++ b/web/src/features/settings/password-section.tsx
@@ -1,0 +1,210 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Password management for the profile tab. Firebase-backed users get a
+// reset-email flow (their provider owns the credential); local database
+// accounts get an in-app change-password form.
+
+import { useCallback, useEffect, useState } from "react";
+import { KeyRoundIcon, Loader2Icon } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  changePassword,
+  fetchAuthConfig,
+  type FirebaseRuntimeConfig,
+} from "@/api/auth";
+import {
+  firebaseUserHasPasswordProvider,
+  sendFirebasePasswordReset,
+} from "@/features/auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const MIN_PASSWORD_LENGTH = 8;
+
+export function PasswordSection({
+  authProvider,
+  email,
+}: {
+  authProvider: string;
+  email: string;
+}) {
+  if (authProvider.startsWith("firebase:")) {
+    return <FirebaseResetPassword email={email} />;
+  }
+  if (authProvider === "database") {
+    return <DatabaseChangePassword />;
+  }
+  return null;
+}
+
+function SectionShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="border-t border-line pt-5 mt-6">
+      <div className="flex items-center gap-2 mb-3">
+        <KeyRoundIcon className="w-4 h-4 text-muted-foreground" />
+        <h2 className="text-sm font-semibold text-foreground">Password</h2>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function FirebaseResetPassword({ email }: { email: string }) {
+  const [sending, setSending] = useState(false);
+  // ``undefined`` = still resolving; ``null`` = no password credential
+  // (Google/GitHub-only — hide entirely); otherwise the config to reset
+  // against.
+  const [config, setConfig] = useState<
+    FirebaseRuntimeConfig | null | undefined
+  >(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const authConfig = await fetchAuthConfig();
+      if (cancelled) return;
+      if (!authConfig.firebase) {
+        setConfig(null);
+        return;
+      }
+      const hasPassword = await firebaseUserHasPasswordProvider(
+        authConfig.firebase,
+      );
+      if (!cancelled) setConfig(hasPassword ? authConfig.firebase : null);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleReset = useCallback(async () => {
+    if (!config) return;
+    setSending(true);
+    try {
+      await sendFirebasePasswordReset(config, email);
+    } catch {
+      // Fall through to the neutral notice — never leak whether the
+      // address is registered.
+    } finally {
+      setSending(false);
+      toast.success("Password-reset link sent to your email.");
+    }
+  }, [config, email]);
+
+  // Only email/password accounts have a password to reset. While the
+  // provider check is in flight, or for Google/GitHub-only accounts,
+  // render nothing.
+  if (!config) return null;
+
+  return (
+    <SectionShell>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          variant="outline"
+          onClick={() => void handleReset()}
+          disabled={sending}
+          className="gap-2"
+        >
+          {sending ? (
+            <Loader2Icon className="w-4 h-4 animate-spin" />
+          ) : (
+            <KeyRoundIcon className="w-4 h-4" />
+          )}
+          Send reset email
+        </Button>
+        <span className="text-sm text-muted-foreground">
+          We will email a link to {email} to set a new password.
+        </span>
+      </div>
+    </SectionShell>
+  );
+}
+
+function DatabaseChangePassword() {
+  const [current, setCurrent] = useState("");
+  const [next, setNext] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const tooShort = next.length > 0 && next.length < MIN_PASSWORD_LENGTH;
+  const mismatch = confirm.length > 0 && next !== confirm;
+  const canSubmit =
+    current.length > 0 &&
+    next.length >= MIN_PASSWORD_LENGTH &&
+    next === confirm &&
+    !saving;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setSaving(true);
+    try {
+      await changePassword({ current_password: current, new_password: next });
+      setCurrent("");
+      setNext("");
+      setConfirm("");
+      toast.success("Password updated.");
+    } catch (err) {
+      toast.error((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }, [canSubmit, current, next]);
+
+  const error = tooShort
+    ? `Use at least ${MIN_PASSWORD_LENGTH} characters.`
+    : mismatch
+      ? "Passwords do not match."
+      : null;
+
+  return (
+    <SectionShell>
+      <form
+        className="space-y-3"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void handleSubmit();
+        }}
+      >
+        <Input
+          type="password"
+          autoComplete="current-password"
+          aria-label="Current password"
+          placeholder="Current password"
+          value={current}
+          onChange={(e) => setCurrent(e.target.value)}
+        />
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Input
+            type="password"
+            autoComplete="new-password"
+            aria-label="New password"
+            placeholder="New password"
+            value={next}
+            onChange={(e) => setNext(e.target.value)}
+          />
+          <Input
+            type="password"
+            autoComplete="new-password"
+            aria-label="Confirm new password"
+            placeholder="Confirm password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+          />
+        </div>
+        <div className="flex items-center gap-3">
+          <Button type="submit" disabled={!canSubmit} className="gap-2">
+            {saving ? (
+              <Loader2Icon className="w-4 h-4 animate-spin" />
+            ) : (
+              <KeyRoundIcon className="w-4 h-4" />
+            )}
+            Update password
+          </Button>
+          {error && <span className="text-sm text-destructive">{error}</span>}
+        </div>
+      </form>
+    </SectionShell>
+  );
+}

--- a/web/src/features/settings/password-section.tsx
+++ b/web/src/features/settings/password-section.tsx
@@ -5,19 +5,12 @@
 // reset-email flow (their provider owns the credential); local database
 // accounts get an in-app change-password form.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { KeyRoundIcon, Loader2Icon } from "lucide-react";
 import { toast } from "sonner";
 
-import {
-  changePassword,
-  fetchAuthConfig,
-  type FirebaseRuntimeConfig,
-} from "@/api/auth";
-import {
-  firebaseUserHasPasswordProvider,
-  sendFirebasePasswordReset,
-} from "@/features/auth";
+import { changePassword, fetchAuthConfig } from "@/api/auth";
+import { sendFirebasePasswordReset } from "@/features/auth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
@@ -25,12 +18,18 @@ const MIN_PASSWORD_LENGTH = 8;
 
 export function PasswordSection({
   authProvider,
+  signInProvider,
   email,
 }: {
   authProvider: string;
+  signInProvider: string | null;
   email: string;
 }) {
+  // Only email/password accounts have a password to manage. Firebase
+  // users who signed in with Google/GitHub (sign_in_provider !==
+  // "password") have no password, so no reset is offered.
   if (authProvider.startsWith("firebase:")) {
+    if (signInProvider !== "password") return null;
     return <FirebaseResetPassword email={email} />;
   }
   if (authProvider === "database") {
@@ -53,37 +52,14 @@ function SectionShell({ children }: { children: React.ReactNode }) {
 
 function FirebaseResetPassword({ email }: { email: string }) {
   const [sending, setSending] = useState(false);
-  // ``undefined`` = still resolving; ``null`` = no password credential
-  // (Google/GitHub-only — hide entirely); otherwise the config to reset
-  // against.
-  const [config, setConfig] = useState<
-    FirebaseRuntimeConfig | null | undefined
-  >(undefined);
-
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      const authConfig = await fetchAuthConfig();
-      if (cancelled) return;
-      if (!authConfig.firebase) {
-        setConfig(null);
-        return;
-      }
-      const hasPassword = await firebaseUserHasPasswordProvider(
-        authConfig.firebase,
-      );
-      if (!cancelled) setConfig(hasPassword ? authConfig.firebase : null);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   const handleReset = useCallback(async () => {
-    if (!config) return;
     setSending(true);
     try {
-      await sendFirebasePasswordReset(config, email);
+      const config = await fetchAuthConfig();
+      if (config.firebase) {
+        await sendFirebasePasswordReset(config.firebase, email);
+      }
     } catch {
       // Fall through to the neutral notice — never leak whether the
       // address is registered.
@@ -91,12 +67,7 @@ function FirebaseResetPassword({ email }: { email: string }) {
       setSending(false);
       toast.success("Password-reset link sent to your email.");
     }
-  }, [config, email]);
-
-  // Only email/password accounts have a password to reset. While the
-  // provider check is in flight, or for Google/GitHub-only accounts,
-  // render nothing.
-  if (!config) return null;
+  }, [email]);
 
   return (
     <SectionShell>

--- a/web/src/features/settings/settings-page.tsx
+++ b/web/src/features/settings/settings-page.tsx
@@ -16,10 +16,7 @@ import { BrowserProfilesTab } from "./browser-profiles-tab";
 import { PlanTokensTab } from "./plan-tokens-tab";
 import { PasswordSection } from "./password-section";
 import { useAppStore } from "@/stores/app-store";
-import {
-  browserCapabilityEnabled,
-  slashCommandEnabled,
-} from "@/stores/capabilities-slice";
+import { slashCommandEnabled } from "@/stores/capabilities-slice";
 import {
   updateCurrentUser,
   fetchMyChannels,
@@ -72,7 +69,8 @@ export function SettingsPage() {
   // Only surface a capability tab the agent actually offers.  Unknown
   // (capabilities not yet loaded) fails open via the helpers.
   const codingAgentsEnabled = slashCommandEnabled(slashCommands, "code");
-  const browserProfilesEnabled = browserCapabilityEnabled(browserEnabled);
+  // Only an explicit false hides browser profiles; unknown fails open.
+  const browserProfilesEnabled = browserEnabled !== false;
   // Connected Channels only makes sense when the agent has a messaging
   // channel to pair against. An empty (loaded) list hides it; ``null``
   // (not yet loaded / older backend) also hides it, since we cannot

--- a/web/src/features/settings/settings-page.tsx
+++ b/web/src/features/settings/settings-page.tsx
@@ -264,8 +264,8 @@ export function SettingsPage() {
             {channelsEnabled && (
             <TabsContent value="channels">
               <p className="mb-6 text-sm text-muted-foreground leading-relaxed">
-                Connect the Slack, Teams, or Telegram account you also use to
-                message this assistant, so it knows that chat is you.
+                Connect the Slack or Telegram account you also use to message
+                this assistant, so it knows that chat is you.
               </p>
               {channelsLoading ? (
                 <div className="flex items-center justify-center py-12 text-muted-foreground">
@@ -279,8 +279,8 @@ export function SettingsPage() {
                     No connected channels yet.
                   </p>
                   <p className="text-sm text-faint">
-                    Use a pairing code from Slack, Teams, or Telegram to link
-                    your account.
+                    Use a pairing code from Slack or Telegram to link your
+                    account.
                   </p>
                   <Button
                     variant="outline"

--- a/web/src/features/settings/settings-page.tsx
+++ b/web/src/features/settings/settings-page.tsx
@@ -254,6 +254,7 @@ export function SettingsPage() {
               {user && (
                 <PasswordSection
                   authProvider={user.auth_provider}
+                  signInProvider={user.sign_in_provider}
                   email={user.email}
                 />
               )}

--- a/web/src/features/settings/settings-page.tsx
+++ b/web/src/features/settings/settings-page.tsx
@@ -14,7 +14,12 @@ import { CodingAgentsPanel } from "@invergent/agent-chat-react";
 import { surogatesWebChatAdapter } from "@/features/chat";
 import { BrowserProfilesTab } from "./browser-profiles-tab";
 import { PlanTokensTab } from "./plan-tokens-tab";
+import { PasswordSection } from "./password-section";
 import { useAppStore } from "@/stores/app-store";
+import {
+  browserCapabilityEnabled,
+  slashCommandEnabled,
+} from "@/stores/capabilities-slice";
 import {
   updateCurrentUser,
   fetchMyChannels,
@@ -59,12 +64,27 @@ export function SettingsPage() {
   const user = useAppStore((s) => s.user);
   const fetchUser = useAppStore((s) => s.fetchUser);
   const fetchSessions = useAppStore((s) => s.fetchSessions);
+  const fetchCapabilities = useAppStore((s) => s.fetchCapabilities);
+  const slashCommands = useAppStore((s) => s.slashCommands);
+  const browserEnabled = useAppStore((s) => s.browserEnabled);
+  const linkableChannels = useAppStore((s) => s.linkableChannels);
 
-  // Load sidebar data.
+  // Only surface a capability tab the agent actually offers.  Unknown
+  // (capabilities not yet loaded) fails open via the helpers.
+  const codingAgentsEnabled = slashCommandEnabled(slashCommands, "code");
+  const browserProfilesEnabled = browserCapabilityEnabled(browserEnabled);
+  // Connected Channels only makes sense when the agent has a messaging
+  // channel to pair against. An empty (loaded) list hides it; ``null``
+  // (not yet loaded / older backend) also hides it, since we cannot
+  // claim a channel exists.
+  const channelsEnabled = (linkableChannels?.length ?? 0) > 0;
+
+  // Load sidebar + capability data.
   useEffect(() => {
     void fetchSessions();
     void fetchUser();
-  }, [fetchSessions, fetchUser]);
+    void fetchCapabilities();
+  }, [fetchSessions, fetchUser, fetchCapabilities]);
 
   // ── Profile tab state ──────────────────────────────────────────────
 
@@ -79,15 +99,15 @@ export function SettingsPage() {
     }
   }, [user]);
 
-  const dirty =
-    user != null &&
-    (displayName !== (user.display_name ?? "") || email !== user.email);
+  // Email is read-only (login identity), so only the display name is
+  // editable here.
+  const dirty = user != null && displayName !== (user.display_name ?? "");
 
   const handleSave = useCallback(async () => {
     if (!dirty) return;
     setSaving(true);
     try {
-      await updateCurrentUser({ display_name: displayName, email });
+      await updateCurrentUser({ display_name: displayName });
       await fetchUser();
       toast.success("Profile updated.");
     } catch (err) {
@@ -95,7 +115,7 @@ export function SettingsPage() {
     } finally {
       setSaving(false);
     }
-  }, [dirty, displayName, email, fetchUser]);
+  }, [dirty, displayName, fetchUser]);
 
   // ── Channels tab state ─────────────────────────────────────────────
 
@@ -145,19 +165,25 @@ export function SettingsPage() {
           <Tabs defaultValue="profile">
             <TabsList variant="line" className="mb-6 overflow-x-auto">
               <TabsTrigger value="profile">Profile</TabsTrigger>
-              <TabsTrigger
-                value="channels"
-                onClick={() => {
-                  if (channels.length === 0) void loadChannels();
-                }}
-              >
-                Connected Channels
-              </TabsTrigger>
+              {channelsEnabled && (
+                <TabsTrigger
+                  value="channels"
+                  onClick={() => {
+                    if (channels.length === 0) void loadChannels();
+                  }}
+                >
+                  Connected Channels
+                </TabsTrigger>
+              )}
               <TabsTrigger value="plan">Plan &amp; Tokens</TabsTrigger>
-              <TabsTrigger value="coding-agents">Coding Agents</TabsTrigger>
-              <TabsTrigger value="browser-profiles">
-                Browser Profiles
-              </TabsTrigger>
+              {codingAgentsEnabled && (
+                <TabsTrigger value="coding-agents">Coding Agents</TabsTrigger>
+              )}
+              {browserProfilesEnabled && (
+                <TabsTrigger value="browser-profiles">
+                  Browser Profiles
+                </TabsTrigger>
+              )}
             </TabsList>
 
             {/* ── Plan & tokens ── */}
@@ -190,25 +216,21 @@ export function SettingsPage() {
                       id="email"
                       type="email"
                       value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      placeholder="you@example.com"
+                      readOnly
+                      disabled
+                      className="cursor-not-allowed opacity-70"
                     />
+                    <p className="text-sm text-muted-foreground">
+                      Your sign-in email cannot be changed here.
+                    </p>
                   </Field>
 
                   {user && (
-                    <div className="pt-2 space-y-1 text-sm text-muted-foreground">
-                      <div>
-                        <span className="text-subtle font-medium">
-                          Auth provider:
-                        </span>{" "}
-                        {user.auth_provider}
-                      </div>
-                      <div>
-                        <span className="text-subtle font-medium">
-                          Member since:
-                        </span>{" "}
-                        {new Date(user.created_at).toLocaleDateString()}
-                      </div>
+                    <div className="pt-2 text-sm text-muted-foreground">
+                      <span className="text-subtle font-medium">
+                        Member since:
+                      </span>{" "}
+                      {new Date(user.created_at).toLocaleDateString()}
                     </div>
                   )}
                 </FieldGroup>
@@ -228,10 +250,22 @@ export function SettingsPage() {
                   </Button>
                 </div>
               </form>
+
+              {user && (
+                <PasswordSection
+                  authProvider={user.auth_provider}
+                  email={user.email}
+                />
+              )}
             </TabsContent>
 
             {/* ── Connected Channels ── */}
+            {channelsEnabled && (
             <TabsContent value="channels">
+              <p className="mb-6 text-sm text-muted-foreground leading-relaxed">
+                Connect the Slack, Teams, or Telegram account you also use to
+                message this assistant, so it knows that chat is you.
+              </p>
               {channelsLoading ? (
                 <div className="flex items-center justify-center py-12 text-muted-foreground">
                   <Loader2Icon className="w-4 h-4 animate-spin mr-2" />
@@ -314,15 +348,20 @@ export function SettingsPage() {
                 onCancel={() => setUnlinkTarget(null)}
               />
             </TabsContent>
+            )}
 
             {/* ── Coding Agents ── */}
-            <TabsContent value="coding-agents">
-              <CodingAgentsPanel adapter={surogatesWebChatAdapter} />
-            </TabsContent>
+            {codingAgentsEnabled && (
+              <TabsContent value="coding-agents">
+                <CodingAgentsPanel adapter={surogatesWebChatAdapter} />
+              </TabsContent>
+            )}
 
-            <TabsContent value="browser-profiles">
-              <BrowserProfilesTab />
-            </TabsContent>
+            {browserProfilesEnabled && (
+              <TabsContent value="browser-profiles">
+                <BrowserProfilesTab />
+              </TabsContent>
+            )}
           </Tabs>
         </div>
       </div>

--- a/web/src/stores/capabilities-slice.ts
+++ b/web/src/stores/capabilities-slice.ts
@@ -19,6 +19,13 @@ export type CapabilitiesSlice = {
   // "Multi session" capability. ``null`` = unknown (fail open — multi on);
   // ``false`` pins each user to one session per channel.
   multiSession: boolean | null;
+  // "Live browser support" capability. ``null`` = unknown (fail open —
+  // browser affordances shown); ``false`` hides them.
+  browserEnabled: boolean | null;
+  // Messaging channels an end-user can link their identity to. ``null`` =
+  // unknown (not loaded); an array (possibly empty) is authoritative — an
+  // empty array hides "Connected Channels".
+  linkableChannels: string[] | null;
 
   fetchCapabilities: () => Promise<void>;
 };
@@ -32,6 +39,8 @@ export const createCapabilitiesSlice: StateCreator<
   slashCommands: null,
   agentId: null,
   multiSession: null,
+  browserEnabled: null,
+  linkableChannels: null,
 
   fetchCapabilities: async () => {
     // ``fetchAuthConfig`` already degrades to a safe fallback on error
@@ -41,6 +50,8 @@ export const createCapabilitiesSlice: StateCreator<
       slashCommands: config.slash_commands ?? null,
       agentId: config.agent_id ?? null,
       multiSession: config.multi_session ?? null,
+      browserEnabled: config.browser_enabled ?? null,
+      linkableChannels: config.linkable_channels ?? null,
     });
   },
 });
@@ -53,4 +64,14 @@ export function slashCommandEnabled(
   id: string,
 ): boolean {
   return slashCommands === null || slashCommands.includes(id);
+}
+
+// True when the browser-profile affordances (settings tab + composer
+// picker) should be surfaced.  Only an explicit ``false`` hides them;
+// unknown (``null``) fails open so a fetch hiccup or older backend keeps
+// them visible.
+export function browserCapabilityEnabled(
+  browserEnabled: boolean | null,
+): boolean {
+  return browserEnabled !== false;
 }

--- a/web/src/stores/capabilities-slice.ts
+++ b/web/src/stores/capabilities-slice.ts
@@ -65,13 +65,3 @@ export function slashCommandEnabled(
 ): boolean {
   return slashCommands === null || slashCommands.includes(id);
 }
-
-// True when the browser-profile affordances (settings tab + composer
-// picker) should be surfaced.  Only an explicit ``false`` hides them;
-// unknown (``null``) fails open so a fetch hiccup or older backend keeps
-// them visible.
-export function browserCapabilityEnabled(
-  browserEnabled: boolean | null,
-): boolean {
-  return browserEnabled !== false;
-}

--- a/web/src/stores/user-slice.ts
+++ b/web/src/stores/user-slice.ts
@@ -11,6 +11,7 @@ export interface UserProfile {
   email: string;
   display_name: string | null;
   auth_provider: string;
+  sign_in_provider: string | null;
   created_at: string;
 }
 


### PR DESCRIPTION
## What

Makes the agent's end-user web app reflect the agent's real capabilities
and the user's real sign-in method instead of showing every surface
unconditionally, and hardens the profile tab.

## Changes

**Sidebar** — single-session agents now show a "Chat" link so users can
return to their pinned conversation from Settings/Inbox. Previously the
sidebar hid every chat entry point in single-session mode.

**Capability gating** — `/auth/config` now carries `browser_enabled` and
`linkable_channels`. The SPA:
- hides the Browser Profiles tab + composer picker when live browser
  support is off;
- hides the Coding Agents tab + `/coding-agents` route when the `code`
  command is disabled;
- hides Connected Channels when the agent has no slack/telegram channel
  to pair against.

**Connected Channels / `/link`** — reworked for end-users: dropped the
operator-marketing tags, explained what a pairing code is and where to
get one, and gated the whole surface on the agent actually having a
linkable channel. Slack/Telegram only (Teams not offered yet).

**Profile tab** — email is read-only (login identity), the internal
auth-provider line is gone, and password management is provider-aware:
- local (database) accounts get an in-app change-password form backed by
  a new `POST /v1/auth/me/password`;
- Firebase accounts get a reset-email action only when the user actually
  signed in with email/password. This reads a new `sign_in_provider`
  (captured from `firebase.sign_in_provider` at token exchange, exposed
  on `/auth/me`), so it stays correct even after the Firebase session
  lapses while the app JWT is still valid. Google/GitHub-only users see
  no password UI.

The login/signup page was already provider-gated on `enabled_providers`,
so it needed no change.

## Testing

- New/updated tests: auth-config capability projection, change-password
  route, `sign_in_provider` claim extraction + exchange storage, resolver
  projection. Verified live against the Ludwig agent
  (`browser_enabled:false`, `linkable_channels:[]`, single-session).
- Full surogates suite: **93 failed / 5099 passed** — identical failure
  set to `master` (93 pre-existing), the +19 passing are new tests. Web
  typecheck, eslint, and production build all pass.

## Related

Depends on `invergent-ai/surogate-ops#290`, which adds `linkable_channels`
to the runtime-config. The field is additive and defaults empty, so
deploy order is safe.
