### PR TITLE
feat(runtime): enforce purchased feature packages per turn

### DIFF
--- a/surogates/api/routes/_commerce_turn.py
+++ b/surogates/api/routes/_commerce_turn.py
@@ -14,6 +14,7 @@ import logging
 
 from fastapi import HTTPException, Request, status
 
+from surogates.runtime.entitlements import ENTITLEMENTS_CONFIG_KEY
 from surogates.runtime.platform_client import (
     AllowanceExhaustedError,
     CommercePaymentRequiredError,
@@ -118,12 +119,9 @@ class AllowanceReserveError(RuntimeError):
     """The allowance plane could not be reached — callers fail closed."""
 
 
-#: Session-config key holding the end-user's effective feature package
-#: for the current turn (``{capabilities, channels, kb_ids,
-#: mcp_server_ids}``; absent key = unrestricted dimension). Pinned by
-#: the authorize gates from the ops receipt; read by the worker/harness
-#: per-session filters. Absent = no restriction (agent defaults).
-ENTITLEMENTS_CONFIG_KEY = "entitlements"
+# The pinned package lives under ``ENTITLEMENTS_CONFIG_KEY`` (imported
+# from ``surogates.runtime.entitlements``, the canonical key + reader
+# module shared with the worker/harness filters).
 
 
 async def pin_entitlements(

--- a/surogates/api/routes/_commerce_turn.py
+++ b/surogates/api/routes/_commerce_turn.py
@@ -196,6 +196,17 @@ async def reserve_allowance(
     website widget embed.
     """
     if not always and runtime_payload.get("end_user_token_allowance") is None:
+        # Uncapped agent: no per-turn authorize, so no receipt carries
+        # the package. The agent's default package (ops projects it for
+        # exactly this) is still the sender's package — pin it here or
+        # a free unlimited agent with a restricted default would serve
+        # every capability unrestricted.
+        await pin_entitlements(
+            session_store,
+            session_id,
+            session_config,
+            runtime_payload.get("default_user_features"),
+        )
         return
     if platform_client is None:
         raise AllowanceReserveError("platform_client not wired")

--- a/surogates/api/routes/_commerce_turn.py
+++ b/surogates/api/routes/_commerce_turn.py
@@ -38,6 +38,7 @@ async def authorize_commerce_turn(
     content: str,
     *,
     buyer: dict | None = None,
+    channel: str | None = None,
 ) -> None:
     """Gate one visitor message behind the agent's monetization mode.
 
@@ -75,6 +76,7 @@ async def authorize_commerce_turn(
             estimated_tokens=estimate_turn_tokens(content),
             email=buyer.get("email"),
             name=buyer.get("name"),
+            channel=channel,
         )
     except CommercePaymentRequiredError as exc:
         raise HTTPException(

--- a/surogates/api/routes/_commerce_turn.py
+++ b/surogates/api/routes/_commerce_turn.py
@@ -92,6 +92,12 @@ async def authorize_commerce_turn(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Access checks are temporarily unavailable; try again.",
         ) from exc
+    await pin_entitlements(
+        getattr(request.app.state, "session_store", None),
+        session.id,
+        session.config,
+        receipt.get("features"),
+    )
     if receipt.get("entitlement_id"):
         store = get_session_store(request)
         # Appended, not overwritten: a second message can land while a
@@ -112,6 +118,47 @@ class AllowanceReserveError(RuntimeError):
     """The allowance plane could not be reached — callers fail closed."""
 
 
+#: Session-config key holding the end-user's effective feature package
+#: for the current turn (``{capabilities, channels, kb_ids,
+#: mcp_server_ids}``; absent key = unrestricted dimension). Pinned by
+#: the authorize gates from the ops receipt; read by the worker/harness
+#: per-session filters. Absent = no restriction (agent defaults).
+ENTITLEMENTS_CONFIG_KEY = "entitlements"
+
+
+async def pin_entitlements(
+    session_store,
+    session_id,
+    current_config: dict | None,
+    features: dict | None,
+) -> None:
+    """Pin the receipt's feature package on the session, minimally.
+
+    ``current_config`` (the caller's already-loaded session config, when
+    it has one) short-circuits the round trip entirely in steady state;
+    the store's reconcile skips the write when nothing changed either
+    way. Best-effort by design — a pin failure must not turn an
+    authorized turn into a 500; the previous turn's package (or none)
+    simply keeps applying.
+    """
+    if session_store is None:
+        return
+    if (
+        current_config is not None
+        and current_config.get(ENTITLEMENTS_CONFIG_KEY) == features
+    ):
+        return
+    try:
+        await session_store.reconcile_session_config_key(
+            session_id, ENTITLEMENTS_CONFIG_KEY, features,
+        )
+    except Exception:
+        logger.warning(
+            "entitlements pin failed for session %s", session_id,
+            exc_info=True,
+        )
+
+
 async def reserve_allowance(
     *,
     platform_client,
@@ -122,6 +169,8 @@ async def reserve_allowance(
     content: str,
     end_user_id: str,
     always: bool = False,
+    channel: str | None = None,
+    session_config: dict | None = None,
 ) -> None:
     """Channel-agnostic per-user allowance reservation (no HTTP request).
 
@@ -131,13 +180,20 @@ async def reserve_allowance(
     per-buyer website embed, where the buyer holds a purchased allowance
     to draw from even when the agent itself has no default cap.
 
+    ``channel`` names the surface carrying the turn; ops gates sellable
+    channels (slack/telegram/website) against the user's purchased
+    package and 402s ``channel_not_included`` when excluded.
+    ``session_config`` is the session's current config, used to pin the
+    receipt's feature package (``entitlements``) without a read.
+
     Reserves the turn's estimate against the end-user's cap and pins the
     receipt on ``session.config`` for the worker to settle. Raises
     :class:`~surogates.runtime.platform_client.AllowanceExhaustedError`
-    on 402 (cap spent / subscription required / operator plan spent) and
-    :class:`AllowanceReserveError` when the allowance plane is unreachable
-    (callers fail closed). Shared by the web message route, the
-    slack/telegram inbound pipeline, and the website widget embed.
+    on 402 (cap spent / subscription required / operator plan spent /
+    channel not in the package) and :class:`AllowanceReserveError` when
+    the allowance plane is unreachable (callers fail closed). Shared by
+    the web message route, the slack/telegram inbound pipeline, and the
+    website widget embed.
     """
     if not always and runtime_payload.get("end_user_token_allowance") is None:
         return
@@ -148,11 +204,15 @@ async def reserve_allowance(
             str(agent_id),
             end_user_id=end_user_id,
             estimated_tokens=estimate_turn_tokens(content),
+            channel=channel,
         )
     except AllowanceExhaustedError:
         raise
     except Exception as exc:
         raise AllowanceReserveError(str(exc)) from exc
+    await pin_entitlements(
+        session_store, session_id, session_config, receipt.get("features"),
+    )
     if receipt.get("allowance_id"):
         if session_store is None:
             raise AllowanceReserveError("session_store not wired")
@@ -177,18 +237,21 @@ async def authorize_allowance_turn(
     *,
     end_user_id: str,
     always: bool = False,
+    channel: str | None = None,
 ) -> None:
     """HTTP gate for one end-user turn behind their per-user allowance.
 
     Thin wrapper over :func:`reserve_allowance` that pulls dependencies
     from ``request.app.state`` and maps the domain outcomes to HTTP: an
-    exhausted allowance (or subscription-required / operator plan spent)
-    to 402 with the machine sentinel, an unreachable allowance plane to
-    503 (fail closed — a capped agent must not serve unmetered turns).
+    exhausted allowance (or subscription-required / operator plan spent /
+    channel excluded from the package) to 402 with the machine sentinel,
+    an unreachable allowance plane to 503 (fail closed — a capped agent
+    must not serve unmetered turns).
 
     ``always`` forces the ops authorize regardless of the agent's default
     cap projection — used by the per-buyer website embed, where the buyer
-    holds a purchased allowance to draw from.
+    holds a purchased allowance to draw from. ``channel`` names the
+    surface for the package's channel gate.
     """
     payload = await runtime_commerce_payload(request, str(session.agent_id))
     try:
@@ -201,6 +264,8 @@ async def authorize_allowance_turn(
             content=content,
             end_user_id=end_user_id,
             always=always,
+            channel=channel,
+            session_config=session.config,
         )
     except AllowanceExhaustedError as exc:
         # Carry the buy-page URL (as the commerce gate does) so the client

--- a/surogates/api/routes/_shared.py
+++ b/surogates/api/routes/_shared.py
@@ -65,6 +65,26 @@ def require_not_channel_principal(tenant: TenantContext) -> None:
         )
 
 
+async def resolve_agent_id(request: Request) -> str | None:
+    """The request's active agent id, or ``None``.
+
+    ``?agent_id=`` query parameter first (ops proxy and Studio), then
+    the ``Host`` subdomain slug (per-tenant chat web apps). Best-effort:
+    never raises.
+    """
+    agent_id = request.query_params.get("agent_id")
+    if not agent_id:
+        host = request.headers.get("host", "")
+        slug = host.split(".", 1)[0] if "." in host else None
+        if slug and slug.lower() not in {"www", "api", "localhost"}:
+            from surogates.runtime.resolver import _resolve_slug_to_agent_id
+            try:
+                agent_id = await _resolve_slug_to_agent_id(request, slug)
+            except Exception:  # noqa: BLE001 — slug lookup is best-effort
+                agent_id = None
+    return agent_id or None
+
+
 async def resolve_agent_bundle(request: Request):
     """Return the active agent's file bundle, or ``None``.
 
@@ -92,16 +112,7 @@ async def resolve_agent_bundle(request: Request):
     cache = getattr(request.app.state, "file_bundle_cache", None)
     if cache is None:
         return None
-    agent_id = request.query_params.get("agent_id")
-    if not agent_id:
-        host = request.headers.get("host", "")
-        slug = host.split(".", 1)[0] if "." in host else None
-        if slug and slug.lower() not in {"www", "api", "localhost"}:
-            from surogates.runtime.resolver import _resolve_slug_to_agent_id
-            try:
-                agent_id = await _resolve_slug_to_agent_id(request, slug)
-            except Exception:  # noqa: BLE001 — slug lookup is best-effort
-                agent_id = None
+    agent_id = await resolve_agent_id(request)
     if not agent_id:
         return None
     try:

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -826,7 +826,11 @@ async def send_message(
     # unaffected. The worker settles ``allowance_reservations`` after.
     if session.channel == "web" and tenant.user_id is not None:
         await authorize_allowance_turn(
-            request, session, body.content, end_user_id=str(tenant.user_id),
+            request,
+            session,
+            body.content,
+            end_user_id=str(tenant.user_id),
+            channel="web",
         )
 
     event_data: dict = {"content": body.content}

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -816,6 +816,7 @@ async def send_message(
                     session,
                     body.content,
                     buyer=buyer,
+                    channel="web",
                 )
 
     # Per-user allowance (a slice of the operator's subscription) applies

--- a/surogates/api/routes/skills.py
+++ b/surogates/api/routes/skills.py
@@ -404,16 +404,41 @@ async def _session_entitled_skills(
     tenant: TenantContext,
     session_id: "UUID | None",
 ) -> frozenset[str] | None:
-    """The session's purchased-package skill allowlist, or ``None``.
+    """The caller's purchased-package skill allowlist, or ``None``.
 
-    ``None`` (no session, unauthorized, no pin, unrestricted dimension)
-    means no restriction, mirroring the runtime reader.
+    ``session_id`` is a client-supplied query parameter, so its absence
+    (or a bogus id) must not read as "no restriction" — a
+    package-restricted user could simply omit it to list and read
+    paywalled skills. When the given session doesn't resolve, fall back
+    to the caller's most recently active session, where the authorize
+    gates pin the package every turn. Only a caller with no sessions at
+    all (nothing ever pinned) reads as unrestricted.
     """
-    if session_id is None:
-        return None
-    try:
-        session = await _authorize_session_for_staging(request, tenant, session_id)
-    except HTTPException:
+    session = None
+    if session_id is not None:
+        try:
+            session = await _authorize_session_for_staging(
+                request, tenant, session_id,
+            )
+        except HTTPException:
+            session = None
+    if session is None and tenant.user_id is not None:
+        from sqlalchemy import select
+
+        from surogates.db.models import Session as SessionRow
+
+        session_factory = request.app.state.session_factory
+        async with session_factory() as db:
+            session = await db.scalar(
+                select(SessionRow)
+                .where(
+                    SessionRow.org_id == tenant.org_id,
+                    SessionRow.user_id == tenant.user_id,
+                )
+                .order_by(SessionRow.updated_at.desc())
+                .limit(1),
+            )
+    if session is None:
         return None
     from surogates.runtime.entitlements import entitled_skills
 

--- a/surogates/api/routes/skills.py
+++ b/surogates/api/routes/skills.py
@@ -403,6 +403,7 @@ async def _session_entitled_skills(
     request: Request,
     tenant: TenantContext,
     session_id: "UUID | None",
+    resolved_session: "Any | None" = None,
 ) -> frozenset[str] | None:
     """The caller's purchased-package skill allowlist, or ``None``.
 
@@ -414,8 +415,8 @@ async def _session_entitled_skills(
     gates pin the package every turn. Only a caller with no sessions at
     all (nothing ever pinned) reads as unrestricted.
     """
-    session = None
-    if session_id is not None:
+    session = resolved_session
+    if session is None and session_id is not None:
         try:
             session = await _authorize_session_for_staging(
                 request, tenant, session_id,
@@ -429,7 +430,7 @@ async def _session_entitled_skills(
 
         session_factory = request.app.state.session_factory
         async with session_factory() as db:
-            session = await db.scalar(
+            rows = await db.execute(
                 select(SessionRow)
                 .where(
                     SessionRow.org_id == tenant.org_id,
@@ -438,11 +439,19 @@ async def _session_entitled_skills(
                 .order_by(SessionRow.updated_at.desc())
                 .limit(1),
             )
+            recent = rows.scalars().all()
+            session = recent[0] if recent else None
     if session is None:
         return None
     from surogates.runtime.entitlements import entitled_skills
 
     return entitled_skills(session.config)
+
+
+def _skill_entitled(skill_def, entitled: frozenset[str] | None) -> bool:
+    from surogates.runtime.entitlements import skill_entitled
+
+    return skill_entitled(skill_def, entitled)
 
 
 # ---------------------------------------------------------------------------
@@ -482,11 +491,7 @@ async def list_skills(
             system_bundle=system_bundle,
             overrides=overrides,
         )
-    if entitled is not None:
-        all_skills = [
-            s for s in all_skills
-            if getattr(s, "builtin", False) or s.name in entitled
-        ]
+    all_skills = [s for s in all_skills if _skill_entitled(s, entitled)]
 
     summaries: list[SkillSummary] = []
     for skill in all_skills:
@@ -544,11 +549,7 @@ async def view_skill(
     if skill_def is None:
         raise HTTPException(status_code=404, detail=f"Skill '{name}' not found.")
     entitled = await _session_entitled_skills(request, tenant, session_id)
-    if (
-        entitled is not None
-        and not getattr(skill_def, "builtin", False)
-        and skill_def.name not in entitled
-    ):
+    if not _skill_entitled(skill_def, entitled):
         # Same shape as unknown so a probing client learns nothing
         # beyond "not available to you".
         raise HTTPException(status_code=404, detail=f"Skill '{name}' not found.")
@@ -660,12 +661,10 @@ async def read_skill_file(
     skill_def = next((s for s in all_skills if s.name == name), None)
     if skill_def is None:
         raise HTTPException(status_code=404, detail=f"Skill '{name}' not found.")
-    entitled = await _session_entitled_skills(request, tenant, session_id)
-    if (
-        entitled is not None
-        and not getattr(skill_def, "builtin", False)
-        and skill_def.name not in entitled
-    ):
+    entitled = await _session_entitled_skills(
+        request, tenant, session_id, resolved_session=session_for_staging,
+    )
+    if not _skill_entitled(skill_def, entitled):
         raise HTTPException(status_code=404, detail=f"Skill '{name}' not found.")
 
     async def _redirect_to_staged(skill_def_to_stage: Any) -> dict[str, Any] | None:

--- a/surogates/api/routes/skills.py
+++ b/surogates/api/routes/skills.py
@@ -414,6 +414,10 @@ async def _session_entitled_skills(
     to the caller's most recently active session, where the authorize
     gates pin the package every turn. Only a caller with no sessions at
     all (nothing ever pinned) reads as unrestricted.
+
+    The fallback is scoped to the active agent when one is resolvable:
+    a user chats with several agents in one org, and another agent's
+    pinned package must not gate (or open) this agent's skills.
     """
     session = resolved_session
     if session is None and session_id is not None:
@@ -428,16 +432,19 @@ async def _session_entitled_skills(
 
         from surogates.db.models import Session as SessionRow
 
+        from surogates.api.routes._shared import resolve_agent_id
+
+        stmt = select(SessionRow).where(
+            SessionRow.org_id == tenant.org_id,
+            SessionRow.user_id == tenant.user_id,
+        )
+        agent_id = await resolve_agent_id(request)
+        if agent_id:
+            stmt = stmt.where(SessionRow.agent_id == agent_id)
         session_factory = request.app.state.session_factory
         async with session_factory() as db:
             rows = await db.execute(
-                select(SessionRow)
-                .where(
-                    SessionRow.org_id == tenant.org_id,
-                    SessionRow.user_id == tenant.user_id,
-                )
-                .order_by(SessionRow.updated_at.desc())
-                .limit(1),
+                stmt.order_by(SessionRow.updated_at.desc()).limit(1),
             )
             recent = rows.scalars().all()
             session = recent[0] if recent else None

--- a/surogates/api/routes/skills.py
+++ b/surogates/api/routes/skills.py
@@ -399,6 +399,27 @@ async def _load_session_skill_overrides(
     return (session.config or {}).get("skill_overrides") or {}
 
 
+async def _session_entitled_skills(
+    request: Request,
+    tenant: TenantContext,
+    session_id: "UUID | None",
+) -> frozenset[str] | None:
+    """The session's purchased-package skill allowlist, or ``None``.
+
+    ``None`` (no session, unauthorized, no pin, unrestricted dimension)
+    means no restriction, mirroring the runtime reader.
+    """
+    if session_id is None:
+        return None
+    try:
+        session = await _authorize_session_for_staging(request, tenant, session_id)
+    except HTTPException:
+        return None
+    from surogates.runtime.entitlements import entitled_skills
+
+    return entitled_skills(session.config)
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -427,6 +448,7 @@ async def list_skills(
     bundle = await _resolve_agent_bundle(request)
     system_bundle = await _resolve_system_bundle(request)
     overrides = await _load_session_skill_overrides(request, tenant, session_id)
+    entitled = await _session_entitled_skills(request, tenant, session_id)
     async with session_factory() as db_session:
         all_skills = await loader.load_skills(
             tenant,
@@ -435,6 +457,11 @@ async def list_skills(
             system_bundle=system_bundle,
             overrides=overrides,
         )
+    if entitled is not None:
+        all_skills = [
+            s for s in all_skills
+            if getattr(s, "builtin", False) or s.name in entitled
+        ]
 
     summaries: list[SkillSummary] = []
     for skill in all_skills:
@@ -490,6 +517,15 @@ async def view_skill(
 
     skill_def = next((s for s in all_skills if s.name == name), None)
     if skill_def is None:
+        raise HTTPException(status_code=404, detail=f"Skill '{name}' not found.")
+    entitled = await _session_entitled_skills(request, tenant, session_id)
+    if (
+        entitled is not None
+        and not getattr(skill_def, "builtin", False)
+        and skill_def.name not in entitled
+    ):
+        # Same shape as unknown so a probing client learns nothing
+        # beyond "not available to you".
         raise HTTPException(status_code=404, detail=f"Skill '{name}' not found.")
 
     detail = SkillDetail(
@@ -598,6 +634,13 @@ async def read_skill_file(
         )
     skill_def = next((s for s in all_skills if s.name == name), None)
     if skill_def is None:
+        raise HTTPException(status_code=404, detail=f"Skill '{name}' not found.")
+    entitled = await _session_entitled_skills(request, tenant, session_id)
+    if (
+        entitled is not None
+        and not getattr(skill_def, "builtin", False)
+        and skill_def.name not in entitled
+    ):
         raise HTTPException(status_code=404, detail=f"Skill '{name}' not found.")
 
     async def _redirect_to_staged(skill_def_to_stage: Any) -> dict[str, Any] | None:

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -845,7 +845,9 @@ async def send_website_message(
             ),
         )
 
-    await authorize_commerce_turn(request, session, body.content)
+    await authorize_commerce_turn(
+        request, session, body.content, channel="website",
+    )
 
     # Per-buyer embed: when the widget key was minted by a buyer, this
     # anonymous visitor's turn draws from that buyer's purchased

--- a/surogates/api/routes/website.py
+++ b/surogates/api/routes/website.py
@@ -860,6 +860,7 @@ async def send_website_message(
             body.content,
             end_user_id=str(embed_end_user_id),
             always=True,
+            channel="website",
         )
 
     if session.status in ("failed", "paused", "completed"):

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -174,6 +174,13 @@ def _allowance_block_notice(code: str | None, buy_url: str | None) -> str:
     link when the agent projects one, so slack/telegram senders get a
     real path to keep going rather than a dead "try again later".
     """
+    if code == "operator_subscription_exhausted":
+        # The agent OWNER ran out of platform credit; buying more access
+        # cannot help the sender, so no buy link is offered.
+        return (
+            "This assistant is temporarily unavailable. Its owner has "
+            "run out of credit."
+        )
     if code == "subscription_required":
         lead = "A subscription is required to keep chatting with this assistant."
     elif code == "channel_not_included":

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -176,6 +176,8 @@ def _allowance_block_notice(code: str | None, buy_url: str | None) -> str:
     """
     if code == "subscription_required":
         lead = "A subscription is required to keep chatting with this assistant."
+    elif code == "channel_not_included":
+        lead = "Your current plan doesn't include this channel."
     else:
         lead = "You've reached your usage limit for this assistant."
     if buy_url:
@@ -771,6 +773,7 @@ class ChannelInboundPipeline:
                     agent_id=routing.agent_id,
                     content=msg.text or "",
                     end_user_id=str(identity.user_id),
+                    channel=routing.platform,
                 )
             except AllowanceExhaustedError as exc:
                 logger.info(

--- a/surogates/db/ops_models.py
+++ b/surogates/db/ops_models.py
@@ -42,6 +42,22 @@ class OpsAgent(OpsBase):
     )
 
 
+class OpsMcpServer(OpsBase):
+    """Mirror of surogate-ops ``mcp_servers`` table.
+
+    Stripped to what package enforcement needs: identity for the
+    entitlement allowlist (ids), ``name`` (embedded in ``mcp__{name}__``
+    tool names), ``transport`` to spot Composio placeholder rows, and
+    ``oauth`` whose ``toolkit`` keys the Composio tool-name prefix.
+    """
+    __tablename__ = "mcp_servers"
+
+    id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
+    name: Mapped[str] = mapped_column(sa.String(255))
+    transport: Mapped[str] = mapped_column(sa.String(32))
+    oauth: Mapped[Optional[dict]] = mapped_column(sa.JSON, nullable=True)
+
+
 class OpsKnowledgeBase(OpsBase):
     """Mirror of surogate-ops ``knowledge_bases`` table.
 

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -3435,6 +3435,32 @@ class AgentHarness(
         updated.add("ask_user_question")
         return updated
 
+    def _apply_entitlement_exclusions(
+        self, tool_filter: set[str] | None,
+    ) -> set[str] | None:
+        """Subtract the purchased-package exclusions, LAST.
+
+        Runs after ``_apply_mcp_schema_filter`` on purpose: that filter
+        can re-add this agent's full discovered MCP set (its contract
+        for sessions without an explicit allowlist), which would
+        resurrect paywalled ``mcp__*`` tools if the exclusion ran
+        earlier. Beats an explicit ``allowed_tools`` for the same
+        reason the ``/code`` rule does: a paywalled tool must never be
+        schema-visible, whatever the session config asks for.
+        ``getattr``: several test harnesses build partial AgentHarness
+        objects that skip ``__init__``; absent means no restriction.
+        """
+        excluded = getattr(self, "_entitlement_excluded_tools", None)
+        if not excluded:
+            return tool_filter
+        base = (
+            set(self._tools.tool_names)
+            if tool_filter is None
+            else set(tool_filter)
+        )
+        base.difference_update(excluded)
+        return base
+
     def _apply_mcp_schema_filter(
         self, tool_filter: set[str] | None, *, explicit_allowed: bool,
     ) -> set[str] | None:
@@ -3556,23 +3582,6 @@ class AgentHarness(
                 tool_filter = set(tool_filter)
             tool_filter.discard("run_coding_agent")
 
-        # Purchased-package exclusions (browser toolset, non-included MCP
-        # servers / Composio toolkits) computed by the worker for this
-        # wake. Beats an explicit ``allowed_tools`` for the same reason
-        # the ``/code`` rule does: a paywalled tool must never be
-        # schema-visible, whatever the session config asks for.
-        # ``getattr``: several test harnesses build partial AgentHarness
-        # objects that skip ``__init__``; absent means no restriction.
-        entitlement_excluded = getattr(
-            self, "_entitlement_excluded_tools", None,
-        )
-        if entitlement_excluded:
-            if tool_filter is None:
-                tool_filter = set(self._tools.tool_names)
-            else:
-                tool_filter = set(tool_filter)
-            tool_filter.difference_update(entitlement_excluded)
-
         # Any session running as one iteration of a schedule (``/loop`` or
         # cron_create-spawned) must not be able to create new schedules.
         # Otherwise the LLM can spawn nested cron jobs from inside a wake —
@@ -3601,6 +3610,7 @@ class AgentHarness(
             tool_filter = self._apply_mcp_schema_filter(
                 tool_filter, explicit_allowed=explicit_allowed,
             )
+            tool_filter = self._apply_entitlement_exclusions(tool_filter)
             tool_filter = self._drop_native_channel_composio_tools(tool_filter, session)
             return self._ensure_always_available_tools(
                 tool_filter, explicit_allowed=explicit_allowed,
@@ -3613,6 +3623,7 @@ class AgentHarness(
         tool_filter = self._apply_mcp_schema_filter(
             tool_filter, explicit_allowed=explicit_allowed,
         )
+        tool_filter = self._apply_entitlement_exclusions(tool_filter)
         tool_filter = self._drop_native_channel_composio_tools(tool_filter, session)
         return self._ensure_always_available_tools(
             tool_filter, explicit_allowed=explicit_allowed,

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -392,6 +392,7 @@ class AgentHarness(
         agent_service_account_id: str | None = None,
         acting_principal: Any | None = None,
         platform_client: Any | None = None,
+        entitlement_excluded_tools: frozenset[str] = frozenset(),
     ) -> None:
         self._store = session_store
         self._tools = tool_registry
@@ -407,6 +408,14 @@ class AgentHarness(
         # session resolved before this was wired keeps every command.
         self._slash_commands: SlashCommandConfig = (
             slash_commands if slash_commands is not None else SlashCommandConfig()
+        )
+        # Tool names the end-user's purchased package excludes for this
+        # wake (computed by the worker from ``session.config["entitlements"]``
+        # plus the ops MCP-server scope; empty = no restriction). Applied
+        # in ``_tool_filter_for_session`` where it beats an explicit
+        # ``allowed_tools``, mirroring the ``/code`` capability rule.
+        self._entitlement_excluded_tools: frozenset[str] = frozenset(
+            entitlement_excluded_tools or (),
         )
         # Per-agent git repos the coding tool / ``/code`` may check out.
         # ``wake`` re-fetches the session from the store, so these are overlaid
@@ -800,9 +809,22 @@ class AgentHarness(
     # Slash-command capability gate
     # ------------------------------------------------------------------
 
-    def _slash_command_enabled(self, name: str) -> bool:
-        """True when slash command *name* is enabled for this agent."""
-        return name in self._slash_commands.commands
+    def _slash_command_enabled(
+        self, name: str, session: Session | None = None,
+    ) -> bool:
+        """True when slash command *name* is enabled for this agent.
+
+        With a ``session``, the end-user's purchased package is checked
+        too: a capability the agent offers but the user's plan does not
+        include is gated exactly like an agent-level switch-off.
+        """
+        if name not in self._slash_commands.commands:
+            return False
+        if session is not None:
+            from surogates.runtime.entitlements import capability_allowed
+
+            return capability_allowed(session.config, name)
+        return True
 
     def _overlay_repos(self, session: Session) -> Session:
         """Overlay the agent's configured repos + ssh targets onto a wake-local session.
@@ -826,11 +848,14 @@ class AgentHarness(
                 config["agent_service_account_id"] = self._agent_service_account_id
         return session.model_copy(update={"config": config})
 
-    def _slash_command_block_reason(self, content: str | None) -> str | None:
+    def _slash_command_block_reason(
+        self, content: str | None, session: Session | None = None,
+    ) -> str | None:
         """User-facing message when the slash command in *content* is gated
-        off for this agent, else None (allowed, or not a gateable command)."""
+        off for this agent (or excluded from the sender's plan), else None
+        (allowed, or not a gateable command)."""
         name = _slash_command_name(content)
-        if name is None or self._slash_command_enabled(name):
+        if name is None or self._slash_command_enabled(name, session):
             return None
         return f"/{name} is disabled for this agent."
 
@@ -1111,7 +1136,9 @@ class AgentHarness(
             # Capability gate: refuse slash commands disabled for this
             # agent (master switch off, or this command individually off)
             # before the dispatch chain below would handle them.
-            slash_block = self._slash_command_block_reason(last_user_content)
+            slash_block = self._slash_command_block_reason(
+                last_user_content, session,
+            )
             if slash_block is not None:
                 await self._emit_loop_response(
                     session, lease, slash_block, user_content=last_user_content
@@ -3522,12 +3549,24 @@ class AgentHarness(
         # that command is disabled the tool must also disappear from the
         # model-visible set (slash gating alone only blocks the human command).
         # This beats an explicit ``allowed_tools`` that lists it.
-        if not self._slash_command_enabled("code"):
+        if not self._slash_command_enabled("code", session):
             if tool_filter is None:
                 tool_filter = set(self._tools.tool_names)
             else:
                 tool_filter = set(tool_filter)
             tool_filter.discard("run_coding_agent")
+
+        # Purchased-package exclusions (browser toolset, non-included MCP
+        # servers / Composio toolkits) computed by the worker for this
+        # wake. Beats an explicit ``allowed_tools`` for the same reason
+        # the ``/code`` rule does: a paywalled tool must never be
+        # schema-visible, whatever the session config asks for.
+        if self._entitlement_excluded_tools:
+            if tool_filter is None:
+                tool_filter = set(self._tools.tool_names)
+            else:
+                tool_filter = set(tool_filter)
+            tool_filter.difference_update(self._entitlement_excluded_tools)
 
         # Any session running as one iteration of a schedule (``/loop`` or
         # cron_create-spawned) must not be able to create new schedules.

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -3561,12 +3561,17 @@ class AgentHarness(
         # wake. Beats an explicit ``allowed_tools`` for the same reason
         # the ``/code`` rule does: a paywalled tool must never be
         # schema-visible, whatever the session config asks for.
-        if self._entitlement_excluded_tools:
+        # ``getattr``: several test harnesses build partial AgentHarness
+        # objects that skip ``__init__``; absent means no restriction.
+        entitlement_excluded = getattr(
+            self, "_entitlement_excluded_tools", None,
+        )
+        if entitlement_excluded:
             if tool_filter is None:
                 tool_filter = set(self._tools.tool_names)
             else:
                 tool_filter = set(tool_filter)
-            tool_filter.difference_update(self._entitlement_excluded_tools)
+            tool_filter.difference_update(entitlement_excluded)
 
         # Any session running as one iteration of a schedule (``/loop`` or
         # cron_create-spawned) must not be able to create new schedules.

--- a/surogates/harness/session_llm.py
+++ b/surogates/harness/session_llm.py
@@ -146,6 +146,7 @@ async def build_session_llm_clients(
     user_id: Any = None,
     service_account_id: Any = None,
     settings: Any = None,
+    main_endpoint_override: "LLMEndpoint | None" = None,
 ) -> SessionLLMClients:
     """Build the per-session LLM bundle.
 
@@ -227,7 +228,12 @@ async def build_session_llm_clients(
         return slot
 
     try:
-        main = await _resolve(ctx.llm_main)
+        # Per-buyer model tier: the worker passes the opposite-tier
+        # endpoint when the sender's package pins a tier that differs
+        # from the agent's own. Client and model swap TOGETHER — the
+        # tier lives in the endpoint URL, so a bare model-string swap
+        # would misroute (see resilience.py's pro-fallback rationale).
+        main = await _resolve(main_endpoint_override or ctx.llm_main)
         summary = await _opt(ctx.llm_summary)
         vision = await _opt(ctx.llm_vision)
         advisor = await _opt(ctx.llm_advisor)

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -22,6 +22,10 @@ from surogates.harness.context import ContextCompressor
 from surogates.harness.loop import AgentHarness
 from surogates.harness.model_metadata import get_model_info
 from surogates.harness.prompt import PromptBuilder
+from surogates.runtime.entitlements import (
+    capability_allowed as _entitlement_capability_allowed,
+    dimension_allowlist,
+)
 from surogates.harness.prompt_library import default_library as default_prompt_library
 from surogates.health import infrastructure_readiness, start_health_server
 from surogates.browser.control import BrowserControlStore
@@ -371,6 +375,102 @@ def _build_fleet_backend(
             f"unknown browser.fleet_fallback_backend: {settings.fleet_fallback_backend}"
         )
     return CompositeFallbackBackend(primary=primary, fallback=fallback)
+
+
+async def _resolve_mcp_entitlement_scope(
+    entitled_ids: frozenset[str],
+    ops_db_url: str,
+) -> tuple[set[str], set[str]] | None:
+    """Resolve entitled MCP-server ids to enforceable name scopes.
+
+    Returns ``(server_names, composio_toolkits)``: plain servers are
+    enforced by the ``mcp__{name}__`` tool-name prefix, Composio
+    placeholder rows by their toolkit's ``TOOLKIT_*`` tool-name prefix.
+    ``None`` means resolution failed — callers must fail CLOSED for the
+    restricted dimension (drop every MCP/Composio tool) rather than
+    serve paid tools unmetered on an infra blip.
+    """
+    if not ops_db_url:
+        return None
+    try:
+        import sqlalchemy as sa
+
+        from surogates.db.ops_engine import get_ops_session_factory
+        from surogates.db.ops_models import OpsMcpServer
+
+        factory = get_ops_session_factory()
+        if factory is None:
+            return None
+        async with factory() as session:
+            rows = (
+                await session.execute(
+                    sa.select(
+                        OpsMcpServer.name,
+                        OpsMcpServer.transport,
+                        OpsMcpServer.oauth,
+                    ).where(OpsMcpServer.id.in_(list(entitled_ids)))
+                )
+            ).all()
+        server_names: set[str] = set()
+        toolkits: set[str] = set()
+        for name, transport, oauth in rows:
+            if str(transport).lower().endswith("composio"):
+                toolkit = str((oauth or {}).get("toolkit") or "").strip()
+                if toolkit:
+                    toolkits.add(toolkit.lower())
+            else:
+                server_names.add(str(name))
+        return server_names, toolkits
+    except Exception:
+        logger.warning(
+            "MCP entitlement scope resolution failed; failing closed",
+            exc_info=True,
+        )
+        return None
+
+
+def _entitlement_tool_exclusions(
+    *,
+    session_config: dict | None,
+    tool_registry: Any,
+    composio_tool_names: frozenset[str],
+    mcp_scope: tuple[set[str], set[str]] | None,
+) -> set[str]:
+    """Concrete tool names the pinned package excludes for this wake.
+
+    Capability exclusions (browser toolset, the coding tool) come
+    straight from the package; MCP/Composio exclusions compare each
+    tool's server name / toolkit prefix against the resolved
+    ``mcp_scope`` (``None`` scope with a restricted dimension = drop
+    them all, see :func:`_resolve_mcp_entitlement_scope`).
+    """
+    excluded: set[str] = set()
+    if not _entitlement_capability_allowed(session_config, "browser"):
+        excluded.update(
+            e.name
+            for e in tool_registry.get_all()
+            if e.toolset == "browser"
+        )
+    if not _entitlement_capability_allowed(session_config, "code"):
+        excluded.add("run_coding_agent")
+    mcp_allow = dimension_allowlist(session_config, "mcp_server_ids")
+    if mcp_allow is not None:
+        allowed_servers = mcp_scope[0] if mcp_scope is not None else set()
+        allowed_toolkits = mcp_scope[1] if mcp_scope is not None else set()
+        for name in tool_registry.tool_names:
+            if not name.startswith("mcp__"):
+                continue
+            parts = name.split("__")
+            server = parts[1] if len(parts) >= 3 else ""
+            if server not in allowed_servers:
+                excluded.add(name)
+        for name in composio_tool_names:
+            if name.startswith("mcp__"):
+                continue  # handled by the server-name pass above
+            toolkit = name.split("_", 1)[0].lower()
+            if toolkit not in allowed_toolkits:
+                excluded.add(name)
+    return excluded
 
 
 async def _load_attached_kbs(
@@ -1367,6 +1467,17 @@ async def run_worker(settings: Settings) -> None:
             agent_id=session.agent_id,
             ops_db_url=settings.ops_db.url,
         )
+        # Purchased-package KB filter: the sender's plan may include only
+        # a subset of the agent's KBs. Applied before the empty-list tool
+        # gate below so a plan with zero included KBs also drops the KB
+        # tools; kb_read_page re-checks per call (kb_tools) so a
+        # remembered kb_id from another user's turn still refuses.
+        entitled_kb_ids = dimension_allowlist(session.config, "kb_ids")
+        if entitled_kb_ids is not None:
+            attached_kbs = [
+                kb for kb in attached_kbs
+                if str(kb.get("id")) in entitled_kb_ids
+            ]
         # Filter the tool set to drop kb_list_pages / kb_read_page
         # when this agent has nothing to navigate. Keeps the LLM from
         # ever seeing tool schemas it cannot meaningfully use, and
@@ -1426,6 +1537,28 @@ async def run_worker(settings: Settings) -> None:
             use_api_for_harness_tools=settings.worker.use_api_for_harness_tools,
         )
 
+        # Purchased-package tool exclusions: browser toolset, the coding
+        # tool, and non-included MCP servers / Composio toolkits. Dropped
+        # from the prompt surface here AND handed to the harness, whose
+        # per-iteration tool filter is what actually bounds the
+        # model-visible schemas and dispatch.
+        mcp_entitlement_allowlist = dimension_allowlist(
+            session.config, "mcp_server_ids",
+        )
+        mcp_entitlement_scope = None
+        if mcp_entitlement_allowlist is not None:
+            mcp_entitlement_scope = await _resolve_mcp_entitlement_scope(
+                mcp_entitlement_allowlist, settings.ops_db.url,
+            )
+        entitlement_excluded_tools = _entitlement_tool_exclusions(
+            session_config=session.config,
+            tool_registry=tool_registry,
+            composio_tool_names=composio_mcp_tools,
+            mcp_scope=mcp_entitlement_scope,
+        )
+        if entitlement_excluded_tools:
+            effective_tools.difference_update(entitlement_excluded_tools)
+
         # Pre-load SOUL.md / AGENT.md from the bundle resolved
         # above.  The PromptBuilder stays sync; the loaders return
         # ``None`` silently when the bundle is missing or doesn't
@@ -1452,7 +1585,15 @@ async def run_worker(settings: Settings) -> None:
             soul_md_content=soul_md_content,
             agent_md_content=agent_md_content,
             slash_commands=ctx.slash_commands,
-            brainstorming_gate=ctx.brainstorming_gate,
+            # The gate is agent-level AND package-level: a plan without
+            # the brainstorming capability turns the guidance off for
+            # this sender even when the agent has it on.
+            brainstorming_gate=(
+                ctx.brainstorming_gate
+                and _entitlement_capability_allowed(
+                    session.config, "brainstorming",
+                )
+            ),
         )
 
         # User / SA / channel-session principals each map to a JWT
@@ -1566,6 +1707,7 @@ async def run_worker(settings: Settings) -> None:
             # this agent's own MCP tools.
             mcp_tool_names=frozenset(discovered_mcp_tools),
             composio_tool_names=composio_mcp_tools,
+            entitlement_excluded_tools=frozenset(entitlement_excluded_tools),
             # Per-agent slash-command gating resolved from the runtime
             # config; the dispatch gate refuses disabled commands.
             slash_commands=ctx.slash_commands,

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -411,6 +411,8 @@ async def _resolve_mcp_entitlement_scope(
                     ).where(OpsMcpServer.id.in_(list(entitled_ids)))
                 )
             ).all()
+        from surogates.tools.mcp.client import sanitize_mcp_name_component
+
         server_names: set[str] = set()
         toolkits: set[str] = set()
         for name, transport, oauth in rows:
@@ -419,7 +421,11 @@ async def _resolve_mcp_entitlement_scope(
                 if toolkit:
                     toolkits.add(toolkit.lower())
             else:
-                server_names.add(str(name))
+                # Tool names embed the SANITIZED server name
+                # (``mcp__{sanitized}__tool``); compare like with like
+                # or a server named "github-mcp" never matches its own
+                # ``mcp__github_mcp__*`` tools.
+                server_names.add(sanitize_mcp_name_component(str(name)))
         return server_names, toolkits
     except Exception:
         logger.warning(
@@ -444,6 +450,8 @@ def _entitlement_tool_exclusions(
     ``mcp_scope`` (``None`` scope with a restricted dimension = drop
     them all, see :func:`_resolve_mcp_entitlement_scope`).
     """
+    from surogates.orchestrator.mcp_client import is_composio_router_name
+
     excluded: set[str] = set()
     if not _entitlement_capability_allowed(session_config, "browser"):
         excluded.update(
@@ -457,18 +465,28 @@ def _entitlement_tool_exclusions(
     if mcp_allow is not None:
         allowed_servers = mcp_scope[0] if mcp_scope is not None else set()
         allowed_toolkits = mcp_scope[1] if mcp_scope is not None else set()
-        for name in tool_registry.tool_names:
+        for name in set(tool_registry.tool_names) | set(composio_tool_names):
             if not name.startswith("mcp__"):
+                # Defensive: Composio names are router-prefixed in
+                # production; a bare TOOLKIT_ACTION name still gets the
+                # toolkit treatment rather than slipping through.
+                if name in composio_tool_names:
+                    toolkit = name.split("_", 1)[0].lower()
+                    if toolkit not in allowed_toolkits:
+                        excluded.add(name)
+                continue
+            if is_composio_router_name(name):
+                # ``mcp__tool_router__TOOLKIT_ACTION``: the sellable
+                # unit is the toolkit, embedded in the tool component.
+                parts = name.split("__")
+                tool_part = parts[2] if len(parts) >= 3 else ""
+                toolkit = tool_part.split("_", 1)[0].lower()
+                if toolkit not in allowed_toolkits:
+                    excluded.add(name)
                 continue
             parts = name.split("__")
             server = parts[1] if len(parts) >= 3 else ""
             if server not in allowed_servers:
-                excluded.add(name)
-        for name in composio_tool_names:
-            if name.startswith("mcp__"):
-                continue  # handled by the server-name pass above
-            toolkit = name.split("_", 1)[0].lower()
-            if toolkit not in allowed_toolkits:
                 excluded.add(name)
     return excluded
 

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -632,6 +632,29 @@ async def _load_prompt_catalogs(
     return available_agents, available_skills
 
 
+async def _load_prompt_catalogs_entitled(
+    *,
+    session_config: dict | None,
+    **kwargs: Any,
+) -> tuple[list[Any], list[Any]]:
+    """Prompt catalogs, narrowed to the sender's purchased package.
+
+    A restricted ``skills`` dimension hides non-included skills from
+    the system prompt; the skill tool and the API listing apply the
+    same allowlist per call, so a remembered name still refuses.
+    """
+    from surogates.runtime.entitlements import entitled_skills
+
+    agents_catalog, skills_catalog = await _load_prompt_catalogs(**kwargs)
+    allowed = entitled_skills(session_config)
+    if allowed is not None:
+        skills_catalog = [
+            s for s in skills_catalog
+            if getattr(s, "builtin", False) or s.name in allowed
+        ]
+    return agents_catalog, skills_catalog
+
+
 def build_agent_principal_resolver(*, session_factory: Any):
     """The cached agent_id -> service-account-principal resolver.
 
@@ -1206,11 +1229,28 @@ async def run_worker(settings: Settings) -> None:
         )
         from surogates.tools.builtin.media_gen import MediaGenConfig
 
+        # Per-buyer model tier: when the sender's package pins a tier
+        # that differs from the agent's own, the main slot is built on
+        # the opposite-tier endpoint ops projected for exactly this.
+        # No projected endpoint (BYO agents, old configs) = no-op; the
+        # proxy meters by endpoint role so billing follows the swap.
+        from surogates.runtime.entitlements import entitled_model_tier
+
+        tier_override = None
+        pinned_tier = entitled_model_tier(session.config)
+        if pinned_tier is not None and ctx.llm_main is not None:
+            agent_is_pro = ctx.llm_main.model == "surogate-pro"
+            if pinned_tier == "pro" and not agent_is_pro:
+                tier_override = ctx.llm_tier_pro
+            elif pinned_tier == "basic" and agent_is_pro:
+                tier_override = ctx.llm_tier_basic
+
         llm_bundle = await build_session_llm_clients(
             ctx, vault=credential_vault,
             user_id=credential.user_id,
             service_account_id=credential.service_account_id,
             settings=settings,
+            main_endpoint_override=tier_override,
         )
 
         if not llm_bundle.main.model:
@@ -1453,7 +1493,8 @@ async def run_worker(settings: Settings) -> None:
         # Coordinator sessions also render sub-agents as an "Available
         # Sub-Agents" block and use their presence to gate delegation
         # tool schemas.
-        available_agents, available_skills = await _load_prompt_catalogs(
+        available_agents, available_skills = await _load_prompt_catalogs_entitled(
+            session_config=session.config,
             tenant=tenant,
             session_factory=session_factory,
             bundle=bundle,

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -379,7 +379,6 @@ def _build_fleet_backend(
 
 async def _resolve_mcp_entitlement_scope(
     entitled_ids: frozenset[str],
-    ops_db_url: str,
 ) -> tuple[set[str], set[str]] | None:
     """Resolve entitled MCP-server ids to enforceable name scopes.
 
@@ -390,8 +389,6 @@ async def _resolve_mcp_entitlement_scope(
     restricted dimension (drop every MCP/Composio tool) rather than
     serve paid tools unmetered on an infra blip.
     """
-    if not ops_db_url:
-        return None
     try:
         import sqlalchemy as sa
 
@@ -439,7 +436,6 @@ def _entitlement_tool_exclusions(
     *,
     session_config: dict | None,
     tool_registry: Any,
-    composio_tool_names: frozenset[str],
     mcp_scope: tuple[set[str], set[str]] | None,
 ) -> set[str]:
     """Concrete tool names the pinned package excludes for this wake.
@@ -465,15 +461,8 @@ def _entitlement_tool_exclusions(
     if mcp_allow is not None:
         allowed_servers = mcp_scope[0] if mcp_scope is not None else set()
         allowed_toolkits = mcp_scope[1] if mcp_scope is not None else set()
-        for name in set(tool_registry.tool_names) | set(composio_tool_names):
+        for name in tool_registry.tool_names:
             if not name.startswith("mcp__"):
-                # Defensive: Composio names are router-prefixed in
-                # production; a bare TOOLKIT_ACTION name still gets the
-                # toolkit treatment rather than slipping through.
-                if name in composio_tool_names:
-                    toolkit = name.split("_", 1)[0].lower()
-                    if toolkit not in allowed_toolkits:
-                        excluded.add(name)
                 continue
             if is_composio_router_name(name):
                 # ``mcp__tool_router__TOOLKIT_ACTION``: the sellable
@@ -661,15 +650,15 @@ async def _load_prompt_catalogs_entitled(
     the system prompt; the skill tool and the API listing apply the
     same allowlist per call, so a remembered name still refuses.
     """
-    from surogates.runtime.entitlements import entitled_skills
+    from surogates.runtime.entitlements import (
+        entitled_skills,
+        filter_entitled_skills,
+    )
 
     agents_catalog, skills_catalog = await _load_prompt_catalogs(**kwargs)
-    allowed = entitled_skills(session_config)
-    if allowed is not None:
-        skills_catalog = [
-            s for s in skills_catalog
-            if getattr(s, "builtin", False) or s.name in allowed
-        ]
+    skills_catalog = filter_entitled_skills(
+        skills_catalog, entitled_skills(session_config),
+    )
     return agents_catalog, skills_catalog
 
 
@@ -1250,18 +1239,18 @@ async def run_worker(settings: Settings) -> None:
         # Per-buyer model tier: when the sender's package pins a tier
         # that differs from the agent's own, the main slot is built on
         # the opposite-tier endpoint ops projected for exactly this.
-        # No projected endpoint (BYO agents, old configs) = no-op; the
-        # proxy meters by endpoint role so billing follows the swap.
+        # Ops projects ``llm_tier_pro`` only for basic-tier agents and
+        # ``llm_tier_basic`` only for pro-tier agents, so a pin that
+        # matches the agent's own tier (or a BYO agent / old config)
+        # finds no endpoint and is a no-op; the proxy meters by
+        # endpoint role so billing follows the swap.
         from surogates.runtime.entitlements import entitled_model_tier
 
-        tier_override = None
         pinned_tier = entitled_model_tier(session.config)
-        if pinned_tier is not None and ctx.llm_main is not None:
-            agent_is_pro = ctx.llm_main.model == "surogate-pro"
-            if pinned_tier == "pro" and not agent_is_pro:
-                tier_override = ctx.llm_tier_pro
-            elif pinned_tier == "basic" and agent_is_pro:
-                tier_override = ctx.llm_tier_basic
+        tier_override = {
+            "pro": ctx.llm_tier_pro,
+            "basic": ctx.llm_tier_basic,
+        }.get(pinned_tier)
 
         llm_bundle = await build_session_llm_clients(
             ctx, vault=credential_vault,
@@ -1607,12 +1596,11 @@ async def run_worker(settings: Settings) -> None:
         mcp_entitlement_scope = None
         if mcp_entitlement_allowlist is not None:
             mcp_entitlement_scope = await _resolve_mcp_entitlement_scope(
-                mcp_entitlement_allowlist, settings.ops_db.url,
+                mcp_entitlement_allowlist,
             )
         entitlement_excluded_tools = _entitlement_tool_exclusions(
             session_config=session.config,
             tool_registry=tool_registry,
-            composio_tool_names=composio_mcp_tools,
             mcp_scope=mcp_entitlement_scope,
         )
         if entitlement_excluded_tools:
@@ -1764,7 +1752,9 @@ async def run_worker(settings: Settings) -> None:
             # Per-agent MCP tool set discovered above; the harness uses
             # it to filter the shared registry's prompt schemas down to
             # this agent's own MCP tools.
-            mcp_tool_names=frozenset(discovered_mcp_tools),
+            mcp_tool_names=(
+                frozenset(discovered_mcp_tools) - entitlement_excluded_tools
+            ),
             composio_tool_names=composio_mcp_tools,
             entitlement_excluded_tools=frozenset(entitlement_excluded_tools),
             # Per-agent slash-command gating resolved from the runtime

--- a/surogates/runtime/context.py
+++ b/surogates/runtime/context.py
@@ -138,6 +138,11 @@ class AgentRuntimeContext:
     llm_advisor: LLMEndpoint | None = None
     llm_image: LLMEndpoint | None = None
     llm_video: LLMEndpoint | None = None
+    # The opposite platform tier, for per-buyer model packages: pro
+    # agents project ``llm_tier_basic``, base agents ``llm_tier_pro``.
+    # Absent for BYO-model agents.
+    llm_tier_basic: LLMEndpoint | None = None
+    llm_tier_pro: LLMEndpoint | None = None
 
     mcp_server_ids: tuple[str, ...] = ()
     governance: dict = field(default_factory=dict)

--- a/surogates/runtime/entitlements.py
+++ b/surogates/runtime/entitlements.py
@@ -30,6 +30,9 @@ _SLASH_CAPABILITIES = frozenset({
     "loop", "mission", "goal",
 })
 
+#: Everything a package can restrict (mirrors ops CAPABILITY_VOCAB).
+_SELLABLE_CAPABILITIES = _SLASH_CAPABILITIES | {"browser", "brainstorming"}
+
 
 def pinned_entitlements(session_config: dict | None) -> dict | None:
     """The pinned package dict, or ``None`` when unrestricted."""
@@ -64,7 +67,7 @@ def capability_allowed(
     allowed = dimension_allowlist(session_config, "capabilities")
     if allowed is None:
         return True
-    if normalized not in _SLASH_CAPABILITIES | {"browser", "brainstorming"}:
+    if normalized not in _SELLABLE_CAPABILITIES:
         return True
     return normalized in allowed
 
@@ -84,6 +87,24 @@ def entitled_skills(session_config: dict | None) -> frozenset[str] | None:
     return dimension_allowlist(session_config, "skills")
 
 
+def skill_entitled(skill, allowed: frozenset[str] | None) -> bool:
+    """Whether one skill survives a package allowlist.
+
+    Built-in platform skills are runtime plumbing, not sellable
+    content, and always pass; ``allowed=None`` means unrestricted.
+    """
+    if allowed is None:
+        return True
+    return bool(getattr(skill, "builtin", False)) or skill.name in allowed
+
+
+def filter_entitled_skills(skills, allowed: frozenset[str] | None) -> list:
+    """The subset of ``skills`` a package allowlist includes."""
+    if allowed is None:
+        return list(skills)
+    return [s for s in skills if skill_entitled(s, allowed)]
+
+
 def kb_allowed(session_config: dict | None, kb_id: str) -> bool:
     """Whether the package includes knowledge base ``kb_id``."""
     allowed = dimension_allowlist(session_config, "kb_ids")
@@ -96,6 +117,8 @@ __all__ = [
     "dimension_allowlist",
     "entitled_model_tier",
     "entitled_skills",
+    "filter_entitled_skills",
+    "skill_entitled",
     "kb_allowed",
     "pinned_entitlements",
 ]

--- a/surogates/runtime/entitlements.py
+++ b/surogates/runtime/entitlements.py
@@ -23,9 +23,10 @@ ENTITLEMENTS_CONFIG_KEY = "entitlements"
 #: Capability ids sellable in a package (mirrors ops
 #: ``core.commerce.features.CAPABILITY_VOCAB``). Slash-command ids are
 #: hyphenated on the wire (``deep-research``); package capabilities use
-#: underscores — :func:`capability_allowed` normalizes.
+#: underscores — :func:`capability_allowed` normalizes. Compress and
+#: multi-session are always included and never restricted here.
 _SLASH_CAPABILITIES = frozenset({
-    "compress", "code", "deep_research", "auto_research",
+    "code", "deep_research", "auto_research",
     "loop", "mission", "goal",
 })
 

--- a/surogates/runtime/entitlements.py
+++ b/surogates/runtime/entitlements.py
@@ -69,6 +69,21 @@ def capability_allowed(
     return normalized in allowed
 
 
+def entitled_model_tier(session_config: dict | None) -> str | None:
+    """The model tier the package pins ("basic"/"pro"), or ``None``
+    for the agent's own tier."""
+    entitlements = pinned_entitlements(session_config)
+    if entitlements is None:
+        return None
+    tier = entitlements.get("model_tier")
+    return tier if tier in ("basic", "pro") else None
+
+
+def entitled_skills(session_config: dict | None) -> frozenset[str] | None:
+    """Allowlist of skill names, or ``None`` when unrestricted."""
+    return dimension_allowlist(session_config, "skills")
+
+
 def kb_allowed(session_config: dict | None, kb_id: str) -> bool:
     """Whether the package includes knowledge base ``kb_id``."""
     allowed = dimension_allowlist(session_config, "kb_ids")
@@ -79,6 +94,8 @@ __all__ = [
     "ENTITLEMENTS_CONFIG_KEY",
     "capability_allowed",
     "dimension_allowlist",
+    "entitled_model_tier",
+    "entitled_skills",
     "kb_allowed",
     "pinned_entitlements",
 ]

--- a/surogates/runtime/entitlements.py
+++ b/surogates/runtime/entitlements.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Per-session purchased-package reader.
+
+The commerce/allowance gates pin the end-user's effective feature
+package on ``session.config["entitlements"]`` from the ops authorize
+receipt (see ``surogates.api.routes._commerce_turn.pin_entitlements``).
+This module is the single reader: the worker's tool gating, the
+harness's tool filter and slash gate, and the KB tools all interpret
+the pinned dict through these helpers so the semantics cannot drift.
+
+Shape: ``{capabilities?, channels?, kb_ids?, mcp_server_ids?}`` where an
+absent key means the dimension is unrestricted and a list (possibly
+empty) is an exact allowlist. No pin at all means no restriction: the
+agent's own configuration shapes the session, exactly as before
+packages existed.
+"""
+
+from __future__ import annotations
+
+ENTITLEMENTS_CONFIG_KEY = "entitlements"
+
+#: Capability ids sellable in a package (mirrors ops
+#: ``core.commerce.features.CAPABILITY_VOCAB``). Slash-command ids are
+#: hyphenated on the wire (``deep-research``); package capabilities use
+#: underscores — :func:`capability_allowed` normalizes.
+_SLASH_CAPABILITIES = frozenset({
+    "compress", "code", "deep_research", "auto_research",
+    "loop", "mission", "goal",
+})
+
+
+def pinned_entitlements(session_config: dict | None) -> dict | None:
+    """The pinned package dict, or ``None`` when unrestricted."""
+    value = (session_config or {}).get(ENTITLEMENTS_CONFIG_KEY)
+    return value if isinstance(value, dict) else None
+
+
+def dimension_allowlist(
+    session_config: dict | None, dimension: str,
+) -> frozenset[str] | None:
+    """The allowlist for one dimension; ``None`` = unrestricted."""
+    entitlements = pinned_entitlements(session_config)
+    if entitlements is None:
+        return None
+    values = entitlements.get(dimension)
+    if values is None:
+        return None
+    return frozenset(str(v) for v in values)
+
+
+def capability_allowed(
+    session_config: dict | None, capability: str,
+) -> bool:
+    """Whether the package includes ``capability``.
+
+    Accepts both the package spelling (``deep_research``) and the
+    slash-command spelling (``deep-research``). Capabilities outside
+    the sellable vocabulary are never restricted, so unrelated slash
+    commands (``clear``, skill invocations) pass untouched.
+    """
+    normalized = capability.replace("-", "_")
+    allowed = dimension_allowlist(session_config, "capabilities")
+    if allowed is None:
+        return True
+    if normalized not in _SLASH_CAPABILITIES | {"browser", "brainstorming"}:
+        return True
+    return normalized in allowed
+
+
+def kb_allowed(session_config: dict | None, kb_id: str) -> bool:
+    """Whether the package includes knowledge base ``kb_id``."""
+    allowed = dimension_allowlist(session_config, "kb_ids")
+    return allowed is None or str(kb_id) in allowed
+
+
+__all__ = [
+    "ENTITLEMENTS_CONFIG_KEY",
+    "capability_allowed",
+    "dimension_allowlist",
+    "kb_allowed",
+    "pinned_entitlements",
+]

--- a/surogates/runtime/platform_client.py
+++ b/surogates/runtime/platform_client.py
@@ -369,6 +369,7 @@ class PlatformClient:
         estimated_tokens: int,
         email: str | None = None,
         name: str | None = None,
+        channel: str | None = None,
     ) -> dict:
         """Reserve tokens for one end-user turn on a monetized agent.
 
@@ -389,6 +390,8 @@ class PlatformClient:
             body["email"] = email
         if name is not None:
             body["name"] = name
+        if channel is not None:
+            body["channel"] = channel
         resp = await self._client.post(
             f"/api/agents/agents/{agent_id}/commerce/authorize",
             json=body,

--- a/surogates/runtime/platform_client.py
+++ b/surogates/runtime/platform_client.py
@@ -509,23 +509,35 @@ class PlatformClient:
         *,
         end_user_id: str,
         estimated_tokens: int,
+        channel: str | None = None,
     ) -> dict:
         """Reserve tokens for one end-user turn against their per-user cap.
 
-        Returns ``{allowance_id, reserved_tokens, reservation_id}`` (all
-        zero/empty when uncapped or the kill-switch is off).  Raises:
+        ``channel`` names the surface carrying the turn (``slack`` /
+        ``telegram`` / ``website`` / ``web``); ops gates sellable
+        channels against the user's purchased package and answers 402
+        ``channel_not_included`` when the package excludes this one.
+
+        Returns ``{allowance_id, reserved_tokens, reservation_id,
+        features}`` (zero/empty when uncapped or the kill-switch is
+        off; ``features`` is the user's effective package, ``None`` =
+        no restriction).  Raises:
 
         * :class:`AllowanceExhaustedError` on 402 — the user has spent
-          their slice of the operator's subscription this cycle.
+          their slice of the operator's subscription this cycle, or the
+          package excludes this channel (``channel_not_included``).
         * :class:`PlatformAuthError` on 401 — operations problem.
         * ``httpx.HTTPStatusError`` on any other non-2xx.
         """
+        payload: dict = {
+            "end_user_id": end_user_id,
+            "estimated_tokens": estimated_tokens,
+        }
+        if channel is not None:
+            payload["channel"] = channel
         resp = await self._client.post(
             f"/api/agents/agents/{agent_id}/allowance/authorize",
-            json={
-                "end_user_id": end_user_id,
-                "estimated_tokens": estimated_tokens,
-            },
+            json=payload,
         )
         if resp.status_code == 402:
             detail = ""

--- a/surogates/runtime/resolver.py
+++ b/surogates/runtime/resolver.py
@@ -106,6 +106,8 @@ def build_agent_runtime_context(payload: dict) -> AgentRuntimeContext:
         llm_advisor=_opt_llm(payload.get("llm_advisor")),
         llm_image=_opt_llm(payload.get("llm_image")),
         llm_video=_opt_llm(payload.get("llm_video")),
+        llm_tier_basic=_opt_llm(payload.get("llm_tier_basic")),
+        llm_tier_pro=_opt_llm(payload.get("llm_tier_pro")),
         mcp_server_ids=tuple(payload.get("mcp_server_ids") or ()),
         repos=tuple(dict(repo) for repo in (payload.get("repos") or ())),
         ssh_targets=tuple(dict(t) for t in (payload.get("ssh_targets") or ())),

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -730,14 +730,27 @@ class SessionStore:
     ) -> None:
         """Make ``config[key]`` equal ``value``, minimally.
 
-        ``value is None`` removes the key. The write is skipped when the
-        stored value already matches, so per-turn reconcilers (e.g. the
-        commerce entitlements pin) stay write-free in steady state while
-        still holding the row lock for the comparison.
+        ``value is None`` removes the key. Matching values are detected
+        with a plain read first, so per-turn reconcilers (e.g. the
+        commerce entitlements pin) stay lock-free as well as write-free
+        in steady state; only a mismatch escalates to the row lock, and
+        the comparison is repeated under it.
         """
         if not key:
             raise ValueError("config key must be non-empty")
+
+        def _matches(config: dict) -> bool:
+            if value is None:
+                return key not in config
+            return config.get(key) == value
+
         async with self._sf() as db:
+            stored = await db.execute(
+                select(SessionRow.config).where(SessionRow.id == session_id)
+            )
+            stored_config = stored.scalar_one_or_none()
+            if stored_config is not None and _matches(stored_config):
+                return
             result = await db.execute(
                 select(SessionRow)
                 .where(SessionRow.id == session_id)
@@ -747,13 +760,11 @@ class SessionStore:
             if row is None:
                 raise SessionNotFoundError(f"session {session_id} not found")
             config = dict(row.config or {})
+            if _matches(config):
+                return
             if value is None:
-                if key not in config:
-                    return
                 config.pop(key)
             else:
-                if config.get(key) == value:
-                    return
                 config[key] = value
             row.config = config
             row.updated_at = func.now()
@@ -761,22 +772,7 @@ class SessionStore:
 
     async def clear_session_config_key(self, session_id: UUID, key: str) -> None:
         """Remove one top-level key from ``sessions.config``."""
-        if not key:
-            raise ValueError("config key must be non-empty")
-        async with self._sf() as db:
-            result = await db.execute(
-                select(SessionRow)
-                .where(SessionRow.id == session_id)
-                .with_for_update()
-            )
-            row = result.scalar_one_or_none()
-            if row is None:
-                raise SessionNotFoundError(f"session {session_id} not found")
-            config = dict(row.config or {})
-            config.pop(key, None)
-            row.config = config
-            row.updated_at = func.now()
-            await db.commit()
+        await self.reconcile_session_config_key(session_id, key, None)
 
     async def append_session_config_list(
         self,

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -722,6 +722,43 @@ class SessionStore:
             row.updated_at = func.now()
             await db.commit()
 
+    async def reconcile_session_config_key(
+        self,
+        session_id: UUID,
+        key: str,
+        value: Any,
+    ) -> None:
+        """Make ``config[key]`` equal ``value``, minimally.
+
+        ``value is None`` removes the key. The write is skipped when the
+        stored value already matches, so per-turn reconcilers (e.g. the
+        commerce entitlements pin) stay write-free in steady state while
+        still holding the row lock for the comparison.
+        """
+        if not key:
+            raise ValueError("config key must be non-empty")
+        async with self._sf() as db:
+            result = await db.execute(
+                select(SessionRow)
+                .where(SessionRow.id == session_id)
+                .with_for_update()
+            )
+            row = result.scalar_one_or_none()
+            if row is None:
+                raise SessionNotFoundError(f"session {session_id} not found")
+            config = dict(row.config or {})
+            if value is None:
+                if key not in config:
+                    return
+                config.pop(key)
+            else:
+                if config.get(key) == value:
+                    return
+                config[key] = value
+            row.config = config
+            row.updated_at = func.now()
+            await db.commit()
+
     async def clear_session_config_key(self, session_id: UUID, key: str) -> None:
         """Remove one top-level key from ``sessions.config``."""
         if not key:

--- a/surogates/tools/builtin/kb_tools.py
+++ b/surogates/tools/builtin/kb_tools.py
@@ -48,6 +48,16 @@ from surogates.tools.registry import ToolRegistry, ToolSchema
 logger = logging.getLogger(__name__)
 
 
+def _kb_plan_denied(kb_id: str, kwargs: dict) -> str | None:
+    """The refusal message when the sender's package excludes *kb_id*."""
+    if kb_allowed(kwargs.get("session_config"), kb_id):
+        return None
+    return (
+        f"Error: knowledge base {kb_id!r} is not included in the "
+        f"current user's plan."
+    )
+
+
 # Wiki content sits in Hub under wiki/<path>. The DB stores the
 # logical path (``sources/d1.md``) so the same path is reusable as a
 # stable identifier; the prefix is a Hub-side storage layout choice.
@@ -147,11 +157,9 @@ async def _kb_list_pages_handler(
         return "Error: kb_id is required."
 
     agent_id = _agent_id_from_kwargs(kwargs)
-    if not kb_allowed(kwargs.get("session_config"), kb_id):
-        return (
-            f"Error: knowledge base {kb_id!r} is not included in the "
-            f"current user's plan."
-        )
+    denied = _kb_plan_denied(kb_id, kwargs)
+    if denied is not None:
+        return denied
 
     factory = ensure_ops_session_factory()
     if factory is None:
@@ -210,11 +218,9 @@ async def _kb_read_page_handler(
         return "Error: both kb_id and path are required."
 
     agent_id = _agent_id_from_kwargs(kwargs)
-    if not kb_allowed(kwargs.get("session_config"), kb_id):
-        return (
-            f"Error: knowledge base {kb_id!r} is not included in the "
-            f"current user's plan."
-        )
+    denied = _kb_plan_denied(kb_id, kwargs)
+    if denied is not None:
+        return denied
 
     factory = ensure_ops_session_factory()
     if factory is None:

--- a/surogates/tools/builtin/kb_tools.py
+++ b/surogates/tools/builtin/kb_tools.py
@@ -36,6 +36,7 @@ from typing import Any
 import sqlalchemy as sa
 
 from surogates.db.ops_engine import ensure_ops_session_factory
+from surogates.runtime.entitlements import kb_allowed
 from surogates.db.ops_models import (
     OpsKBWikiPage,
     OpsKnowledgeBase,
@@ -146,6 +147,11 @@ async def _kb_list_pages_handler(
         return "Error: kb_id is required."
 
     agent_id = _agent_id_from_kwargs(kwargs)
+    if not kb_allowed(kwargs.get("session_config"), kb_id):
+        return (
+            f"Error: knowledge base {kb_id!r} is not included in the "
+            f"current user's plan."
+        )
 
     factory = ensure_ops_session_factory()
     if factory is None:
@@ -204,6 +210,11 @@ async def _kb_read_page_handler(
         return "Error: both kb_id and path are required."
 
     agent_id = _agent_id_from_kwargs(kwargs)
+    if not kb_allowed(kwargs.get("session_config"), kb_id):
+        return (
+            f"Error: knowledge base {kb_id!r} is not included in the "
+            f"current user's plan."
+        )
 
     factory = ensure_ops_session_factory()
     if factory is None:

--- a/surogates/tools/builtin/skills.py
+++ b/surogates/tools/builtin/skills.py
@@ -198,7 +198,10 @@ async def _load_all_skills(tenant: Any, **kwargs: Any) -> list:
     platform skills always pass — they are runtime plumbing, not
     sellable content).
     """
-    from surogates.runtime.entitlements import entitled_skills
+    from surogates.runtime.entitlements import (
+        entitled_skills,
+        filter_entitled_skills,
+    )
     from surogates.tools.loader import ResourceLoader
 
     loader = ResourceLoader.from_settings(_settings_from_kwargs(kwargs))
@@ -211,13 +214,9 @@ async def _load_all_skills(tenant: Any, **kwargs: Any) -> list:
             )
     else:
         skills = await loader.load_skills(tenant, overrides=overrides)
-    allowed = entitled_skills(kwargs.get("session_config"))
-    if allowed is not None:
-        skills = [
-            s for s in skills
-            if getattr(s, "builtin", False) or s.name in allowed
-        ]
-    return skills
+    return filter_entitled_skills(
+        skills, entitled_skills(kwargs.get("session_config")),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/surogates/tools/builtin/skills.py
+++ b/surogates/tools/builtin/skills.py
@@ -190,7 +190,15 @@ def _active_skill_override(kwargs: dict[str, Any], name: str) -> dict | None:
 
 
 async def _load_all_skills(tenant: Any, **kwargs: Any) -> list:
-    """Load skills from all layers, using DB when a session factory is available."""
+    """Load skills from all layers, using DB when a session factory is available.
+
+    The sender's purchased package narrows the result: a restricted
+    ``skills`` dimension on ``session_config["entitlements"]`` hides
+    non-included skills from the tool and slash surfaces (built-in
+    platform skills always pass — they are runtime plumbing, not
+    sellable content).
+    """
+    from surogates.runtime.entitlements import entitled_skills
     from surogates.tools.loader import ResourceLoader
 
     loader = ResourceLoader.from_settings(_settings_from_kwargs(kwargs))
@@ -198,10 +206,18 @@ async def _load_all_skills(tenant: Any, **kwargs: Any) -> list:
     session_factory = kwargs.get("session_factory")
     if session_factory is not None:
         async with session_factory() as db_session:
-            return await loader.load_skills(
+            skills = await loader.load_skills(
                 tenant, db_session=db_session, overrides=overrides,
             )
-    return await loader.load_skills(tenant, overrides=overrides)
+    else:
+        skills = await loader.load_skills(tenant, overrides=overrides)
+    allowed = entitled_skills(kwargs.get("session_config"))
+    if allowed is not None:
+        skills = [
+            s for s in skills
+            if getattr(s, "builtin", False) or s.name in allowed
+        ]
+    return skills
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_allowance_turn.py
+++ b/tests/api/test_allowance_turn.py
@@ -231,3 +231,130 @@ async def test_metering_plane_error_fails_closed_503():
             request, _session(), "content", end_user_id="u1",
         )
     assert exc.value.status_code == 503
+
+
+# ── Package plumbing: channel forwarding + entitlements pinning ───────
+
+
+class _ReconcilingStore(_FakeStore):
+    def __init__(self):
+        super().__init__()
+        self.reconciled: list[tuple] = []
+
+    async def reconcile_session_config_key(self, session_id, key, value):
+        self.reconciled.append((session_id, key, value))
+
+
+@pytest.mark.asyncio
+async def test_channel_is_forwarded_to_ops():
+    client = _FakePlatformClient(
+        receipt={"allowance_id": "", "reserved_tokens": 0},
+    )
+    store = _ReconcilingStore()
+    request = _request(
+        runtime_payload={"end_user_token_allowance": 1000},
+        platform_client=client,
+        store=store,
+    )
+    await authorize_allowance_turn(
+        request, _session(), "hi", end_user_id="u1", channel="web",
+    )
+    assert client.calls[0]["channel"] == "web"
+
+
+@pytest.mark.asyncio
+async def test_features_receipt_pins_entitlements_on_the_session():
+    client = _FakePlatformClient(
+        receipt={
+            "allowance_id": "al-1",
+            "reserved_tokens": 5,
+            "reservation_id": "r-1",
+            "features": {"capabilities": ["code"], "channels": ["website"]},
+        },
+    )
+    store = _ReconcilingStore()
+    request = _request(
+        runtime_payload={"end_user_token_allowance": 1000},
+        platform_client=client,
+        store=store,
+    )
+    session = _session()
+    await authorize_allowance_turn(
+        request, session, "hello", end_user_id="u1", channel="website",
+    )
+    assert store.reconciled == [
+        (
+            session.id,
+            "entitlements",
+            {"capabilities": ["code"], "channels": ["website"]},
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unrestricted_receipt_clears_a_stale_pin():
+    """A user whose package went away (cancelled sub, cleared offer)
+    must not keep yesterday's restrictions pinned on the session."""
+    client = _FakePlatformClient(
+        receipt={"allowance_id": "", "reserved_tokens": 0, "features": None},
+    )
+    store = _ReconcilingStore()
+    request = _request(
+        runtime_payload={"end_user_token_allowance": 1000},
+        platform_client=client,
+        store=store,
+    )
+    session = _session()
+    session.config = {"entitlements": {"capabilities": []}}
+    await authorize_allowance_turn(
+        request, session, "hi", end_user_id="u1",
+    )
+    assert store.reconciled == [(session.id, "entitlements", None)]
+
+
+@pytest.mark.asyncio
+async def test_steady_state_pin_is_write_free():
+    """Same package as already pinned → no store round trip at all."""
+    features = {"capabilities": ["code"]}
+    client = _FakePlatformClient(
+        receipt={
+            "allowance_id": "", "reserved_tokens": 0, "features": features,
+        },
+    )
+    store = _ReconcilingStore()
+    request = _request(
+        runtime_payload={"end_user_token_allowance": 1000},
+        platform_client=client,
+        store=store,
+    )
+    session = _session()
+    session.config = {"entitlements": {"capabilities": ["code"]}}
+    await authorize_allowance_turn(
+        request, session, "hi", end_user_id="u1",
+    )
+    assert store.reconciled == []
+
+
+@pytest.mark.asyncio
+async def test_channel_not_included_402_carries_code_and_buy_url():
+    client = _FakePlatformClient(
+        error=AllowanceExhaustedError("channel_not_included"),
+    )
+    store = _ReconcilingStore()
+    request = _request(
+        runtime_payload={
+            "end_user_token_allowance": 50,
+            "commerce_buy_url": "https://buy.example/agent",
+        },
+        platform_client=client,
+        store=store,
+    )
+    with pytest.raises(HTTPException) as exc:
+        await authorize_allowance_turn(
+            request, _session(), "content", end_user_id="u1", channel="slack",
+        )
+    assert exc.value.status_code == 402
+    assert exc.value.detail == {
+        "code": "channel_not_included",
+        "buy_url": "https://buy.example/agent",
+    }

--- a/tests/api/test_allowance_turn.py
+++ b/tests/api/test_allowance_turn.py
@@ -358,3 +358,29 @@ async def test_channel_not_included_402_carries_code_and_buy_url():
         "code": "channel_not_included",
         "buy_url": "https://buy.example/agent",
     }
+
+
+@pytest.mark.asyncio
+async def test_uncapped_agent_pins_the_projected_default_package():
+    """An uncapped agent never phones home per turn, so the agent's
+    default package (projected as ``default_user_features``) must be
+    pinned locally — otherwise a free unlimited agent with a restricted
+    default serves every capability unrestricted."""
+    client = _FakePlatformClient(receipt={"allowance_id": "x"})
+    store = _ReconcilingStore()
+    request = _request(
+        runtime_payload={
+            "commerce_mode": "free",
+            "default_user_features": {"capabilities": ["loop"]},
+        },
+        platform_client=client,
+        store=store,
+    )
+    session = _session()
+    await authorize_allowance_turn(
+        request, session, "hello", end_user_id="u1",
+    )
+    assert client.calls == []
+    assert store.reconciled == [
+        (session.id, "entitlements", {"capabilities": ["loop"]}),
+    ]

--- a/tests/api/test_website_commerce.py
+++ b/tests/api/test_website_commerce.py
@@ -141,13 +141,16 @@ async def test_paid_with_buyer_reserves_and_pins_receipt():
             },
         },
     )
-    await website.authorize_commerce_turn(request, session, "x" * 100)
+    await website.authorize_commerce_turn(
+        request, session, "x" * 100, channel="website",
+    )
 
     assert client.calls == [
         {
             "agent_id": "a-1",
             "firebase_uid": "fb-1",
             "estimated_tokens": (100 + 16) // 4,
+            "channel": "website",
             "email": "b@example.com",
             "name": "B",
         },

--- a/tests/test_channel_pipeline.py
+++ b/tests/test_channel_pipeline.py
@@ -1368,12 +1368,15 @@ class _FakeAllowanceClient:
         self.error = error
         self.calls: list[dict] = []
 
-    async def allowance_authorize(self, agent_id, *, end_user_id, estimated_tokens):
+    async def allowance_authorize(
+        self, agent_id, *, end_user_id, estimated_tokens, channel=None,
+    ):
         self.calls.append(
             {
                 "agent_id": agent_id,
                 "end_user_id": end_user_id,
                 "estimated_tokens": estimated_tokens,
+                "channel": channel,
             },
         )
         if self.error is not None:
@@ -1487,3 +1490,48 @@ async def test_allowance_gate_noop_for_uncapped_agent():
     assert deps._enqueued
     # Uncapped agent → no ops round trip.
     assert deps.platform_client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_allowance_gate_forwards_the_channel_and_blocks_excluded():
+    """The gate names the platform as the turn's channel so ops can gate
+    it against the sender's package; a channel_not_included 402 drops the
+    message with the plan notice + buy link."""
+    msg = _make_msg(is_dm=True, ts="allow.ch1")
+    deps = _make_deps()
+    deps.platform_client = _FakeAllowanceClient(
+        receipt={"allowance_id": "", "reserved_tokens": 0},
+    )
+    deps.runtime_config = _capped_config()
+    await ChannelInboundPipeline().handle(
+        msg, routing=_make_routing(), config=_make_config(), deps=deps,
+    )
+    assert deps.platform_client.calls[0]["channel"] == _make_routing().platform
+
+    from surogates.runtime.platform_client import AllowanceExhaustedError
+
+    msg2 = _make_msg(is_dm=True, ts="allow.ch2")
+    deps2 = _make_deps()
+    deps2.platform_client = _FakeAllowanceClient(
+        error=AllowanceExhaustedError("channel_not_included"),
+    )
+
+    async def _rc_with_buy_url(agent_id):
+        return {
+            "end_user_token_allowance": 1000,
+            "commerce_buy_url": "https://buy.example/agent",
+        }
+
+    deps2.runtime_config = _rc_with_buy_url
+    nudges: list[str] = []
+
+    async def _nudge(session_id, msg_in, text):
+        nudges.append(text)
+
+    deps2.input_nudge = _nudge
+    result = await ChannelInboundPipeline().handle(
+        msg2, routing=_make_routing(), config=_make_config(), deps=deps2,
+    )
+    assert result == InboundOutcome.DROPPED
+    assert nudges and "doesn't include this channel" in nudges[0]
+    assert "https://buy.example/agent" in nudges[0]

--- a/tests/test_entitlement_enforcement.py
+++ b/tests/test_entitlement_enforcement.py
@@ -357,3 +357,94 @@ def test_tier_override_endpoint_selection():
     assert pick(basic_pin, pro, base, None) is base
     assert pick(basic_pin, base, None, pro) is None  # already basic
     assert pick({}, base, None, pro) is None
+
+
+# ── production-shaped MCP/Composio names + filter ordering ────────────
+
+
+def test_router_prefixed_composio_tools_filtered_by_toolkit():
+    """Real Composio tools are mcp__tool_router__TOOLKIT_ACTION; the
+    sellable unit is the toolkit inside the tool component."""
+    registry = _registry_with(
+        ("mcp__tool_router__GMAIL_SEND_EMAIL", "mcp"),
+        ("mcp__tool_router__SLACK_SEND_MESSAGE", "mcp"),
+        ("mcp__composio_tool_router__GMAIL_LIST", "mcp"),
+        ("mcp__crm__lookup", "mcp"),
+    )
+    excluded = _entitlement_tool_exclusions(
+        session_config={"entitlements": {"mcp_server_ids": ["id-x"]}},
+        tool_registry=registry,
+        composio_tool_names=frozenset({
+            "mcp__tool_router__GMAIL_SEND_EMAIL",
+            "mcp__tool_router__SLACK_SEND_MESSAGE",
+            "mcp__composio_tool_router__GMAIL_LIST",
+        }),
+        mcp_scope=({"crm"}, {"gmail"}),
+    )
+    # Gmail toolkit entitled (both router prefixes), slack not; the
+    # plain crm server is entitled.
+    assert excluded == {"mcp__tool_router__SLACK_SEND_MESSAGE"}
+
+
+@pytest.mark.asyncio
+async def test_scope_resolution_sanitizes_server_names(monkeypatch):
+    """A server named github-mcp must match its mcp__github_mcp__* tools."""
+    from surogates.orchestrator.worker import _resolve_mcp_entitlement_scope
+
+    class _Result:
+        def all(self):
+            return [
+                ("github-mcp", "http", None),
+                ("billing", "composio", {"toolkit": "Stripe"}),
+            ]
+
+    class _Session:
+        async def execute(self, *_a, **_k):
+            return _Result()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    import surogates.db.ops_engine as ops_engine
+
+    monkeypatch.setattr(
+        ops_engine, "get_ops_session_factory", lambda: (lambda: _Session()),
+    )
+    scope = await _resolve_mcp_entitlement_scope(
+        frozenset({"id-1", "id-2"}), "postgresql://x",
+    )
+    assert scope == ({"github_mcp"}, {"stripe"})
+
+
+def test_entitlement_exclusions_survive_the_mcp_schema_filter():
+    """Regression: _apply_mcp_schema_filter re-adds this agent's full
+    discovered MCP set when the registry holds a foreign agent's tools;
+    the entitlement subtraction must run after it."""
+    registry = ToolRegistry()
+    h = _harness(entitlement_excluded=frozenset({"mcp__crm__lookup"}))
+    # Simulate the shared registry: this agent discovered crm+billing,
+    # another agent's tool is also present.
+    async def _noop(arguments, **kwargs):
+        return ""
+
+    for name in (
+        "mcp__crm__lookup", "mcp__billing__charge", "mcp__foreign__x",
+    ):
+        h._tools.register(
+            name,
+            {"name": name, "description": "", "parameters": {}},
+            _noop,
+            toolset="mcp",
+        )
+    h._mcp_tool_names = frozenset({"mcp__crm__lookup", "mcp__billing__charge"})
+
+    tool_filter = h._tool_filter_for_session(_session())
+    assert tool_filter is not None
+    assert "mcp__foreign__x" not in tool_filter
+    assert "mcp__billing__charge" in tool_filter
+    # The paywalled tool stays out even though the schema filter
+    # re-materialized this agent's discovered set.
+    assert "mcp__crm__lookup" not in tool_filter

--- a/tests/test_entitlement_enforcement.py
+++ b/tests/test_entitlement_enforcement.py
@@ -273,3 +273,87 @@ async def test_kb_list_refuses_a_kb_outside_the_plan():
         session_config={"entitlements": {"kb_ids": []}},
     )
     assert "not included in the current user's plan" in result
+
+
+# ── skills + model tier (v2) ──────────────────────────────────────────
+
+
+def test_entitled_model_tier_reads_the_scalar():
+    from surogates.runtime.entitlements import entitled_model_tier
+
+    assert entitled_model_tier(None) is None
+    assert entitled_model_tier({"entitlements": {}}) is None
+    assert entitled_model_tier(
+        {"entitlements": {"model_tier": "pro"}},
+    ) == "pro"
+    assert entitled_model_tier(
+        {"entitlements": {"model_tier": "ultra"}},
+    ) is None
+
+
+def test_entitled_skills_allowlist():
+    from surogates.runtime.entitlements import entitled_skills
+
+    assert entitled_skills(None) is None
+    assert entitled_skills(
+        {"entitlements": {"skills": ["contracts"]}},
+    ) == frozenset({"contracts"})
+    assert entitled_skills({"entitlements": {"capabilities": []}}) is None
+
+
+@pytest.mark.asyncio
+async def test_prompt_catalog_skills_filtered_by_package(monkeypatch):
+    from surogates.orchestrator import worker as worker_mod
+
+    class _Skill:
+        def __init__(self, name, builtin=False):
+            self.name = name
+            self.builtin = builtin
+
+    async def _fake_catalogs(**kwargs):
+        return (["agent"], [
+            _Skill("contracts"), _Skill("litigation"),
+            _Skill("platform-core", builtin=True),
+        ])
+
+    monkeypatch.setattr(worker_mod, "_load_prompt_catalogs", _fake_catalogs)
+    agents, skills = await worker_mod._load_prompt_catalogs_entitled(
+        session_config={"entitlements": {"skills": ["contracts"]}},
+    )
+    assert agents == ["agent"]
+    assert [s.name for s in skills] == ["contracts", "platform-core"]
+
+    # Unrestricted stays untouched.
+    _, all_skills = await worker_mod._load_prompt_catalogs_entitled(
+        session_config={},
+    )
+    assert len(all_skills) == 3
+
+
+def test_tier_override_endpoint_selection():
+    """The worker swaps the main slot only when the pinned tier differs
+    from the agent's own and ops projected the opposite endpoint."""
+    from surogates.runtime.context import LLMEndpoint
+    from surogates.runtime.entitlements import entitled_model_tier
+
+    base = LLMEndpoint(model="surogate", base_url="http://p/base", api_key_ref="r")
+    pro = LLMEndpoint(model="surogate-pro", base_url="http://p/pro", api_key_ref="r")
+
+    def pick(session_config, llm_main, tier_basic, tier_pro):
+        override = None
+        pinned = entitled_model_tier(session_config)
+        if pinned is not None and llm_main is not None:
+            agent_is_pro = llm_main.model == "surogate-pro"
+            if pinned == "pro" and not agent_is_pro:
+                override = tier_pro
+            elif pinned == "basic" and agent_is_pro:
+                override = tier_basic
+        return override
+
+    pro_pin = {"entitlements": {"model_tier": "pro"}}
+    basic_pin = {"entitlements": {"model_tier": "basic"}}
+    assert pick(pro_pin, base, None, pro) is pro
+    assert pick(pro_pin, pro, base, None) is None  # already pro
+    assert pick(basic_pin, pro, base, None) is base
+    assert pick(basic_pin, base, None, pro) is None  # already basic
+    assert pick({}, base, None, pro) is None

--- a/tests/test_entitlement_enforcement.py
+++ b/tests/test_entitlement_enforcement.py
@@ -71,6 +71,8 @@ def test_unsold_capabilities_are_never_restricted():
     config = {"entitlements": {"capabilities": []}}
     assert capability_allowed(config, "clear")
     assert capability_allowed(config, "some-skill")
+    # Compress ships with every purchase; only the sellable set restricts.
+    assert capability_allowed(config, "compress")
     assert not capability_allowed(config, "loop")
 
 
@@ -225,8 +227,10 @@ def test_no_exclusions_leave_the_filter_untouched():
 def test_slash_gate_honours_the_package():
     h = _harness()
     restricted = _session(
-        {"entitlements": {"capabilities": ["compress"]}},
+        {"entitlements": {"capabilities": ["goal"]}},
     )
+    assert h._slash_command_enabled("goal", restricted)
+    # Compress is always included, even under a restricted package.
     assert h._slash_command_enabled("compress", restricted)
     assert not h._slash_command_enabled("mission", restricted)
     assert not h._slash_command_enabled("deep-research", restricted)

--- a/tests/test_entitlement_enforcement.py
+++ b/tests/test_entitlement_enforcement.py
@@ -98,6 +98,7 @@ _REGISTRY_ENTRIES = (
     ("read_file", "file"),
     ("mcp__crm__lookup", "mcp"),
     ("mcp__billing__charge", "mcp"),
+    ("mcp__tool_router__SLACK_SEND_MESSAGE", "mcp"),
 )
 
 
@@ -105,7 +106,6 @@ def test_no_pin_excludes_nothing():
     excluded = _entitlement_tool_exclusions(
         session_config={},
         tool_registry=_registry_with(*_REGISTRY_ENTRIES),
-        composio_tool_names=frozenset({"SLACK_SEND_MESSAGE"}),
         mcp_scope=None,
     )
     assert excluded == set()
@@ -115,7 +115,6 @@ def test_capability_exclusions_drop_browser_and_coding():
     excluded = _entitlement_tool_exclusions(
         session_config={"entitlements": {"capabilities": ["mission"]}},
         tool_registry=_registry_with(*_REGISTRY_ENTRIES),
-        composio_tool_names=frozenset(),
         mcp_scope=None,
     )
     assert excluded == {"browser_navigate", "browser_click", "run_coding_agent"}
@@ -125,13 +124,12 @@ def test_mcp_servers_filtered_by_resolved_scope():
     excluded = _entitlement_tool_exclusions(
         session_config={"entitlements": {"mcp_server_ids": ["id-crm"]}},
         tool_registry=_registry_with(*_REGISTRY_ENTRIES),
-        composio_tool_names=frozenset(
-            {"SLACK_SEND_MESSAGE", "GMAIL_SEND_EMAIL"},
-        ),
         mcp_scope=({"crm"}, {"gmail"}),
     )
     # billing server not entitled; slack toolkit not entitled.
-    assert excluded == {"mcp__billing__charge", "SLACK_SEND_MESSAGE"}
+    assert excluded == {
+        "mcp__billing__charge", "mcp__tool_router__SLACK_SEND_MESSAGE",
+    }
 
 
 def test_mcp_restriction_fails_closed_without_a_scope():
@@ -141,11 +139,12 @@ def test_mcp_restriction_fails_closed_without_a_scope():
     excluded = _entitlement_tool_exclusions(
         session_config={"entitlements": {"mcp_server_ids": ["id-crm"]}},
         tool_registry=_registry_with(*_REGISTRY_ENTRIES),
-        composio_tool_names=frozenset({"SLACK_SEND_MESSAGE"}),
         mcp_scope=None,
     )
     assert excluded == {
-        "mcp__crm__lookup", "mcp__billing__charge", "SLACK_SEND_MESSAGE",
+        "mcp__crm__lookup",
+        "mcp__billing__charge",
+        "mcp__tool_router__SLACK_SEND_MESSAGE",
     }
 
 
@@ -153,11 +152,12 @@ def test_empty_mcp_allowlist_drops_all():
     excluded = _entitlement_tool_exclusions(
         session_config={"entitlements": {"mcp_server_ids": []}},
         tool_registry=_registry_with(*_REGISTRY_ENTRIES),
-        composio_tool_names=frozenset({"SLACK_SEND_MESSAGE"}),
         mcp_scope=(set(), set()),
     )
     assert excluded == {
-        "mcp__crm__lookup", "mcp__billing__charge", "SLACK_SEND_MESSAGE",
+        "mcp__crm__lookup",
+        "mcp__billing__charge",
+        "mcp__tool_router__SLACK_SEND_MESSAGE",
     }
 
 
@@ -374,11 +374,6 @@ def test_router_prefixed_composio_tools_filtered_by_toolkit():
     excluded = _entitlement_tool_exclusions(
         session_config={"entitlements": {"mcp_server_ids": ["id-x"]}},
         tool_registry=registry,
-        composio_tool_names=frozenset({
-            "mcp__tool_router__GMAIL_SEND_EMAIL",
-            "mcp__tool_router__SLACK_SEND_MESSAGE",
-            "mcp__composio_tool_router__GMAIL_LIST",
-        }),
         mcp_scope=({"crm"}, {"gmail"}),
     )
     # Gmail toolkit entitled (both router prefixes), slack not; the
@@ -414,7 +409,7 @@ async def test_scope_resolution_sanitizes_server_names(monkeypatch):
         ops_engine, "get_ops_session_factory", lambda: (lambda: _Session()),
     )
     scope = await _resolve_mcp_entitlement_scope(
-        frozenset({"id-1", "id-2"}), "postgresql://x",
+        frozenset({"id-1", "id-2"}),
     )
     assert scope == ({"github_mcp"}, {"stripe"})
 
@@ -423,7 +418,6 @@ def test_entitlement_exclusions_survive_the_mcp_schema_filter():
     """Regression: _apply_mcp_schema_filter re-adds this agent's full
     discovered MCP set when the registry holds a foreign agent's tools;
     the entitlement subtraction must run after it."""
-    registry = ToolRegistry()
     h = _harness(entitlement_excluded=frozenset({"mcp__crm__lookup"}))
     # Simulate the shared registry: this agent discovered crm+billing,
     # another agent's tool is also present.

--- a/tests/test_entitlement_enforcement.py
+++ b/tests/test_entitlement_enforcement.py
@@ -1,0 +1,271 @@
+"""Purchased-package enforcement in the runtime.
+
+The authorize gates pin ``session.config["entitlements"]``; these tests
+cover every reader of that pin: the shared reader module, the worker's
+tool-exclusion computation (browser / coding / MCP servers / Composio
+toolkits, including the fail-closed path when the ops scope cannot be
+resolved), the harness tool filter and slash gate, and the KB tools'
+per-call guard.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from surogates.harness.budget import IterationBudget
+from surogates.harness.context import ContextCompressor
+from surogates.harness.loop import AgentHarness
+from surogates.harness.prompt import PromptBuilder
+from surogates.orchestrator.worker import _entitlement_tool_exclusions
+from surogates.runtime import SLASH_COMMAND_IDS, SlashCommandConfig
+from surogates.runtime.entitlements import (
+    capability_allowed,
+    dimension_allowlist,
+    kb_allowed,
+    pinned_entitlements,
+)
+from surogates.sandbox.pool import SandboxPool
+from surogates.session.models import Session
+from surogates.tenant.context import TenantContext
+from surogates.tools.registry import ToolRegistry
+
+
+# ── shared reader ─────────────────────────────────────────────────────
+
+
+def test_no_pin_means_unrestricted():
+    assert pinned_entitlements(None) is None
+    assert pinned_entitlements({}) is None
+    assert dimension_allowlist({}, "capabilities") is None
+    assert capability_allowed({}, "code")
+    assert kb_allowed(None, "kb-1")
+
+
+def test_malformed_pin_reads_as_unrestricted():
+    assert pinned_entitlements({"entitlements": "garbage"}) is None
+    assert capability_allowed({"entitlements": ["not-a-dict"]}, "code")
+
+
+def test_dimension_allowlist_and_membership():
+    config = {"entitlements": {"kb_ids": ["kb-1"], "capabilities": ["code"]}}
+    assert dimension_allowlist(config, "kb_ids") == frozenset({"kb-1"})
+    assert kb_allowed(config, "kb-1")
+    assert not kb_allowed(config, "kb-2")
+    # Absent dimension stays unrestricted.
+    assert dimension_allowlist(config, "mcp_server_ids") is None
+
+
+def test_capability_allowed_normalizes_slash_spelling():
+    config = {"entitlements": {"capabilities": ["deep_research"]}}
+    assert capability_allowed(config, "deep-research")
+    assert capability_allowed(config, "deep_research")
+    assert not capability_allowed(config, "mission")
+    assert not capability_allowed(config, "code")
+
+
+def test_unsold_capabilities_are_never_restricted():
+    config = {"entitlements": {"capabilities": []}}
+    assert capability_allowed(config, "clear")
+    assert capability_allowed(config, "some-skill")
+    assert not capability_allowed(config, "loop")
+
+
+# ── worker exclusion computation ──────────────────────────────────────
+
+
+def _registry_with(*entries: tuple[str, str]) -> ToolRegistry:
+    registry = MagicMock(spec=ToolRegistry)
+    all_entries = [
+        MagicMock(name=n, toolset=ts) for n, ts in entries
+    ]
+    for mock, (n, _ts) in zip(all_entries, entries):
+        mock.name = n
+    registry.get_all.return_value = all_entries
+    registry.tool_names = [n for n, _ in entries]
+    return registry
+
+
+_REGISTRY_ENTRIES = (
+    ("browser_navigate", "browser"),
+    ("browser_click", "browser"),
+    ("run_coding_agent", "code"),
+    ("read_file", "file"),
+    ("mcp__crm__lookup", "mcp"),
+    ("mcp__billing__charge", "mcp"),
+)
+
+
+def test_no_pin_excludes_nothing():
+    excluded = _entitlement_tool_exclusions(
+        session_config={},
+        tool_registry=_registry_with(*_REGISTRY_ENTRIES),
+        composio_tool_names=frozenset({"SLACK_SEND_MESSAGE"}),
+        mcp_scope=None,
+    )
+    assert excluded == set()
+
+
+def test_capability_exclusions_drop_browser_and_coding():
+    excluded = _entitlement_tool_exclusions(
+        session_config={"entitlements": {"capabilities": ["mission"]}},
+        tool_registry=_registry_with(*_REGISTRY_ENTRIES),
+        composio_tool_names=frozenset(),
+        mcp_scope=None,
+    )
+    assert excluded == {"browser_navigate", "browser_click", "run_coding_agent"}
+
+
+def test_mcp_servers_filtered_by_resolved_scope():
+    excluded = _entitlement_tool_exclusions(
+        session_config={"entitlements": {"mcp_server_ids": ["id-crm"]}},
+        tool_registry=_registry_with(*_REGISTRY_ENTRIES),
+        composio_tool_names=frozenset(
+            {"SLACK_SEND_MESSAGE", "GMAIL_SEND_EMAIL"},
+        ),
+        mcp_scope=({"crm"}, {"gmail"}),
+    )
+    # billing server not entitled; slack toolkit not entitled.
+    assert excluded == {"mcp__billing__charge", "SLACK_SEND_MESSAGE"}
+
+
+def test_mcp_restriction_fails_closed_without_a_scope():
+    """Scope resolution failed (ops DB unreachable): a restricted
+    dimension drops every MCP/Composio tool rather than serving paid
+    tools unmetered."""
+    excluded = _entitlement_tool_exclusions(
+        session_config={"entitlements": {"mcp_server_ids": ["id-crm"]}},
+        tool_registry=_registry_with(*_REGISTRY_ENTRIES),
+        composio_tool_names=frozenset({"SLACK_SEND_MESSAGE"}),
+        mcp_scope=None,
+    )
+    assert excluded == {
+        "mcp__crm__lookup", "mcp__billing__charge", "SLACK_SEND_MESSAGE",
+    }
+
+
+def test_empty_mcp_allowlist_drops_all():
+    excluded = _entitlement_tool_exclusions(
+        session_config={"entitlements": {"mcp_server_ids": []}},
+        tool_registry=_registry_with(*_REGISTRY_ENTRIES),
+        composio_tool_names=frozenset({"SLACK_SEND_MESSAGE"}),
+        mcp_scope=(set(), set()),
+    )
+    assert excluded == {
+        "mcp__crm__lookup", "mcp__billing__charge", "SLACK_SEND_MESSAGE",
+    }
+
+
+# ── harness: tool filter + slash gate ─────────────────────────────────
+
+
+def _tenant() -> TenantContext:
+    return TenantContext(
+        org_id=UUID("00000000-0000-0000-0000-000000000001"),
+        user_id=UUID("00000000-0000-0000-0000-000000000002"),
+        org_config={}, user_preferences={}, permissions=frozenset(),
+        asset_root="/tmp/test",
+    )
+
+
+def _session(config=None) -> Session:
+    now = datetime.now(timezone.utc)
+    return Session(
+        id=uuid4(), user_id=uuid4(), org_id=uuid4(), agent_id="a1",
+        channel="api", status="active", config=config or {},
+        created_at=now, updated_at=now,
+    )
+
+
+def _harness(
+    *,
+    entitlement_excluded: frozenset[str] = frozenset(),
+) -> AgentHarness:
+    registry = ToolRegistry()
+    return AgentHarness(
+        session_store=AsyncMock(),
+        tool_registry=registry,
+        llm_client=AsyncMock(),
+        tenant=_tenant(),
+        worker_id="test-worker",
+        budget=IterationBudget(max_total=10),
+        context_compressor=MagicMock(spec=ContextCompressor),
+        prompt_builder=MagicMock(spec=PromptBuilder),
+        sandbox_pool=MagicMock(spec=SandboxPool),
+        slash_commands=SlashCommandConfig(
+            commands=frozenset(SLASH_COMMAND_IDS),
+        ),
+        entitlement_excluded_tools=entitlement_excluded,
+    )
+
+
+def test_entitlement_exclusions_beat_an_explicit_allowlist():
+    h = _harness(entitlement_excluded=frozenset({"browser_navigate"}))
+    tool_filter = h._tool_filter_for_session(
+        _session({"allowed_tools": ["browser_navigate", "read_file"]}),
+    )
+    assert tool_filter is not None
+    assert "browser_navigate" not in tool_filter
+    assert "read_file" in tool_filter
+
+
+def test_no_exclusions_leave_the_filter_untouched():
+    h = _harness()
+    tool_filter = h._tool_filter_for_session(
+        _session({"allowed_tools": ["read_file"]}),
+    )
+    assert tool_filter == {"read_file", "ask_user_question"} or (
+        "read_file" in tool_filter
+    )
+
+
+def test_slash_gate_honours_the_package():
+    h = _harness()
+    restricted = _session(
+        {"entitlements": {"capabilities": ["compress"]}},
+    )
+    assert h._slash_command_enabled("compress", restricted)
+    assert not h._slash_command_enabled("mission", restricted)
+    assert not h._slash_command_enabled("deep-research", restricted)
+    # Without a session (agent-level checks) the package cannot apply.
+    assert h._slash_command_enabled("mission")
+    # Without a pin the package never restricts.
+    assert h._slash_command_enabled("mission", _session())
+
+
+def test_slash_block_reason_names_the_blocked_command():
+    h = _harness()
+    restricted = _session({"entitlements": {"capabilities": []}})
+    reason = h._slash_command_block_reason("/mission do things", restricted)
+    assert reason is not None
+    assert h._slash_command_block_reason("hello there", restricted) is None
+
+
+# ── KB tools per-call guard ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_kb_read_refuses_a_kb_outside_the_plan():
+    from surogates.tools.builtin.kb_tools import _kb_read_page_handler
+
+    result = await _kb_read_page_handler(
+        {"kb_id": "kb-locked", "path": "index.md"},
+        agent_id="a1",
+        session_config={"entitlements": {"kb_ids": ["kb-open"]}},
+    )
+    assert "not included in the current user's plan" in result
+
+
+@pytest.mark.asyncio
+async def test_kb_list_refuses_a_kb_outside_the_plan():
+    from surogates.tools.builtin.kb_tools import _kb_list_pages_handler
+
+    result = await _kb_list_pages_handler(
+        {"kb_id": "kb-locked"},
+        agent_id="a1",
+        session_config={"entitlements": {"kb_ids": []}},
+    )
+    assert "not included in the current user's plan" in result

--- a/web/src/api/_errors.ts
+++ b/web/src/api/_errors.ts
@@ -60,6 +60,7 @@ const PAYWALL_LEADS: Record<string, string> = {
   allowance_exhausted: "You've reached your usage limit for this assistant.",
   subscription_required:
     "A subscription is required to keep chatting with this assistant.",
+  channel_not_included: "Your current plan doesn't include this channel.",
   operator_subscription_exhausted:
     "This assistant is temporarily unavailable. Its owner has run out of credit.",
   sign_in_required: "Please sign in to keep chatting with this assistant.",

--- a/web/src/features/settings/plan-usage-tab.tsx
+++ b/web/src/features/settings/plan-usage-tab.tsx
@@ -28,6 +28,7 @@ interface CommerceOffer {
   amount_cents: number;
   billing_interval: string | null;
   token_amount: number;
+  description?: string | null;
   /** Buyer-facing labels for a custom package; [] or absent = full
    * access (subscriptions) / pure extra usage (packs). */
   included?: string[];
@@ -207,7 +208,7 @@ export function PlanUsageTab() {
         // highlightFirst: the lead plan is the recommended one and gets
         // the brand beam; selection is a data flag, not display copy.
         { label: "Plans", items: subscriptions, verb: "Subscribe", highlightFirst: true },
-        { label: "Extra usage", items: packs, verb: "Buy", highlightFirst: false },
+        { label: "One-time packs", items: packs, verb: "Buy", highlightFirst: false },
       ]
         .filter((s) => s.items.length > 0)
         .map((section) => (
@@ -230,11 +231,21 @@ export function PlanUsageTab() {
                   <div className="flex min-w-0 flex-1 flex-col">
                     <span className="text-sm font-medium">{offer.name}</span>
                     <span className="text-xs text-muted-foreground">
-                      {approxMessagesLabel(offer.token_amount)}
-                      {offer.kind === "subscription"
-                        ? " every period"
-                        : " of extra usage · one-time"}
+                      {offer.token_amount > 0
+                        ? `${approxMessagesLabel(offer.token_amount)}${
+                            offer.kind === "subscription"
+                              ? " every period"
+                              : " of extra usage · one-time"
+                          }`
+                        : offer.kind === "subscription"
+                          ? "Access included"
+                          : "Feature add-on · one-time"}
                     </span>
+                    {offer.description ? (
+                      <span className="text-xs text-muted-foreground/80">
+                        {offer.description}
+                      </span>
+                    ) : null}
                     {(offer.included?.length ?? 0) > 0 ? (
                       <span className="text-xs text-muted-foreground/80">
                         Includes: {offer.included?.join(" · ")}

--- a/web/src/features/settings/plan-usage-tab.tsx
+++ b/web/src/features/settings/plan-usage-tab.tsx
@@ -28,6 +28,9 @@ interface CommerceOffer {
   amount_cents: number;
   billing_interval: string | null;
   token_amount: number;
+  /** Buyer-facing labels for a custom package; [] or absent = full
+   * access (subscriptions) / pure extra usage (packs). */
+  included?: string[];
 }
 
 interface CommerceOverview {
@@ -39,6 +42,7 @@ interface CommerceOverview {
     current_period_end: string | null;
     period_token_remaining: number;
     topup_token_remaining: number;
+    included?: string[];
   } | null;
   purchasable: boolean;
 }
@@ -180,6 +184,19 @@ export function PlanUsageTab() {
                   {approxMessagesLabel(ent.topup_token_remaining)}
                 </span>
               </div>
+              {(ent.included?.length ?? 0) > 0 ? (
+                <div
+                  className="flex items-start justify-between gap-4"
+                  data-testid="plan-tab-included"
+                >
+                  <span className="shrink-0 text-muted-foreground">
+                    Your plan includes
+                  </span>
+                  <span className="text-right font-medium">
+                    {ent.included?.join(" · ")}
+                  </span>
+                </div>
+              ) : null}
             </>
           )}
         </CardContent>
@@ -218,6 +235,11 @@ export function PlanUsageTab() {
                         ? " every period"
                         : " of extra usage · one-time"}
                     </span>
+                    {(offer.included?.length ?? 0) > 0 ? (
+                      <span className="text-xs text-muted-foreground/80">
+                        Includes: {offer.included?.join(" · ")}
+                      </span>
+                    ) : null}
                   </div>
                   <span className="shrink-0 text-sm font-semibold tabular-nums">
                     {formatPrice(offer.amount_cents, offer.currency)}

--- a/web/src/features/settings/plan-usage-tab.tsx
+++ b/web/src/features/settings/plan-usage-tab.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) 2026, Invergent SA, developed by Flavius Burca
 // SPDX-License-Identifier: AGPL-3.0-only
 //
-// Settings → Plan & tokens: what this agent sells and what the
-// signed-in user currently holds. Data comes from the harness's
-// /v1/commerce endpoints (which front surogate-ops with the runtime
-// token) — the browser never talks to ops directly.
+// Settings → Plan & usage: what this agent sells and what the
+// signed-in user currently holds. Balances arrive token-denominated
+// from the harness's /v1/commerce endpoints (which front surogate-ops
+// with the runtime token) and are shown as messages; the browser
+// never talks to ops directly.
 
 import { BrandBeam } from "@invergent/agent-chat-react";
 import { useCallback, useEffect, useState } from "react";
@@ -17,6 +18,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { approxMessagesLabel } from "@/lib/usage-units";
 
 interface CommerceOffer {
   id: string;
@@ -54,11 +56,7 @@ function formatPrice(amountCents: number, currency: string): string {
   }).format(amountCents / 100);
 }
 
-function formatTokens(n: number): string {
-  return n.toLocaleString("en-US");
-}
-
-export function PlanTokensTab() {
+export function PlanUsageTab() {
   const [overview, setOverview] = useState<CommerceOverview | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busyOfferId, setBusyOfferId] = useState<string | null>(null);
@@ -122,7 +120,7 @@ export function PlanTokensTab() {
   if (overview.mode === "free") {
     return (
       <p className="text-sm text-muted-foreground" data-testid="plan-tab-free">
-        This agent is free to use — there are no plans or token packs.
+        This agent is free to use. There is nothing to buy.
       </p>
     );
   }
@@ -170,16 +168,16 @@ export function PlanTokensTab() {
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">
-                  Plan tokens this period
+                  Included usage left this period
                 </span>
                 <span className="font-medium tabular-nums">
-                  {formatTokens(ent.period_token_remaining)}
+                  {approxMessagesLabel(ent.period_token_remaining)}
                 </span>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-muted-foreground">Top-up tokens</span>
+                <span className="text-muted-foreground">Extra usage</span>
                 <span className="font-medium tabular-nums">
-                  {formatTokens(ent.topup_token_remaining)}
+                  {approxMessagesLabel(ent.topup_token_remaining)}
                 </span>
               </div>
             </>
@@ -192,7 +190,7 @@ export function PlanTokensTab() {
         // highlightFirst: the lead plan is the recommended one and gets
         // the brand beam; selection is a data flag, not display copy.
         { label: "Plans", items: subscriptions, verb: "Subscribe", highlightFirst: true },
-        { label: "Token packs", items: packs, verb: "Buy", highlightFirst: false },
+        { label: "Extra usage", items: packs, verb: "Buy", highlightFirst: false },
       ]
         .filter((s) => s.items.length > 0)
         .map((section) => (
@@ -215,10 +213,10 @@ export function PlanTokensTab() {
                   <div className="flex min-w-0 flex-1 flex-col">
                     <span className="text-sm font-medium">{offer.name}</span>
                     <span className="text-xs text-muted-foreground">
-                      {formatTokens(offer.token_amount)} tokens
+                      {approxMessagesLabel(offer.token_amount)}
                       {offer.kind === "subscription"
                         ? " every period"
-                        : " · one-time"}
+                        : " of extra usage · one-time"}
                     </span>
                   </div>
                   <span className="shrink-0 text-sm font-semibold tabular-nums">

--- a/web/src/features/settings/settings-page.tsx
+++ b/web/src/features/settings/settings-page.tsx
@@ -13,7 +13,7 @@ import { toast } from "sonner";
 import { CodingAgentsPanel } from "@invergent/agent-chat-react";
 import { surogatesWebChatAdapter } from "@/features/chat";
 import { BrowserProfilesTab } from "./browser-profiles-tab";
-import { PlanTokensTab } from "./plan-tokens-tab";
+import { PlanUsageTab } from "./plan-usage-tab";
 import { PasswordSection } from "./password-section";
 import { useAppStore } from "@/stores/app-store";
 import { slashCommandEnabled } from "@/stores/capabilities-slice";
@@ -173,7 +173,7 @@ export function SettingsPage() {
                   Connected Channels
                 </TabsTrigger>
               )}
-              <TabsTrigger value="plan">Plan &amp; Tokens</TabsTrigger>
+              <TabsTrigger value="plan">Plan &amp; Usage</TabsTrigger>
               {codingAgentsEnabled && (
                 <TabsTrigger value="coding-agents">Coding Agents</TabsTrigger>
               )}
@@ -184,9 +184,9 @@ export function SettingsPage() {
               )}
             </TabsList>
 
-            {/* ── Plan & tokens ── */}
+            {/* ── Plan & usage ── */}
             <TabsContent value="plan">
-              <PlanTokensTab />
+              <PlanUsageTab />
             </TabsContent>
 
             {/* ── Profile ── */}

--- a/web/src/lib/usage-units.ts
+++ b/web/src/lib/usage-units.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// The buyer-facing usage unit. Commerce balances arrive from the
+// harness token-denominated (period_token_remaining and friends), but
+// end-users reason in "messages": one question plus the agent's
+// answer. Mirrors surogate-ops frontend/src/utils/usage-units.ts so
+// the buy page and this app describe the same purchase identically.
+
+/**
+ * How many tokens one message stands for. Purely presentational: the
+ * API payloads stay token-denominated.
+ */
+export const TOKENS_PER_MESSAGE = 1_000;
+
+/** Display-side conversion, floored: a balance shows what the holder
+ * can still do, so 1,999 tokens reads as 1 message, not 2. */
+export function tokensToMessages(tokens: number): number {
+  if (!Number.isFinite(tokens) || tokens <= 0) {
+    return 0;
+  }
+  return Math.floor(tokens / TOKENS_PER_MESSAGE);
+}
+
+export function formatMessageCount(messages: number): string {
+  return messages.toLocaleString("en-US");
+}
+
+/**
+ * Human label for a token amount: "~1,500 messages", "~1 message",
+ * "under 1 message" (a positive balance too small to floor to one),
+ * or "0 messages". The tilde is deliberate: a message is an average,
+ * long conversations use more.
+ */
+export function approxMessagesLabel(tokens: number): string {
+  if (!Number.isFinite(tokens) || tokens <= 0) {
+    return "0 messages";
+  }
+  const messages = tokensToMessages(tokens);
+  if (messages < 1) {
+    return "under 1 message";
+  }
+  return `~${formatMessageCount(messages)} ${
+    messages === 1 ? "message" : "messages"
+  }`;
+}


### PR DESCRIPTION
# feat(runtime): enforce purchased feature packages per turn

Companion to invergent-ai/surogate-ops#303: ops sells packages (capabilities, channels, KBs, MCP/Composio tools, skills, model tier); this PR makes the runtime honor them for every turn.

## How enforcement works

- **Pinning**: every authorize receipt from ops carries the buyer's effective features; `_commerce_turn` reconciles them onto `session.config["entitlements"]` (write-free in steady state). `surogates/runtime/entitlements.py` is the single reader.
- **Channels**: the channel is sent with every allowance/commerce authorize; ops answers 402 `channel_not_included` before reserving, and the channel pipeline surfaces a friendly notice.
- **Tools**: the worker resolves entitled MCP-server ids to sanitized server-name scopes and Composio toolkits (fail-**closed** on resolution failure), computes concrete exclusions (browser toolset, coding tool, non-included servers/toolkits), removes them from the prompt surface, hands the harness both a pre-subtracted discovered-MCP set and the exclusion list, and the harness re-applies exclusions **after** `_apply_mcp_schema_filter` (which re-materializes the discovered set) so they survive on every return path.
- **Skills**: package allowlist filters the worker's prompt catalog, the skills tool, and the skills API routes (list/view/read-file). When `session_id` is omitted or bogus, the API falls back to the caller's most recent session so omission never reads as "no restriction". Built-in platform skills always pass.
- **KBs**: filtered per wake plus a per-call guard inside the kb tools (dispatch-injected `session_config`), so a prompt-injected kb_id outside the plan still refuses.
- **Capabilities**: slash surfaces (code, deep research, auto-research, loop, mission, goal) and the brainstorm gate/browser check the pinned package; compress and multi-session are always included and never restricted.
- **Model tier**: the buyer's pinned tier swaps the main LLM slot onto the opposite-tier endpoint ops projected for exactly this (`llm_tier_pro` on basic agents, `llm_tier_basic` on pro agents); no projection = no-op, and the proxy meters by endpoint role so billing follows the swap.

## Web channel
- Plan & Usage shows package contents, offer descriptions, and "One-time packs" naming; `channel_not_included` gets a clear paywall lead.

## Related
- Browser-minutes metering: invergent-ai/surogate-ops#300 (out of scope here).

## Notes for reviewers
- Test baseline: the 23 pre-existing failures on master are unchanged; new/touched suites green (`test_entitlement_enforcement`, `api/test_allowance_turn`, `api/test_website_commerce`, `test_channel_pipeline`, kb/skills/store suites).
