### PR TITLE
feat: per-buyer browser-minutes gate at pod provision

### DIFF
--- a/surogates/browser/base.py
+++ b/surogates/browser/base.py
@@ -155,7 +155,9 @@ class BrowserSpec:
     # ({owner_kind, owner_id, reservation_id, balance_id}); the k8s
     # backend stamps it as pod labels and the fleet backend forwards it
     # in the lease body so the ops BrowserMonitor can extend and settle
-    # the hold. None on unmetered agents.
+    # the hold. None on unmetered agents. The process backend (dev)
+    # ignores it like the identity ids — an orphaned hold on that path
+    # is reclaimed by the ops reservation reaper.
     billing: dict[str, str] | None = None
 
 

--- a/surogates/browser/base.py
+++ b/surogates/browser/base.py
@@ -31,6 +31,21 @@ class BrowserCreditsExhaustedError(BrowserUnavailableError):
         super().__init__(reason, classification="credits")
 
 
+class BrowserBudgetExhaustedError(BrowserUnavailableError):
+    """Raised when the SENDER'S purchased browser-minutes budget is spent.
+
+    The operator-wallet sibling of :class:`BrowserCreditsExhaustedError`
+    covers the project's own minutes; this one covers a buyer/end-user
+    balance on a metered agent. Same subclassing rationale: parent-only
+    call sites degrade gracefully, the tool layer catches it first to
+    render a buy prompt.
+    """
+
+    def __init__(self, reason: str, *, buy_url: str | None = None) -> None:
+        super().__init__(reason, classification="budget")
+        self.buy_url = buy_url
+
+
 def browser_unavailable_result(
     reason: str,
     *,
@@ -73,6 +88,33 @@ def browser_credits_exhausted_result(reason: str) -> str:
     })
 
 
+def browser_budget_exhausted_result(
+    reason: str, *, buy_url: str | None = None,
+) -> str:
+    """Return the JSON tool body for a spent per-buyer minutes budget.
+
+    Like :func:`browser_credits_exhausted_result` the remedy is the
+    user's — but here it is the SENDER's purchased balance, so the
+    guidance points at the agent's own buy page rather than the
+    operator's billing settings.
+    """
+
+    payload: dict[str, object] = {
+        "error": "browser_minutes_exhausted",
+        "reason": reason,
+        "guidance": (
+            "You have no browsing minutes left on your plan for this "
+            "agent, so no browser can be started. Do not retry "
+            "browser_* tools. Tell the user their browsing time is used "
+            "up and that they can buy more from the agent's plan page; "
+            "continue with non-browser tools if you can."
+        ),
+    }
+    if buy_url:
+        payload["buy_url"] = buy_url
+    return json.dumps(payload)
+
+
 class BrowserStatus(str, Enum):
     """Observable lifecycle states for a browser instance."""
 
@@ -109,6 +151,12 @@ class BrowserSpec:
     # When set, the pool injects this Playwright storage_state into the fresh
     # context at provision time (before registry publish / navigation).
     storage_state: dict | None = None
+    # Per-buyer minutes attribution from the ops pre-flight authorize
+    # ({owner_kind, owner_id, reservation_id, balance_id}); the k8s
+    # backend stamps it as pod labels and the fleet backend forwards it
+    # in the lease body so the ops BrowserMonitor can extend and settle
+    # the hold. None on unmetered agents.
+    billing: dict[str, str] | None = None
 
 
 class BrowserBackend(Protocol):

--- a/surogates/browser/composite.py
+++ b/surogates/browser/composite.py
@@ -7,6 +7,11 @@ composite transparently provisions via the fallback so a fleet outage
 or capacity-exhaustion event degrades to today's per-session
 behaviour rather than failing the lease outright.
 
+Metering caveat: a k8s fallback still carries ``spec.billing`` as pod
+labels, but a process fallback (dev) drops it — the sender's hold then
+has no pod to settle against and is reclaimed by the ops-side
+reservation reaper's podless sweep.
+
 The composite maintains an in-memory ``browser_id → backend`` routing
 table so ``destroy`` and ``status`` calls reach the backend that
 originally provisioned the browser. After a worker restart the table

--- a/surogates/browser/fleet.py
+++ b/surogates/browser/fleet.py
@@ -88,6 +88,10 @@ class FleetBackend:
             "env": dict(spec.env),
             "s3_creds": self._resolve_s3_creds(spec),
         }
+        if spec.billing:
+            # Per-buyer minutes attribution — the fleet manager stamps
+            # it as pod labels for the ops BrowserMonitor.
+            body["billing"] = dict(spec.billing)
         r = await self.http.post(
             f"{self.endpoint}/lease",
             json=body,

--- a/surogates/browser/kubernetes.py
+++ b/surogates/browser/kubernetes.py
@@ -367,6 +367,23 @@ class K8sBrowserBackend:
             "surogates.ai/org-id": org_id,
             "surogates.ai/user-id": user_id,
         }
