### PR TITLE
fix(tools): hide unwired media tools and surface budget exhaustion

### DIFF
--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -602,6 +602,31 @@ def _entitlement_tool_exclusions(
     return excluded
 
 
+def _media_tool_exclusions(media_gen_config: Any) -> set[str]:
+    """Media tools with no model behind them for this session.
+
+    ``generate_image`` / ``generate_video`` are registered
+    unconditionally but only work when a model is wired (per-agent
+    pick, platform preset, or deployment fallback). Dropping the
+    schema keeps the LLM from burning a turn on a tool that can only
+    answer "not available" — 10 of 48 prod generate_image calls did
+    exactly that. Predicates mirror the handlers' own availability
+    checks in tools/builtin/media_gen.py.
+    """
+    excluded: set[str] = set()
+    if (
+        getattr(media_gen_config, "image_client", None) is None
+        or not getattr(media_gen_config, "image_model", "")
+    ):
+        excluded.add("generate_image")
+    if not (
+        getattr(media_gen_config, "video_model", "")
+        and getattr(media_gen_config, "video_base_url", "")
+    ):
+        excluded.add("generate_video")
+    return excluded
+
+
 async def _load_attached_kbs(
     *,
     agent_id: str,
@@ -1683,6 +1708,9 @@ async def run_worker(settings: Settings) -> None:
                 for e in tool_registry.get_all()
                 if e.toolset == "browser"
             )
+        effective_tools.difference_update(
+            _media_tool_exclusions(media_gen_config),
+        )
         # user_reports exposes other end-users' data, so non-operator
         # sessions must not be primed with guidance about it.  This
         # keeps the PROMPT fragments in sync; the LLM-visible schema is

--- a/surogates/tools/builtin/media_gen.py
+++ b/surogates/tools/builtin/media_gen.py
@@ -50,6 +50,30 @@ _MIME_EXTENSIONS = {
     "image/gif": "gif",
 }
 
+_MEDIA_BUDGET_ERROR = (
+    "media_budget_exhausted: the workspace has no media generation "
+    "credits left, so this request was refused before anything was "
+    "charged. Tell the user they can top up media credits or wait for "
+    "the monthly allowance to reset in Studio -> Settings -> Billing. "
+    "Do not retry until more credits are available."
+)
+
+
+def _is_insufficient_credits(exc: Exception) -> bool:
+    """True when the call was refused for lack of budget (HTTP 402).
+
+    The platform proxy answers 402 ``insufficient_credits`` when the
+    media wallet can't cover the request — surfaced by the OpenAI SDK
+    as an ``APIStatusError`` carrying ``status_code`` and by httpx as
+    an ``HTTPStatusError`` carrying ``response.status_code``. A BYO
+    provider's own 402 matches too; either way the honest tool answer
+    is "no budget", not a stack trace the model can't act on.
+    """
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+    return status == 402
+
 
 @dataclass(frozen=True)
 class MediaGenConfig:
@@ -241,6 +265,8 @@ async def _generate_image_handler(arguments: dict[str, Any], **kwargs: Any) -> s
             extra_body=extra_body,
         )
     except Exception as exc:  # noqa: BLE001 — provider errors become tool errors
+        if _is_insufficient_credits(exc):
+            return _json_error(_MEDIA_BUDGET_ERROR)
         return _json_error(f"Image generation failed: {exc}")
 
     image_url = _first_generated_image_url(response)
@@ -386,6 +412,8 @@ async def _generate_video_handler(arguments: dict[str, Any], **kwargs: Any) -> s
                 )
             data = await _download_video(client, str(urls[0]))
     except httpx.HTTPStatusError as exc:
+        if _is_insufficient_credits(exc):
+            return _json_error(_MEDIA_BUDGET_ERROR)
         detail = _upstream_error_detail(exc)
         return _json_error(
             f"Video generation request failed: {exc}"

--- a/tests/test_media_gen_tools.py
+++ b/tests/test_media_gen_tools.py
@@ -554,3 +554,146 @@ async def test_generate_video_surfaces_upstream_error_body(tmp_path, monkeypatch
     ))
     assert "400 Bad Request" in result["error"]
     assert "not a valid model ID" in result["error"]  # upstream body surfaced
