### PR TITLE
feat(browser): markdown page state and in-page JavaScript

### DIFF
--- a/docs/browser-use/index.md
+++ b/docs/browser-use/index.md
@@ -73,7 +73,8 @@ Every call still passes through governance before execution.
 | Tool | Purpose |
 |---|---|
 | `browser_navigate` | Navigate to a URL and return the final URL and page title. |
-| `browser_get_state` | Return the rendered page's accessibility tree with stable `@eN` refs. |
+| `browser_get_state` | Return the rendered page as a markdown outline with stable `@eN` refs. |
+| `browser_evaluate` | Run JavaScript in the page and return a JSON-serializable value. |
 | `browser_click` | Click an `@eN` ref or viewport coordinates. |
 | `browser_type` | Type text at the current focus or into an `@eN` ref. |
 | `browser_press_key` | Press keys or chords such as `Enter`, `Tab`, or `Control+L`. |
@@ -86,6 +87,19 @@ Every call still passes through governance before execution.
 `browser_get_state` is the default perception channel. It caches element refs
 such as `@e3`, which `browser_click` and `browser_type` can use later. After
 navigation or large page changes, call `browser_get_state` again to refresh refs.
+
+By default it renders markdown: headings carry the page structure,
+`- role @eN "name"` lines mark the interactive elements, and page text appears
+once at the element that owns it rather than being repeated by every ancestor.
+Pass `format="json"` for the raw node tree when viewport coordinates are needed.
+Output is capped at 500 elements, with an explicit truncation line when it bites;
+scope large pages with `selector`.
+
+`browser_evaluate` is the reading channel. It runs a JavaScript function body in
+page context and returns whatever that body returns, so extracting every row of
+a table or every option of a `<select>` is one call rather than a scroll-and-
+restate loop. The DOM may be mutated by the script, so cached refs are dropped
+after every evaluate — call `browser_get_state` again before using a ref.
 
 `browser_screenshot` saves each PNG in the session workspace under
 `browser-screenshots/` and returns both a tool-usable absolute `path`, such as

--- a/docs/superpowers/plans/2026-07-28-browser-state-grounding.md
+++ b/docs/superpowers/plans/2026-07-28-browser-state-grounding.md
@@ -194,12 +194,14 @@ class TestMotivatingCases:
     def test_sentence_around_a_link_keeps_both_parts(self) -> None:
         # <p>Read our <a href="…">privacy policy</a> for details</p>
         # The p is not a text block (interactive descendant), so it emits its
-        # own text runs; the link renders as its own control line.
+        # own text runs.  The a IS a text block (pure-inline subtree), so it
+        # carries its text in text_block — but the serializer ignores
+        # text_block for interactive roles and renders the control line.
         tree = [
             {"ref": "@e1", "role": "paragraph", "name": "Read our privacy policy for details",
              "x": 0, "y": 0, "text_block": "Read our for details"},
             {"ref": "@e2", "role": "link", "name": "privacy policy",
-             "x": 0, "y": 0, "text_block": ""},
+             "x": 0, "y": 0, "text_block": "privacy policy"},
         ]
         out = render_markdown(_state(tree))
         assert "Read our for details" in out
@@ -312,8 +314,10 @@ def render_markdown(state: dict[str, Any]) -> str:
 
     tree = state.get("tree") or []
     emitted = 0
+    capped = False
     for entry in tree:
         if emitted >= MAX_MARKDOWN_NODES:
+            capped = True
             break
         line = _render_entry(entry)
         if line is None:
@@ -323,7 +327,7 @@ def render_markdown(state: dict[str, Any]) -> str:
 
     if not emitted:
         lines.append("(no visible elements)")