+        if spec.billing:
+            # Per-buyer minutes attribution, read by the ops
+            # BrowserMonitor to extend and settle the sender's hold.
+            labels.update({
+                "surogates.ai/minutes-owner-kind": (
+                    spec.billing.get("owner_kind") or ""
+                ),
+                "surogates.ai/minutes-owner-id": (
+                    spec.billing.get("owner_id") or ""
+                ),
+                "surogates.ai/minutes-reservation-id": (
+                    spec.billing.get("reservation_id") or ""
+                ),
+                "surogates.ai/minutes-balance-id": (
+                    spec.billing.get("balance_id") or ""
+                ),
+            })
         env_vars = [
             client.V1EnvVar(name=key, value=value)
             for key, value in sorted(spec.env.items())

--- a/surogates/browser/kubernetes.py
+++ b/surogates/browser/kubernetes.py
@@ -31,6 +31,19 @@ SERVICE_PORT_LIVE_VIEW = 443
 TARGET_PORT_LIVE_VIEW = 8080
 
 
+_LABEL_VALUE_DISALLOWED = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def _label_safe(raw: str) -> str:
+    """Coerce a string to a legal k8s label value (charset + 63 cap).
+
+    Lossy is fine for the billing values this guards — the ids that
+    settlement depends on are our own UUIDs; only the owner id can be
+    externally chosen.
+    """
+    return _LABEL_VALUE_DISALLOWED.sub("-", raw)[:63].strip("-_.")
+
+
 def _image_pull_policy(image: str) -> str:
     if "@" in image:
         return "IfNotPresent"
@@ -370,17 +383,20 @@ class K8sBrowserBackend:
         if spec.billing:
             # Per-buyer minutes attribution, read by the ops
             # BrowserMonitor to extend and settle the sender's hold.
+            # Values are sanitized to the k8s label charset: the owner
+            # id on the end-user plane can be an externally chosen
+            # string, and one bad character 422s the whole pod create.
             labels.update({
-                "surogates.ai/minutes-owner-kind": (
+                "surogates.ai/minutes-owner-kind": _label_safe(
                     spec.billing.get("owner_kind") or ""
                 ),
-                "surogates.ai/minutes-owner-id": (
+                "surogates.ai/minutes-owner-id": _label_safe(
                     spec.billing.get("owner_id") or ""
                 ),
-                "surogates.ai/minutes-reservation-id": (
+                "surogates.ai/minutes-reservation-id": _label_safe(
                     spec.billing.get("reservation_id") or ""
                 ),
-                "surogates.ai/minutes-balance-id": (
+                "surogates.ai/minutes-balance-id": _label_safe(
                     spec.billing.get("balance_id") or ""
                 ),
             })

--- a/surogates/browser/pool.py
+++ b/surogates/browser/pool.py
@@ -29,9 +29,10 @@ CreditGuard = Callable[[str], Awaitable[None]]
 # provisions with keyword args (session_id, org_id, user_id). Returns
 # a billing block to stamp on the pod ({owner_kind, owner_id,
 # reservation_id, balance_id}), or ``None`` when the agent is
-# unmetered or the session is operator-driven (the guard resolves the
-# session row itself — provisioning is a once-per-session event, so
-# the extra read is negligible). Raises
+# unmetered or the session runs on the operator plane — profile
+# capture (``browser_setup``) and service-account-principal sessions.
+# The guard resolves the session row itself; provisioning is a
+# once-per-session event, so the extra read is negligible. Raises
 # ``BrowserBudgetExhaustedError`` when the sender's balance is spent.
 BudgetGuard = Callable[..., Awaitable[dict[str, str] | None]]
 

--- a/surogates/browser/pool.py
+++ b/surogates/browser/pool.py
@@ -25,6 +25,15 @@ EventEmitter = Callable[[str, str, dict[str, Any]], Awaitable[None]]
 # pod is provisioned; raises ``BrowserCreditsExhaustedError`` when the
 # project is out of minutes. ``None`` disables the gate entirely.
 CreditGuard = Callable[[str], Awaitable[None]]
+# Per-buyer minutes gate, called after the operator gate on fresh
+# provisions with keyword args (session_id, org_id, user_id). Returns
+# a billing block to stamp on the pod ({owner_kind, owner_id,
+# reservation_id, balance_id}), or ``None`` when the agent is
+# unmetered or the session is operator-driven (the guard resolves the
+# session row itself — provisioning is a once-per-session event, so
+# the extra read is negligible). Raises
+# ``BrowserBudgetExhaustedError`` when the sender's balance is spent.
+BudgetGuard = Callable[..., Awaitable[dict[str, str] | None]]
 
 
 @dataclass(slots=True)
@@ -52,12 +61,17 @@ class BrowserPool:
         registry: BrowserRegistry,
         event_emitter: EventEmitter | None = None,
         credit_guard: CreditGuard | None = None,
+        budget_guard: BudgetGuard | None = None,
         browser_profile_store: Any | None = None,
     ) -> None:
         self._backend = backend
         self._registry = registry
         self._emit = event_emitter
         self._credit_guard = credit_guard
+        # Public so the worker can wire it after construction — the
+        # guard closes over runtime plumbing (platform client, runtime
+        # config cache) that is installed later in worker boot.
+        self.budget_guard = budget_guard
         # Read by the browser tool layer to inject a session's saved login
         # state at provision; public so handlers reach it via the pool they
         # already hold (avoids threading the store through the executor chain).
@@ -131,6 +145,18 @@ class BrowserPool:
             # provisions. Raises BrowserCreditsExhaustedError when empty.
             if self._credit_guard is not None:
                 await self._credit_guard(org_id)
+            # Per-buyer gate, after the operator gate: metered agents
+            # hold a chunk of the sender's minutes and the returned
+            # billing block rides the spec into the pod labels so the
+            # ops monitor extends and settles the hold.
+            if self.budget_guard is not None:
+                billing = await self.budget_guard(
+                    session_id=session_id,
+                    org_id=org_id,
+                    user_id=user_id,
+                )
+                if billing:
+                    spec.billing = billing
 
             browser_id, endpoint = await self._backend.provision(
                 spec,

--- a/surogates/db/ops_credits.py
+++ b/surogates/db/ops_credits.py
@@ -1,16 +1,19 @@
-"""Read-only browser-minutes gate backed by the surogate-ops DB.
+"""Read-only OPERATOR-plane browser-minutes gate (ops DB).
 
-Browser pods are billed per wall-clock minute by surogate-ops'
-``BrowserMonitor`` after they terminate. Enforcement, though, has to
-happen *before* a pod starts — at the point of use, not at session
-creation — so a project that is out of minutes simply can't open a new
-browser while a plain chat session keeps working.
+Browser pods are billed to the operator's project wallet per
+wall-clock minute by surogate-ops' ``BrowserMonitor``. Enforcement,
+though, has to happen *before* a pod starts — at the point of use,
+not at session creation — so a project that is out of minutes simply
+can't open a new browser while a plain chat session keeps working.
 
-This module is the use-time gate: given a project (``org_id``), it
-reads the ``browser_minutes`` row from the ops ``credit_balances``
-table and raises :class:`BrowserCreditsExhaustedError` when the balance
-is empty. Writes stay entirely on the ops side; this is SELECT-only,
-mirroring the KB tools' access pattern.
+This module is the operator plane's use-time gate: given a project
+(``org_id``), it reads the ``browser_minutes`` row from the ops
+``credit_balances`` table and raises
+:class:`BrowserCreditsExhaustedError` when the balance is empty.
+Writes stay entirely on the ops side; this is SELECT-only, mirroring
+the KB tools' access pattern. The sibling per-BUYER gate (an agent's
+sold browsing time) is the pool's ``budget_guard`` — see
+``surogates.orchestrator.worker._build_browser_budget_guard``.
 """
 
 from __future__ import annotations

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -325,6 +325,8 @@ def _build_browser_budget_guard(
         try:
             session_uuid = UUID(str(session_id))
         except ValueError:
+            # Session ids are store-issued UUIDs; anything else cannot
+            # map to a billable session row — unmetered, not blocked.
             return None
         async with session_factory() as db:
             row = (
@@ -333,23 +335,40 @@ def _build_browser_budget_guard(
                         SessionRow.agent_id,
                         SessionRow.channel,
                         SessionRow.user_id,
+                        SessionRow.service_account_id,
                         SessionRow.config,
                     ).where(SessionRow.id == session_uuid),
                 )
             ).one_or_none()
         if row is None:
             return None
-        agent_id, channel, session_user_id, config = row
-        if channel == "browser_setup":
-            # Operator-driven profile capture — operator plane only.
+        agent_id, channel, session_user_id, sa_id, config = row
+        if channel == "browser_setup" or sa_id is not None:
+            # Operator plane: profile-capture sessions and every
+            # service-account-principal session (ops-chat, api,
+            # scheduled runs). Mirrors the token plane, which meters
+            # only end-user identities — an operator testing their own
+            # metered agent must not hit a buy prompt.
             return None
         if runtime_config_cache is None or platform_client is None:
             return None
         try:
             payload = await runtime_config_cache.get(str(agent_id)) or {}
         except LookupError:
+            # Ops does not know the agent — nothing to meter.
             return None
+        except Exception as exc:
+            # The metered-check itself needs ops; an unreachable
+            # control plane degrades to the structured browser_
+            # unavailable tool result, never a raw traceback — and
+            # never a free browser on what might be a metered agent.
+            raise BrowserUnavailableError(
+                f"browser minutes check unavailable: {exc}",
+            ) from exc
         if not payload.get("browser_minutes_metered"):
+            # Deliberately open: a payload from an ops build predating
+            # the flag reads as unmetered, which is why the ops side
+            # deploys first in the rollout.
             return None
         config = config or {}
         buy_url = payload.get("commerce_buy_url")

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -291,6 +291,109 @@ def _warn_if_base_model_missing_from_metadata(model_id: str) -> None:
     )
 
 
+def _build_browser_budget_guard(
+    session_factory: Any,
+    platform_client: Any,
+    runtime_config_cache: Any,
+) -> Any:
+    """Per-buyer browser-minutes gate for ``BrowserPool.ensure``.
+
+    Runs once per fresh pod provision. Resolves the session row itself
+    (agent, channel, sender identities — provisioning is a
+    once-per-session event, so the read is negligible), short-circuits
+    for unmetered agents via the cached runtime config, and otherwise
+    holds a chunk of the sender's minutes through the ops pre-flight
+    authorize. The returned billing block rides the pod's labels so
+    the ops monitor extends and settles the same hold. Fails CLOSED
+    for metered agents when the metering plane is unreachable — a paid
+    browser must not run free because ops blinked.
+    """
+    import sqlalchemy as sa
+
+    from surogates.browser.base import (
+        BrowserBudgetExhaustedError,
+        BrowserUnavailableError,
+    )
+    from surogates.db.models import Session as SessionRow
+    from surogates.runtime.platform_client import (
+        BrowserMinutesExhaustedError,
+    )
+
+    async def guard(
+        *, session_id: str, org_id: str, user_id: str,
+    ) -> dict[str, str] | None:
+        try:
+            session_uuid = UUID(str(session_id))
+        except ValueError:
+            return None
+        async with session_factory() as db:
+            row = (
+                await db.execute(
+                    sa.select(
+                        SessionRow.agent_id,
+                        SessionRow.channel,
+                        SessionRow.user_id,
+                        SessionRow.config,
+                    ).where(SessionRow.id == session_uuid),
+                )
+            ).one_or_none()
+        if row is None:
+            return None
+        agent_id, channel, session_user_id, config = row
+        if channel == "browser_setup":
+            # Operator-driven profile capture — operator plane only.
+            return None
+        if runtime_config_cache is None or platform_client is None:
+            return None
+        try:
+            payload = await runtime_config_cache.get(str(agent_id)) or {}
+        except LookupError:
+            return None
+        if not payload.get("browser_minutes_metered"):
+            return None
+        config = config or {}
+        buy_url = payload.get("commerce_buy_url")
+        firebase_uid = (config.get("commerce_buyer") or {}).get(
+            "firebase_uid",
+        )
+        end_user_id = (
+            config.get("embed_end_user_id")
+            or user_id
+            or (str(session_user_id) if session_user_id else None)
+        )
+        if not firebase_uid and not end_user_id:
+            # Metered agent, anonymous sender: nothing could hold a
+            # balance — same buy prompt as an empty one.
+            raise BrowserBudgetExhaustedError(
+                "browser_minutes_exhausted", buy_url=buy_url,
+            )
+        try:
+            receipt = await platform_client.browser_authorize(
+                str(agent_id),
+                session_id=str(session_id),
+                firebase_uid=firebase_uid,
+                end_user_id=str(end_user_id) if end_user_id else None,
+            )
+        except BrowserMinutesExhaustedError as exc:
+            raise BrowserBudgetExhaustedError(
+                exc.detail, buy_url=buy_url,
+            ) from exc
+        except Exception as exc:
+            raise BrowserUnavailableError(
+                f"browser minutes authorization unavailable: {exc}",
+            ) from exc
+        if not receipt.get("metered"):
+            return None
+        return {
+            "owner_kind": str(receipt.get("owner_kind") or ""),
+            "owner_id": str(receipt.get("owner_id") or ""),
+            "reservation_id": str(receipt.get("reservation_id") or ""),
+            "balance_id": str(receipt.get("balance_id") or ""),
+        }
+
+    return guard
+
+
 def _build_browser_backend(
     settings: "BrowserSettings",
     *,
@@ -1084,6 +1187,12 @@ async def run_worker(settings: Settings) -> None:
     _start_worker_invalidator(worker_state)
     runtime_config_cache = worker_state["runtime_config_cache"]
     platform_client = worker_state["platform_client"]
+    # Wired post-construction: the guard closes over the runtime
+    # plumbing installed just above, while the pool is built earlier
+    # with the rest of the compute plumbing.
+    browser_pool.budget_guard = _build_browser_budget_guard(
+        session_factory, platform_client, runtime_config_cache,
+    )
 
     # Credential vault — required for per-session ``vault://<name>``
     # resolution.  Pod cannot serve sessions without it.

--- a/surogates/runtime/platform_client.py
+++ b/surogates/runtime/platform_client.py
@@ -66,6 +66,18 @@ class AllowanceExhaustedError(RuntimeError):
         self.detail = detail
 
 
+class BrowserMinutesExhaustedError(RuntimeError):
+    """Ops refused a browser provision authorization with 402.
+
+    The sender has no browsing minutes left on a metered agent;
+    ``detail`` is the machine sentinel (``browser_minutes_exhausted``).
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
 class PlatformClient:
     """Async HTTP client for surogate-ops.
 
@@ -549,6 +561,59 @@ class PlatformClient:
             except ValueError:
                 pass
             raise AllowanceExhaustedError(detail or "allowance_exhausted")
+        if resp.status_code == 401:
+            raise PlatformAuthError(
+                "surogate-ops rejected runtime token (401); "
+                "is the token revoked or missing the 'runtime' scope?",
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def browser_authorize(
+        self,
+        agent_id: str,
+        *,
+        session_id: str | None = None,
+        firebase_uid: str | None = None,
+        end_user_id: str | None = None,
+        requested_minutes: int | None = None,
+    ) -> dict:
+        """Pre-flight hold before provisioning a browser pod.
+
+        Called once per fresh provision on agents whose runtime config
+        reports ``browser_minutes_metered``. Returns ``{metered,
+        reservation_id, balance_id, reserved_minutes, owner_kind,
+        owner_id}`` — ``metered=False`` means provision exactly as
+        before (no billing block). Raises:
+
+        * :class:`BrowserMinutesExhaustedError` on 402 — the sender has
+          no browsing minutes left (or no identity that could hold a
+          balance).
+        * :class:`PlatformAuthError` on 401 — operations problem.
+        * ``httpx.HTTPStatusError`` on any other non-2xx.
+        """
+        payload: dict = {}
+        if session_id:
+            payload["session_id"] = session_id
+        if firebase_uid:
+            payload["firebase_uid"] = firebase_uid
+        if end_user_id:
+            payload["end_user_id"] = end_user_id
+        if requested_minutes:
+            payload["requested_minutes"] = requested_minutes
+        resp = await self._client.post(
+            f"/api/agents/agents/{agent_id}/browser/authorize",
+            json=payload,
+        )
+        if resp.status_code == 402:
+            detail = ""
+            try:
+                detail = str(resp.json().get("detail") or "")
+            except ValueError:
+                pass
+            raise BrowserMinutesExhaustedError(
+                detail or "browser_minutes_exhausted",
+            )
         if resp.status_code == 401:
             raise PlatformAuthError(
                 "surogate-ops rejected runtime token (401); "

--- a/surogates/tools/builtin/browser.py
+++ b/surogates/tools/builtin/browser.py
@@ -10,10 +10,12 @@ from typing import Any, Callable
 from uuid import UUID, uuid4
 
 from surogates.browser.base import (
+    BrowserBudgetExhaustedError,
     BrowserCreditsExhaustedError,
     BrowserEndpoint,
     BrowserSpec,
     BrowserUnavailableError,
+    browser_budget_exhausted_result,
     browser_credits_exhausted_result,
     browser_unavailable_result,
 )
@@ -205,15 +207,23 @@ async def _resolve_session_browser(
                         service_account_id,
                     )
 
+        tenant_user_id = getattr(tenant, "user_id", None) if tenant else None
         result = await browser_pool.ensure(
             session_id=sid,
             org_id=str(getattr(tenant, "org_id", "")) if tenant is not None else "",
-            user_id=str(getattr(tenant, "user_id", "")) if tenant is not None else "",
+            # Empty for anonymous sessions — never the literal "None"
+            # (it used to leak into the pod's user-id label).
+            user_id=str(tenant_user_id) if tenant_user_id is not None else "",
             spec=browser_spec,
         )
+    except BrowserBudgetExhaustedError as exc:
+        # Subclasses of BrowserUnavailableError — caught first so the
+        # user gets a buy prompt, not "infra is broken".
+        return browser_budget_exhausted_result(
+            exc.reason, buy_url=exc.buy_url,
+        )
     except BrowserCreditsExhaustedError as exc:
-        # Subclass of BrowserUnavailableError — must be caught first so
-        # the user gets top-up guidance, not "infra is broken".
+        # Same precedence rationale, for the operator's own wallet.
         return browser_credits_exhausted_result(exc.reason)
     except BrowserUnavailableError as exc:
         return browser_unavailable_result(exc.reason)

--- a/tests/test_browser_budget.py
+++ b/tests/test_browser_budget.py
@@ -1,0 +1,451 @@
+"""Per-buyer browser-minutes gate: platform client, worker guard,
+pool integration, and the billing block's ride to both backends."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+import httpx
+import pytest
+
+from surogates.browser.base import (
+    BrowserBudgetExhaustedError,
+    BrowserEndpoint,
+    BrowserSpec,
+    BrowserStatus,
+    BrowserUnavailableError,
+    browser_budget_exhausted_result,
+)
+from surogates.browser.fleet import FleetBackend
+from surogates.browser.pool import BrowserPool
+from surogates.orchestrator.worker import _build_browser_budget_guard
+from surogates.runtime.platform_client import (
+    BrowserMinutesExhaustedError,
+    PlatformClient,
+)
+
+BILLING = {
+    "owner_kind": "buyer",
+    "owner_id": "ent-1",
+    "reservation_id": "res-1",
+    "balance_id": "bal-1",
+}
+
+
+# ── platform client ─────────────────────────────────────────────────
+
+
+def _client(handler):
+    transport = httpx.MockTransport(handler)
+    return PlatformClient(base_url="http://ops", token="t", transport=transport)
+
+
+async def test_browser_authorize_returns_receipt():
+    def handler(request):
+        assert request.url.path == "/api/agents/agents/a1/browser/authorize"
+        body = json.loads(request.content)
+        assert body == {
+            "session_id": "s1",
+            "firebase_uid": "fb1",
+            "end_user_id": "eu1",
+        }
+        return httpx.Response(200, json={
+            "metered": True,
+            "reservation_id": "res-1",
+            "balance_id": "bal-1",
+            "reserved_minutes": 10,
+            "owner_kind": "buyer",
+            "owner_id": "ent-1",
+        })
+
+    pc = _client(handler)
+    out = await pc.browser_authorize(
+        "a1", session_id="s1", firebase_uid="fb1", end_user_id="eu1",
+    )
+    assert out["metered"] is True
+    assert out["reservation_id"] == "res-1"
+
+
+async def test_browser_authorize_402_raises_typed_error():
+    def handler(request):
+        return httpx.Response(
+            402, json={"detail": "browser_minutes_exhausted"},
+        )
+
+    pc = _client(handler)
+    with pytest.raises(BrowserMinutesExhaustedError) as err:
+        await pc.browser_authorize("a1", end_user_id="eu1")
+    assert err.value.detail == "browser_minutes_exhausted"
+
+
+# ── worker guard ────────────────────────────────────────────────────
+
+
+class _FakeRow:
+    def __init__(self, row):
+        self._row = row
+
+    def one_or_none(self):
+        return self._row
+
+
+class _FakeDb:
+    def __init__(self, row):
+        self._row = row
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, stmt):
+        return _FakeRow(self._row)
+
+
+def _session_factory(row):
+    return lambda: _FakeDb(row)
+
+
+class _FakeCache:
+    def __init__(self, payload):
+        self.payload = payload
+        self.requested: list[str] = []
+
+    async def get(self, agent_id: str):
+        self.requested.append(agent_id)
+        if self.payload is None:
+            raise LookupError(agent_id)
+        return self.payload
+
+
+class _FakePlatform:
+    def __init__(self, receipt=None, error: Exception | None = None):
+        self.receipt = receipt or {"metered": True, **BILLING}
+        self.error = error
+        self.calls: list[dict] = []
+
+    async def browser_authorize(self, agent_id, **kwargs):
+        self.calls.append({"agent_id": agent_id, **kwargs})
+        if self.error is not None:
+            raise self.error
+        return self.receipt
+
+
+_SID = str(uuid.uuid4())
+
+
+def _row(
+    *,
+    channel: str = "web",
+    user_id: Any = None,
+    config: dict | None = None,
+):
+    return ("agent-1", channel, user_id, config or {})
+
+
+async def test_guard_skips_unmetered_agents():
+    platform = _FakePlatform()
+    guard = _build_browser_budget_guard(
+        _session_factory(_row()),
+        platform,
+        _FakeCache({"browser_minutes_metered": False}),
+    )
+    assert await guard(session_id=_SID, org_id="o", user_id="u") is None
+    assert platform.calls == []
+
+
+async def test_guard_skips_browser_setup_sessions():
+    platform = _FakePlatform()
+    guard = _build_browser_budget_guard(
+        _session_factory(_row(channel="browser_setup")),
+        platform,
+        _FakeCache({"browser_minutes_metered": True}),
+    )
+    assert await guard(session_id=_SID, org_id="o", user_id="u") is None
+    assert platform.calls == []
+
+
+async def test_guard_returns_billing_block_for_metered_sender():
+    platform = _FakePlatform()
+    guard = _build_browser_budget_guard(
+        _session_factory(_row(config={"embed_end_user_id": "eu-7"})),
+        platform,
+        _FakeCache({"browser_minutes_metered": True}),
+    )
+    billing = await guard(session_id=_SID, org_id="o", user_id="")
+    assert billing == BILLING
+    assert platform.calls[0]["end_user_id"] == "eu-7"
+    assert platform.calls[0]["agent_id"] == "agent-1"
+
+
+async def test_guard_prefers_commerce_buyer_identity():
+    platform = _FakePlatform()
+    guard = _build_browser_budget_guard(
+        _session_factory(
+            _row(config={"commerce_buyer": {"firebase_uid": "fb-9"}}),
+        ),
+        platform,
+        _FakeCache({"browser_minutes_metered": True}),
+    )
+    await guard(session_id=_SID, org_id="o", user_id="u-1")
+    call = platform.calls[0]
+    assert call["firebase_uid"] == "fb-9"
+    assert call["end_user_id"] == "u-1"
+
+
+async def test_guard_falls_back_to_session_row_user():
+    platform = _FakePlatform()
+    guard = _build_browser_budget_guard(
+        _session_factory(_row(user_id=uuid.UUID(int=7))),
+        platform,
+        _FakeCache({"browser_minutes_metered": True}),
+    )
+    await guard(session_id=_SID, org_id="o", user_id="")
+    assert platform.calls[0]["end_user_id"] == str(uuid.UUID(int=7))
+
+
+async def test_guard_anonymous_sender_gets_buy_prompt():
+    platform = _FakePlatform()
+    guard = _build_browser_budget_guard(
+        _session_factory(_row()),
+        platform,
+        _FakeCache({
+            "browser_minutes_metered": True,
+            "commerce_buy_url": "https://buy.example/x",
+        }),
+    )
+    with pytest.raises(BrowserBudgetExhaustedError) as err:
+        await guard(session_id=_SID, org_id="o", user_id="")
+    assert err.value.buy_url == "https://buy.example/x"
+    assert platform.calls == []
+
+
+async def test_guard_maps_402_to_budget_exhausted():
+    platform = _FakePlatform(
+        error=BrowserMinutesExhaustedError("browser_minutes_exhausted"),
+    )
+    guard = _build_browser_budget_guard(
+        _session_factory(_row(config={"embed_end_user_id": "eu-7"})),
+        platform,
+        _FakeCache({
+            "browser_minutes_metered": True,
+            "commerce_buy_url": "https://buy.example/x",
+        }),
+    )
+    with pytest.raises(BrowserBudgetExhaustedError) as err:
+        await guard(session_id=_SID, org_id="o", user_id="")
+    assert err.value.buy_url == "https://buy.example/x"
+
+
+async def test_guard_fails_closed_when_ops_unreachable():
+    platform = _FakePlatform(error=RuntimeError("connection refused"))
+    guard = _build_browser_budget_guard(
+        _session_factory(_row(config={"embed_end_user_id": "eu-7"})),
+        platform,
+        _FakeCache({"browser_minutes_metered": True}),
+    )
+    with pytest.raises(BrowserUnavailableError):
+        await guard(session_id=_SID, org_id="o", user_id="")
+
+
+async def test_guard_unmetered_receipt_returns_none():
+    platform = _FakePlatform(receipt={"metered": False})
+    guard = _build_browser_budget_guard(
+        _session_factory(_row(config={"embed_end_user_id": "eu-7"})),
+        platform,
+        _FakeCache({"browser_minutes_metered": True}),
+    )
+    assert await guard(session_id=_SID, org_id="o", user_id="") is None
+
+
+# ── pool integration ────────────────────────────────────────────────
+
+
+from tests.test_browser_pool import FakeBackend, FakeRegistry  # noqa: E402
+
+
+async def test_pool_threads_billing_into_spec():
+    backend = FakeBackend()
+    specs: list[BrowserSpec] = []
+    orig = backend.provision
+
+    async def capture(spec, **kwargs):
+        specs.append(spec)
+        return await orig(spec, **kwargs)
+
+    backend.provision = capture
+    calls: list[dict] = []
+
+    async def guard(**kwargs):
+        calls.append(kwargs)
+        return dict(BILLING)
+
+    pool = BrowserPool(
+        backend=backend, registry=FakeRegistry(), budget_guard=guard,
+    )
+    await pool.ensure("s1", "org", "user", BrowserSpec())
+    assert calls == [{"session_id": "s1", "org_id": "org", "user_id": "user"}]
+    assert specs[0].billing == BILLING
+
+    # Reuse of a running pod never re-authorizes.
+    await pool.ensure("s1", "org", "user", BrowserSpec())
+    assert len(calls) == 1
+    assert backend.provisions == 1
+
+
+async def test_pool_budget_denial_blocks_provision():
+    backend = FakeBackend()
+
+    async def guard(**kwargs):
+        raise BrowserBudgetExhaustedError("browser_minutes_exhausted")
+
+    pool = BrowserPool(
+        backend=backend, registry=FakeRegistry(), budget_guard=guard,
+    )
+    with pytest.raises(BrowserBudgetExhaustedError):
+        await pool.ensure("s1", "org", "user", BrowserSpec())
+    assert backend.provisions == 0
+
+
+async def test_pool_none_billing_leaves_spec_clean():
+    backend = FakeBackend()
+
+    async def guard(**kwargs):
+        return None
+
+    pool = BrowserPool(
+        backend=backend, registry=FakeRegistry(), budget_guard=guard,
+    )
+    spec = BrowserSpec()
+    await pool.ensure("s1", "org", "user", spec)
+    assert spec.billing is None
+
+
+# ── backends carry the block ────────────────────────────────────────
+
+
+async def test_fleet_lease_body_includes_billing():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(json.loads(request.content))
+        return httpx.Response(200, json={
+            "lease_id": "L1",
+            "browser_id": "b1",
+            "endpoint": {
+                "rest_url": "http://p:10001",
+                "cdp_url": "ws://p:9222",
+                "live_view_url": "ws://p:8080",
+            },
+        })
+
+    backend = FleetBackend(
+        endpoint="http://ops/api/browser-fleet",
+        worker_token="tok",
+        http=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    spec = BrowserSpec(billing=dict(BILLING))
+    await backend.provision(spec, session_id="s1", org_id="p1", user_id="u1")
+    assert captured["billing"] == BILLING
+
+
+async def test_fleet_lease_body_omits_billing_when_absent():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(json.loads(request.content))
+        return httpx.Response(200, json={
+            "lease_id": "L1",
+            "browser_id": "b1",
+            "endpoint": {
+                "rest_url": "http://p:10001",
+                "cdp_url": "ws://p:9222",
+                "live_view_url": "ws://p:8080",
+            },
+        })
+
+    backend = FleetBackend(
+        endpoint="http://ops/api/browser-fleet",
+        worker_token="tok",
+        http=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    await backend.provision(
+        BrowserSpec(), session_id="s1", org_id="p1", user_id="u1",
+    )
+    assert "billing" not in captured
+
+
+def test_k8s_manifest_stamps_billing_labels():
+    from surogates.browser.kubernetes import K8sBrowserBackend
+
+    backend = K8sBrowserBackend(namespace="test-ns")
+    pod = backend._build_pod_manifest(
+        browser_id="bid",
+        pod_name="browser-x",
+        session_id="s1",
+        org_id="p1",
+        user_id="u1",
+        spec=BrowserSpec(billing=dict(BILLING)),
+    )
+    labels = pod.metadata.labels
+    assert labels["surogates.ai/minutes-owner-kind"] == "buyer"
+    assert labels["surogates.ai/minutes-owner-id"] == "ent-1"
+    assert labels["surogates.ai/minutes-reservation-id"] == "res-1"
+    assert labels["surogates.ai/minutes-balance-id"] == "bal-1"
+
+
+def test_k8s_manifest_omits_billing_labels_when_absent():
+    from surogates.browser.kubernetes import K8sBrowserBackend
+
+    backend = K8sBrowserBackend(namespace="test-ns")
+    pod = backend._build_pod_manifest(
+        browser_id="bid",
+        pod_name="browser-x",
+        session_id="s1",
+        org_id="p1",
+        user_id="u1",
+        spec=BrowserSpec(),
+    )
+    assert not any(
+        key.startswith("surogates.ai/minutes-")
+        for key in pod.metadata.labels
+    )
+
+
+# ── tool-layer rendering ────────────────────────────────────────────
+
+
+def test_budget_exhausted_result_carries_buy_url():
+    body = json.loads(browser_budget_exhausted_result(
+        "browser_minutes_exhausted", buy_url="https://buy.example/x",
+    ))
+    assert body["error"] == "browser_minutes_exhausted"
+    assert body["buy_url"] == "https://buy.example/x"
+    assert "buy" in body["guidance"]
+
+
+async def test_tool_preflight_renders_buy_prompt():
+    from surogates.tools.builtin.browser import _resolve_session_browser
+
+    class _Pool:
+        browser_profile_store = None
+
+        async def ensure(self, **kwargs):
+            raise BrowserBudgetExhaustedError(
+                "browser_minutes_exhausted",
+                buy_url="https://buy.example/x",
+            )
+
+    out = await _resolve_session_browser(
+        tenant=None,
+        session_id="s1",
+        browser_pool=_Pool(),
+        browser_control=None,
+    )
+    assert isinstance(out, str)
+    body = json.loads(out)
+    assert body["error"] == "browser_minutes_exhausted"
+    assert body["buy_url"] == "https://buy.example/x"

--- a/tests/test_browser_budget.py
+++ b/tests/test_browser_budget.py
@@ -141,9 +141,10 @@ def _row(
     *,
     channel: str = "web",
     user_id: Any = None,
+    service_account_id: Any = None,
     config: dict | None = None,
 ):
-    return ("agent-1", channel, user_id, config or {})
+    return ("agent-1", channel, user_id, service_account_id, config or {})
 
 
 async def test_guard_skips_unmetered_agents():
@@ -449,3 +450,59 @@ async def test_tool_preflight_renders_buy_prompt():
     body = json.loads(out)
     assert body["error"] == "browser_minutes_exhausted"
     assert body["buy_url"] == "https://buy.example/x"
+
+
+async def test_guard_skips_service_account_sessions():
+    """Operator-plane sessions (ops chat, api, scheduled runs) run
+    under a service account and are never metered — mirroring the
+    token plane's end-user-only scope."""
+    platform = _FakePlatform()
+    guard = _build_browser_budget_guard(
+        _session_factory(_row(service_account_id=uuid.UUID(int=3))),
+        platform,
+        _FakeCache({"browser_minutes_metered": True}),
+    )
+    assert await guard(session_id=_SID, org_id="o", user_id="") is None
+    assert platform.calls == []
+
+
+async def test_guard_wraps_cache_failures_as_unavailable():
+    """A control-plane blip during the metered check degrades to the
+    structured browser_unavailable result, never a raw traceback."""
+    import httpx as _httpx
+
+    class _FlakyCache:
+        async def get(self, agent_id):
+            raise _httpx.ConnectError("boom")
+
+    platform = _FakePlatform()
+    guard = _build_browser_budget_guard(
+        _session_factory(_row(config={"embed_end_user_id": "eu-7"})),
+        platform,
+        _FlakyCache(),
+    )
+    with pytest.raises(BrowserUnavailableError):
+        await guard(session_id=_SID, org_id="o", user_id="")
+    assert platform.calls == []
+
+
+def test_k8s_billing_labels_are_sanitized():
+    from surogates.browser.kubernetes import K8sBrowserBackend
+
+    backend = K8sBrowserBackend(namespace="test-ns")
+    pod = backend._build_pod_manifest(
+        browser_id="bid",
+        pod_name="browser-x",
+        session_id="s1",
+        org_id="p1",
+        user_id="u1",
+        spec=BrowserSpec(billing={
+            "owner_kind": "end_user",
+            "owner_id": "visitor@example.com",
+            "reservation_id": "res-1",
+            "balance_id": "bal-1",
+        }),
+    )
+    assert pod.metadata.labels["surogates.ai/minutes-owner-id"] == (
+        "visitor-example.com"
+    )

--- a/web/src/features/settings/plan-usage-tab.tsx
+++ b/web/src/features/settings/plan-usage-tab.tsx
@@ -28,6 +28,8 @@ interface CommerceOffer {
   amount_cents: number;
   billing_interval: string | null;
   token_amount: number;
+  /** Metered browser time the offer sells, in minutes (0 = none). */
+  browser_minutes_amount?: number;
   description?: string | null;
   /** Buyer-facing labels for a custom package; [] or absent = full
    * access (subscriptions) / pure extra usage (packs). */
@@ -43,6 +45,11 @@ interface CommerceOverview {
     current_period_end: string | null;
     period_token_remaining: number;
     topup_token_remaining: number;
+    browser_minutes?: {
+      metered: boolean;
+      period_remaining: number;
+      topup_remaining: number;
+    };
     included?: string[];
   } | null;
   purchasable: boolean;
@@ -185,6 +192,21 @@ export function PlanUsageTab() {
                   {approxMessagesLabel(ent.topup_token_remaining)}
                 </span>
               </div>
+              {ent.browser_minutes?.metered ? (
+                <div
+                  className="flex items-center justify-between"
+                  data-testid="plan-tab-browser-minutes"
+                >
+                  <span className="text-muted-foreground">
+                    Browsing time left
+                  </span>
+                  <span className="font-medium tabular-nums">
+                    {ent.browser_minutes.period_remaining +
+                      ent.browser_minutes.topup_remaining}{" "}
+                    min
+                  </span>
+                </div>
+              ) : null}
               {(ent.included?.length ?? 0) > 0 ? (
                 <div
                   className="flex items-start justify-between gap-4"
@@ -231,8 +253,18 @@ export function PlanUsageTab() {
                   <div className="flex min-w-0 flex-1 flex-col">
                     <span className="text-sm font-medium">{offer.name}</span>
                     <span className="text-xs text-muted-foreground">
-                      {offer.token_amount > 0
-                        ? `${approxMessagesLabel(offer.token_amount)}${
+                      {offer.token_amount > 0 ||
+                      (offer.browser_minutes_amount ?? 0) > 0
+                        ? `${[
+                            offer.token_amount > 0
+                              ? approxMessagesLabel(offer.token_amount)
+                              : "",
+                            (offer.browser_minutes_amount ?? 0) > 0
+                              ? `${offer.browser_minutes_amount} min browsing`
+                              : "",
+                          ]
+                            .filter(Boolean)
+                            .join(" + ")}${
                             offer.kind === "subscription"
                               ? " every period"
                               : " of extra usage · one-time"


### PR DESCRIPTION
Runtime half of invergent-ai/surogate-ops#311 (metered browser minutes in agent packages, invergent-ai/surogate-ops#300).

On agents whose runtime config reports `browser_minutes_metered`, a fresh browser-pod provision now passes a **budget guard** wired onto `BrowserPool`:

- The guard resolves the session row itself (agent, channel, sender identities — provisioning is a once-per-session event, so the extra read is negligible), which keeps all 11 `browser_*` tool signatures untouched and automatically skips operator-driven `browser_setup` sessions.
- Sender identity is the website embed's `embed_end_user_id`, the buy-page embed's `commerce_buyer.firebase_uid`, or the signed-in web/channel user — whichever the session carries; ops resolves the matching balance plane.
- The ops pre-flight (`platform_client.browser_authorize`) holds a chunk of the sender's minutes; the returned billing block rides `BrowserSpec.billing` into the fleet lease body and the k8s pod labels (`surogates.ai/minutes-*`) so the ops `BrowserMonitor` extends and settles the same hold.
- A spent balance renders a **buy prompt** tool result (`browser_minutes_exhausted` + the agent's buy URL) via the new `BrowserBudgetExhaustedError`, mirroring the existing operator-wallet top-up guidance; an unreachable metering plane fails **closed** — a paid browser must not run free because ops blinked.
- Pod reuse never re-authorizes (accrual is covered by the monitor's live enforcement), matching the existing operator credit gate's semantics.

Also fixed in passing: anonymous sessions no longer stamp the literal string `"None"` into the pod's `surogates.ai/user-id` label.

The Plan & tokens tab shows remaining browsing time when metered, and offer cards say how much browsing time each plan or pack sells.

Everything is inert until ops ships the pre-flight endpoint and flips `browser_minutes_commerce_enabled` — until then `browser_minutes_metered` is absent from runtime payloads and the guard short-circuits.

## Testing

- Full suite (minus environment-bound `tests/integration/`): **4650 passed**; all 24 failures reproduce identically on `master` (pre-existing drift, none browser-related).
- New coverage (20 tests): platform-client receipt/402 mapping, guard matrix (unmetered skip, `browser_setup` skip, identity preference order, session-row fallback, anonymous buy prompt, 402 mapping with buy URL, fail-closed, unmetered receipt), pool integration (billing threaded into the spec, reuse never re-authorizes, denial blocks provision), fleet lease body with/without billing, k8s manifest labels with/without billing, tool-layer buy-prompt rendering.
- Web: typecheck clean.
