### PR TITLE
feat: enforce per-end-user token allowances across every channel + buy prompts

### DIFF
--- a/surogates/api/routes/_commerce_turn.py
+++ b/surogates/api/routes/_commerce_turn.py
@@ -108,6 +108,62 @@ async def authorize_commerce_turn(
         )
 
 
+class AllowanceReserveError(RuntimeError):
+    """The allowance plane could not be reached — callers fail closed."""
+
+
+async def reserve_allowance(
+    *,
+    platform_client,
+    runtime_payload: dict,
+    session_store,
+    session_id,
+    agent_id: str,
+    content: str,
+    end_user_id: str,
+) -> None:
+    """Channel-agnostic per-user allowance reservation (no HTTP request).
+
+    A no-op unless ops projects a positive ``end_user_token_allowance``.
+    Reserves the turn's estimate against the end-user's cap and pins the
+    receipt on ``session.config`` for the worker to settle. Raises
+    :class:`~surogates.runtime.platform_client.AllowanceExhaustedError`
+    on 402 (cap spent / subscription required / operator plan spent) and
+    :class:`AllowanceReserveError` when the allowance plane is unreachable
+    (callers fail closed). Shared by the web message route and the
+    slack/telegram inbound pipeline.
+    """
+    if runtime_payload.get("end_user_token_allowance") is None:
+        return
+    if platform_client is None:
+        raise AllowanceReserveError("platform_client not wired")
+    try:
+        receipt = await platform_client.allowance_authorize(
+            str(agent_id),
+            end_user_id=end_user_id,
+            estimated_tokens=estimate_turn_tokens(content),
+        )
+    except AllowanceExhaustedError:
+        raise
+    except Exception as exc:
+        raise AllowanceReserveError(str(exc)) from exc
+    if receipt.get("allowance_id"):
+        if session_store is None:
+            raise AllowanceReserveError("session_store not wired")
+        # Appended, not overwritten: a second message can land while a
+        # turn is still running, and each hold must survive until the
+        # worker settles the whole list atomically.
+        await session_store.append_session_config_list(
+            session_id,
+            "allowance_reservations",
+            {
+                "allowance_id": receipt["allowance_id"],
+                "reserved_tokens": int(receipt.get("reserved_tokens") or 0),
+                "reservation_id": receipt.get("reservation_id") or "",
+            },
+        )
+
+
 async def authorize_allowance_turn(
     request: Request,
     session,
@@ -115,44 +171,31 @@ async def authorize_allowance_turn(
     *,
     end_user_id: str,
 ) -> None:
-    """Gate one end-user turn behind their per-user token allowance.
+    """HTTP gate for one end-user turn behind their per-user allowance.
 
-    Unlike :func:`authorize_commerce_turn` this applies to **every**
-    signed-in end-user regardless of identity provider or channel, and is
-    independent of the agent's commerce mode: it enforces the operator's
-    per-user slice of their own subscription.  It is a no-op unless ops
-    projects a positive ``end_user_token_allowance`` (kill-switch on and
-    the operator set a cap), so free/uncapped agents are unaffected.
-
-    On success the reservation receipt is pinned on ``session.config`` for
-    the worker to settle after the turn.  An exhausted allowance raises
-    402 ``allowance_exhausted``.
+    Thin wrapper over :func:`reserve_allowance` that pulls dependencies
+    from ``request.app.state`` and maps the domain outcomes to HTTP: an
+    exhausted allowance (or subscription-required / operator plan spent)
+    to 402 with the machine sentinel, an unreachable allowance plane to
+    503 (fail closed — a capped agent must not serve unmetered turns).
     """
     payload = await runtime_commerce_payload(request, str(session.agent_id))
-    allowance = payload.get("end_user_token_allowance")
-    if allowance is None:
-        return
-    client = getattr(request.app.state, "platform_client", None)
-    if client is None:
-        logger.error("platform_client is not wired on app.state")
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Access checks are temporarily unavailable; try again.",
-        )
     try:
-        receipt = await client.allowance_authorize(
-            str(session.agent_id),
+        await reserve_allowance(
+            platform_client=getattr(request.app.state, "platform_client", None),
+            runtime_payload=payload,
+            session_store=getattr(request.app.state, "session_store", None),
+            session_id=session.id,
+            agent_id=session.agent_id,
+            content=content,
             end_user_id=end_user_id,
-            estimated_tokens=estimate_turn_tokens(content),
         )
     except AllowanceExhaustedError as exc:
         raise HTTPException(
             status_code=status.HTTP_402_PAYMENT_REQUIRED,
             detail={"code": exc.detail or "allowance_exhausted"},
         ) from exc
-    except Exception as exc:
-        # Fail closed: a capped agent must not serve unmetered turns
-        # because the allowance plane blinked.
+    except AllowanceReserveError as exc:
         logger.error(
             "Allowance authorization failed for session %s: %s",
             session.id,
@@ -162,20 +205,6 @@ async def authorize_allowance_turn(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Access checks are temporarily unavailable; try again.",
         ) from exc
-    if receipt.get("allowance_id"):
-        store = get_session_store(request)
-        # Appended, not overwritten: a second message can land while a
-        # turn is still running, and each hold must survive until the
-        # worker settles the whole list atomically.
-        await store.append_session_config_list(
-            session.id,
-            "allowance_reservations",
-            {
-                "allowance_id": receipt["allowance_id"],
-                "reserved_tokens": int(receipt.get("reserved_tokens") or 0),
-                "reservation_id": receipt.get("reservation_id") or "",
-            },
-        )
 
 
 def get_session_store(request: Request) -> "SessionStore":

--- a/surogates/api/routes/_commerce_turn.py
+++ b/surogates/api/routes/_commerce_turn.py
@@ -121,19 +121,25 @@ async def reserve_allowance(
     agent_id: str,
     content: str,
     end_user_id: str,
+    always: bool = False,
 ) -> None:
     """Channel-agnostic per-user allowance reservation (no HTTP request).
 
-    A no-op unless ops projects a positive ``end_user_token_allowance``.
+    A no-op unless ops projects a positive ``end_user_token_allowance``,
+    *unless* ``always`` is set — then the ops authorize is called
+    regardless of the agent's default cap. ``always`` is for the
+    per-buyer website embed, where the buyer holds a purchased allowance
+    to draw from even when the agent itself has no default cap.
+
     Reserves the turn's estimate against the end-user's cap and pins the
     receipt on ``session.config`` for the worker to settle. Raises
     :class:`~surogates.runtime.platform_client.AllowanceExhaustedError`
     on 402 (cap spent / subscription required / operator plan spent) and
     :class:`AllowanceReserveError` when the allowance plane is unreachable
-    (callers fail closed). Shared by the web message route and the
-    slack/telegram inbound pipeline.
+    (callers fail closed). Shared by the web message route, the
+    slack/telegram inbound pipeline, and the website widget embed.
     """
-    if runtime_payload.get("end_user_token_allowance") is None:
+    if not always and runtime_payload.get("end_user_token_allowance") is None:
         return
     if platform_client is None:
         raise AllowanceReserveError("platform_client not wired")
@@ -170,6 +176,7 @@ async def authorize_allowance_turn(
     content: str,
     *,
     end_user_id: str,
+    always: bool = False,
 ) -> None:
     """HTTP gate for one end-user turn behind their per-user allowance.
 
@@ -178,6 +185,10 @@ async def authorize_allowance_turn(
     exhausted allowance (or subscription-required / operator plan spent)
     to 402 with the machine sentinel, an unreachable allowance plane to
     503 (fail closed — a capped agent must not serve unmetered turns).
+
+    ``always`` forces the ops authorize regardless of the agent's default
+    cap projection — used by the per-buyer website embed, where the buyer
+    holds a purchased allowance to draw from.
     """
     payload = await runtime_commerce_payload(request, str(session.agent_id))
     try:
@@ -189,6 +200,7 @@ async def authorize_allowance_turn(
             agent_id=session.agent_id,
             content=content,
             end_user_id=end_user_id,
+            always=always,
         )
     except AllowanceExhaustedError as exc:
         # Carry the buy-page URL (as the commerce gate does) so the client

--- a/surogates/api/routes/_commerce_turn.py
+++ b/surogates/api/routes/_commerce_turn.py
@@ -191,9 +191,14 @@ async def authorize_allowance_turn(
             end_user_id=end_user_id,
         )
     except AllowanceExhaustedError as exc:
+        # Carry the buy-page URL (as the commerce gate does) so the client
+        # renders a real buy prompt rather than a generic error.
         raise HTTPException(
             status_code=status.HTTP_402_PAYMENT_REQUIRED,
-            detail={"code": exc.detail or "allowance_exhausted"},
+            detail={
+                "code": exc.detail or "allowance_exhausted",
+                "buy_url": payload.get("commerce_buy_url"),
+            },
         ) from exc
     except AllowanceReserveError as exc:
         logger.error(

--- a/surogates/api/routes/_commerce_turn.py
+++ b/surogates/api/routes/_commerce_turn.py
@@ -15,6 +15,7 @@ import logging
 from fastapi import HTTPException, Request, status
 
 from surogates.runtime.platform_client import (
+    AllowanceExhaustedError,
     CommercePaymentRequiredError,
 )
 from surogates.session.store import SessionStore
@@ -101,6 +102,76 @@ async def authorize_commerce_turn(
             "commerce_reservations",
             {
                 "entitlement_id": receipt["entitlement_id"],
+                "reserved_tokens": int(receipt.get("reserved_tokens") or 0),
+                "reservation_id": receipt.get("reservation_id") or "",
+            },
+        )
+
+
+async def authorize_allowance_turn(
+    request: Request,
+    session,
+    content: str,
+    *,
+    end_user_id: str,
+) -> None:
+    """Gate one end-user turn behind their per-user token allowance.
+
+    Unlike :func:`authorize_commerce_turn` this applies to **every**
+    signed-in end-user regardless of identity provider or channel, and is
+    independent of the agent's commerce mode: it enforces the operator's
+    per-user slice of their own subscription.  It is a no-op unless ops
+    projects a positive ``end_user_token_allowance`` (kill-switch on and
+    the operator set a cap), so free/uncapped agents are unaffected.
+
+    On success the reservation receipt is pinned on ``session.config`` for
+    the worker to settle after the turn.  An exhausted allowance raises
+    402 ``allowance_exhausted``.
+    """
+    payload = await runtime_commerce_payload(request, str(session.agent_id))
+    allowance = payload.get("end_user_token_allowance")
+    if allowance is None:
+        return
+    client = getattr(request.app.state, "platform_client", None)
+    if client is None:
+        logger.error("platform_client is not wired on app.state")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Access checks are temporarily unavailable; try again.",
+        )
+    try:
+        receipt = await client.allowance_authorize(
+            str(session.agent_id),
+            end_user_id=end_user_id,
+            estimated_tokens=estimate_turn_tokens(content),
+        )
+    except AllowanceExhaustedError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail={"code": exc.detail or "allowance_exhausted"},
+        ) from exc
+    except Exception as exc:
+        # Fail closed: a capped agent must not serve unmetered turns
+        # because the allowance plane blinked.
+        logger.error(
+            "Allowance authorization failed for session %s: %s",
+            session.id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Access checks are temporarily unavailable; try again.",
+        ) from exc
+    if receipt.get("allowance_id"):
+        store = get_session_store(request)
+        # Appended, not overwritten: a second message can land while a
+        # turn is still running, and each hold must survive until the
+        # worker settles the whole list atomically.
+        await store.append_session_config_list(
+            session.id,
+            "allowance_reservations",
+            {
+                "allowance_id": receipt["allowance_id"],
                 "reserved_tokens": int(receipt.get("reserved_tokens") or 0),
                 "reservation_id": receipt.get("reservation_id") or "",
             },

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -39,6 +39,7 @@ from surogates.api.session_guards import (
 from surogates.coding_agents.command import is_code_command
 from surogates.config import INTERRUPT_CHANNEL_PREFIX, enqueue_session
 from surogates.api.routes._commerce_turn import (
+    authorize_allowance_turn,
     authorize_commerce_turn,
     firebase_buyer_identity,
     runtime_commerce_payload,
@@ -816,6 +817,17 @@ async def send_message(
                     body.content,
                     buyer=buyer,
                 )
+
+    # Per-user allowance (a slice of the operator's subscription) applies
+    # to EVERY signed-in end-user — any identity provider, regardless of
+    # commerce mode — closing the Firebase-only and free-mode gaps of the
+    # commerce gate above. A no-op unless ops projects a positive cap
+    # (kill-switch on + operator opt-in), so free/uncapped agents are
+    # unaffected. The worker settles ``allowance_reservations`` after.
+    if session.channel == "web" and tenant.user_id is not None:
+        await authorize_allowance_turn(
+            request, session, body.content, end_user_id=str(tenant.user_id),
+        )
 
     event_data: dict = {"content": body.content}
     if body.images:

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -67,6 +67,7 @@ from surogates.channels.website_session import (
 )
 from surogates.config import Settings, enqueue_session
 from surogates.api.routes._commerce_turn import (
+    authorize_allowance_turn,
     authorize_commerce_turn,
     estimate_turn_tokens,
     get_session_store,
@@ -715,6 +716,15 @@ async def bootstrap_website_session(
     if cap:
         config["session_message_cap"] = cap
 
+    # Per-buyer embed: a widget key a buyer minted carries the buyer's
+    # end_user_id in the routing config. Pin it so every anonymous
+    # visitor turn on the buyer's site draws from that buyer's purchased
+    # allowance (the resell-on-your-site flow). Absent on an operator's
+    # own agent key, which stays anonymous.
+    embed_end_user_id = routing_config.get("embed_end_user_id")
+    if embed_end_user_id:
+        config["embed_end_user_id"] = str(embed_end_user_id)
+
     # Server-verified buyer identity, pinned at bootstrap so every
     # later message inherits it from the session row rather than
     # re-verifying a client-supplied token per message.
@@ -826,6 +836,21 @@ async def send_website_message(
         )
 
     await authorize_commerce_turn(request, session, body.content)
+
+    # Per-buyer embed: when the widget key was minted by a buyer, this
+    # anonymous visitor's turn draws from that buyer's purchased
+    # allowance (``always`` because the buyer holds the allowance even
+    # when the agent has no default cap). An exhausted allowance 402s
+    # with the buy link the widget renders as a paywall.
+    embed_end_user_id = (session.config or {}).get("embed_end_user_id")
+    if embed_end_user_id:
+        await authorize_allowance_turn(
+            request,
+            session,
+            body.content,
+            end_user_id=str(embed_end_user_id),
+            always=True,
+        )
 
     if session.status in ("failed", "paused", "completed"):
         await store.update_session_status(session_id, "active")

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -683,6 +683,16 @@ async def bootstrap_website_session(
                     await store.update_session_config_key(
                         existing.id, "commerce_buyer", buyer,
                     )
+            # Absorb the per-buyer embed identity onto a reused session too,
+            # or a canonical session created before the key carried an
+            # embed_end_user_id would skip the allowance gate on every turn.
+            embed_eu = routing_config.get("embed_end_user_id")
+            if embed_eu and (existing.config or {}).get(
+                "embed_end_user_id",
+            ) != str(embed_eu):
+                await store.update_session_config_key(
+                    existing.id, "embed_end_user_id", str(embed_eu),
+                )
             response.status_code = status.HTTP_200_OK
             return _issue_bootstrap_response(
                 response,

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -229,6 +229,10 @@ _PendingInput = Callable[[Any], Awaitable[dict | None]]
 #: Async callable: (session_id, msg, text) -> None. Posts a nudge to the channel/thread.
 _InputNudge = Callable[[Any, "InboundMessage", str], Awaitable[None]]
 
+#: Async callable: (agent_id) -> runtime-config payload dict (for the
+#: projected ``end_user_token_allowance``).
+_RuntimeConfig = Callable[[str], Awaitable[dict]]
+
 
 @dataclass
 class PipelineDeps:
@@ -293,6 +297,13 @@ class PipelineDeps:
     attachments: _Attachments | None = None
     pending_input: _PendingInput | None = None
     input_nudge: _InputNudge | None = None
+    # Per-user token allowance enforcement (a slice of the operator's
+    # subscription). ``platform_client`` reserves against ops;
+    # ``runtime_config`` resolves the agent's projected allowance. Both
+    # ``None`` disables the gate (older wiring / tests), so slack/telegram
+    # behave exactly as before until this is wired.
+    platform_client: Any = None
+    runtime_config: _RuntimeConfig | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -705,6 +716,74 @@ class ChannelInboundPipeline:
         ]
         if _file_refs:
             event_data["source"]["files"] = _file_refs
+
+        # ------------------------------------------------------------------
+        # Gate 7.5: per-user token allowance (a slice of the operator's
+        # subscription). Reserve this turn against the sender's cap before
+        # emitting/enqueueing; an exhausted allowance (or subscription-
+        # required / operator plan spent) drops the message with a notice.
+        # No-op unless ops projects a positive cap for this agent, so
+        # free/uncapped agents are unaffected; an unreachable allowance
+        # plane fails closed (a capped agent must not serve unmetered).
+        # ------------------------------------------------------------------
+        if (
+            identity.user_id is not None
+            and deps.platform_client is not None
+            and deps.runtime_config is not None
+        ):
+            from surogates.api.routes._commerce_turn import (
+                AllowanceReserveError,
+                reserve_allowance,
+            )
+            from surogates.runtime.platform_client import (
+                AllowanceExhaustedError,
+            )
+
+            try:
+                runtime_payload = await deps.runtime_config(routing.agent_id) or {}
+            except Exception:
+                # Can't resolve the agent's config → fail OPEN (do not gate).
+                # Only a fetched, capped payload should ever block a turn;
+                # a cache blip must not drop every channel message.
+                runtime_payload = {}
+            try:
+                await reserve_allowance(
+                    platform_client=deps.platform_client,
+                    runtime_payload=runtime_payload,
+                    session_store=deps.session_store,
+                    session_id=session_id,
+                    agent_id=routing.agent_id,
+                    content=msg.text or "",
+                    end_user_id=str(identity.user_id),
+                )
+            except AllowanceExhaustedError as exc:
+                logger.info(
+                    "[channels] allowance gate blocked session %s (%s)",
+                    session_id,
+                    exc.detail,
+                )
+                if deps.input_nudge is not None:
+                    try:
+                        await deps.input_nudge(
+                            session_id,
+                            msg,
+                            "You've reached your usage limit for this "
+                            "assistant. Please try again later.",
+                        )
+                    except Exception:
+                        logger.warning(
+                            "[channels] allowance-limit notice failed",
+                            exc_info=True,
+                        )
+                return InboundOutcome.DROPPED
+            except AllowanceReserveError:
+                logger.warning(
+                    "[channels] allowance plane unreachable — failing closed "
+                    "for session %s",
+                    session_id,
+                    exc_info=True,
+                )
+                return InboundOutcome.DROPPED
 
         await deps.session_store.emit_event(
             session_id,

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -167,6 +167,22 @@ class InboundOutcome(str, Enum):
     session message was emitted or enqueued."""
 
 
+def _allowance_block_notice(code: str | None, buy_url: str | None) -> str:
+    """User-facing notice when the allowance gate drops a channel turn.
+
+    Names the reason (subscription vs. usage limit) and appends the buy
+    link when the agent projects one, so slack/telegram senders get a
+    real path to keep going rather than a dead "try again later".
+    """
+    if code == "subscription_required":
+        lead = "A subscription is required to keep chatting with this assistant."
+    else:
+        lead = "You've reached your usage limit for this assistant."
+    if buy_url:
+        return f"{lead} Get more access here: {buy_url}"
+    return f"{lead} Please try again later."
+
+
 @lru_cache(maxsize=256)
 def _mention_pattern_regex(csv: str) -> re.Pattern | None:
     """Compile a routing config's ``mention_patterns`` CSV into one regex.
@@ -767,8 +783,10 @@ class ChannelInboundPipeline:
                         await deps.input_nudge(
                             session_id,
                             msg,
-                            "You've reached your usage limit for this "
-                            "assistant. Please try again later.",
+                            _allowance_block_notice(
+                                exc.detail,
+                                runtime_payload.get("commerce_buy_url"),
+                            ),
                         )
                     except Exception:
                         logger.warning(

--- a/surogates/channels/runner.py
+++ b/surogates/channels/runner.py
@@ -94,6 +94,8 @@ def _make_deps_factory(
     link_url_base: str = "",
     storage: Any = None,
     settings: Any = None,
+    platform_client: Any = None,
+    runtime_config: Any = None,
 ) -> Any:
     """Return a deps_factory for :class:`ChannelWebhookDispatcher`.
 
@@ -332,6 +334,8 @@ def _make_deps_factory(
             attachments=_attachments,
             pending_input=_pending_input,
             input_nudge=_input_nudge,
+            platform_client=platform_client,
+            runtime_config=runtime_config,
         )
 
     # Expose both resolvers' caches so the channels process can wire them into
@@ -400,6 +404,16 @@ def build_channels_app(
         registry = _global_registry
 
     pipeline = ChannelInboundPipeline()
+    # Per-user allowance enforcement (slack/telegram): resolve the agent's
+    # projected ``end_user_token_allowance`` through a short-TTL cache over
+    # the platform client, so uncapped agents skip the ops round trip.
+    from surogates.runtime import RuntimeConfigCache
+
+    _runtime_config_cache = (
+        RuntimeConfigCache(platform_client.get_runtime_config)
+        if platform_client is not None
+        else None
+    )
     deps_factory = _make_deps_factory(
         session_store=session_store,
         redis=redis,
@@ -408,6 +422,10 @@ def build_channels_app(
         link_url_base=getattr(getattr(settings, "channels", None), "studio_url", ""),
         storage=storage,
         settings=settings,
+        platform_client=platform_client,
+        runtime_config=(
+            _runtime_config_cache.get if _runtime_config_cache is not None else None
+        ),
     )
 
     dispatcher = ChannelWebhookDispatcher(

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -30,6 +30,20 @@ from surogates.session.events import EventType
 logger = logging.getLogger(__name__)
 
 
+def _should_take_reservations(session: Any, config_key: str) -> bool:
+    """Whether the worker must pop ``config_key`` from the live session
+    config at settle time.
+
+    Channel gate, not a config gate: the wake-time session object is
+    stale, and a hold appended after wake start must still be taken — only
+    website sessions ever carry these, so every other channel skips the
+    extra round trip unless the wake object already shows a hold. Shared by
+    the commerce and per-user allowance settlements."""
+    if getattr(session, "channel", None) == "website":
+        return True
+    return bool((session.config or {}).get(config_key))
+
+
 class ArtifactCompletionMixin:
     async def _promote_fenced_artifacts(
         self,
@@ -550,13 +564,7 @@ class ArtifactCompletionMixin:
         as the floor: content may already have been delivered, and a
         hold must never turn into a free turn.
         """
-        # Channel gate, not a config gate: the wake-time session object
-        # is stale, and a hold appended after wake start must still be
-        # taken — only website sessions ever carry these, so every
-        # other channel skips the extra round trip.
-        if getattr(session, "channel", None) != "website" and not (
-            (session.config or {}).get("commerce_reservations")
-        ):
+        if not _should_take_reservations(session, "commerce_reservations"):
             return
         client = getattr(self, "_platform_client", None)
         if client is None:
@@ -635,9 +643,7 @@ class ArtifactCompletionMixin:
         leak (there is no allowance reaper), the same escape the commerce
         settle makes for website sessions.
         """
-        if getattr(session, "channel", None) != "website" and not (
-            (session.config or {}).get("allowance_reservations")
-        ):
+        if not _should_take_reservations(session, "allowance_reservations"):
             return
         client = getattr(self, "_platform_client", None)
         if client is None:

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -773,8 +773,13 @@ class ArtifactCompletionMixin:
         if cost_tracker is not None:
             complete_data["cost_summary"] = cost_tracker.summary()
 
-        await self._settle_commerce_reservation(session, cost_tracker)
-        await self._settle_allowance_reservation(session, cost_tracker)
+        # Two independent best-effort settlements (neither raises); run
+        # them concurrently to halve the session-complete round trip when
+        # both a commerce and an allowance hold are present.
+        await asyncio.gather(
+            self._settle_commerce_reservation(session, cost_tracker),
+            self._settle_allowance_reservation(session, cost_tracker),
+        )
 
         session_complete_event_id = await self._store.emit_event(
             session.id,

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -629,11 +629,15 @@ class ArtifactCompletionMixin:
         right per-user charge.
 
         Gated on the wake-time config carrying holds, so uncapped agents
-        (the default) skip the round trip. A hold appended mid-turn that
-        the stale wake object misses is bounded — there is no reaper, but
-        the next per-user cycle refill clears any leaked hold.
+        (the default) skip the round trip. Website sessions always pop the
+        live config regardless of the stale wake object: an embed hold
+        pinned by ``send_website_message`` after wake start would otherwise
+        leak (there is no allowance reaper), the same escape the commerce
+        settle makes for website sessions.
         """
-        if not (session.config or {}).get("allowance_reservations"):
+        if getattr(session, "channel", None) != "website" and not (
+            (session.config or {}).get("allowance_reservations")
+        ):
             return
         client = getattr(self, "_platform_client", None)
         if client is None:

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -613,6 +613,79 @@ class ArtifactCompletionMixin:
                     exc_info=True,
                 )
 
+    async def _settle_allowance_reservation(
+        self,
+        session: Session,
+        cost_tracker: SessionCostTracker | None,
+    ) -> None:
+        """Settle the per-user allowance holds pinned at message accept.
+
+        Mirrors :meth:`_settle_commerce_reservation` but for the operator-
+        granted per-user cap: pops the whole ``allowance_reservations``
+        list and debits the wake's total LLM usage against the oldest hold
+        (the rest release with zero usage — their messages folded into
+        this wake, which already charges their tokens). All holds on a web
+        session belong to the same end-user, so the wake total is the
+        right per-user charge.
+
+        Gated on the wake-time config carrying holds, so uncapped agents
+        (the default) skip the round trip. A hold appended mid-turn that
+        the stale wake object misses is bounded — there is no reaper, but
+        the next per-user cycle refill clears any leaked hold.
+        """
+        if not (session.config or {}).get("allowance_reservations"):
+            return
+        client = getattr(self, "_platform_client", None)
+        if client is None:
+            logger.warning(
+                "Session %s carries allowance reservations but the worker "
+                "has no platform client; the next cycle refill clears them",
+                session.id,
+            )
+            return
+        try:
+            taken = await self._store.pop_session_config_key(
+                session.id, "allowance_reservations",
+            )
+        except Exception:
+            logger.warning(
+                "Failed to take allowance reservations for session %s; "
+                "the next cycle refill will clear them",
+                session.id,
+                exc_info=True,
+            )
+            return
+        reservations = [r for r in (taken or []) if isinstance(r, dict)]
+        if not reservations:
+            return
+        actual_total = (
+            cost_tracker.total_input_tokens + cost_tracker.total_output_tokens
+            if cost_tracker is not None
+            else None
+        )
+        for index, reservation in enumerate(reservations):
+            reserved = int(reservation.get("reserved_tokens") or 0)
+            if actual_total is None:
+                actual = reserved
+            else:
+                actual = actual_total if index == 0 else 0
+            try:
+                await client.allowance_debit(
+                    session.agent_id,
+                    allowance_id=str(reservation.get("allowance_id") or ""),
+                    reserved_tokens=reserved,
+                    actual_tokens=actual,
+                    reservation_id=reservation.get("reservation_id") or None,
+                )
+            except Exception:
+                logger.warning(
+                    "Allowance settlement failed for session %s "
+                    "(reservation %s); the next cycle refill clears the hold",
+                    session.id,
+                    reservation.get("reservation_id"),
+                    exc_info=True,
+                )
+
     async def _complete_session(
         self,
         session: Session,
@@ -697,6 +770,7 @@ class ArtifactCompletionMixin:
             complete_data["cost_summary"] = cost_tracker.summary()
 
         await self._settle_commerce_reservation(session, cost_tracker)
+        await self._settle_allowance_reservation(session, cost_tracker)
 
         session_complete_event_id = await self._store.emit_event(
             session.id,

--- a/surogates/runtime/context.py
+++ b/surogates/runtime/context.py
@@ -183,6 +183,14 @@ class AgentRuntimeContext:
     # reports a channel).
     linkable_channels: tuple[str, ...] = ()
 
+    # Per-end-user token cap (a slice of the operator's subscription),
+    # projected from ops.  ``None`` = do not enforce — either the platform
+    # kill-switch is off or the operator set no cap — and the runtime skips
+    # per-user authorize/settle entirely.  A positive value tells the
+    # runtime to reserve/settle each end-user turn against the ops
+    # allowance ledger (ops holds the authoritative balance).
+    end_user_token_allowance: int | None = None
+
     # File-bundle reference.  Both optional so agents that haven't
     # been onboarded to Hub-backed bundles yet still work.
     # ``bundle_hub_ref`` is the Hub repository in ``<owner>/<repo>``

--- a/surogates/runtime/platform_client.py
+++ b/surogates/runtime/platform_client.py
@@ -564,17 +564,9 @@ class PlatformClient:
         }
         if reservation_id:
             body["reservation_id"] = reservation_id
-        resp = await self._client.post(
-            f"/api/agents/agents/{agent_id}/allowance/debit",
-            json=body,
+        return await self._post_commerce(
+            f"/api/agents/agents/{agent_id}/allowance/debit", body,
         )
-        if resp.status_code == 401:
-            raise PlatformAuthError(
-                "surogate-ops rejected runtime token (401); "
-                "is the token revoked or missing the 'runtime' scope?",
-            )
-        resp.raise_for_status()
-        return resp.json()
 
     async def aclose(self) -> None:
         await self._client.aclose()

--- a/surogates/runtime/platform_client.py
+++ b/surogates/runtime/platform_client.py
@@ -30,6 +30,7 @@ from typing import Any
 import httpx
 
 __all__ = [
+    "AllowanceExhaustedError",
     "CommercePaymentRequiredError",
     "PlatformAuthError",
     "PlatformClient",
@@ -45,6 +46,19 @@ class CommercePaymentRequiredError(RuntimeError):
 
     ``detail`` carries the machine sentinel (``subscription_required``
     / ``insufficient_tokens``) the widget maps to its paywall copy.
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+class AllowanceExhaustedError(RuntimeError):
+    """Ops refused a per-end-user allowance authorization with 402.
+
+    The end-user has spent their per-cycle slice of the operator's
+    subscription; ``detail`` is the machine sentinel
+    (``allowance_exhausted``).
     """
 
     def __init__(self, detail: str) -> None:
@@ -479,6 +493,79 @@ class PlatformClient:
             body["reservation_id"] = reservation_id
         resp = await self._client.post(
             f"/api/agents/agents/{agent_id}/commerce/debit",
+            json=body,
+        )
+        if resp.status_code == 401:
+            raise PlatformAuthError(
+                "surogate-ops rejected runtime token (401); "
+                "is the token revoked or missing the 'runtime' scope?",
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def allowance_authorize(
+        self,
+        agent_id: str,
+        *,
+        end_user_id: str,
+        estimated_tokens: int,
+    ) -> dict:
+        """Reserve tokens for one end-user turn against their per-user cap.
+
+        Returns ``{allowance_id, reserved_tokens, reservation_id}`` (all
+        zero/empty when uncapped or the kill-switch is off).  Raises:
+
+        * :class:`AllowanceExhaustedError` on 402 — the user has spent
+          their slice of the operator's subscription this cycle.
+        * :class:`PlatformAuthError` on 401 — operations problem.
+        * ``httpx.HTTPStatusError`` on any other non-2xx.
+        """
+        resp = await self._client.post(
+            f"/api/agents/agents/{agent_id}/allowance/authorize",
+            json={
+                "end_user_id": end_user_id,
+                "estimated_tokens": estimated_tokens,
+            },
+        )
+        if resp.status_code == 402:
+            detail = ""
+            try:
+                detail = str(resp.json().get("detail") or "")
+            except ValueError:
+                pass
+            raise AllowanceExhaustedError(detail or "allowance_exhausted")
+        if resp.status_code == 401:
+            raise PlatformAuthError(
+                "surogate-ops rejected runtime token (401); "
+                "is the token revoked or missing the 'runtime' scope?",
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def allowance_debit(
+        self,
+        agent_id: str,
+        *,
+        allowance_id: str,
+        reserved_tokens: int,
+        actual_tokens: int,
+        reservation_id: str | None = None,
+    ) -> dict:
+        """Settle an allowance reservation with the turn's actual usage.
+
+        Returns ``{"debited_tokens": int}``. Idempotent on the ops side.
+        Callers treat failures as best-effort — an unsettled hold is
+        cleared by the next per-user cycle refill.
+        """
+        body: dict = {
+            "allowance_id": allowance_id,
+            "reserved_tokens": reserved_tokens,
+            "actual_tokens": actual_tokens,
+        }
+        if reservation_id:
+            body["reservation_id"] = reservation_id
+        resp = await self._client.post(
+            f"/api/agents/agents/{agent_id}/allowance/debit",
             json=body,
         )
         if resp.status_code == 401:

--- a/surogates/runtime/resolver.py
+++ b/surogates/runtime/resolver.py
@@ -115,6 +115,7 @@ def build_agent_runtime_context(payload: dict) -> AgentRuntimeContext:
         browser_enabled=bool(payload.get("browser_enabled", True)),
         multi_session=multi_session_from_payload(payload),
         linkable_channels=tuple(payload.get("linkable_channels") or ()),
+        end_user_token_allowance=payload.get("end_user_token_allowance"),
         # bundle reference.  Empty strings → None
         # (a misconfigured payload that ships "" must not turn into
         # a Hub fetch against an empty ref).

--- a/tests/api/test_allowance_turn.py
+++ b/tests/api/test_allowance_turn.py
@@ -115,6 +115,44 @@ async def test_capped_user_reserves_and_pins_receipt():
 
 
 @pytest.mark.asyncio
+async def test_always_reserves_even_without_a_projected_cap():
+    """The per-buyer website embed forces authorization against the
+    buyer's purchased allowance even when the agent projects no default
+    cap (``end_user_token_allowance`` absent)."""
+    client = _FakePlatformClient(
+        receipt={
+            "allowance_id": "al-e",
+            "reserved_tokens": 5,
+            "reservation_id": "r-e",
+        },
+    )
+    store = _FakeStore()
+    request = _request(
+        runtime_payload={},  # no end_user_token_allowance projected
+        platform_client=client,
+        store=store,
+    )
+    await authorize_allowance_turn(
+        request, _session(), "hello there", end_user_id="buyer-1", always=True,
+    )
+    assert len(client.calls) == 1
+    assert client.calls[0]["end_user_id"] == "buyer-1"
+    assert store.updates and store.updates[0][1] == "allowance_reservations"
+
+
+@pytest.mark.asyncio
+async def test_without_always_no_projection_stays_a_noop():
+    """The default (non-embed) path is still a no-op with no projection."""
+    client = _FakePlatformClient(receipt={"allowance_id": "x"})
+    store = _FakeStore()
+    request = _request(runtime_payload={}, platform_client=client, store=store)
+    await authorize_allowance_turn(
+        request, _session(), "hi", end_user_id="u1",
+    )
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
 async def test_uncapped_receipt_pins_no_hold():
     """Ops may report an uncapped user (empty allowance_id) even with the
     flag on — nothing to settle, so no hold is pinned."""

--- a/tests/api/test_allowance_turn.py
+++ b/tests/api/test_allowance_turn.py
@@ -1,0 +1,168 @@
+"""Per-end-user allowance enforcement on the web channel.
+
+``authorize_allowance_turn`` applies to every signed-in end-user (any
+identity provider, regardless of commerce mode) — closing the
+Firebase-only / free-mode gaps of the commerce gate — but only when ops
+projects a positive ``end_user_token_allowance``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from surogates.api.routes._commerce_turn import authorize_allowance_turn
+from surogates.runtime.platform_client import AllowanceExhaustedError
+
+
+class _FakeCache:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def get(self, key):
+        if key not in self._rows:
+            raise LookupError(key)
+        return self._rows[key]
+
+
+class _FakeStore:
+    def __init__(self):
+        self.updates: list[tuple] = []
+
+    async def append_session_config_list(self, session_id, key, value):
+        self.updates.append((session_id, key, value))
+
+
+class _FakePlatformClient:
+    def __init__(self, *, receipt=None, error=None):
+        self.receipt = receipt
+        self.error = error
+        self.calls: list[dict] = []
+
+    async def allowance_authorize(self, agent_id, **kwargs):
+        self.calls.append({"agent_id": agent_id, **kwargs})
+        if self.error is not None:
+            raise self.error
+        return self.receipt
+
+
+def _request(*, runtime_payload=None, platform_client=None, store=None):
+    state = SimpleNamespace()
+    if runtime_payload is not None:
+        state.runtime_config_cache = _FakeCache({"a-1": runtime_payload})
+    if platform_client is not None:
+        state.platform_client = platform_client
+    if store is not None:
+        state.session_store = store
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+def _session():
+    return SimpleNamespace(id=uuid.uuid4(), agent_id="a-1", config={})
+
+
+@pytest.mark.asyncio
+async def test_no_allowance_projected_is_a_noop():
+    """No ``end_user_token_allowance`` in the payload → no client call, no
+    hold (uncapped agents, the default, are untouched)."""
+    client = _FakePlatformClient(receipt={"allowance_id": "x"})
+    store = _FakeStore()
+    request = _request(
+        runtime_payload={"commerce_mode": "free"},
+        platform_client=client,
+        store=store,
+    )
+    await authorize_allowance_turn(
+        request, _session(), "hello", end_user_id="db-user-1",
+    )
+    assert client.calls == []
+    assert store.updates == []
+
+
+@pytest.mark.asyncio
+async def test_capped_user_reserves_and_pins_receipt():
+    client = _FakePlatformClient(
+        receipt={
+            "allowance_id": "al-1",
+            "reserved_tokens": 12,
+            "reservation_id": "r-1",
+        },
+    )
+    store = _FakeStore()
+    request = _request(
+        runtime_payload={"end_user_token_allowance": 1000},
+        platform_client=client,
+        store=store,
+    )
+    session = _session()
+    # A database (non-Firebase) end-user is metered too — the hatch is closed.
+    await authorize_allowance_turn(
+        request, session, "some message content", end_user_id="db-user-1",
+    )
+    assert len(client.calls) == 1
+    assert client.calls[0]["end_user_id"] == "db-user-1"
+    assert client.calls[0]["estimated_tokens"] > 0
+    assert store.updates == [
+        (
+            session.id,
+            "allowance_reservations",
+            {"allowance_id": "al-1", "reserved_tokens": 12, "reservation_id": "r-1"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_uncapped_receipt_pins_no_hold():
+    """Ops may report an uncapped user (empty allowance_id) even with the
+    flag on — nothing to settle, so no hold is pinned."""
+    client = _FakePlatformClient(
+        receipt={"allowance_id": "", "reserved_tokens": 0, "reservation_id": ""},
+    )
+    store = _FakeStore()
+    request = _request(
+        runtime_payload={"end_user_token_allowance": 1000},
+        platform_client=client,
+        store=store,
+    )
+    await authorize_allowance_turn(
+        request, _session(), "hi", end_user_id="u1",
+    )
+    assert len(client.calls) == 1
+    assert store.updates == []
+
+
+@pytest.mark.asyncio
+async def test_exhausted_allowance_raises_402():
+    client = _FakePlatformClient(error=AllowanceExhaustedError("allowance_exhausted"))
+    store = _FakeStore()
+    request = _request(
+        runtime_payload={"end_user_token_allowance": 50},
+        platform_client=client,
+        store=store,
+    )
+    with pytest.raises(HTTPException) as exc:
+        await authorize_allowance_turn(
+            request, _session(), "content", end_user_id="u1",
+        )
+    assert exc.value.status_code == 402
+    assert exc.value.detail == {"code": "allowance_exhausted"}
+    assert store.updates == []
+
+
+@pytest.mark.asyncio
+async def test_metering_plane_error_fails_closed_503():
+    client = _FakePlatformClient(error=RuntimeError("ops down"))
+    store = _FakeStore()
+    request = _request(
+        runtime_payload={"end_user_token_allowance": 50},
+        platform_client=client,
+        store=store,
+    )
+    with pytest.raises(HTTPException) as exc:
+        await authorize_allowance_turn(
+            request, _session(), "content", end_user_id="u1",
+        )
+    assert exc.value.status_code == 503

--- a/tests/api/test_allowance_turn.py
+++ b/tests/api/test_allowance_turn.py
@@ -135,8 +135,36 @@ async def test_uncapped_receipt_pins_no_hold():
 
 
 @pytest.mark.asyncio
-async def test_exhausted_allowance_raises_402():
+async def test_exhausted_allowance_raises_402_with_buy_url():
+    """The 402 carries the agent's buy-page URL so the client can render a
+    real buy prompt (matching the commerce gate's structured detail)."""
     client = _FakePlatformClient(error=AllowanceExhaustedError("allowance_exhausted"))
+    store = _FakeStore()
+    request = _request(
+        runtime_payload={
+            "end_user_token_allowance": 50,
+            "commerce_buy_url": "https://buy.example/agent",
+        },
+        platform_client=client,
+        store=store,
+    )
+    with pytest.raises(HTTPException) as exc:
+        await authorize_allowance_turn(
+            request, _session(), "content", end_user_id="u1",
+        )
+    assert exc.value.status_code == 402
+    assert exc.value.detail == {
+        "code": "allowance_exhausted",
+        "buy_url": "https://buy.example/agent",
+    }
+    assert store.updates == []
+
+
+@pytest.mark.asyncio
+async def test_subscription_required_402_carries_code_and_null_buy_url():
+    """No buy URL projected → the key is still present (value None) so the
+    client's paywall branch is uniform."""
+    client = _FakePlatformClient(error=AllowanceExhaustedError("subscription_required"))
     store = _FakeStore()
     request = _request(
         runtime_payload={"end_user_token_allowance": 50},
@@ -148,8 +176,7 @@ async def test_exhausted_allowance_raises_402():
             request, _session(), "content", end_user_id="u1",
         )
     assert exc.value.status_code == 402
-    assert exc.value.detail == {"code": "allowance_exhausted"}
-    assert store.updates == []
+    assert exc.value.detail == {"code": "subscription_required", "buy_url": None}
 
 
 @pytest.mark.asyncio

--- a/tests/harness/test_commerce_settlement.py
+++ b/tests/harness/test_commerce_settlement.py
@@ -48,6 +48,12 @@ class _FakePlatformClient:
         self.debits.append({"agent_id": agent_id, **kwargs})
         return {"debited_tokens": kwargs["actual_tokens"]}
 
+    async def allowance_debit(self, agent_id, **kwargs):
+        if self.error is not None:
+            raise self.error
+        self.debits.append({"agent_id": agent_id, **kwargs})
+        return {"debited_tokens": kwargs["actual_tokens"]}
+
 
 def _session(*, channel="website", config=None):
     return SimpleNamespace(
@@ -172,3 +178,47 @@ async def test_missing_platform_client_leaves_holds_to_the_reaper():
     )
 
     assert store.pops == []
+
+
+# ── Per-user allowance settlement (website embed holds) ───────────────
+
+_AR1 = {"allowance_id": "al-1", "reserved_tokens": 500, "reservation_id": "res-1"}
+
+
+@pytest.mark.asyncio
+async def test_allowance_website_session_pops_even_when_wake_config_is_stale():
+    """A per-buyer embed hold pinned by send_website_message after wake
+    start would leak without the website escape (there is no allowance
+    reaper) — website sessions always take the live list."""
+    client = _FakePlatformClient()
+    store = _FakeStore(reservations=[_AR1])
+    harness = _Harness(platform_client=client, store=store)
+
+    await harness._settle_allowance_reservation(
+        _session(config={}), _tracker(10, 5),
+    )
+
+    assert store.pops == [(store.pops[0][0], "allowance_reservations")]
+    assert client.debits == [
+        {
+            "agent_id": "a-1",
+            "allowance_id": "al-1",
+            "reserved_tokens": 500,
+            "actual_tokens": 15,
+            "reservation_id": "res-1",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_allowance_non_website_without_pin_skips_the_round_trip():
+    client = _FakePlatformClient()
+    store = _FakeStore(reservations=[_AR1])
+    harness = _Harness(platform_client=client, store=store)
+
+    await harness._settle_allowance_reservation(
+        _session(channel="web", config={}), _tracker(10, 5),
+    )
+
+    assert store.pops == []
+    assert client.debits == []

--- a/tests/runtime/test_resolver_projection.py
+++ b/tests/runtime/test_resolver_projection.py
@@ -239,3 +239,19 @@ def test_linkable_channels_null_normalises_to_empty():
     payload["linkable_channels"] = None
     ctx = build_agent_runtime_context(payload)
     assert ctx.linkable_channels == ()
+
+
+def test_end_user_token_allowance_defaults_to_none():
+    from surogates.runtime import build_agent_runtime_context
+
+    ctx = build_agent_runtime_context(_minimum_payload())
+    assert ctx.end_user_token_allowance is None
+
+
+def test_end_user_token_allowance_projects_when_present():
+    from surogates.runtime import build_agent_runtime_context
+
+    payload = _minimum_payload()
+    payload["end_user_token_allowance"] = 1000
+    ctx = build_agent_runtime_context(payload)
+    assert ctx.end_user_token_allowance == 1000

--- a/tests/test_channel_pipeline.py
+++ b/tests/test_channel_pipeline.py
@@ -1355,3 +1355,102 @@ async def test_channel_session_blank_identifier_memory_boundary_fails_closed():
 
     created = deps._sessions_created[-1]
     assert created["config"]["memory_boundary"] == f"slack:iso:{created['session_key']}"
+
+
+# ---------------------------------------------------------------------------
+# Slice C: per-user allowance gate on the slack/telegram inbound pipeline
+# ---------------------------------------------------------------------------
+
+
+class _FakeAllowanceClient:
+    def __init__(self, *, receipt=None, error=None):
+        self.receipt = receipt
+        self.error = error
+        self.calls: list[dict] = []
+
+    async def allowance_authorize(self, agent_id, *, end_user_id, estimated_tokens):
+        self.calls.append(
+            {
+                "agent_id": agent_id,
+                "end_user_id": end_user_id,
+                "estimated_tokens": estimated_tokens,
+            },
+        )
+        if self.error is not None:
+            raise self.error
+        return self.receipt
+
+
+def _capped_config():
+    async def _rc(agent_id):
+        return {"end_user_token_allowance": 1000}
+
+    return _rc
+
+
+def _uncapped_config():
+    async def _rc(agent_id):
+        return {}
+
+    return _rc
+
+
+@pytest.mark.asyncio
+async def test_allowance_gate_blocks_exhausted_channel_user():
+    from surogates.runtime.platform_client import AllowanceExhaustedError
+
+    msg = _make_msg(is_dm=True, ts="allow.1")
+    deps = _make_deps()
+    deps.platform_client = _FakeAllowanceClient(
+        error=AllowanceExhaustedError("allowance_exhausted"),
+    )
+    deps.runtime_config = _capped_config()
+
+    result = await ChannelInboundPipeline().handle(
+        msg, routing=_make_routing(), config=_make_config(), deps=deps,
+    )
+    assert result == InboundOutcome.DROPPED
+    # Blocked BEFORE emit/enqueue: no turn runs.
+    assert deps._enqueued == []
+    assert not any(e[1] == EventType.USER_MESSAGE for e in deps.session_store.events)
+
+
+@pytest.mark.asyncio
+async def test_allowance_gate_passes_and_pins_reservation():
+    msg = _make_msg(is_dm=True, ts="allow.2")
+    deps = _make_deps()
+    deps.platform_client = _FakeAllowanceClient(
+        receipt={"allowance_id": "al-1", "reserved_tokens": 7, "reservation_id": "r-1"},
+    )
+    deps.runtime_config = _capped_config()
+    pins: list[tuple] = []
+
+    async def _append(session_id, key, value):
+        pins.append((session_id, key, value))
+
+    deps.session_store.append_session_config_list = _append
+
+    result = await ChannelInboundPipeline().handle(
+        msg, routing=_make_routing(), config=_make_config(), deps=deps,
+    )
+    assert result == InboundOutcome.PROCESSED
+    assert deps._enqueued
+    assert pins and pins[0][1] == "allowance_reservations"
+    assert len(deps.platform_client.calls) == 1
+    assert deps.platform_client.calls[0]["end_user_id"] == str(USER_ID)
+
+
+@pytest.mark.asyncio
+async def test_allowance_gate_noop_for_uncapped_agent():
+    msg = _make_msg(is_dm=True, ts="allow.3")
+    deps = _make_deps()
+    deps.platform_client = _FakeAllowanceClient(receipt={})
+    deps.runtime_config = _uncapped_config()
+
+    result = await ChannelInboundPipeline().handle(
+        msg, routing=_make_routing(), config=_make_config(), deps=deps,
+    )
+    assert result == InboundOutcome.PROCESSED
+    assert deps._enqueued
+    # Uncapped agent → no ops round trip.
+    assert deps.platform_client.calls == []

--- a/tests/test_channel_pipeline.py
+++ b/tests/test_channel_pipeline.py
@@ -1416,6 +1416,39 @@ async def test_allowance_gate_blocks_exhausted_channel_user():
 
 
 @pytest.mark.asyncio
+async def test_allowance_block_nudge_names_reason_and_includes_buy_link():
+    from surogates.runtime.platform_client import AllowanceExhaustedError
+
+    msg = _make_msg(is_dm=True, ts="allow.buy")
+    deps = _make_deps()
+    deps.platform_client = _FakeAllowanceClient(
+        error=AllowanceExhaustedError("subscription_required"),
+    )
+
+    async def _rc(agent_id):
+        return {
+            "end_user_token_allowance": 1000,
+            "commerce_buy_url": "https://buy.example/agent",
+        }
+
+    deps.runtime_config = _rc
+    nudges: list[str] = []
+
+    async def _nudge(session_id, m, text):
+        nudges.append(text)
+
+    deps.input_nudge = _nudge
+
+    result = await ChannelInboundPipeline().handle(
+        msg, routing=_make_routing(), config=_make_config(), deps=deps,
+    )
+    assert result == InboundOutcome.DROPPED
+    assert len(nudges) == 1
+    assert "https://buy.example/agent" in nudges[0]
+    assert "subscription" in nudges[0].lower()
+
+
+@pytest.mark.asyncio
 async def test_allowance_gate_passes_and_pins_reservation():
     msg = _make_msg(is_dm=True, ts="allow.2")
     deps = _make_deps()

--- a/web/src/api/_errors.ts
+++ b/web/src/api/_errors.ts
@@ -52,3 +52,39 @@ export async function parseError(
   } | null;
   throw new Error(errorDetailMessage(payload?.detail) ?? fallback);
 }
+
+// Lead copy per 402 paywall code emitted by the commerce/allowance gates
+// (``{code, buy_url}``). ``operator_subscription_exhausted`` is the agent
+// owner's problem, not the visitor's, so it offers no buy action.
+const PAYWALL_LEADS: Record<string, string> = {
+  allowance_exhausted: "You've reached your usage limit for this assistant.",
+  subscription_required:
+    "A subscription is required to keep chatting with this assistant.",
+  operator_subscription_exhausted:
+    "This assistant is temporarily unavailable — its owner has run out of credit.",
+  sign_in_required: "Please sign in to keep chatting with this assistant.",
+};
+
+/**
+ * Turn a 402 paywall detail (``{code, buy_url}``) into a user-facing
+ * message, appending the agent's buy link when there is a buyer action to
+ * take. Returns ``undefined`` when the detail is not a recognised paywall
+ * payload so callers fall back to their generic handling.
+ */
+export function paywallErrorMessage(detail: unknown): string | undefined {
+  if (!detail || typeof detail !== "object") {
+    return undefined;
+  }
+  const record = detail as Record<string, unknown>;
+  const code = nonEmptyString(record.code);
+  if (!code) {
+    return undefined;
+  }
+  const lead =
+    PAYWALL_LEADS[code] ?? "You need to buy access to keep chatting.";
+  const buyUrl = nonEmptyString(record.buy_url);
+  if (buyUrl && code !== "operator_subscription_exhausted") {
+    return `${lead} Get more access here: ${buyUrl}`;
+  }
+  return lead;
+}

--- a/web/src/api/_errors.ts
+++ b/web/src/api/_errors.ts
@@ -61,7 +61,7 @@ const PAYWALL_LEADS: Record<string, string> = {
   subscription_required:
     "A subscription is required to keep chatting with this assistant.",
   operator_subscription_exhausted:
-    "This assistant is temporarily unavailable — its owner has run out of credit.",
+    "This assistant is temporarily unavailable. Its owner has run out of credit.",
   sign_in_required: "Please sign in to keep chatting with this assistant.",
 };
 

--- a/web/src/api/sessions.ts
+++ b/web/src/api/sessions.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 import { authFetch } from "./auth";
-import { errorDetailMessage } from "./_errors";
+import { errorDetailMessage, paywallErrorMessage } from "./_errors";
 import type {
   Session,
   SessionChildrenResponse,
@@ -98,7 +98,18 @@ export async function sendMessage(
       body: JSON.stringify(payload),
     },
   );
-  if (!response.ok) throw new Error("Failed to send message");
+  if (!response.ok) {
+    if (response.status === 402) {
+      const body = (await response.json().catch(() => null)) as {
+        detail?: unknown;
+      } | null;
+      const paywall = paywallErrorMessage(body?.detail);
+      if (paywall) {
+        throw new Error(paywall);
+      }
+    }
+    throw new Error("Failed to send message");
+  }
   return (await response.json()) as { event_id: number; status: string };
 }
 


### PR DESCRIPTION
## Enforce per-end-user token allowances across every channel + buy prompts

The runtime half of the ops per-end-user allowance feature. Reserves each end-user turn against their allowance (a slice of the operator's subscription) before it runs, and settles actual usage after — on **every** channel. A no-op unless ops projects an allowance, so uncapped/free agents are untouched.

### Gates (one shared reserve/settle path)
- **Web channel** (`api/routes/sessions.py`): every signed-in end-user turn reserves against their allowance before emit/enqueue.
- **Slack / Telegram** (`channels/inbound.py`, "Gate 7.5"): the sender's turn reserves against their allowance; an exhausted allowance drops the message with a notice.
- **Website widget** (`api/routes/website.py`): a buyer-minted embed key carries the buyer's `embed_end_user_id`; the bootstrap pins it and every anonymous visitor turn reserves against that buyer's purchased allowance (`always`-authorize, since the buyer holds the allowance even when the agent has no default cap).
- Fail-closed when the allowance plane is unreachable; the worker settles the pinned reservations after the turn.

### Buy prompts
- The allowance 402 now carries the agent's buy-page URL (like the commerce gate), so a blocked user gets a real path to buy.
- The web SPA renders that as a paywall message on the failed send; the slack/telegram block notice names the reason (subscription vs usage limit) and appends the buy link.

### Tests
New/extended suites for the shared allowance gate (`always` embed path + buy_url in the 402), the channel pipeline block-notice, and no regressions across the website suites.