+
+
+# ── budget-exhausted (HTTP 402) handling ────────────────────────────
+
+
+class _Broke402Client:
+    """Raises the shape the OpenAI SDK uses for a 402 from the proxy."""
+
+    class _Error(Exception):
+        status_code = 402
+
+    def __init__(self):
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(create=self._create),
+        )
+
+    async def _create(self, **_kwargs):
+        raise self._Error("Error code: 402 - insufficient_credits")
+
+
+@pytest.mark.asyncio
+async def test_generate_image_402_returns_budget_guidance(tmp_path):
+    from surogates.tools.builtin.media_gen import _generate_image_handler
+
+    result = json.loads(await _generate_image_handler(
+        {"prompt": "a red square"},
+        media_gen=_image_cfg(_Broke402Client()),
+        workspace_path=str(tmp_path),
+    ))
+    assert result["error"].startswith("media_budget_exhausted")
+    assert "top up" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_generate_image_non_402_keeps_generic_error(tmp_path):
+    from surogates.tools.builtin.media_gen import _generate_image_handler
+
+    class _Broke500Client(_Broke402Client):
+        class _Error(Exception):
+            status_code = 500
+
+        async def _create(self, **_kwargs):
+            raise self._Error("boom")
+
+    result = json.loads(await _generate_image_handler(
+        {"prompt": "a red square"},
+        media_gen=_image_cfg(_Broke500Client()),
+        workspace_path=str(tmp_path),
+    ))
+    assert result["error"].startswith("Image generation failed")
+
+
+@pytest.mark.asyncio
+async def test_generate_video_402_returns_budget_guidance(monkeypatch, tmp_path):
+    import httpx
+
+    from surogates.tools.builtin.media_gen import (
+        MediaGenConfig,
+        _generate_video_handler,
+    )
+
+    def _respond(request):
+        return httpx.Response(
+            402,
+            json={"detail": {"error": "insufficient_credits",
+                             "resource": "media_credits"}},
+        )
+
+    transport = httpx.MockTransport(_respond)
+    real_client = httpx.AsyncClient
+
+    def _patched_client(**kwargs):
+        kwargs["transport"] = transport
+        return real_client(**kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", _patched_client)
+    cfg = MediaGenConfig(
+        video_model="x-ai/grok-imagine-video",
+        video_base_url="http://proxy.test/v1",
+        video_api_key="k",
+        video_poll_interval=1,
+    )
+    result = json.loads(await _generate_video_handler(
+        {"prompt": "a rocket"},
+        media_gen=cfg,
+        workspace_path=str(tmp_path),
+    ))
+    assert result["error"].startswith("media_budget_exhausted")
+
+
+# ── worker schema gating (_media_tool_exclusions) ───────────────────
+
+
+def _cfg(**kwargs):
+    from surogates.tools.builtin.media_gen import MediaGenConfig
+
+    return MediaGenConfig(**kwargs)
+
+
+def test_media_tool_exclusions_drop_both_when_nothing_configured():
+    from surogates.orchestrator.worker import _media_tool_exclusions
+
+    assert _media_tool_exclusions(_cfg()) == {
+        "generate_image", "generate_video",
+    }
+
+
+def test_media_tool_exclusions_keep_image_when_wired():
+    from surogates.orchestrator.worker import _media_tool_exclusions
+
+    cfg = _cfg(image_client=object(), image_model="google/gemini-2.5-flash-image")
+    assert _media_tool_exclusions(cfg) == {"generate_video"}
+
+
+def test_media_tool_exclusions_keep_video_when_wired():
+    from surogates.orchestrator.worker import _media_tool_exclusions
+
+    cfg = _cfg(video_model="x-ai/grok-imagine-video",
+               video_base_url="http://proxy.test/v1")
+    assert _media_tool_exclusions(cfg) == {"generate_image"}
+
+
+def test_media_tool_exclusions_empty_when_both_wired():
+    from surogates.orchestrator.worker import _media_tool_exclusions
+
+    cfg = _cfg(
+        image_client=object(),
+        image_model="google/gemini-2.5-flash-image",
+        video_model="x-ai/grok-imagine-video",
+        video_base_url="http://proxy.test/v1",
+    )
+    assert _media_tool_exclusions(cfg) == set()
+
+
+def test_media_tool_exclusions_video_needs_both_model_and_url():
+    from surogates.orchestrator.worker import _media_tool_exclusions
+
+    assert "generate_video" in _media_tool_exclusions(
+        _cfg(video_model="x-ai/grok-imagine-video"),
+    )
+    assert "generate_video" in _media_tool_exclusions(
+        _cfg(video_base_url="http://proxy.test/v1"),
+    )


### PR DESCRIPTION
## What

Two runtime fixes for `generate_image` / `generate_video`:

1. **Schema gating.** The tools were advertised to every agent even with no image/video model configured — 10 of 48 prod `generate_image` calls burned a turn just to learn the tool doesn't work. The worker now drops whichever media tool has no model behind it (`_media_tool_exclusions`, mirroring the browser-toolset gate; predicates match the handlers' own availability checks).
2. **Friendly 402.** When the platform proxy refuses a generation over budget (the new media wallet in surogate-ops PR #314, or any provider 402), both tools now return an actionable `media_budget_exhausted` error pointing at the Billing top-up instead of a raw stack trace the model can't act on.

## Tests

`tests/test_media_gen_tools.py`: 32 passed (8 new — exclusion matrix per wired slot, image 402 vs generic error, video 402 via MockTransport). Full suite failure set is byte-identical to master (93 pre-existing, verified against a master worktree).

Companion PR: invergent-ai/surogate-ops #314 (media wallet).