-    elif len(tree) > emitted:
+    elif capped:
         lines.append("")
         lines.append(
             f"[truncated: {emitted} of {len(tree)} nodes shown — narrow with "
@@ -361,6 +365,13 @@ def _heading_level(entry: dict[str, Any]) -> int:
 Note the consent-ordering tests pass without sorting here: `get_state` already
 runs `_prioritize_state_entries` before the serializer sees the tree, and the
 test builds its tree pre-sorted. Do **not** add a second sort.
+
+The truncation line hangs off the `capped` flag, not `len(tree) > emitted` —
+silent nodes (covered spans, empty containers) make `emitted` fall short of
+`len(tree)` on virtually every real page, and a length comparison would append
+a bogus truncation notice when nothing was cut.
+`test_price_split_across_spans_reads_as_one_line` pins this: 3 nodes, 1 line,
+no notice.
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -470,13 +481,15 @@ class TestSnapshotScriptShape:
         # child are lost -- querySelectorAll('*') returns elements only.
         assert "ownTextOf" in script
 
-    def test_script_reuses_the_existing_computed_style_call(self) -> None:
+    def test_script_computes_style_once_per_element(self) -> None:
         from surogates.browser.client import KernelBrowserClient
 
-        # One getComputedStyle per element in the main walk -- the visibility
-        # check.  A second per-element call would double snapshot cost.
+        # Style is resolved exactly once per element, into the __style map
+        # that both the visibility check and isBlockLevel read.  A second
+        # getComputedStyle call site would re-resolve style for every
+        # descendant scanned inside isTextBlock and multiply snapshot cost.
         assert KernelBrowserClient._SNAPSHOT_SCRIPT.count(
-            "window.getComputedStyle(el)"
+            "window.getComputedStyle"
         ) == 1
 ```
 
@@ -492,7 +505,10 @@ helpers immediately after the existing `depthOf` function:
 
 ```javascript
 function isBlockLevel(el) {
-  const d = window.getComputedStyle(el).display;
+  // Reads the precomputed __style map -- getComputedStyle here would run once
+  // per scanned descendant and is exactly what the call-count test forbids.
+  const s = __style.get(el);
+  const d = s ? s.display : 'block';
   return d !== 'inline' && d !== 'inline-block' && d !== 'contents' && d !== 'none';
 }
 
@@ -534,11 +550,32 @@ function clean(s) {
 }
 ```
 
-Declare the covered-set immediately before the main walk, beside `const out = []`:
+Immediately before the main walk, beside `const out = []`, declare the covered
+set and resolve every element's style **once** into a map:
 
 ```javascript
 const covered = new Set();
+const __els = Array.from(root.querySelectorAll('*'));
+const __style = new Map();
+for (const el of __els) __style.set(el, window.getComputedStyle(el));
 ```
+
+Change the walk to consume both — replace its header and style lookup
+
+```javascript
+for (const el of Array.from(root.querySelectorAll('*'))) {
+  const style = window.getComputedStyle(el);
+```
+
+with
+
+```javascript
+for (const el of __els) {
+  const style = __style.get(el);
+```
+
+so the map fill is the script's only `getComputedStyle` call site — one style
+resolution per element no matter how many subtrees `isTextBlock` scans.
 
 Then in the main walk, replace the `out.push({...})` call with:
 
@@ -765,7 +802,7 @@ GET_STATE_SCHEMA = {
             "enum": ["markdown", "json"],
             "default": "markdown",
             "description": (
-                "Output shape. 'markdown' (default) is a compact page outline: "
+                "Output shape. 'markdown' (default) is a concise page outline: "
                 "headings for structure, '- role @eN \"name\"' lines for "
                 "clickable elements, plain lines for text. 'json' returns the "
                 "raw node tree with viewport coordinates — only needed when you "
@@ -1147,6 +1184,11 @@ JavaScript can mutate the DOM, so the tool belongs with the mutating set — the
 no-progress guardrail would otherwise treat repeated evaluates as read-only
 spinning.
 
+While in that set, fix the stale `"browser_press"` entry to
+`"browser_press_key"` — no tool named `browser_press` exists (the registered
+name is `browser_press_key`, see `TOOL_LOCATIONS`), so the entry never matches
+and key presses are currently misclassified as non-mutating.
+
 - [ ] **Step 6: Run the full browser suite**
 
 Run: `cd /work/surogates && python -m pytest tests/test_browser_tools.py tests/test_browser_client.py tests/test_browser_serialize.py -v`
@@ -1235,6 +1277,11 @@ def _browser_state_result(n: int) -> str:
 
 Update the module docstrings that describe the old shape at
 `tests/test_context_prune.py:4` and `tests/test_context_prune_integration.py:7`.
+
+`tests/test_context_prune_integration.py` also fakes the tool-call arguments as
+`'{"interactive_only": true, "compact": true}'` (line 62, with a matching
+comment at line 25) — drop `compact` from both, since the parameter no longer
+exists.
 
 - [ ] **Step 4: Register the new tool in the ops frontend**
 

--- a/docs/superpowers/plans/2026-07-28-browser-state-grounding.md
+++ b/docs/superpowers/plans/2026-07-28-browser-state-grounding.md
@@ -1,0 +1,1303 @@
+# Browser State Grounding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the browser agent a JavaScript execution tool and replace `browser_get_state`'s duplicated JSON dump with deduplicated markdown.
+
+**Architecture:** The page snapshot is produced by a JavaScript string (`_SNAPSHOT_SCRIPT`) that `KernelBrowserClient` POSTs to the browser pod's `/playwright/execute` endpoint. That script gains two fields per node — `text_block` (coherent text, emitted once at the deepest node that owns it) and `heading_level`. A new pure module renders the resulting node list as markdown. A new `browser_evaluate` tool wraps the same `/playwright/execute` transport to run agent-supplied JavaScript in page context.
+
+**Tech Stack:** Python 3.12, async httpx, pytest (async tests, no `asyncio_mode` decorator needed — see existing browser tests), Playwright-in-pod via kernel-images REST.
+
+**Spec:** `docs/superpowers/specs/2026-07-28-browser-state-grounding-design.md`
+
+## Global Constraints
+
+- Branch is `feat/browser-state-grounding`. Do not create another.
+- **Do not run `uv run`** in this repo — it reinstalls the pinned `surogates` wheel and clobbers the local dev install. Run `pytest` directly.
+- Conventional Commits for every commit (`type(scope): subject`).
+- No `Co-Authored-By` trailer.
+- Never reference plan/task/phase/step numbers in code comments or commit messages.
+- No legacy fallbacks: when replacing a path, delete the old one rather than branching on both.
+- Markdown result cap: **500 nodes**. Evaluate result cap: **20 000 characters**.
+- All tests run from the repo root: `cd /work/surogates`.
+
+---
+
+### Task 1: Markdown serializer
+
+Pure function, no I/O. Written first so later tasks have a stable target.
+
+**Files:**
+- Create: `surogates/browser/serialize.py`
+- Test: `tests/test_browser_serialize.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `render_markdown(state: dict[str, Any]) -> str` and the module
+  constant `MAX_MARKDOWN_NODES: int = 500`.
+
+  `state` is the dict `KernelBrowserClient.get_state` builds:
+  ```python
+  {
+      "url": str,
+      "title": str,
+      "viewport": {"width": int, "height": int},
+      "tree": [
+          {
+              "ref": "@e1",            # always present
+              "role": "button",        # always present
+              "name": "Search",        # always present, may be ""
+              "x": 120, "y": 44,       # always present (centre point)
+              "depth": 12,             # optional
+              "intent": "accept_consent",  # optional
+              "text_block": "£128 per night",  # optional, "" when not a text block
+              "heading_level": 2,      # optional, only on role == "heading"
+          },
+      ],
+  }
+  ```
+  Task 2 populates `text_block` and `heading_level`; Task 3 calls
+  `render_markdown`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_browser_serialize.py`:
+
+```python
+"""Tests for surogates.browser.serialize."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from surogates.browser.serialize import MAX_MARKDOWN_NODES, render_markdown
+
+
+def _state(tree: list[dict[str, Any]], **overrides: Any) -> dict[str, Any]:
+    state = {
+        "url": "https://example.com/",
+        "title": "Example",
+        "viewport": {"width": 1280, "height": 800},
+        "tree": tree,
+    }
+    state.update(overrides)
+    return state
+
+
+class TestHeader:
+    def test_emits_title_url_and_viewport(self) -> None:
+        out = render_markdown(_state([]))
+        assert out.splitlines()[:3] == [
+            "# Example",
+            "https://example.com/",
+            "viewport 1280x800",
+        ]
+
+    def test_survives_missing_fields(self) -> None:
+        out = render_markdown({"tree": []})
+        assert out.splitlines()[:3] == ["# ", "", "viewport 0x0"]
+
+
+class TestHeadings:
+    def test_heading_level_maps_to_hashes(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e1", "role": "heading", "name": "Results",
+             "x": 0, "y": 0, "heading_level": 2, "text_block": "Results"},
+        ]))
+        assert "## Results" in out
+
+    def test_level_is_clamped_to_two_through_six(self) -> None:
+        tree = [
+            {"ref": "@e1", "role": "heading", "name": "Top", "x": 0, "y": 0,
+             "heading_level": 1, "text_block": "Top"},
+            {"ref": "@e2", "role": "heading", "name": "Deep", "x": 0, "y": 0,
+             "heading_level": 9, "text_block": "Deep"},
+        ]
+        out = render_markdown(_state(tree))
+        assert "## Top" in out
+        assert "###### Deep" in out
+
+    def test_missing_level_defaults_to_two(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e1", "role": "heading", "name": "H",
+             "x": 0, "y": 0, "text_block": "H"},
+        ]))
+        assert "## H" in out
+
+
+class TestInteractiveNodes:
+    def test_rendered_as_ref_lines(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e7", "role": "button", "name": "Search", "x": 0, "y": 0},
+        ]))
+        assert '- button @e7 "Search"' in out
+
+    def test_rendered_even_without_text_block(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e7", "role": "checkbox", "name": "Free cancellation",
+             "x": 0, "y": 0, "text_block": ""},
+        ]))
+        assert '- checkbox @e7 "Free cancellation"' in out
+
+    def test_unnamed_interactive_still_addressable(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e9", "role": "button", "name": "", "x": 0, "y": 0},
+        ]))
+        assert '- button @e9 ""' in out
+
+
+class TestTextBlocks:
+    def test_text_block_emitted_as_plain_line(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e3", "role": "paragraph", "name": "ignored",
+             "x": 0, "y": 0, "text_block": "£128 per night"},
+        ]))
+        assert "£128 per night" in out
+        assert "ignored" not in out
+
+    def test_container_owning_no_text_contributes_nothing(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e2", "role": "generic", "name": "whole page text",
+             "x": 0, "y": 0, "text_block": ""},
+        ]))
+        assert "whole page text" not in out
+
+    def test_generic_without_text_block_key_contributes_nothing(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e2", "role": "generic", "name": "leaked", "x": 0, "y": 0},
+        ]))
+        assert "leaked" not in out
+
+
+class TestMotivatingCases:
+    """The two shapes that drove the text-block rule.
+
+    Both use the node lists the snapshot script produces for the markup in the
+    docstrings, so they pin the contract between derivation and rendering.
+    """
+
+    def test_price_split_across_spans_reads_as_one_line(self) -> None:
+        # <div class="price"><span>£</span><span>128</span></div>
+        # The div is a text block; both spans are covered by it.
+        tree = [
+            {"ref": "@e1", "role": "generic", "name": "£128",
+             "x": 0, "y": 0, "text_block": "£128"},
+            {"ref": "@e2", "role": "generic", "name": "£",
+             "x": 0, "y": 0, "text_block": ""},
+            {"ref": "@e3", "role": "generic", "name": "128",
+             "x": 0, "y": 0, "text_block": ""},
+        ]
+        out = render_markdown(_state(tree))
+        body = out.split("viewport 1280x800\n")[1]
+        assert body.strip() == "£128"
+
+    def test_sentence_around_a_link_keeps_both_parts(self) -> None:
+        # <p>Read our <a href="…">privacy policy</a> for details</p>
+        # The p is not a text block (interactive descendant), so it emits its
+        # own text runs; the link renders as its own control line.
+        tree = [
+            {"ref": "@e1", "role": "paragraph", "name": "Read our privacy policy for details",
+             "x": 0, "y": 0, "text_block": "Read our for details"},
+            {"ref": "@e2", "role": "link", "name": "privacy policy",
+             "x": 0, "y": 0, "text_block": ""},
+        ]
+        out = render_markdown(_state(tree))
+        assert "Read our for details" in out
+        assert '- link @e2 "privacy policy"' in out
+
+
+class TestOrdering:
+    def test_consent_intent_sorts_first(self) -> None:
+        tree = [
+            {"ref": "@e5", "role": "link", "name": "Home", "x": 0, "y": 0},
+            {"ref": "@e9", "role": "button", "name": "Accept all",
+             "x": 0, "y": 0, "intent": "accept_consent"},
+        ]
+        out = render_markdown(_state(tree))
+        assert out.index("@e9") < out.index("@e5")
+
+    def test_otherwise_document_order_is_preserved(self) -> None:
+        tree = [
+            {"ref": "@e1", "role": "link", "name": "First", "x": 0, "y": 0},
+            {"ref": "@e2", "role": "link", "name": "Second", "x": 0, "y": 0},
+        ]
+        out = render_markdown(_state(tree))
+        assert out.index("@e1") < out.index("@e2")
+
+
+class TestNodeCap:
+    def test_caps_emitted_nodes_and_reports_truncation(self) -> None:
+        tree = [
+            {"ref": f"@e{i}", "role": "link", "name": f"L{i}", "x": 0, "y": 0}
+            for i in range(1, MAX_MARKDOWN_NODES + 51)
+        ]
+        out = render_markdown(_state(tree))
+        assert out.count('- link @e') == MAX_MARKDOWN_NODES
+        assert f"[truncated: {MAX_MARKDOWN_NODES} of {MAX_MARKDOWN_NODES + 50} nodes shown" in out
+        assert "browser_evaluate" in out
+
+    def test_no_truncation_line_when_under_cap(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e1", "role": "link", "name": "Only", "x": 0, "y": 0},
+        ]))
+        assert "truncated" not in out
+
+
+class TestEmptyPage:
+    def test_empty_tree_yields_header_only(self) -> None:
+        out = render_markdown(_state([]))
+        assert "no visible elements" in out
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /work/surogates && python -m pytest tests/test_browser_serialize.py -v`
+Expected: collection error — `ModuleNotFoundError: No module named 'surogates.browser.serialize'`
+
+- [ ] **Step 3: Write the serializer**
+
+Create `surogates/browser/serialize.py`:
+
+```python
+"""Markdown rendering of a browser page snapshot.
+
+The page tree from ``KernelBrowserClient.get_state`` is a flat, document-ordered
+node list.  This module renders it as markdown: interactive nodes become
+addressable ``@eN`` lines, text blocks become plain lines, and heading roles
+provide the structure.  Pure -- no I/O, no client, no page access -- so it is
+testable in isolation and cannot fail on a slow page.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Interactive roles get a ``- role @eN "name"`` line whether or not they own
+# text.  Mirrors ``KernelBrowserClient._INTERACTIVE_ROLES``; kept as a separate
+# constant so the serializer does not import the HTTP client.
+INTERACTIVE_ROLES: frozenset[str] = frozenset({
+    "button",
+    "link",
+    "textbox",
+    "combobox",
+    "checkbox",
+    "radio",
+    "menuitem",
+    "tab",
+    "switch",
+    "searchbox",
+    "slider",
+    "spinbutton",
+})
+
+# Cap on emitted nodes.  Deliberately not a tool parameter: ``browser_evaluate``
+# is the escape hatch for reading past it, and extracting 1200 rows in one call
+# beats re-requesting a bigger tree.
+MAX_MARKDOWN_NODES: int = 500
+
+_MIN_HEADING_LEVEL: int = 2
+_MAX_HEADING_LEVEL: int = 6
+
+
+def render_markdown(state: dict[str, Any]) -> str:
+    """Render a ``get_state`` result as markdown."""
+
+    viewport = state.get("viewport") or {}
+    lines: list[str] = [
+        f"# {state.get('title', '')}",
+        str(state.get("url", "")),
+        f"viewport {int(viewport.get('width', 0))}x{int(viewport.get('height', 0))}",
+        "",
+    ]
+
+    tree = state.get("tree") or []
+    emitted = 0
+    for entry in tree:
+        if emitted >= MAX_MARKDOWN_NODES:
+            break
+        line = _render_entry(entry)
+        if line is None:
+            continue
+        lines.append(line)
+        emitted += 1
+
+    if not emitted:
+        lines.append("(no visible elements)")
+    elif len(tree) > emitted:
+        lines.append("")
+        lines.append(
+            f"[truncated: {emitted} of {len(tree)} nodes shown — narrow with "
+            f"selector, or read the rest with browser_evaluate]"
+        )
+
+    return "\n".join(lines)
+
+
+def _render_entry(entry: dict[str, Any]) -> str | None:
+    """Return the markdown line for one node, or ``None`` to skip it."""
+
+    role = str(entry.get("role", ""))
+    if role == "heading":
+        text = str(entry.get("text_block") or "").strip()
+        if not text:
+            return None
+        return f"{'#' * _heading_level(entry)} {text}"
+
+    if role in INTERACTIVE_ROLES:
+        return f'- {role} {entry.get("ref", "")} "{entry.get("name", "")}"'
+
+    text = str(entry.get("text_block") or "").strip()
+    return text or None
+
+
+def _heading_level(entry: dict[str, Any]) -> int:
+    try:
+        level = int(entry.get("heading_level", _MIN_HEADING_LEVEL))
+    except (TypeError, ValueError):
+        level = _MIN_HEADING_LEVEL
+    return max(_MIN_HEADING_LEVEL, min(_MAX_HEADING_LEVEL, level))
+```
+
+Note the consent-ordering tests pass without sorting here: `get_state` already
+runs `_prioritize_state_entries` before the serializer sees the tree, and the
+test builds its tree pre-sorted. Do **not** add a second sort.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /work/surogates && python -m pytest tests/test_browser_serialize.py -v`
+Expected: PASS, all tests.
+
+If `test_consent_intent_sorts_first` fails, the fixture is out of document order
+— fix the fixture, not the serializer.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /work/surogates
+git add surogates/browser/serialize.py tests/test_browser_serialize.py
+git commit -m "feat(browser): add markdown serializer for page snapshots"
+```
+
+---
+
+### Task 2: `text_block` and `heading_level` derivation
+
+Adds the two fields to the in-page snapshot script and carries them through the
+tree builder.
+
+**Files:**
+- Modify: `surogates/browser/client.py` — `_SNAPSHOT_SCRIPT` (lines 70-151) and `_build_tree_and_cache` (lines 632-683)
+- Test: `tests/test_browser_client.py`
+
+**Interfaces:**
+- Consumes: nothing (Task 1's serializer reads these fields but is not imported here).
+- Produces: every entry in `get_state()["tree"]` may carry `text_block: str` and,
+  when `role == "heading"`, `heading_level: int`. Absent keys mean "no text" and
+  "no level" respectively.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_browser_client.py`:
+
+```python
+class TestTextBlockDerivation:
+    """The snapshot script derives text at the text-block level.
+
+    A text block is the deepest node whose subtree holds no interactive and no
+    block-level element.  These tests assert the Python side carries the fields
+    through; the in-page derivation itself is exercised in the e2e suite.
+    """
+
+    async def test_tree_carries_text_block_and_heading_level(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        client = KernelBrowserClient("http://browser:30000")
+        nodes = [
+            {"role": "heading", "name": "Results", "x": 0, "y": 0,
+             "width": 100, "height": 20, "depth": 3, "children_count": 0,
+             "idx": 0, "backend_node_id": 11,
+             "text_block": "Results", "heading_level": 2},
+            {"role": "generic", "name": "Results £128", "x": 0, "y": 0,
+             "width": 100, "height": 20, "depth": 3, "children_count": 2,
+             "idx": 1, "backend_node_id": 12, "text_block": ""},
+        ]
+        tree, cache = client._build_tree_and_cache(nodes)
+
+        assert tree[0]["text_block"] == "Results"
+        assert tree[0]["heading_level"] == 2
+        assert tree[1]["text_block"] == ""
+        assert "heading_level" not in tree[1]
+        # Refs and centres are unchanged by the new fields.
+        assert tree[0]["ref"] == "@e1"
+        assert cache["@e1"]["backend_node_id"] == 11
+
+    async def test_missing_fields_are_omitted_not_defaulted(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        client = KernelBrowserClient("http://browser:30000")
+        nodes = [
+            {"role": "link", "name": "Home", "x": 0, "y": 0,
+             "width": 10, "height": 10, "depth": 2, "children_count": 0,
+             "idx": 0, "backend_node_id": 5},
+        ]
+        tree, _ = client._build_tree_and_cache(nodes)
+
+        assert "heading_level" not in tree[0]
+        assert tree[0].get("text_block", "") == ""
+
+
+class TestSnapshotScriptShape:
+    """Guards on the injected JS -- it is a string, so nothing else type-checks it."""
+
+    def test_script_derives_text_block_and_heading_level(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        script = KernelBrowserClient._SNAPSHOT_SCRIPT
+        assert "text_block" in script
+        assert "heading_level" in script
+        # The text-block test must consider both interactive and block-level
+        # descendants; a check for only one of them is the bug this guards.
+        assert "isTextBlock" in script
+
+    def test_script_guards_against_both_duplication_and_text_loss(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        script = KernelBrowserClient._SNAPSHOT_SCRIPT
+        # Without the covered set, nested pure-inline elements each emit the
+        # same text ("£128", then "£", then "128").
+        assert "covered.add" in script
+        # Without the own-text branch, bare text runs beside an interactive
+        # child are lost -- querySelectorAll('*') returns elements only.
+        assert "ownTextOf" in script
+
+    def test_script_reuses_the_existing_computed_style_call(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        # One getComputedStyle per element in the main walk -- the visibility
+        # check.  A second per-element call would double snapshot cost.
+        assert KernelBrowserClient._SNAPSHOT_SCRIPT.count(
+            "window.getComputedStyle(el)"
+        ) == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /work/surogates && python -m pytest tests/test_browser_client.py -k "TextBlock or SnapshotScript" -v`
+Expected: FAIL — `KeyError: 'text_block'` / `assert 'text_block' in script`
+
+- [ ] **Step 3: Add the derivation to the snapshot script**
+
+In `surogates/browser/client.py`, inside `_SNAPSHOT_SCRIPT`, add these two
+helpers immediately after the existing `depthOf` function:
+
+```javascript
+function isBlockLevel(el) {
+  const d = window.getComputedStyle(el).display;
+  return d !== 'inline' && d !== 'inline-block' && d !== 'contents' && d !== 'none';
+}
+
+const __INTERACTIVE = new Set(['button','link','textbox','combobox','checkbox',
+  'radio','menuitem','tab','switch','searchbox','slider','spinbutton']);
+
+function isTextBlock(el) {
+  // A text block is an element whose subtree holds no interactive element and
+  // no block-level element -- i.e. pure inline markup, so its innerText reads
+  // as one coherent run.
+  for (const child of Array.from(el.querySelectorAll('*'))) {
+    if (__INTERACTIVE.has(roleOf(child))) return false;
+    if (isBlockLevel(child)) return false;
+  }
+  return true;
+}
+
+function ownTextOf(el) {
+  // Text nodes that are direct children of *el*, i.e. the runs that belong to
+  // no descendant element.  Used for elements that are NOT text blocks: their
+  // descendants' text is emitted separately, but these loose runs would
+  // otherwise be lost, since querySelectorAll('*') returns elements only.
+  let out = '';
+  for (const node of Array.from(el.childNodes)) {
+    if (node.nodeType === 3) out += node.nodeValue;
+  }
+  return out;
+}
+
+function headingLevelOf(el) {
+  const tag = el.tagName.toLowerCase();
+  if (/^h[1-6]$/.test(tag)) return Number(tag.slice(1));
+  const aria = Number(el.getAttribute('aria-level'));
+  return Number.isFinite(aria) && aria > 0 ? aria : 2;
+}
+
+function clean(s) {
+  return String(s || '').replace(/\\s+/g, ' ').trim().slice(0, 2000);
+}
+```
+
+Declare the covered-set immediately before the main walk, beside `const out = []`:
+
+```javascript
+const covered = new Set();
+```
+
+Then in the main walk, replace the `out.push({...})` call with:
+
+```javascript
+  const role = roleOf(el);
+  let textBlock = '';
+  if (covered.has(el)) {
+    // An ancestor text block already emitted this element's text.
+    textBlock = '';
+  } else if (isTextBlock(el)) {
+    textBlock = clean(el.innerText || el.textContent);
+    for (const d of Array.from(el.querySelectorAll('*'))) covered.add(d);
+  } else {
+    textBlock = clean(ownTextOf(el));
+  }
+  const entry = {
+    role: role,
+    name: nameOf(el),
+    x: Math.round(bbox.x),
+    y: Math.round(bbox.y),
+    width: Math.round(bbox.width),
+    height: Math.round(bbox.height),
+    depth: depthOf(el),
+    children_count: el.children ? el.children.length : 0,
+    idx: out.length,
+    text_block: textBlock,
+  };
+  if (role === 'heading') entry.heading_level = headingLevelOf(el);
+  out.push(entry);
+```
+
+The `\\s` escaping in `clean` is required — this JavaScript lives inside a
+Python string literal, exactly as the existing `nameOf` body does.
+
+**Why the covered-set and the own-text branch both exist.** Without the covered
+set, `<div class="price"><span>£</span><span>128</span></div>` emits three
+times: the div is a text block (`£128`) and so is each span (`£`, `128`).
+Marking the subtree covered when a text block fires means the shallowest pure-
+inline element wins and its descendants stay silent.
+
+Without the own-text branch, `<p>Read our <a>privacy policy</a> for details</p>`
+loses text: the `<p>` is not a text block (it contains an interactive `<a>`),
+and the runs `Read our` and `for details` are bare text nodes, which
+`querySelectorAll('*')` never returns. The own-text branch catches exactly the
+runs no descendant element owns.
+
+Together they emit every text node exactly once: either inside the innerText of
+the shallowest text-block ancestor, or as a direct-child run of the nearest
+non-text-block ancestor.
+
+- [ ] **Step 4: Carry the fields through the tree builder**
+
+In `_build_tree_and_cache`, after the existing `depth` block:
+
+```python
+            depth = node.get("depth")
+            if depth is not None:
+                entry["depth"] = int(depth)
+            entry["text_block"] = str(node.get("text_block") or "")
+            heading_level = node.get("heading_level")
+            if heading_level is not None:
+                entry["heading_level"] = int(heading_level)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /work/surogates && python -m pytest tests/test_browser_client.py -v`
+Expected: PASS — the new tests and every pre-existing client test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /work/surogates
+git add surogates/browser/client.py tests/test_browser_client.py
+git commit -m "feat(browser): derive text blocks and heading levels in page snapshots"
+```
+
+---
+
+### Task 3: `get_state` markdown output
+
+Wires the serializer in, adds `format`, deletes `compact`, documents every
+parameter.
+
+**Files:**
+- Modify: `surogates/browser/client.py` — `get_state` (lines 245-278), `_state_entry_visible` (lines 685-702)
+- Modify: `surogates/tools/builtin/browser.py` — `GET_STATE_SCHEMA`, `_browser_get_state_handler`, the `browser_get_state` registration
+- Test: `tests/test_browser_tools.py`
+
+**Interfaces:**
+- Consumes: `render_markdown` from Task 1; `text_block` / `heading_level` from Task 2.
+- Produces: `browser_get_state` returns a **raw markdown string** by default and
+  a JSON object when called with `format="json"`. Errors stay JSON in both modes.
+  `KernelBrowserClient.get_state` keeps returning a dict; the handler renders.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_browser_tools.py`, extend `FakeClient.get_state` to return a
+populated tree, then add the test class. Replace the existing `FakeClient.get_state`
+body with:
+
+```python
+    async def get_state(self, **kwargs: Any) -> dict[str, Any]:
+        self.get_state_kwargs = kwargs
+        return {
+            "url": "http://example.com/",
+            "title": "Test",
+            "viewport": {"width": 1280, "height": 800},
+            "tree": [
+                {"ref": "@e1", "role": "heading", "name": "Results",
+                 "x": 0, "y": 0, "text_block": "Results", "heading_level": 2},
+                {"ref": "@e2", "role": "button", "name": "Search",
+                 "x": 10, "y": 20, "text_block": ""},
+            ],
+        }
+```
+
+Add to the same file:
+
+```python
+class TestGetStateFormat:
+    async def test_defaults_to_markdown(self, tenant) -> None:
+        from surogates.tools.builtin.browser import _browser_get_state_handler
+
+        result = await _browser_get_state_handler(
+            {},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FakeClient(),
+        )
+        assert result.startswith("# Test")
+        assert "## Results" in result
+        assert '- button @e2 "Search"' in result
+
+    async def test_json_format_returns_the_tree(self, tenant) -> None:
+        from surogates.tools.builtin.browser import _browser_get_state_handler
+
+        result = await _browser_get_state_handler(
+            {"format": "json"},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FakeClient(),
+        )
+        body = json.loads(result)
+        assert body["tree"][0]["text_block"] == "Results"
+        assert body["tree"][0]["heading_level"] == 2
+        assert body["tree"][1]["x"] == 10
+
+    async def test_errors_stay_json_in_markdown_mode(self, tenant) -> None:
+        from surogates.tools.builtin.browser import _browser_get_state_handler
+
+        result = await _browser_get_state_handler(
+            {},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FailingStateClient(),
+        )
+        assert json.loads(result)["error"] == "get_state_failed"
+
+
+class TestGetStateSchema:
+    def test_compact_is_gone(self) -> None:
+        from surogates.tools.builtin.browser import GET_STATE_SCHEMA
+
+        assert "compact" not in GET_STATE_SCHEMA["properties"]
+
+    def test_every_parameter_is_documented(self) -> None:
+        from surogates.tools.builtin.browser import GET_STATE_SCHEMA
+
+        for name, prop in GET_STATE_SCHEMA["properties"].items():
+            assert prop.get("description"), f"{name} has no description"
+
+    def test_format_enumerates_both_modes(self) -> None:
+        from surogates.tools.builtin.browser import GET_STATE_SCHEMA
+
+        assert GET_STATE_SCHEMA["properties"]["format"]["enum"] == ["markdown", "json"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /work/surogates && python -m pytest tests/test_browser_tools.py -k "GetStateFormat or GetStateSchema" -v`
+Expected: FAIL — `AssertionError: assert 'compact' not in {...}` and the markdown
+test failing because the handler still returns JSON.
+
+- [ ] **Step 3: Drop `compact` from the client**
+
+In `surogates/browser/client.py`, remove the `compact` parameter from
+`get_state`'s signature and its forwarding into `_state_entry_visible`, and
+delete this branch from `_state_entry_visible`:
+
+```python
+        if compact and not entry.get("name") and role not in self._INTERACTIVE_ROLES:
+            return False
+```
+
+`_state_entry_visible`'s signature becomes:
+
+```python
+    def _state_entry_visible(
+        self,
+        entry: dict[str, Any],
+        *,
+        interactive_only: bool,
+        max_depth: int | None,
+    ) -> bool:
+```
+
+- [ ] **Step 4: Update the schema and handler**
+
+In `surogates/tools/builtin/browser.py`, replace `GET_STATE_SCHEMA`:
+
+```python
+GET_STATE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "format": {
+            "type": "string",
+            "enum": ["markdown", "json"],
+            "default": "markdown",
+            "description": (
+                "Output shape. 'markdown' (default) is a compact page outline: "
+                "headings for structure, '- role @eN \"name\"' lines for "
+                "clickable elements, plain lines for text. 'json' returns the "
+                "raw node tree with viewport coordinates — only needed when you "
+                "must click by coordinate rather than by ref."
+            ),
+        },
+        "interactive_only": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "Return only clickable and typeable elements, dropping all page "
+                "text. Use when you know what you are looking for and only need "
+                "its ref."
+            ),
+        },
+        "max_depth": {
+            "type": "integer",
+            "minimum": 0,
+            "description": (
+                "Drop elements nested deeper than this in the DOM. Rarely "
+                "useful — prefer 'selector' to scope by region."
+            ),
+        },
+        "selector": {
+            "type": "string",
+            "description": (
+                "CSS selector limiting the snapshot to one subtree, e.g. "
+                "'#search-results'. The best way to keep a large page under the "
+                "node cap."
+            ),
+        },
+    },
+    "additionalProperties": False,
+}
+```
+
+Then in `_browser_get_state_handler`, drop the `compact` argument and render:
+
+```python
+    _browser_id, endpoint, snapshot_cache = preflight
+    client = _make_client(_client_factory, endpoint, snapshot_cache)
+    async with client:
+        try:
+            state = await client.get_state(
+                interactive_only=arguments.get("interactive_only", False),
+                max_depth=arguments.get("max_depth"),
+                selector=arguments.get("selector"),
+            )
+        except RuntimeError as exc:
+            return json.dumps({"error": "get_state_failed", "detail": str(exc)})
+    if arguments.get("format", "markdown") == "json":
+        return json.dumps(state)
+    return render_markdown(state)
+```
+
+Add the import at the top of the file:
+
+```python
+from surogates.browser.serialize import render_markdown
+```
+
+Finally update the tool description in `register`:
+
+```python
+            description=(
+                "Return the current page as a markdown outline with @eN refs "
+                "for browser_click and browser_type. Pass format='json' for the "
+                "raw node tree with coordinates."
+            ),
+```
+
+- [ ] **Step 5: Run the full browser suite**
+
+Run: `cd /work/surogates && python -m pytest tests/test_browser_tools.py tests/test_browser_client.py tests/test_browser_serialize.py -v`
+Expected: PASS. `TestGetStateHandler::test_returns_tree` will fail — it asserts
+`"tree" in body` against what is now markdown. Update it to pass
+`{"format": "json"}`, since it is testing the tree path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /work/surogates
+git add surogates/browser/client.py surogates/tools/builtin/browser.py tests/test_browser_tools.py
+git commit -m "feat(browser): return page state as markdown by default"
+```
+
+---
+
+### Task 4: `browser_evaluate`
+
+**Files:**
+- Modify: `surogates/browser/client.py` — new `evaluate` method beside `navigate`
+- Modify: `surogates/tools/builtin/browser.py` — schema, handler, registration
+- Modify: `surogates/tools/router.py` — `TOOL_LOCATIONS` (lines 76-86)
+- Modify: `surogates/harness/tool_guardrails.py` — `MUTATING_TOOL_NAMES` (lines 23-38)
+- Test: `tests/test_browser_tools.py`, `tests/test_browser_client.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `KernelBrowserClient.evaluate(code: str) -> Any` and tool
+  `browser_evaluate` taking `{"code": str}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_browser_tools.py`:
+
+```python
+class FakeEvaluateClient(FakeClient):
+    def __init__(self, result: Any = None) -> None:
+        super().__init__()
+        self.evaluated: list[str] = []
+        self._result = result if result is not None else {"rows": 3}
+
+    async def evaluate(self, code: str) -> Any:
+        self.evaluated.append(code)
+        return self._result
+
+
+class FailingEvaluateClient(FakeClient):
+    async def evaluate(self, code: str) -> Any:
+        raise RuntimeError("SyntaxError: Unexpected token '}'")
+
+
+class TestEvaluateHandler:
+    async def test_returns_the_json_result(self, tenant) -> None:
+        from surogates.tools.builtin.browser import _browser_evaluate_handler
+
+        result = await _browser_evaluate_handler(
+            {"code": "return document.title;"},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FakeEvaluateClient({"title": "T"}),
+        )
+        assert json.loads(result) == {"title": "T"}
+
+    async def test_returns_structured_error_on_js_failure(self, tenant) -> None:
+        from surogates.tools.builtin.browser import _browser_evaluate_handler
+
+        result = await _browser_evaluate_handler(
+            {"code": "return }"},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FailingEvaluateClient(),
+        )
+        body = json.loads(result)
+        assert body["error"] == "evaluate_failed"
+        assert "SyntaxError" in body["detail"]
+
+    async def test_truncates_oversized_results(self, tenant) -> None:
+        from surogates.tools.builtin.browser import (
+            _MAX_EVALUATE_RESULT_CHARS,
+            _browser_evaluate_handler,
+        )
+
+        huge = "x" * (_MAX_EVALUATE_RESULT_CHARS + 5000)
+        result = await _browser_evaluate_handler(
+            {"code": "return document.body.innerHTML;"},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FakeEvaluateClient(huge),
+        )
+        body = json.loads(result)
+        assert body["truncated"] is True
+        assert body["original_length"] > _MAX_EVALUATE_RESULT_CHARS
+        assert len(body["result"]) == _MAX_EVALUATE_RESULT_CHARS
+
+    async def test_rejects_missing_code(self, tenant) -> None:
+        from surogates.tools.builtin.browser import _browser_evaluate_handler
+
+        result = await _browser_evaluate_handler(
+            {},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FakeEvaluateClient(),
+        )
+        assert json.loads(result)["error"] == "missing_code"
+```
+
+Add `"browser_evaluate"` to `BROWSER_TOOL_NAMES` and
+`("_browser_evaluate_handler", {"code": "return 1;"})` to
+`BROWSER_SUSPEND_HANDLERS` in the same file.
+
+Add to `tests/test_browser_client.py`:
+
+```python
+class TestEvaluate:
+    async def test_wraps_code_in_a_page_evaluate_callback(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        client = KernelBrowserClient("http://browser:30000")
+        sent: list[str] = []
+
+        async def fake_execute(code: str, **kwargs: Any) -> Any:
+            sent.append(code)
+            return {"ok": True}
+
+        client._playwright_execute = fake_execute  # type: ignore[assignment]
+        result = await client.evaluate("return document.title;")
+
+        assert result == {"ok": True}
+        assert "await page.evaluate(async () => {" in sent[0]
+        assert "return document.title;" in sent[0]
+
+    async def test_invalidates_the_snapshot_cache(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        client = KernelBrowserClient("http://browser:30000")
+        client._snapshot_cache["@e1"] = {"x": 1, "y": 2}
+
+        async def fake_execute(code: str, **kwargs: Any) -> Any:
+            return None
+
+        client._playwright_execute = fake_execute  # type: ignore[assignment]
+        await client.evaluate("document.body.innerHTML = '';")
+
+        assert client._snapshot_cache == {}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /work/surogates && python -m pytest tests/test_browser_tools.py tests/test_browser_client.py -k "Evaluate or evaluate" -v`
+Expected: FAIL — `ImportError: cannot import name '_browser_evaluate_handler'`
+
+- [ ] **Step 3: Add the client method**
+
+In `surogates/browser/client.py`, immediately after `navigate`:
+
+```python
+    async def evaluate(self, code: str) -> Any:
+        """Run agent-supplied JavaScript in page context and return its value.
+
+        *code* is a function **body**, not an expression: it must ``return`` a
+        JSON-serializable value.  Raw interpolation is correct here -- the
+        payload is code, and it sits in a function body with no surrounding
+        literal to escape from.  The callback is ``async`` so the body may
+        ``await``.
+
+        The snapshot cache is cleared afterwards: JavaScript can move or replace
+        elements, and a stale ``@eN`` that resolves to the wrong node is worse
+        than one that fails to resolve.
+        """
+
+        wrapped = (
+            "const __result = await page.evaluate(async () => {\n"
+            f"{code}\n"
+            "});\n"
+            "return __result;"
+        )
+        result = await self._playwright_execute(wrapped)
+        self._invalidate_snapshot_cache()
+        return result
+```
+
+- [ ] **Step 4: Add the schema, handler, and registration**
+
+In `surogates/tools/builtin/browser.py`, beside the other module constants:
+
+```python
+# Cap on a single evaluate result.  Matches ``_MAX_TOOL_RESULT_CHARS`` in
+# ``surogates/tools/builtin/expert_loop.py``: a ``document.body.innerHTML``
+# return would otherwise swallow the context window.
+_MAX_EVALUATE_RESULT_CHARS: int = 20_000
+```
+
+```python
+EVALUATE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "code": {
+            "type": "string",
+            "description": (
+                "JavaScript function body run inside the page. 'document' and "
+                "'window' are available; Playwright's 'page' is not. You must "
+                "'return' a JSON-serializable value — DOM nodes are not "
+                "serializable, so return their properties instead. 'await' is "
+                "allowed. Example: return [...document.querySelectorAll('tr')]"
+                ".map(r => r.innerText);"
+            ),
+        },
+    },
+    "required": ["code"],
+    "additionalProperties": False,
+}
+
+
+async def _browser_evaluate_handler(
+    arguments: dict[str, Any],
+    *,
+    tenant: Any = None,
+    session_id: UUID | str | None = None,
+    browser_pool: BrowserPool | None = None,
+    browser_control: BrowserControlStore | None = None,
+    _client_factory: Callable[..., Any] = _default_client_factory,
+    workspace_path: str | None = None,
+    session_config: dict[str, Any] | None = None,
+    **_: Any,
+) -> str:
+    code = arguments.get("code")
+    if not code or not str(code).strip():
+        return json.dumps({
+            "error": "missing_code",
+            "detail": "browser_evaluate requires a non-empty 'code' argument.",
+        })
+
+    preflight = await _resolve_session_browser(
+        tenant=tenant,
+        session_id=session_id,
+        browser_pool=browser_pool,
+        browser_control=browser_control,
+        workspace_path=workspace_path,
+        session_config=session_config,
+    )
+    if isinstance(preflight, str):
+        return preflight
+
+    _browser_id, endpoint, snapshot_cache = preflight
+    client = _make_client(_client_factory, endpoint, snapshot_cache)
+    async with client:
+        try:
+            result = await client.evaluate(str(code))
+        except RuntimeError as exc:
+            return json.dumps({"error": "evaluate_failed", "detail": str(exc)})
+
+    serialized = json.dumps(result)
+    if len(serialized) > _MAX_EVALUATE_RESULT_CHARS:
+        kept = serialized[:_MAX_EVALUATE_RESULT_CHARS]
+        return json.dumps({
+            "truncated": True,
+            "original_length": len(serialized),
+            "result": kept,
+        })
+    return serialized
+```
+
+And in `register`:
+
+```python
+    registry.register(
+        name="browser_evaluate",
+        schema=ToolSchema(
+            name="browser_evaluate",
+            description=(
+                "Run JavaScript in the page and return its value. Use this to "
+                "read structured page state — full tables, hidden input values, "
+                "every option of a select — in one call instead of many "
+                "get_state and scroll round trips."
+            ),
+            parameters=EVALUATE_SCHEMA,
+        ),
+        handler=_browser_evaluate_handler,
+        toolset="browser",
+    )
+```
+
+- [ ] **Step 5: Wire routing and guardrails**
+
+In `surogates/tools/router.py`, add to `TOOL_LOCATIONS` beside the other browser
+entries:
+
+```python
+    "browser_evaluate": ToolLocation.HARNESS,
+```
+
+In `surogates/harness/tool_guardrails.py`, add to `MUTATING_TOOL_NAMES`:
+
+```python
+    "browser_evaluate",
+```
+
+JavaScript can mutate the DOM, so the tool belongs with the mutating set — the
+no-progress guardrail would otherwise treat repeated evaluates as read-only
+spinning.
+
+- [ ] **Step 6: Run the full browser suite**
+
+Run: `cd /work/surogates && python -m pytest tests/test_browser_tools.py tests/test_browser_client.py tests/test_browser_serialize.py -v`
+Expected: PASS, including the parametrized `paused_by_user` test now covering
+`browser_evaluate` and the `TestToolWiring` routing assertion.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /work/surogates
+git add surogates/browser/client.py surogates/tools/builtin/browser.py \
+        surogates/tools/router.py surogates/harness/tool_guardrails.py \
+        tests/test_browser_tools.py tests/test_browser_client.py
+git commit -m "feat(browser): add browser_evaluate for in-page JavaScript"
+```
+
+---
+
+### Task 5: Guidance, fixtures, and callers
+
+The behaviour change has to reach the prompt that tells the agent how to browse,
+and the fixtures that claim to mirror real tool output.
+
+**Files:**
+- Modify: `surogates/harness/prompts/guidance/browser.md`
+- Modify: `tests/test_context_prune.py`, `tests/test_context_prune_integration.py`
+- Modify: `/work/surogate-ops/frontend/src/features/agents/builtin-tools.ts:27`
+
+**Interfaces:**
+- Consumes: the tool surface from Tasks 3 and 4.
+- Produces: no code interfaces.
+
+- [ ] **Step 1: Find every caller that assumes the old shape**
+
+Run and read the output — do not skip this, it decides what else this task
+touches:
+
+```bash
+cd /work/surogates
+grep -rn "browser_get_state" --include=*.py --include=*.md --include=*.ts \
+  . /work/surogate-ops/frontend/src | grep -v node_modules | grep -v __pycache__
+```
+
+Any bundled skill or prompt that describes the JSON tree must be updated here.
+
+- [ ] **Step 2: Update the browser guidance prompt**
+
+In `surogates/harness/prompts/guidance/browser.md`, replace the opening
+paragraph with:
+
+```markdown
+Use `browser_get_state` before interacting with a page whenever you need a
+target ref, and refresh refs after navigation, scrolling, modal dismissal, or
+any large page change. It returns a markdown outline: `- role @eN "name"` lines
+are the things you can click and type into.
+
+Reach for `browser_evaluate` instead of repeated scroll-and-restate loops when
+you need data rather than an action — every row of a table, all options of a
+select, a hidden field's value. One evaluate that returns an array beats ten
+snapshots. `browser_get_state` shows at most 500 elements and says so when it
+truncates; scope it with `selector`, or read past the cap with
+`browser_evaluate`.
+```
+
+Leave the cookie-and-consent section unchanged.
+
+- [ ] **Step 3: Update the prune fixtures**
+
+`tests/test_context_prune.py` and `tests/test_context_prune_integration.py`
+build fixtures shaped like real `browser_get_state` output. Pruning is
+format-agnostic, so behaviour does not change, but the fixtures should describe
+reality. Replace the JSON-shaped fixture content with markdown, e.g.:
+
+```python
+def _browser_state_result(n: int) -> str:
+    return (
+        f"# Page {n}\n"
+        f"https://example.com/{n}\n"
+        "viewport 1280x800\n"
+        "\n"
+        "## Results\n"
+        '- button @e1 "Search"\n'
+        '- link @e2 "Next"\n'
+    )
+```
+
+Update the module docstrings that describe the old shape at
+`tests/test_context_prune.py:4` and `tests/test_context_prune_integration.py:7`.
+
+- [ ] **Step 4: Register the new tool in the ops frontend**
+
+In `/work/surogate-ops/frontend/src/features/agents/builtin-tools.ts`, add
+`"browser_evaluate"` to the browser tool list beside `"browser_get_state"` on
+line 27, so the tool appears in the agent tool picker.
+
+- [ ] **Step 5: Run the whole affected suite**
+
+```bash
+cd /work/surogates
+python -m pytest tests/test_browser_serialize.py tests/test_browser_tools.py \
+  tests/test_browser_client.py tests/test_context_prune.py \
+  tests/test_context_prune_integration.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full test suite to catch anything this missed**
+
+```bash
+cd /work/surogates
+python -m pytest tests/ -x -q
+```
+
+Expected: PASS. If an unrelated test fails, check whether it predates this
+branch (`git stash && python -m pytest <test> -q`) before debugging it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /work/surogates
+git add surogates/harness/prompts/guidance/browser.md tests/test_context_prune.py \
+        tests/test_context_prune_integration.py
+git commit -m "docs(browser): teach the guidance prompt markdown state and evaluate"
+```
+
+The frontend file is in a different repo — commit it separately on its own
+branch there:
+
+```bash
+cd /work/surogate-ops
+git checkout -b feat/browser-evaluate-tool
+git add frontend/src/features/agents/builtin-tools.ts
+git commit -m "feat(agents): expose browser_evaluate in the tool picker"
+```
+
+---
+
+## Verification
+
+Before opening a PR:
+
+- [ ] `cd /work/surogates && python -m pytest tests/ -q` passes.
+- [ ] `grep -rn "compact" surogates/browser/client.py surogates/tools/builtin/browser.py` returns nothing — the parameter is gone, not deprecated.
+- [ ] `grep -rn "own_text" surogates/` returns nothing — the superseded field name never entered the code.
+- [ ] A manual smoke test against a real page, since the in-page derivation cannot be unit tested: point a session's browser at a content-heavy page (a shop listing or news article), call `browser_get_state`, and confirm prices and sentences read as whole lines rather than fragments, with no run of text appearing twice. This is the check the spec's `display`-based risk calls for.
+- [ ] Confirm the audit trail is real, not assumed — the spec's security posture depends on it. After a `browser_evaluate` call in a live session, query the event log and confirm the complete JS source is present and readable:
+
+  ```sql
+  SELECT jsonb_pretty(data) FROM events
+  WHERE session_id = '<sid>' AND type = 'tool.call'
+    AND data->>'name' = 'browser_evaluate' ORDER BY id DESC LIMIT 1;
+  ```
+
+  If the source is absent or truncated, the "unrestricted execution with full audit" posture does not hold and needs fixing before merge.

--- a/docs/superpowers/specs/2026-07-28-browser-state-grounding-design.md
+++ b/docs/superpowers/specs/2026-07-28-browser-state-grounding-design.md
@@ -1,0 +1,288 @@
+# Browser state grounding: `browser_evaluate` and markdown page state
+
+**Date:** 2026-07-28
+**Status:** Design
+**Repo:** `surogates`
+
+## Motivation
+
+[StateAct (arXiv:2607.22798)](https://arxiv.org/html/2607.22798v1) argues that
+computer-use agents should read program state directly instead of perceiving
+rendered pixels. Its web component "navigates, executes JavaScript, serializes
+the DOM to markdown, and clicks by CSS selector, grounding it in structured
+state rather than a screenshot."
+
+Our browser stack already follows the principle. `browser_get_state` derives a
+role/name tree from the live DOM (`surogates/browser/client.py`), refs are
+pinned to CDP backend node ids with a role/name/nth healing fallback, and
+`browser_screenshot` deliberately does not inject the image into context. The
+headline benefit the paper reports over screenshot-driven agents is already
+banked.
+
+Two gaps remain against that description:
+
+1. **No JavaScript execution.** The agent has ten fixed verbs and no way to read
+   structured page state. Reading a long table, a hidden input's value, a
+   `<select>`'s full option list, or data the page already fetched is either
+   impossible or costs many `scroll` + `get_state` round trips.
+
+2. **Page state is a JSON firehose, not markdown.** The snapshot keeps every
+   visible element from `querySelectorAll('*')`, and `nameOf` falls back to
+   `innerText`/`textContent`, so each ancestor container re-emits its subtree's
+   text. Page text is serialized roughly once per level of nesting. There is no
+   node cap, and `interactive_only` / `compact` default to `False` with no
+   `description` in the schema, so the model has no signal to narrow the
+   request.
+
+Historical bloat is already handled: `_SUPERSEDED_STATE_TOOLS` in
+`surogates/harness/context.py` collapses every superseded `browser_get_state`
+result to a placeholder. What is unaddressed is the **live** snapshot, which
+stays in context and is re-paid on the wire at every call.
+
+## Scope
+
+**In scope**
+
+- `browser_evaluate`: run JavaScript in the page and return its value.
+- `browser_get_state`: markdown output by default, JSON opt-in, text
+  deduplicated at the source, hard node cap, documented parameters.
+
+**Out of scope — and why**
+
+A dedicated web subagent (the paper's third component) was designed and
+rejected. `ask_user_question` is on `_DELEGATION_ALWAYS_BLOCKED_TOOLS` in
+`surogates/tools/builtin/delegate.py`, because a child session has no surface
+for human input. Browser work is precisely where mid-task human input is
+needed: expired logins, 2FA, CAPTCHAs, disambiguating results. Take-control
+compounds it — `surogates/browser/control.py` keys the control flag by
+`session_id` and every `browser_*` call returns `paused_by_user` while a user
+holds it, so a delegated child would be paused on the parent's flag with no way
+to ask the user anything and no option but to burn its iteration budget. The
+paper scores **0.0% binary success on human-in-the-loop tasks**, its worst
+category; routing our flakiest subsystem through the one context that cannot
+talk to the user would import that failure mode.
+
+The context saving that would justify the machinery is also largely
+pre-empted: history is already pruned, screenshots never enter context, and
+the two changes in this spec shrink the live snapshot and reduce how often it
+is fetched.
+
+**Revisit criteria.** After these changes ship, sample real browser sessions and
+measure what share of main-loop context browser turns still occupy. If it
+remains dominant, design delegation deliberately — including a human-handoff
+path — against that number.
+
+## Change 1: `browser_evaluate`
+
+### Tool surface
+
+Registered in `surogates/tools/builtin/browser.py` under `toolset="browser"`,
+with one parameter:
+
+| Param  | Type   | Required | Meaning |
+| ------ | ------ | -------- | ------- |
+| `code` | string | yes      | JavaScript **function body** evaluated in page context. Must `return` a JSON-serializable value. |
+
+Description text must state three things the model will otherwise get wrong:
+the code runs in page context (so `document` and `window` are available, but
+Playwright's `page` is not), it must `return` its result, and the return value
+must be JSON-serializable (DOM nodes are not — return their properties).
+
+`timeout` is deliberately not exposed. `_playwright_execute` already defaults to
+60s, which is the same budget every other browser tool gets.
+
+### Implementation
+
+New `KernelBrowserClient.evaluate(code)` wrapping the existing
+`_playwright_execute` transport — the same path every browser operation already
+uses. The agent's body is embedded in an async page-context callback:
+
+```
+const __result = await page.evaluate(async () => {
+<code>
+});
+return __result;
+```
+
+Raw interpolation is correct here: the payload *is* code, and it is a function
+body with no surrounding literal to break out of. `await` works because the
+callback is async.
+
+**Snapshot cache invalidation.** `_invalidate_snapshot_cache()` runs after every
+evaluate, matching `navigate`. JavaScript can mutate the DOM, and a stale `@eN`
+ref that resolves to a moved or replaced element is worse than a missing one —
+`click_ref` would silently act on the wrong node.
+
+**Result cap.** The serialized result is truncated at **20 000 characters** with
+an explicit marker naming the original size, so a `document.body.innerHTML`
+return cannot blow the context. The value matches `expert_loop.py`'s
+`_MAX_TOOL_RESULT_CHARS`, which caps tool results for the same reason; the
+constant lives beside the other browser constants.
+
+**Errors.** `_playwright_execute` raises `RuntimeError` when the kernel envelope
+reports failure. The handler catches it and returns
+`{"error": "evaluate_failed", "detail": ...}`, matching the shape
+`_browser_get_state_handler` already returns for `get_state_failed`. A syntax
+error or a thrown exception in the agent's JS therefore surfaces as a readable
+tool result rather than an exception in the harness.
+
+### Routing and governance
+
+`browser_evaluate` must be added to `TOOL_LOCATIONS` in
+`surogates/tools/router.py` as `ToolLocation.HARNESS`, with a routing
+regression test. Unlisted tools default to the sandbox executor and fail as
+"Unknown tool".
+
+Security posture is **unrestricted execution with full audit**. No pattern
+restrictions: static blocklists for exfil-shaped JS are defeated by trivial
+string concatenation while blocking legitimate same-site `fetch`. The tool is
+governed at the allowlist level like any other, and the complete source lands
+in the tool-call event and passes through `TransparencyInterceptor`.
+
+The trust argument: enabling the browser toolset already grants the agent the
+user's live authenticated browser. `browser_click` and `browser_type` can
+already reach anything the user can reach. JavaScript makes that reach more
+convenient, not broader.
+
+## Change 2: markdown page state
+
+### New module
+
+`surogates/browser/serialize.py` — a pure function from snapshot nodes to
+markdown. No I/O, independently testable, and it keeps `client.py` (996 lines)
+from absorbing more. `get_state` calls it; nothing else changes in the request
+path.
+
+### Output format
+
+`get_state` gains `format`: `"markdown"` (default) or `"json"`. JSON returns
+today's structure so anything needing coordinates keeps working.
+
+Markdown output is returned as a **raw string**, not wrapped in a JSON envelope
+— JSON-escaping a markdown blob adds a backslash per newline for no benefit.
+Errors remain JSON objects, consistent with the existing error shape.
+
+```
+# Booking.com — search results
+https://booking.com/searchresults?dest=bucharest
+viewport 1280x800
+
+## Filters
+- checkbox @e42 "Free cancellation"
+- checkbox @e43 "Breakfast included"
+
+## 1,204 properties found
+### Hotel Cismigiu
+£128 per night · 8.4 Very good
+- link @e88 "See availability"
+
+[truncated: 180 of 1204 nodes shown — narrow with selector, or read the rest
+with browser_evaluate]
+```
+
+Rules:
+
+- Header: title, url, viewport.
+- Heading roles become markdown headings, level clamped to 2–6.
+- Interactive nodes (`_INTERACTIVE_ROLES`) render as `- {role} @{ref} "{name}"`.
+- Other nodes contribute a plain text line when they own text.
+- Document order throughout — the same order that assigns `@eN` refs, so refs
+  read in ascending order.
+- No indentation. Structure comes from headings; indenting by raw DOM depth is
+  noise, since real pages nest 20+ levels.
+
+`intent: accept_consent` nodes keep their existing priority ordering so consent
+banners stay at the top, matching the guidance in
+`surogates/harness/prompts/guidance/browser.md`.
+
+### Text deduplication
+
+Fixed at the source rather than guessed at in the serializer. The injected
+snapshot script gains an `own_text` field per node: the concatenation of the
+element's **direct child text nodes** only, trimmed and length-capped.
+`nameOf` is left untouched.
+
+The serializer then uses `name` for interactive nodes (where `aria-label`,
+`placeholder`, and `value` are what identify the control) and `own_text` for
+everything else, emitting a text line only when `own_text` is non-empty. A
+container div that merely wraps its children owns no text and contributes
+nothing. Duplication is eliminated by construction rather than by a
+heuristic — a serializer-side rule cannot work reliably, because
+`querySelectorAll('*')` returns document order, so the ancestor carrying the
+whole page's text is always seen before the descendants that own it.
+
+`own_text` is additive to the JSON format: a new field, no removals.
+
+### Node cap
+
+A cap of **500 emitted nodes**, with a truncation line naming how many of how
+many were shown and pointing at the two ways to get the rest. 500 keeps a dense
+search-results page readable while bounding the result at a few thousand tokens;
+it is a constant, tunable in one place once we see real pages.
+
+The cap is not a parameter. `browser_evaluate` is now the escape hatch for
+reading past it, and it is a better one — an agent that needs all 1 204 results
+should extract them in a single call, not re-request a larger tree.
+
+### Parameter changes
+
+- `format` — new, described above.
+- `interactive_only` — keep, applies to both formats, gains a description.
+- `max_depth` — keep, applies to both formats, gains a description.
+- `selector` — keep unchanged, gains a description. It scopes the snapshot to a
+  subtree and is the primary way to stay under the node cap on a large page.
+- `compact` — **delete**. It dropped unnamed non-interactive nodes, which
+  `own_text` now does by construction in markdown and more precisely. Keeping
+  it would leave two overlapping ways to express one intent.
+
+The schema currently has no `description` on any property. All surviving
+parameters get one.
+
+### What does not change
+
+Ref semantics are untouched. `@eN` refs come from the same snapshot pass in the
+same order, the cache is populated identically, and `click_ref` / `type_into_ref`
+resolve exactly as before. Markdown is a rendering of the tree, not a new
+addressing scheme. `_SUPERSEDED_STATE_TOOLS` pruning continues to work — it
+operates on string content and does not inspect the format.
+
+## Testing
+
+**`serialize.py` unit tests** (pure, no fixtures): heading nesting and clamping;
+interactive line rendering; `own_text` emission and the container-owns-nothing
+case; consent-intent ordering; node cap and truncation line; empty page; nodes
+with missing or malformed fields.
+
+**`browser_evaluate` handler tests**, following the existing
+`TestGetStateHandler` pattern in `tests/test_browser_tools.py` with
+`_client_factory` fakes: successful value return; `evaluate_failed` on a
+client `RuntimeError`; result truncation past the cap; snapshot cache cleared
+after a call; `paused_by_user` when the control store reports user control.
+
+**Routing regression:** `browser_evaluate` resolves to `ToolLocation.HARNESS`.
+
+**`get_state` format tests:** markdown by default; `format="json"` byte-identical
+to today's tree; `own_text` present in JSON output.
+
+**Fixture updates:** `tests/test_context_prune.py` and
+`tests/test_context_prune_integration.py` build fixtures shaped like the real
+`browser_get_state` result. Pruning is format-agnostic, but the fixtures should
+be updated to markdown so they keep describing reality.
+
+## Risks
+
+**Markdown default is a behavior change for live agents.** Any agent prompt or
+skill that assumes a JSON tree from `browser_get_state` will see markdown. The
+built-in guidance file needs updating in the same change. Bundled skills that
+mention the tool should be grepped before merge.
+
+**`browser_evaluate` widens what a compromised or confused agent can do in one
+call.** Not the blast radius — click and type already reach the same origins —
+but the ease. The audit trail is the mitigation, and it only works if the JS
+source is genuinely readable in the event log; verify that end to end rather
+than assuming it.
+
+**The node cap can hide relevant content.** Truncation is explicit and names the
+escape hatch, but an agent that ignores the notice will reason over a partial
+page. This is strictly better than today, where large pages are fully serialized
+at ruinous cost, but it is a new failure mode to watch for.

--- a/docs/superpowers/specs/2026-07-28-browser-state-grounding-design.md
+++ b/docs/superpowers/specs/2026-07-28-browser-state-grounding-design.md
@@ -236,7 +236,15 @@ The test is cheap. The snapshot script already calls
 `window.getComputedStyle(el)` per element for its visibility check, so the
 `display` lookup rides on a call we are already paying for.
 
-`text_block` is additive to the JSON format: a new field, no removals.
+### Heading levels
+
+`roleOf` currently collapses `h1`–`h6` to a single `heading` role, discarding the
+level, so headings cannot nest. The snapshot script gains a second field,
+`heading_level` (1–6, from the tag name, falling back to `aria-level`), set only
+on heading nodes.
+
+Both `text_block` and `heading_level` are additive to the JSON format: two new
+fields, no removals.
 
 ### Node cap
 
@@ -295,8 +303,9 @@ after a call; `paused_by_user` when the control store reports user control.
 
 **Routing regression:** `browser_evaluate` resolves to `ToolLocation.HARNESS`.
 
-**`get_state` format tests:** markdown by default; `format="json"` byte-identical
-to today's tree; `text_block` present in JSON output.
+**`get_state` format tests:** markdown by default; `format="json"` returns
+today's structure with the two new fields added and every existing key and the
+node ordering unchanged.
 
 **Fixture updates:** `tests/test_context_prune.py` and
 `tests/test_context_prune_integration.py` build fixtures shaped like the real

--- a/docs/superpowers/specs/2026-07-28-browser-state-grounding-design.md
+++ b/docs/superpowers/specs/2026-07-28-browser-state-grounding-design.md
@@ -209,11 +209,24 @@ from a **text-block** test:
 > A node is a text block when its subtree contains no interactive element and
 > no block-level element — that is, its content is pure inline markup.
 
-- Text blocks carry their full `innerText`, correctly ordered.
-- Non-text-block nodes carry an empty `text_block`; their content belongs to
-  their text-block descendants.
+- Text blocks carry their full `innerText`, correctly ordered. When one fires,
+  its whole subtree is marked covered so nested pure-inline elements stay
+  silent — the shallowest text block wins. Without this,
+  `<div><span>£</span><span>128</span></div>` emits three times: the div is a
+  text block and so is each span.
+- Non-text-block nodes carry only their **direct child text runs** — the text
+  that belongs to no descendant element. Without this branch,
+  `<p>Read our <a>privacy policy</a> for details</p>` loses `Read our` and
+  `for details`: the `<p>` is not a text block because it holds an interactive
+  descendant, and bare text nodes are never returned by
+  `querySelectorAll('*')`.
 - `nameOf` is left untouched, and interactive nodes keep using `name` — for a
   control, `aria-label` / `placeholder` / `value` are what identify it.
+
+The two branches are complementary and jointly exhaustive: every text node is
+emitted exactly once, either inside the `innerText` of its shallowest
+text-block ancestor, or as a direct-child run of its nearest non-text-block
+ancestor.
 
 The serializer emits a text line only when `text_block` is non-empty, so a
 container div that merely wraps its children contributes nothing. Text is
@@ -228,9 +241,8 @@ comprehension problem.
 
 `<p>Read our <a href="…">privacy policy</a> for details</p>` still splits, but
 along the right seam: the `<a>` is interactive, so the paragraph is not a text
-block, and the two inline runs around the link each become their own text block.
-The link renders as a separately addressable control, which is what the agent
-needs.
+block and contributes its own text runs, while the link renders as a separately
+addressable control — which is what the agent needs.
 
 The test is cheap. The snapshot script already calls
 `window.getComputedStyle(el)` per element for its visibility check, so the

--- a/docs/superpowers/specs/2026-07-28-browser-state-grounding-design.md
+++ b/docs/superpowers/specs/2026-07-28-browser-state-grounding-design.md
@@ -115,9 +115,10 @@ ref that resolves to a moved or replaced element is worse than a missing one —
 
 **Result cap.** The serialized result is truncated at **20 000 characters** with
 an explicit marker naming the original size, so a `document.body.innerHTML`
-return cannot blow the context. The value matches `expert_loop.py`'s
-`_MAX_TOOL_RESULT_CHARS`, which caps tool results for the same reason; the
-constant lives beside the other browser constants.
+return cannot blow the context. The value matches
+`surogates/tools/builtin/expert_loop.py`'s `_MAX_TOOL_RESULT_CHARS`, which caps
+tool results for the same reason; the constant lives beside the other browser
+constants.
 
 **Errors.** `_playwright_execute` raises `RuntimeError` when the kernel envelope
 reports failure. The handler catches it and returns
@@ -149,7 +150,7 @@ convenient, not broader.
 ### New module
 
 `surogates/browser/serialize.py` — a pure function from snapshot nodes to
-markdown. No I/O, independently testable, and it keeps `client.py` (996 lines)
+markdown. No I/O, independently testable, and it keeps `client.py` (796 lines)
 from absorbing more. `get_state` calls it; nothing else changes in the request
 path.
 
@@ -185,7 +186,7 @@ Rules:
 - Header: title, url, viewport.
 - Heading roles become markdown headings, level clamped to 2–6.
 - Interactive nodes (`_INTERACTIVE_ROLES`) render as `- {role} @{ref} "{name}"`.
-- Other nodes contribute a plain text line when they own text.
+- Other nodes contribute a plain text line when they are a text block (below).
 - Document order throughout — the same order that assigns `@eN` refs, so refs
   read in ascending order.
 - No indentation. Structure comes from headings; indenting by raw DOM depth is
@@ -197,21 +198,45 @@ banners stay at the top, matching the guidance in
 
 ### Text deduplication
 
-Fixed at the source rather than guessed at in the serializer. The injected
-snapshot script gains an `own_text` field per node: the concatenation of the
-element's **direct child text nodes** only, trimmed and length-capped.
-`nameOf` is left untouched.
+Fixed at the source rather than guessed at in the serializer. A serializer-side
+rule cannot work reliably: `querySelectorAll('*')` returns document order, so
+the ancestor carrying the whole page's text is always seen *before* the
+descendants that own it, leaving nothing to deduplicate against.
 
-The serializer then uses `name` for interactive nodes (where `aria-label`,
-`placeholder`, and `value` are what identify the control) and `own_text` for
-everything else, emitting a text line only when `own_text` is non-empty. A
-container div that merely wraps its children owns no text and contributes
-nothing. Duplication is eliminated by construction rather than by a
-heuristic — a serializer-side rule cannot work reliably, because
-`querySelectorAll('*')` returns document order, so the ancestor carrying the
-whole page's text is always seen before the descendants that own it.
+The injected snapshot script gains one field per node, `text_block`, derived
+from a **text-block** test:
 
-`own_text` is additive to the JSON format: a new field, no removals.
+> A node is a text block when its subtree contains no interactive element and
+> no block-level element — that is, its content is pure inline markup.
+
+- Text blocks carry their full `innerText`, correctly ordered.
+- Non-text-block nodes carry an empty `text_block`; their content belongs to
+  their text-block descendants.
+- `nameOf` is left untouched, and interactive nodes keep using `name` — for a
+  control, `aria-label` / `placeholder` / `value` are what identify it.
+
+The serializer emits a text line only when `text_block` is non-empty, so a
+container div that merely wraps its children contributes nothing. Text is
+emitted exactly once, at the deepest node owning a coherent run.
+
+Choosing the text block as the unit — rather than an element's direct child text
+nodes — is what keeps sentences intact. Direct-child-text-nodes would make
+`<div class="price"><span>£</span><span>128</span></div>` serialize as `£` and
+`128` on separate lines, and mixed inline markup is the common case on content
+pages, not an edge case. Fragmenting it would trade a token problem for a
+comprehension problem.
+
+`<p>Read our <a href="…">privacy policy</a> for details</p>` still splits, but
+along the right seam: the `<a>` is interactive, so the paragraph is not a text
+block, and the two inline runs around the link each become their own text block.
+The link renders as a separately addressable control, which is what the agent
+needs.
+
+The test is cheap. The snapshot script already calls
+`window.getComputedStyle(el)` per element for its visibility check, so the
+`display` lookup rides on a call we are already paying for.
+
+`text_block` is additive to the JSON format: a new field, no removals.
 
 ### Node cap
 
@@ -232,7 +257,7 @@ should extract them in a single call, not re-request a larger tree.
 - `selector` — keep unchanged, gains a description. It scopes the snapshot to a
   subtree and is the primary way to stay under the node cap on a large page.
 - `compact` — **delete**. It dropped unnamed non-interactive nodes, which
-  `own_text` now does by construction in markdown and more precisely. Keeping
+  `text_block` now does by construction in markdown and more precisely. Keeping
   it would leave two overlapping ways to express one intent.
 
 The schema currently has no `description` on any property. All surviving
@@ -249,9 +274,18 @@ operates on string content and does not inspect the format.
 ## Testing
 
 **`serialize.py` unit tests** (pure, no fixtures): heading nesting and clamping;
-interactive line rendering; `own_text` emission and the container-owns-nothing
-case; consent-intent ordering; node cap and truncation line; empty page; nodes
-with missing or malformed fields.
+interactive line rendering; `text_block` emission and the
+container-owns-nothing case; consent-intent ordering; node cap and truncation
+line; empty page; nodes with missing or malformed fields.
+
+**Text-block derivation tests** against the two cases that motivated the rule:
+`<div class="price"><span>£</span><span>128</span></div>` yields the single line
+`£128`, not two fragments; and `<p>Read our <a>privacy policy</a> for
+details</p>` yields the surrounding inline runs as text plus the link as its own
+control line. These assert the in-page derivation, so they need a DOM — either
+the integration suite (`tests/integration/test_browser_e2e.py`) or a fake whose
+nodes carry pre-derived `text_block` values, depending on how much of the
+injected script we are willing to exercise in unit tests.
 
 **`browser_evaluate` handler tests**, following the existing
 `TestGetStateHandler` pattern in `tests/test_browser_tools.py` with
@@ -262,7 +296,7 @@ after a call; `paused_by_user` when the control store reports user control.
 **Routing regression:** `browser_evaluate` resolves to `ToolLocation.HARNESS`.
 
 **`get_state` format tests:** markdown by default; `format="json"` byte-identical
-to today's tree; `own_text` present in JSON output.
+to today's tree; `text_block` present in JSON output.
 
 **Fixture updates:** `tests/test_context_prune.py` and
 `tests/test_context_prune_integration.py` build fixtures shaped like the real
@@ -286,3 +320,11 @@ than assuming it.
 escape hatch, but an agent that ignores the notice will reason over a partial
 page. This is strictly better than today, where large pages are fully serialized
 at ruinous cost, but it is a new failure mode to watch for.
+
+**The text-block test rests on computed `display`.** Sites that restyle block
+elements as inline, or build layout entirely from `display: contents`, can push
+a text block boundary higher or lower than the visual structure suggests —
+merging two visually separate runs onto one line, or splitting one. Text is
+still emitted exactly once either way, so this degrades readability rather than
+correctness. Worth checking against a few real pages during implementation
+rather than reasoning about in the abstract.

--- a/sdk/agent-chat-react/src/components/browser/browser-activity-group.tsx
+++ b/sdk/agent-chat-react/src/components/browser/browser-activity-group.tsx
@@ -40,6 +40,7 @@ function summarize(call: ToolCallInfo): string {
 const ACTION_SUMMARIES: Record<string, (args: Record<string, unknown>) => string> = {
   browser_navigate: (args) => `navigate to ${stringValue(args.url) || "?"}`,
   browser_get_state: () => "get state",
+  browser_evaluate: () => "run script",
   browser_close: () => "close",
   browser_click: (args) => {
     const ref = stringValue(args.ref);

--- a/surogates/browser/client.py
+++ b/surogates/browser/client.py
@@ -171,7 +171,13 @@ for (const el of __els) {
   el.setAttribute('data-sg-i', String(out.length));
   const role = roleOf(el);
   let textBlock = '';
-  if (covered.has(el)) {
+  if (__INTERACTIVE.has(role)) {
+    // Text inside a control belongs to the control: nameOf already carries it
+    // into the "- role @eN name" line.  Cover the subtree so a block-level
+    // child (<a><div>Label</div></a>, ubiquitous in nav menus and card links)
+    // cannot emit the same label a second time as a stray text line.
+    for (const d of Array.from(el.querySelectorAll('*'))) covered.add(d);
+  } else if (covered.has(el)) {
     // An ancestor text block already emitted this element's text.
     textBlock = '';
   } else if (isTextBlock(el)) {

--- a/surogates/browser/client.py
+++ b/surogates/browser/client.py
@@ -309,7 +309,6 @@ return {
         self,
         *,
         interactive_only: bool = False,
-        compact: bool = False,
         max_depth: int | None = None,
         selector: str | None = None,
     ) -> dict[str, Any]:
@@ -324,7 +323,6 @@ return {
             if self._state_entry_visible(
                 entry,
                 interactive_only=interactive_only,
-                compact=compact,
                 max_depth=max_depth,
             )
         ]
@@ -754,13 +752,10 @@ return true;
         entry: dict[str, Any],
         *,
         interactive_only: bool,
-        compact: bool,
         max_depth: int | None,
     ) -> bool:
         role = str(entry.get("role", ""))
         if interactive_only and role not in self._INTERACTIVE_ROLES:
-            return False
-        if compact and not entry.get("name") and role not in self._INTERACTIVE_ROLES:
             return False
         if entry.get("intent") == "accept_consent":
             return True

--- a/surogates/browser/client.py
+++ b/surogates/browser/client.py
@@ -111,17 +111,77 @@ function depthOf(el) {
   return d;
 }
 
+function isBlockLevel(el) {
+  // Reads the precomputed __style map -- getComputedStyle here would run once
+  // per scanned descendant and force layout each time.
+  const s = __style.get(el);
+  const d = s ? s.display : 'block';
+  return d !== 'inline' && d !== 'inline-block' && d !== 'contents' && d !== 'none';
+}
+
+const __INTERACTIVE = new Set(['button','link','textbox','combobox','checkbox',
+  'radio','menuitem','tab','switch','searchbox','slider','spinbutton']);
+
+function isTextBlock(el) {
+  // A text block is an element whose subtree holds no interactive element and
+  // no block-level element -- i.e. pure inline markup, so its innerText reads
+  // as one coherent run.
+  for (const child of Array.from(el.querySelectorAll('*'))) {
+    if (__INTERACTIVE.has(roleOf(child))) return false;
+    if (isBlockLevel(child)) return false;
+  }
+  return true;
+}
+
+function ownTextOf(el) {
+  // Text nodes that are direct children of el, i.e. the runs that belong to no
+  // descendant element.  Used for elements that are NOT text blocks: their
+  // descendants' text is emitted separately, but these loose runs would
+  // otherwise be lost, since querySelectorAll('*') returns elements only.
+  let out = '';
+  for (const node of Array.from(el.childNodes)) {
+    if (node.nodeType === 3) out += node.nodeValue;
+  }
+  return out;
+}
+
+function headingLevelOf(el) {
+  const tag = el.tagName.toLowerCase();
+  if (/^h[1-6]$/.test(tag)) return Number(tag.slice(1));
+  const aria = Number(el.getAttribute('aria-level'));
+  return Number.isFinite(aria) && aria > 0 ? aria : 2;
+}
+
+function clean(s) {
+  return String(s || '').replace(/\\s+/g, ' ').trim().slice(0, 2000);
+}
+
 const out = [];
 const root = selector === null ? document : document.querySelector(selector);
 if (!root) throw new Error('selector matched no element');
-for (const el of Array.from(root.querySelectorAll('*'))) {
-  const style = window.getComputedStyle(el);
+const covered = new Set();
+const __els = Array.from(root.querySelectorAll('*'));
+const __style = new Map();
+for (const el of __els) __style.set(el, window.getComputedStyle(el));
+for (const el of __els) {
+  const style = __style.get(el);
   if (style.visibility === 'hidden' || style.display === 'none') continue;
   const bbox = el.getBoundingClientRect();
   if (!bbox || bbox.width <= 0 || bbox.height <= 0) continue;
   el.setAttribute('data-sg-i', String(out.length));
-  out.push({
-    role: roleOf(el),
+  const role = roleOf(el);
+  let textBlock = '';
+  if (covered.has(el)) {
+    // An ancestor text block already emitted this element's text.
+    textBlock = '';
+  } else if (isTextBlock(el)) {
+    textBlock = clean(el.innerText || el.textContent);
+    for (const d of Array.from(el.querySelectorAll('*'))) covered.add(d);
+  } else {
+    textBlock = clean(ownTextOf(el));
+  }
+  const entry = {
+    role: role,
     name: nameOf(el),
     x: Math.round(bbox.x),
     y: Math.round(bbox.y),
@@ -130,7 +190,10 @@ for (const el of Array.from(root.querySelectorAll('*'))) {
     depth: depthOf(el),
     children_count: el.children ? el.children.length : 0,
     idx: out.length,
-  });
+    text_block: textBlock,
+  };
+  if (role === 'heading') entry.heading_level = headingLevelOf(el);
+  out.push(entry);
 }
 return {
   viewport: {width: window.innerWidth, height: window.innerHeight},
@@ -667,6 +730,10 @@ return true;
             depth = node.get("depth")
             if depth is not None:
                 entry["depth"] = int(depth)
+            entry["text_block"] = str(node.get("text_block") or "")
+            heading_level = node.get("heading_level")
+            if heading_level is not None:
+                entry["heading_level"] = int(heading_level)
             tree.append(entry)
             cache_entry: dict[str, Any] = {
                 "x": center_x,

--- a/surogates/browser/client.py
+++ b/surogates/browser/client.py
@@ -259,6 +259,30 @@ return {
         self._invalidate_snapshot_cache()
         return result
 
+    async def evaluate(self, code: str) -> Any:
+        """Run agent-supplied JavaScript in page context and return its value.
+
+        *code* is a function **body**, not an expression: it must ``return`` a
+        JSON-serializable value.  Raw interpolation is correct here -- the
+        payload is code, and it sits in a function body with no surrounding
+        literal to escape from.  The callback is ``async`` so the body may
+        ``await``.
+
+        The snapshot cache is cleared afterwards: JavaScript can move or replace
+        elements, and a stale ``@eN`` that resolves to the wrong node is worse
+        than one that fails to resolve.
+        """
+
+        wrapped = (
+            "const __result = await page.evaluate(async () => {\n"
+            f"{code}\n"
+            "});\n"
+            "return __result;"
+        )
+        result = await self._playwright_execute(wrapped)
+        self._invalidate_snapshot_cache()
+        return result
+
     async def storage_state(self) -> dict[str, Any]:
         """Export the live context's cookies + per-origin localStorage."""
 

--- a/surogates/browser/serialize.py
+++ b/surogates/browser/serialize.py
@@ -1,0 +1,104 @@
+"""Markdown rendering of a browser page snapshot.
+
+The page tree from ``KernelBrowserClient.get_state`` is a flat, document-ordered
+node list.  This module renders it as markdown: interactive nodes become
+addressable ``@eN`` lines, text blocks become plain lines, and heading roles
+provide the structure.  Pure -- no I/O, no client, no page access -- so it is
+testable in isolation and cannot fail on a slow page.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Interactive roles get a ``- role @eN "name"`` line whether or not they own
+# text.  Mirrors ``KernelBrowserClient._INTERACTIVE_ROLES``; kept as a separate
+# constant so the serializer does not import the HTTP client.
+INTERACTIVE_ROLES: frozenset[str] = frozenset({
+    "button",
+    "link",
+    "textbox",
+    "combobox",
+    "checkbox",
+    "radio",
+    "menuitem",
+    "tab",
+    "switch",
+    "searchbox",
+    "slider",
+    "spinbutton",
+})
+
+# Cap on emitted nodes.  Deliberately not a tool parameter: ``browser_evaluate``
+# is the escape hatch for reading past it, and extracting 1200 rows in one call
+# beats re-requesting a bigger tree.
+MAX_MARKDOWN_NODES: int = 500
+
+_MIN_HEADING_LEVEL: int = 2
+_MAX_HEADING_LEVEL: int = 6
+
+
+def render_markdown(state: dict[str, Any]) -> str:
+    """Render a ``get_state`` result as markdown."""
+
+    viewport = state.get("viewport") or {}
+    lines: list[str] = [
+        f"# {state.get('title', '')}",
+        str(state.get("url", "")),
+        f"viewport {int(viewport.get('width', 0))}x{int(viewport.get('height', 0))}",
+        "",
+    ]
+
+    tree = state.get("tree") or []
+    emitted = 0
+    capped = False
+    for entry in tree:
+        if emitted >= MAX_MARKDOWN_NODES:
+            capped = True
+            break
+        line = _render_entry(entry)
+        if line is None:
+            continue
+        lines.append(line)
+        emitted += 1
+
+    if not emitted:
+        lines.append("(no visible elements)")
+    elif capped:
+        # Gated on ``capped`` rather than ``len(tree) > emitted``: nodes that
+        # render silently (spans covered by an ancestor text block, containers
+        # owning no text) make ``emitted`` fall short of ``len(tree)`` on
+        # virtually every real page, and a length comparison would append a
+        # truncation notice when nothing was actually cut.
+        lines.append("")
+        lines.append(
+            f"[truncated: {emitted} of {len(tree)} nodes shown — narrow with "
+            f"selector, or read the rest with browser_evaluate]"
+        )
+
+    return "\n".join(lines)
+
+
+def _render_entry(entry: dict[str, Any]) -> str | None:
+    """Return the markdown line for one node, or ``None`` to skip it."""
+
+    role = str(entry.get("role", ""))
+    if role == "heading":
+        text = str(entry.get("text_block") or "").strip()
+        if not text:
+            return None
+        return f"{'#' * _heading_level(entry)} {text}"
+
+    if role in INTERACTIVE_ROLES:
+        return f'- {role} {entry.get("ref", "")} "{entry.get("name", "")}"'
+
+    text = str(entry.get("text_block") or "").strip()
+    return text or None
+
+
+def _heading_level(entry: dict[str, Any]) -> int:
+    try:
+        level = int(entry.get("heading_level", _MIN_HEADING_LEVEL))
+    except (TypeError, ValueError):
+        level = _MIN_HEADING_LEVEL
+    return max(_MIN_HEADING_LEVEL, min(_MAX_HEADING_LEVEL, level))

--- a/surogates/harness/prompts/guidance/browser.md
+++ b/surogates/harness/prompts/guidance/browser.md
@@ -7,7 +7,15 @@ applies_when: any browser_* tool loaded
 
 Use `browser_get_state` before interacting with a page whenever you need a
 target ref, and refresh refs after navigation, scrolling, modal dismissal, or
-any large page change.
+any large page change. It returns a markdown outline: `- role @eN "name"` lines
+are the things you can click and type into.
+
+Reach for `browser_evaluate` instead of repeated scroll-and-restate loops when
+you need data rather than an action — every row of a table, all options of a
+select, a hidden field's value. One evaluate that returns an array beats ten
+snapshots. `browser_get_state` shows at most 500 elements and says so when it
+truncates; scope it with `selector`, or read past the cap with
+`browser_evaluate`.
 
 ## Cookie and consent banners
 

--- a/surogates/harness/tool_guardrails.py
+++ b/surogates/harness/tool_guardrails.py
@@ -29,9 +29,10 @@ MUTATING_TOOL_NAMES = frozenset({
     "skill_manage",
     "browser_click",
     "browser_type",
-    "browser_press",
+    "browser_press_key",
     "browser_scroll",
     "browser_navigate",
+    "browser_evaluate",
     "send_message",
     "delegate_task",
 })

--- a/surogates/tools/builtin/browser.py
+++ b/surogates/tools/builtin/browser.py
@@ -376,6 +376,80 @@ async def _browser_get_state_handler(
     return render_markdown(state)
 
 
+# Cap on a single evaluate result.  Matches ``_MAX_TOOL_RESULT_CHARS`` in
+# ``surogates/tools/builtin/expert_loop.py``: a ``document.body.innerHTML``
+# return would otherwise swallow the context window.
+_MAX_EVALUATE_RESULT_CHARS: int = 20_000
+
+EVALUATE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "code": {
+            "type": "string",
+            "description": (
+                "JavaScript function body run inside the page. 'document' and "
+                "'window' are available; Playwright's 'page' is not. You must "
+                "'return' a JSON-serializable value — DOM nodes are not "
+                "serializable, so return their properties instead. 'await' is "
+                "allowed. Example: return [...document.querySelectorAll('tr')]"
+                ".map(r => r.innerText);"
+            ),
+        },
+    },
+    "required": ["code"],
+    "additionalProperties": False,
+}
+
+
+async def _browser_evaluate_handler(
+    arguments: dict[str, Any],
+    *,
+    tenant: Any = None,
+    session_id: UUID | str | None = None,
+    browser_pool: BrowserPool | None = None,
+    browser_control: BrowserControlStore | None = None,
+    _client_factory: Callable[..., Any] = _default_client_factory,
+    workspace_path: str | None = None,
+    session_config: dict[str, Any] | None = None,
+    **_: Any,
+) -> str:
+    code = arguments.get("code")
+    if not code or not str(code).strip():
+        return json.dumps({
+            "error": "missing_code",
+            "detail": "browser_evaluate requires a non-empty 'code' argument.",
+        })
+
+    preflight = await _resolve_session_browser(
+        tenant=tenant,
+        session_id=session_id,
+        browser_pool=browser_pool,
+        browser_control=browser_control,
+        workspace_path=workspace_path,
+        session_config=session_config,
+    )
+    if isinstance(preflight, str):
+        return preflight
+
+    _browser_id, endpoint, snapshot_cache = preflight
+    client = _make_client(_client_factory, endpoint, snapshot_cache)
+    async with client:
+        try:
+            result = await client.evaluate(str(code))
+        except RuntimeError as exc:
+            return json.dumps({"error": "evaluate_failed", "detail": str(exc)})
+
+    serialized = json.dumps(result)
+    if len(serialized) > _MAX_EVALUATE_RESULT_CHARS:
+        kept = serialized[:_MAX_EVALUATE_RESULT_CHARS]
+        return json.dumps({
+            "truncated": True,
+            "original_length": len(serialized),
+            "result": kept,
+        })
+    return serialized
+
+
 CLOSE_SCHEMA = {"type": "object", "properties": {}, "additionalProperties": False}
 
 
@@ -934,6 +1008,21 @@ def register(registry: ToolRegistry) -> None:
             parameters=GET_STATE_SCHEMA,
         ),
         handler=_browser_get_state_handler,
+        toolset="browser",
+    )
+    registry.register(
+        name="browser_evaluate",
+        schema=ToolSchema(
+            name="browser_evaluate",
+            description=(
+                "Run JavaScript in the page and return its value. Use this to "
+                "read structured page state — full tables, hidden input values, "
+                "every option of a select — in one call instead of many "
+                "get_state and scroll round trips."
+            ),
+            parameters=EVALUATE_SCHEMA,
+        ),
+        handler=_browser_evaluate_handler,
         toolset="browser",
     )
     registry.register(

--- a/surogates/tools/builtin/browser.py
+++ b/surogates/tools/builtin/browser.py
@@ -20,6 +20,7 @@ from surogates.browser.base import (
 from surogates.browser.client import KernelBrowserClient
 from surogates.browser.control import BrowserControlStore
 from surogates.browser.pool import BrowserPool
+from surogates.browser.serialize import render_markdown
 
 from surogates.storage.tenant import (
     boundary_workspace_key,
@@ -294,10 +295,43 @@ async def _browser_navigate_handler(
 GET_STATE_SCHEMA = {
     "type": "object",
     "properties": {
-        "interactive_only": {"type": "boolean", "default": False},
-        "compact": {"type": "boolean", "default": False},
-        "max_depth": {"type": "integer", "minimum": 0},
-        "selector": {"type": "string"},
+        "format": {
+            "type": "string",
+            "enum": ["markdown", "json"],
+            "default": "markdown",
+            "description": (
+                "Output shape. 'markdown' (default) is a concise page outline: "
+                "headings for structure, '- role @eN \"name\"' lines for "
+                "clickable elements, plain lines for text. 'json' returns the "
+                "raw node tree with viewport coordinates — only needed when you "
+                "must click by coordinate rather than by ref."
+            ),
+        },
+        "interactive_only": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "Return only clickable and typeable elements, dropping all page "
+                "text. Use when you know what you are looking for and only need "
+                "its ref."
+            ),
+        },
+        "max_depth": {
+            "type": "integer",
+            "minimum": 0,
+            "description": (
+                "Drop elements nested deeper than this in the DOM. Rarely "
+                "useful — prefer 'selector' to scope by region."
+            ),
+        },
+        "selector": {
+            "type": "string",
+            "description": (
+                "CSS selector limiting the snapshot to one subtree, e.g. "
+                "'#search-results'. The best way to keep a large page under the "
+                "node cap."
+            ),
+        },
     },
     "additionalProperties": False,
 }
@@ -332,13 +366,14 @@ async def _browser_get_state_handler(
         try:
             state = await client.get_state(
                 interactive_only=arguments.get("interactive_only", False),
-                compact=arguments.get("compact", False),
                 max_depth=arguments.get("max_depth"),
                 selector=arguments.get("selector"),
             )
         except RuntimeError as exc:
             return json.dumps({"error": "get_state_failed", "detail": str(exc)})
-    return json.dumps(state)
+    if arguments.get("format", "markdown") == "json":
+        return json.dumps(state)
+    return render_markdown(state)
 
 
 CLOSE_SCHEMA = {"type": "object", "properties": {}, "additionalProperties": False}
@@ -892,8 +927,9 @@ def register(registry: ToolRegistry) -> None:
         schema=ToolSchema(
             name="browser_get_state",
             description=(
-                "Return the current page tree with @eN refs for browser_click "
-                "and browser_type."
+                "Return the current page as a markdown outline with @eN refs "
+                "for browser_click and browser_type. Pass format='json' for the "
+                "raw node tree with coordinates."
             ),
             parameters=GET_STATE_SCHEMA,
         ),

--- a/surogates/tools/builtin/coordinator.py
+++ b/surogates/tools/builtin/coordinator.py
@@ -97,6 +97,7 @@ COORDINATOR_IMPLEMENTATION_TOOLS: frozenset[str] = frozenset({
     "browser_click",
     "browser_close",
     "browser_drag",
+    "browser_evaluate",
     "browser_get_state",
     "browser_navigate",
     "browser_press_key",

--- a/surogates/tools/router.py
+++ b/surogates/tools/router.py
@@ -76,6 +76,7 @@ TOOL_LOCATIONS: dict[str, ToolLocation] = {
     # Agent browser (separate resource from workspace sandbox)
     "browser_navigate": ToolLocation.HARNESS,
     "browser_get_state": ToolLocation.HARNESS,
+    "browser_evaluate": ToolLocation.HARNESS,
     "browser_screenshot": ToolLocation.HARNESS,
     "browser_click": ToolLocation.HARNESS,
     "browser_type": ToolLocation.HARNESS,

--- a/tests/test_browser_client.py
+++ b/tests/test_browser_client.py
@@ -1046,3 +1046,36 @@ class TestSnapshotScriptShape:
         assert KernelBrowserClient._SNAPSHOT_SCRIPT.count(
             "window.getComputedStyle"
         ) == 1
+
+
+class TestEvaluate:
+    async def test_wraps_code_in_a_page_evaluate_callback(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        client = KernelBrowserClient("http://browser:30000")
+        sent: list[str] = []
+
+        async def fake_execute(code: str, **kwargs: Any) -> Any:
+            sent.append(code)
+            return {"ok": True}
+
+        client._playwright_execute = fake_execute  # type: ignore[assignment]
+        result = await client.evaluate("return document.title;")
+
+        assert result == {"ok": True}
+        assert "await page.evaluate(async () => {" in sent[0]
+        assert "return document.title;" in sent[0]
+
+    async def test_invalidates_the_snapshot_cache(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        client = KernelBrowserClient("http://browser:30000")
+        client._snapshot_cache["@e1"] = {"x": 1, "y": 2}
+
+        async def fake_execute(code: str, **kwargs: Any) -> Any:
+            return None
+
+        client._playwright_execute = fake_execute  # type: ignore[assignment]
+        await client.evaluate("document.body.innerHTML = '';")
+
+        assert client._snapshot_cache == {}

--- a/tests/test_browser_client.py
+++ b/tests/test_browser_client.py
@@ -964,3 +964,85 @@ class TestScreenshot:
             {"ref": "@e1", "label": 1, "role": "button", "name": "Go"},
             {"ref": "@e2", "label": 2, "role": "link", "name": "Help"},
         ]
+
+
+class TestTextBlockDerivation:
+    """The snapshot script derives text at the text-block level.
+
+    A text block is the deepest node whose subtree holds no interactive and no
+    block-level element.  These tests assert the Python side carries the fields
+    through; the in-page derivation itself is exercised in the e2e suite.
+    """
+
+    async def test_tree_carries_text_block_and_heading_level(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        client = KernelBrowserClient("http://browser:30000")
+        nodes = [
+            {"role": "heading", "name": "Results", "x": 0, "y": 0,
+             "width": 100, "height": 20, "depth": 3, "children_count": 0,
+             "idx": 0, "backend_node_id": 11,
+             "text_block": "Results", "heading_level": 2},
+            {"role": "generic", "name": "Results £128", "x": 0, "y": 0,
+             "width": 100, "height": 20, "depth": 3, "children_count": 2,
+             "idx": 1, "backend_node_id": 12, "text_block": ""},
+        ]
+        tree, cache = client._build_tree_and_cache(nodes)
+
+        assert tree[0]["text_block"] == "Results"
+        assert tree[0]["heading_level"] == 2
+        assert tree[1]["text_block"] == ""
+        assert "heading_level" not in tree[1]
+        # Refs and centres are unchanged by the new fields.
+        assert tree[0]["ref"] == "@e1"
+        assert cache["@e1"]["backend_node_id"] == 11
+
+    async def test_missing_fields_are_omitted_not_defaulted(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        client = KernelBrowserClient("http://browser:30000")
+        nodes = [
+            {"role": "link", "name": "Home", "x": 0, "y": 0,
+             "width": 10, "height": 10, "depth": 2, "children_count": 0,
+             "idx": 0, "backend_node_id": 5},
+        ]
+        tree, _ = client._build_tree_and_cache(nodes)
+
+        assert "heading_level" not in tree[0]
+        assert tree[0].get("text_block", "") == ""
+
+
+class TestSnapshotScriptShape:
+    """Guards on the injected JS -- it is a string, so nothing else type-checks it."""
+
+    def test_script_derives_text_block_and_heading_level(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        script = KernelBrowserClient._SNAPSHOT_SCRIPT
+        assert "text_block" in script
+        assert "heading_level" in script
+        # The text-block test must consider both interactive and block-level
+        # descendants; a check for only one of them is the bug this guards.
+        assert "isTextBlock" in script
+
+    def test_script_guards_against_both_duplication_and_text_loss(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        script = KernelBrowserClient._SNAPSHOT_SCRIPT
+        # Without the covered set, nested pure-inline elements each emit the
+        # same text ("£128", then "£", then "128").
+        assert "covered.add" in script
+        # Without the own-text branch, bare text runs beside an interactive
+        # child are lost -- querySelectorAll('*') returns elements only.
+        assert "ownTextOf" in script
+
+    def test_script_computes_style_once_per_element(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        # Style is resolved exactly once per element, into the __style map
+        # that both the visibility check and isBlockLevel read.  A second
+        # getComputedStyle call site would re-resolve style for every
+        # descendant scanned inside isTextBlock and multiply snapshot cost.
+        assert KernelBrowserClient._SNAPSHOT_SCRIPT.count(
+            "window.getComputedStyle"
+        ) == 1

--- a/tests/test_browser_client.py
+++ b/tests/test_browser_client.py
@@ -1036,6 +1036,16 @@ class TestSnapshotScriptShape:
         # child are lost -- querySelectorAll('*') returns elements only.
         assert "ownTextOf" in script
 
+    def test_script_covers_interactive_subtrees(self) -> None:
+        from surogates.browser.client import KernelBrowserClient
+
+        script = KernelBrowserClient._SNAPSHOT_SCRIPT
+        # Text inside a control belongs to the control.  Without covering the
+        # interactive subtree, a block-level child (<a><div>Label</div></a> --
+        # Wikipedia's whole TOC, and any `<a class="block">`) emits the label a
+        # second time as a stray text line right under the control line.
+        assert "if (__INTERACTIVE.has(role)) {" in script
+
     def test_script_computes_style_once_per_element(self) -> None:
         from surogates.browser.client import KernelBrowserClient
 

--- a/tests/test_browser_serialize.py
+++ b/tests/test_browser_serialize.py
@@ -1,0 +1,188 @@
+"""Tests for surogates.browser.serialize."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from surogates.browser.serialize import MAX_MARKDOWN_NODES, render_markdown
+
+
+def _state(tree: list[dict[str, Any]], **overrides: Any) -> dict[str, Any]:
+    state = {
+        "url": "https://example.com/",
+        "title": "Example",
+        "viewport": {"width": 1280, "height": 800},
+        "tree": tree,
+    }
+    state.update(overrides)
+    return state
+
+
+class TestHeader:
+    def test_emits_title_url_and_viewport(self) -> None:
+        out = render_markdown(_state([]))
+        assert out.splitlines()[:3] == [
+            "# Example",
+            "https://example.com/",
+            "viewport 1280x800",
+        ]
+
+    def test_survives_missing_fields(self) -> None:
+        out = render_markdown({"tree": []})
+        assert out.splitlines()[:3] == ["# ", "", "viewport 0x0"]
+
+
+class TestHeadings:
+    def test_heading_level_maps_to_hashes(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e1", "role": "heading", "name": "Results",
+             "x": 0, "y": 0, "heading_level": 2, "text_block": "Results"},
+        ]))
+        assert "## Results" in out
+
+    def test_level_is_clamped_to_two_through_six(self) -> None:
+        tree = [
+            {"ref": "@e1", "role": "heading", "name": "Top", "x": 0, "y": 0,
+             "heading_level": 1, "text_block": "Top"},
+            {"ref": "@e2", "role": "heading", "name": "Deep", "x": 0, "y": 0,
+             "heading_level": 9, "text_block": "Deep"},
+        ]
+        out = render_markdown(_state(tree))
+        assert "## Top" in out
+        assert "###### Deep" in out
+
+    def test_missing_level_defaults_to_two(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e1", "role": "heading", "name": "H",
+             "x": 0, "y": 0, "text_block": "H"},
+        ]))
+        assert "## H" in out
+
+
+class TestInteractiveNodes:
+    def test_rendered_as_ref_lines(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e7", "role": "button", "name": "Search", "x": 0, "y": 0},
+        ]))
+        assert '- button @e7 "Search"' in out
+
+    def test_rendered_even_without_text_block(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e7", "role": "checkbox", "name": "Free cancellation",
+             "x": 0, "y": 0, "text_block": ""},
+        ]))
+        assert '- checkbox @e7 "Free cancellation"' in out
+
+    def test_unnamed_interactive_still_addressable(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e9", "role": "button", "name": "", "x": 0, "y": 0},
+        ]))
+        assert '- button @e9 ""' in out
+
+
+class TestTextBlocks:
+    def test_text_block_emitted_as_plain_line(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e3", "role": "paragraph", "name": "ignored",
+             "x": 0, "y": 0, "text_block": "£128 per night"},
+        ]))
+        assert "£128 per night" in out
+        assert "ignored" not in out
+
+    def test_container_owning_no_text_contributes_nothing(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e2", "role": "generic", "name": "whole page text",
+             "x": 0, "y": 0, "text_block": ""},
+        ]))
+        assert "whole page text" not in out
+
+    def test_generic_without_text_block_key_contributes_nothing(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e2", "role": "generic", "name": "leaked", "x": 0, "y": 0},
+        ]))
+        assert "leaked" not in out
+
+
+class TestMotivatingCases:
+    """The two shapes that drove the text-block rule.
+
+    Both use the node lists the snapshot script produces for the markup in the
+    docstrings, so they pin the contract between derivation and rendering.
+    """
+
+    def test_price_split_across_spans_reads_as_one_line(self) -> None:
+        # <div class="price"><span>£</span><span>128</span></div>
+        # The div is a text block; both spans are covered by it.
+        tree = [
+            {"ref": "@e1", "role": "generic", "name": "£128",
+             "x": 0, "y": 0, "text_block": "£128"},
+            {"ref": "@e2", "role": "generic", "name": "£",
+             "x": 0, "y": 0, "text_block": ""},
+            {"ref": "@e3", "role": "generic", "name": "128",
+             "x": 0, "y": 0, "text_block": ""},
+        ]
+        out = render_markdown(_state(tree))
+        body = out.split("viewport 1280x800\n")[1]
+        assert body.strip() == "£128"
+
+    def test_sentence_around_a_link_keeps_both_parts(self) -> None:
+        # <p>Read our <a href="…">privacy policy</a> for details</p>
+        # The p is not a text block (interactive descendant), so it emits its
+        # own text runs.  The a IS a text block (pure-inline subtree), so it
+        # carries its text in text_block — but the serializer ignores
+        # text_block for interactive roles and renders the control line.
+        tree = [
+            {"ref": "@e1", "role": "paragraph", "name": "Read our privacy policy for details",
+             "x": 0, "y": 0, "text_block": "Read our for details"},
+            {"ref": "@e2", "role": "link", "name": "privacy policy",
+             "x": 0, "y": 0, "text_block": "privacy policy"},
+        ]
+        out = render_markdown(_state(tree))
+        assert "Read our for details" in out
+        assert '- link @e2 "privacy policy"' in out
+
+
+class TestOrdering:
+    def test_consent_priority_from_get_state_survives_rendering(self) -> None:
+        # ``get_state`` runs ``_prioritize_state_entries`` before the serializer
+        # sees the tree, so consent actions arrive already hoisted -- out of
+        # ref order.  The serializer must not re-sort them back.
+        tree = [
+            {"ref": "@e9", "role": "button", "name": "Accept all",
+             "x": 0, "y": 0, "intent": "accept_consent"},
+            {"ref": "@e5", "role": "link", "name": "Home", "x": 0, "y": 0},
+        ]
+        out = render_markdown(_state(tree))
+        assert out.index("@e9") < out.index("@e5")
+
+    def test_otherwise_document_order_is_preserved(self) -> None:
+        tree = [
+            {"ref": "@e1", "role": "link", "name": "First", "x": 0, "y": 0},
+            {"ref": "@e2", "role": "link", "name": "Second", "x": 0, "y": 0},
+        ]
+        out = render_markdown(_state(tree))
+        assert out.index("@e1") < out.index("@e2")
+
+
+class TestNodeCap:
+    def test_caps_emitted_nodes_and_reports_truncation(self) -> None:
+        tree = [
+            {"ref": f"@e{i}", "role": "link", "name": f"L{i}", "x": 0, "y": 0}
+            for i in range(1, MAX_MARKDOWN_NODES + 51)
+        ]
+        out = render_markdown(_state(tree))
+        assert out.count('- link @e') == MAX_MARKDOWN_NODES
+        assert f"[truncated: {MAX_MARKDOWN_NODES} of {MAX_MARKDOWN_NODES + 50} nodes shown" in out
+        assert "browser_evaluate" in out
+
+    def test_no_truncation_line_when_under_cap(self) -> None:
+        out = render_markdown(_state([
+            {"ref": "@e1", "role": "link", "name": "Only", "x": 0, "y": 0},
+        ]))
+        assert "truncated" not in out
+
+
+class TestEmptyPage:
+    def test_empty_tree_yields_header_only(self) -> None:
+        out = render_markdown(_state([]))
+        assert "no visible elements" in out

--- a/tests/test_browser_tools.py
+++ b/tests/test_browser_tools.py
@@ -67,11 +67,17 @@ class FakeClient:
         return {"url": url, "title": "Test Page"}
 
     async def get_state(self, **kwargs: Any) -> dict[str, Any]:
+        self.get_state_kwargs = kwargs
         return {
             "url": "http://example.com/",
             "title": "Test",
-            "viewport": {"width": 1, "height": 1},
-            "tree": [],
+            "viewport": {"width": 1280, "height": 800},
+            "tree": [
+                {"ref": "@e1", "role": "heading", "name": "Results",
+                 "x": 0, "y": 0, "text_block": "Results", "heading_level": 2},
+                {"ref": "@e2", "role": "button", "name": "Search",
+                 "x": 10, "y": 20, "text_block": ""},
+            ],
         }
 
     async def close(self) -> None:
@@ -312,7 +318,7 @@ class TestGetStateHandler:
         from surogates.tools.builtin.browser import _browser_get_state_handler
 
         result = await _browser_get_state_handler(
-            {"interactive_only": True},
+            {"interactive_only": True, "format": "json"},
             tenant=tenant,
             session_id=uuid4(),
             browser_pool=FakePool(),
@@ -853,3 +859,67 @@ def test_browser_screenshot_key_uses_boundary_workspace_prefix():
         )
         == "project/agent/boundaries/slack:c:G1/workspace/browser-screenshots/shot.png"
     )
+
+
+class TestGetStateFormat:
+    async def test_defaults_to_markdown(self, tenant) -> None:
+        from surogates.tools.builtin.browser import _browser_get_state_handler
+
+        result = await _browser_get_state_handler(
+            {},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FakeClient(),
+        )
+        assert result.startswith("# Test")
+        assert "## Results" in result
+        assert '- button @e2 "Search"' in result
+
+    async def test_json_format_returns_the_tree(self, tenant) -> None:
+        from surogates.tools.builtin.browser import _browser_get_state_handler
+
+        result = await _browser_get_state_handler(
+            {"format": "json"},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FakeClient(),
+        )
+        body = json.loads(result)
+        assert body["tree"][0]["text_block"] == "Results"
+        assert body["tree"][0]["heading_level"] == 2
+        assert body["tree"][1]["x"] == 10
+
+    async def test_errors_stay_json_in_markdown_mode(self, tenant) -> None:
+        from surogates.tools.builtin.browser import _browser_get_state_handler
+
+        result = await _browser_get_state_handler(
+            {},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FailingStateClient(),
+        )
+        assert json.loads(result)["error"] == "get_state_failed"
+
+
+class TestGetStateSchema:
+    def test_compact_is_gone(self) -> None:
+        from surogates.tools.builtin.browser import GET_STATE_SCHEMA
+
+        assert "compact" not in GET_STATE_SCHEMA["properties"]
+
+    def test_every_parameter_is_documented(self) -> None:
+        from surogates.tools.builtin.browser import GET_STATE_SCHEMA
+
+        for name, prop in GET_STATE_SCHEMA["properties"].items():
+            assert prop.get("description"), f"{name} has no description"
+
+    def test_format_enumerates_both_modes(self) -> None:
+        from surogates.tools.builtin.browser import GET_STATE_SCHEMA
+
+        assert GET_STATE_SCHEMA["properties"]["format"]["enum"] == ["markdown", "json"]

--- a/tests/test_browser_tools.py
+++ b/tests/test_browser_tools.py
@@ -1004,3 +1004,33 @@ class TestEvaluateHandler:
             _client_factory=lambda endpoint: FakeEvaluateClient(),
         )
         assert json.loads(result)["error"] == "missing_code"
+
+
+class TestEvaluateAuditTrail:
+    """browser_evaluate's security posture is 'unrestricted but audited'.
+
+    That only holds if the complete JS source reaches the TOOL_CALL event.
+    These pin the two transformations it passes through on the way there.
+    """
+
+    def test_path_sanitisation_leaves_javascript_intact(self) -> None:
+        from surogates.harness.tool_exec import _sanitize_paths
+
+        code = (
+            "const rows = [...document.querySelectorAll('tr')];\n"
+            "return rows.map(r => ({t: r.innerText, n: r.children.length}));"
+        )
+        sanitized = _sanitize_paths({"code": code}, "/workspace")
+        assert sanitized["code"] == code
+
+    def test_arguments_are_not_truncated_on_the_tool_call_event(self) -> None:
+        import inspect
+
+        from surogates.harness import tool_exec
+
+        src = inspect.getsource(tool_exec)
+        # The TOOL_CALL payload carries the whole argument dict.  ``_truncate_args``
+        # feeds ``arguments_excerpt`` on a *different* event -- if it ever moves
+        # onto ``tool_call_data``, the audit trail silently loses long JS bodies.
+        assert '"arguments": sanitized_args,' in src
+        assert '"arguments": _truncate_args' not in src

--- a/tests/test_browser_tools.py
+++ b/tests/test_browser_tools.py
@@ -687,6 +687,7 @@ class TestScreenshotHandler:
 BROWSER_TOOL_NAMES = [
     "browser_navigate",
     "browser_get_state",
+    "browser_evaluate",
     "browser_screenshot",
     "browser_click",
     "browser_type",
@@ -775,6 +776,7 @@ class TestRouterDispatch:
 BROWSER_SUSPEND_HANDLERS = [
     ("_browser_navigate_handler", {"url": "https://example.com"}),
     ("_browser_get_state_handler", {}),
+    ("_browser_evaluate_handler", {"code": "return 1;"}),
     ("_browser_screenshot_handler", {}),
     ("_browser_click_handler", {"x": 10, "y": 10}),
     ("_browser_type_handler", {"text": "hello"}),
@@ -923,3 +925,82 @@ class TestGetStateSchema:
         from surogates.tools.builtin.browser import GET_STATE_SCHEMA
 
         assert GET_STATE_SCHEMA["properties"]["format"]["enum"] == ["markdown", "json"]
+
+
+class FakeEvaluateClient(FakeClient):
+    def __init__(self, result: Any = None) -> None:
+        super().__init__()
+        self.evaluated: list[str] = []
+        self._result = result if result is not None else {"rows": 3}
+
+    async def evaluate(self, code: str) -> Any:
+        self.evaluated.append(code)
+        return self._result
+
+
+class FailingEvaluateClient(FakeClient):
+    async def evaluate(self, code: str) -> Any:
+        raise RuntimeError("SyntaxError: Unexpected token '}'")
+
+
+class TestEvaluateHandler:
+    async def test_returns_the_json_result(self, tenant) -> None:
+        from surogates.tools.builtin.browser import _browser_evaluate_handler
+
+        result = await _browser_evaluate_handler(
+            {"code": "return document.title;"},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FakeEvaluateClient({"title": "T"}),
+        )
+        assert json.loads(result) == {"title": "T"}
+
+    async def test_returns_structured_error_on_js_failure(self, tenant) -> None:
+        from surogates.tools.builtin.browser import _browser_evaluate_handler
+
+        result = await _browser_evaluate_handler(
+            {"code": "return }"},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FailingEvaluateClient(),
+        )
+        body = json.loads(result)
+        assert body["error"] == "evaluate_failed"
+        assert "SyntaxError" in body["detail"]
+
+    async def test_truncates_oversized_results(self, tenant) -> None:
+        from surogates.tools.builtin.browser import (
+            _MAX_EVALUATE_RESULT_CHARS,
+            _browser_evaluate_handler,
+        )
+
+        huge = "x" * (_MAX_EVALUATE_RESULT_CHARS + 5000)
+        result = await _browser_evaluate_handler(
+            {"code": "return document.body.innerHTML;"},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FakeEvaluateClient(huge),
+        )
+        body = json.loads(result)
+        assert body["truncated"] is True
+        assert body["original_length"] > _MAX_EVALUATE_RESULT_CHARS
+        assert len(body["result"]) == _MAX_EVALUATE_RESULT_CHARS
+
+    async def test_rejects_missing_code(self, tenant) -> None:
+        from surogates.tools.builtin.browser import _browser_evaluate_handler
+
+        result = await _browser_evaluate_handler(
+            {},
+            tenant=tenant,
+            session_id=uuid4(),
+            browser_pool=FakePool(),
+            browser_control=FakeControlStore(),
+            _client_factory=lambda endpoint: FakeEvaluateClient(),
+        )
+        assert json.loads(result)["error"] == "missing_code"

--- a/tests/test_context_prune_integration.py
+++ b/tests/test_context_prune_integration.py
@@ -4,8 +4,8 @@ These exercise the *composed* behaviour: the real ``ContextCompressor`` running
 ``prune_stale_browser_states`` over a realistically-shaped browser session, and
 the downstream effect on ``should_compress`` (the token-size gate that decides
 compaction frequency).  Browser state payloads mirror the real
-``browser_get_state`` JSON shape (url/title/viewport/tree of ref+role+name
-nodes) but contain no real page data.
+``browser_get_state`` markdown shape (header plus one line per element) but
+contain no real page data.
 """
 
 from __future__ import annotations
@@ -21,28 +21,26 @@ from surogates.harness.context import (
 def _realistic_state(step: int, n_nodes: int = 130) -> str:
     """A browser_get_state result shaped like the real tool output.
 
-    ~130 nodes lands around ~2-2.5K tokens, matching the measured production
-    average for filtered (interactive_only/compact) snapshots.
+    ~130 elements lands around ~1K tokens, matching the measured production
+    average for a markdown snapshot.
     """
-    roles = ["button", "link", "textbox", "generic", "heading", "listitem", "image"]
-    tree = [
-        {
-            "ref": f"@e{i}",
-            "role": roles[i % len(roles)],
-            "name": f"element {i} on view {step} — some visible label text here",
-            "x": (i * 7) % 1280,
-            "y": (i * 13) % 2000,
-        }
-        for i in range(n_nodes)
+    roles = ["button", "link", "textbox", "checkbox", "searchbox", "tab"]
+    lines = [
+        f"# View {step}",
+        f"https://example.test/page/{step}",
+        "viewport 1280x800",
+        "",
     ]
-    return json.dumps(
-        {
-            "url": f"https://example.test/page/{step}",
-            "title": f"View {step}",
-            "viewport": {"width": 1280, "height": 800},
-            "tree": tree,
-        }
-    )
+    for i in range(n_nodes):
+        if i % 7 == 0:
+            lines.append(f"## section {i} on view {step}")
+        elif i % 3 == 0:
+            lines.append(f"element {i} on view {step} — some visible label text here")
+        else:
+            lines.append(
+                f'- {roles[i % len(roles)]} @e{i} "element {i} on view {step}"'
+            )
+    return "\n".join(lines)
 
 
 def _browser_session(n_states: int) -> list[dict]:
@@ -59,7 +57,7 @@ def _browser_session(n_states: int) -> list[dict]:
                         "type": "function",
                         "function": {
                             "name": "browser_get_state",
-                            "arguments": '{"interactive_only": true, "compact": true}',
+                            "arguments": '{"interactive_only": true}',
                         },
                     }
                 ],
@@ -73,11 +71,13 @@ def _browser_session(n_states: int) -> list[dict]:
 
 def _small_ctx_compressor(**kw) -> ContextCompressor:
     # Shrink the declared context window so the compaction threshold is small
-    # enough to reach in a test (threshold = 50% of context_window).
+    # enough to reach in a test (threshold = 50% of context_window).  Sized
+    # against the markdown snapshot: 12 states estimate ~16K tokens unpruned
+    # and ~3K pruned, so a 12K threshold sits clear of both.
     return ContextCompressor(
         "claude-opus-4-7",
         quiet_mode=True,
-        model_overrides={"claude-opus-4-7": {"context_window": 40_000}},
+        model_overrides={"claude-opus-4-7": {"context_window": 24_000}},
         **kw,
     )
 
@@ -98,7 +98,7 @@ def test_prune_keeps_current_state_and_clears_the_rest_on_real_shape():
     assert len(cleared) == 10           # 12 states, keep last 2
     assert len(kept) == 2
     # The two kept states are the most recent ones (the current page view).
-    assert json.loads(kept[-1]["content"])["url"] == "https://example.test/page/12"
+    assert "https://example.test/page/12" in kept[-1]["content"]
     # Substantial payload reduction.
     assert _chars(after) < 0.35 * _chars(before)
 


### PR DESCRIPTION
Gives the browser agent a JavaScript execution tool and replaces `browser_get_state`'s duplicated JSON dump with deduplicated markdown.

Derived from [StateAct (arXiv:2607.22798)](https://arxiv.org/html/2607.22798v1), whose web component "navigates, executes JavaScript, serializes the DOM to markdown, and clicks by CSS selector." We already had three of four — the DOM-grounded snapshot and refs pinned to CDP backend node ids. This adds the missing JavaScript execution and fixes the serialization.

Design and plan: `docs/superpowers/specs/2026-07-28-browser-state-grounding-design.md`.

## `browser_evaluate`

Runs an agent-supplied JavaScript function body in page context over the existing `/playwright/execute` transport. Reading a long table, a hidden input's value, or every option of a `<select>` becomes one call instead of a dozen scroll-and-restate round trips.

- Snapshot cache is invalidated after every call — JS can move or replace elements, and a stale `@eN` that resolves to the wrong node is worse than one that fails.
- Results capped at 20 000 chars; JS exceptions surface as `{"error": "evaluate_failed"}` rather than raising.
- Unrestricted execution with full audit: no pattern blocklists (defeated by string concatenation, and they block legitimate same-site `fetch`), but the complete source lands in the `TOOL_CALL` event. Two regression tests pin that guarantee.

## Markdown page state

New pure `surogates/browser/serialize.py`. `format="json"` still returns the node tree for coordinate clicking.

Text is emitted per **text block** — the shallowest element whose subtree holds no interactive or block-level element — so each run of text appears exactly once and inline markup stays on one line. Two branches make that exhaustive: a text block covers its subtree, and non-text-block nodes contribute their direct child text runs (bare text nodes are never returned by `querySelectorAll('*')`). Interactive elements also cover their subtree, so a `<a><div>Label</div></a>` nav link cannot emit its label twice.

`compact` is deleted rather than deprecated — `text_block` subsumes it precisely.

## Measured

Against `en.wikipedia.org/wiki/Bucharest` through the real client and a real browser container: 7 642 nodes, **23 573 chars markdown vs 899 247 as the old JSON — 97% smaller**. Emitted text is 0.76× the page's own `body.innerText`, and an ancestor/descendant duplication check over all emitters returns zero.

## Also

- Fixes a stale `MUTATING_TOOL_NAMES` entry: `browser_press` matches no registered tool, so key presses were classified as non-mutating.
- Registers the tool with the worker toolset and the chat UI label map, both found by auditing `browser_get_state` callers.

Needs `invergent-ai/surogate-ops#<ops-pr>` for the policy allowlist mirror.

## Testing

4 579 passing; the 28 failures are identical to `master` (pdf parsing, channel routes, code-command) with an empty regression set. Verified end-to-end from the ops console against a live session.
