### PR TITLE
feat(runtime): meter buyer media credits on generate_image/video

### DIFF
--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -413,6 +413,80 @@ def _build_browser_budget_guard(
     return guard
 
 
+def _build_media_budget_hooks(
+    *,
+    ctx: Any,
+    session: Any,
+    service_account_id: Any,
+    platform_client: Any,
+) -> tuple[Any, Any]:
+    """Per-buyer media metering hooks for ``MediaGenConfig``.
+
+    ``(None, None)`` for unmetered agents, operator-plane sessions
+    (service-account principals — ops-chat, api, scheduled runs;
+    mirrors the browser guard's stance), or a missing platform client.
+    Otherwise: authorize holds against the sender's media balance via
+    the ops pre-flight endpoint; settle spends the same hold with the
+    generation's actual cost. Identity resolution matches the browser
+    guard: buy-page buyer first, embed end-user, then the session's
+    tenant user.
+    """
+    if not getattr(ctx, "media_credits_metered", False):
+        return None, None
+    if platform_client is None or service_account_id is not None:
+        return None, None
+
+    from surogates.runtime.platform_client import MediaCreditsExhaustedError
+    from surogates.tools.builtin.media_gen import MediaBudgetExhaustedError
+
+    config = session.config or {}
+    buy_url = getattr(ctx, "commerce_buy_url", None)
+    firebase_uid = (config.get("commerce_buyer") or {}).get("firebase_uid")
+    end_user_id = (
+        config.get("embed_end_user_id")
+        or (str(session.user_id) if session.user_id else None)
+    )
+    agent_id = str(ctx.agent_id)
+    session_id = str(session.id)
+
+    async def authorize(requested_cents: int | None = None) -> dict | None:
+        if not firebase_uid and not end_user_id:
+            # Metered agent, anonymous sender: nothing could hold a
+            # balance — same buy prompt as an empty one.
+            raise MediaBudgetExhaustedError(
+                "media_credits_exhausted", buy_url=buy_url,
+            )
+        try:
+            receipt = await platform_client.media_authorize(
+                agent_id,
+                session_id=session_id,
+                firebase_uid=firebase_uid,
+                end_user_id=end_user_id,
+                requested_cents=requested_cents,
+            )
+        except MediaCreditsExhaustedError as exc:
+            raise MediaBudgetExhaustedError(
+                exc.detail, buy_url=buy_url,
+            ) from exc
+        if not receipt.get("metered"):
+            return None
+        return receipt
+
+    async def settle(
+        receipt: dict, actual_cents: int, external_ref: str,
+    ) -> None:
+        await platform_client.media_settle(
+            agent_id,
+            balance_id=str(receipt.get("balance_id") or ""),
+            reserved_cents=int(receipt.get("reserved_cents") or 0),
+            actual_cents=actual_cents,
+            external_ref=external_ref,
+            reservation_id=str(receipt.get("reservation_id") or "") or None,
+        )
+
+    return authorize, settle
+
+
 def _build_browser_backend(
     settings: "BrowserSettings",
     *,
@@ -579,6 +653,10 @@ def _entitlement_tool_exclusions(
         )
     if not _entitlement_capability_allowed(session_config, "code"):
         excluded.add("run_coding_agent")
+    if not _entitlement_capability_allowed(session_config, "image"):
+        excluded.add("generate_image")
+    if not _entitlement_capability_allowed(session_config, "video"):
+        excluded.add("generate_video")
     mcp_allow = dimension_allowlist(session_config, "mcp_server_ids")
     if mcp_allow is not None:
         allowed_servers = mcp_scope[0] if mcp_scope is not None else set()
@@ -1446,6 +1524,12 @@ async def run_worker(settings: Settings) -> None:
             service_account_id=credential.service_account_id,
             settings=settings,
         )
+        media_budget_authorize, media_budget_settle = _build_media_budget_hooks(
+            ctx=ctx,
+            session=session,
+            service_account_id=credential.service_account_id,
+            platform_client=platform_client,
+        )
         media_gen_config = MediaGenConfig(
             image_client=image_slot.client if image_slot is not None else None,
             image_model=image_slot.model if image_slot is not None else "",
@@ -1458,6 +1542,9 @@ async def run_worker(settings: Settings) -> None:
             ),
             video_timeout=settings.llm.video_timeout,
             video_poll_interval=settings.llm.video_poll_interval,
+            budget_authorize=media_budget_authorize,
+            budget_settle=media_budget_settle,
+            image_cents=ctx.media_image_cents,
         )
         compressor = ContextCompressor(
             model_id,

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -417,23 +417,30 @@ def _build_media_budget_hooks(
     *,
     ctx: Any,
     session: Any,
-    service_account_id: Any,
     platform_client: Any,
 ) -> tuple[Any, Any]:
     """Per-buyer media metering hooks for ``MediaGenConfig``.
 
-    ``(None, None)`` for unmetered agents, operator-plane sessions
-    (service-account principals — ops-chat, api, scheduled runs;
-    mirrors the browser guard's stance), or a missing platform client.
-    Otherwise: authorize holds against the sender's media balance via
-    the ops pre-flight endpoint; settle spends the same hold with the
-    generation's actual cost. Identity resolution matches the browser
-    guard: buy-page buyer first, embed end-user, then the session's
-    tenant user.
+    ``(None, None)`` for unmetered agents, operator-plane sessions, or
+    a missing platform client. The operator check reads the SESSION
+    row's ``service_account_id`` (set only when the session itself is
+    owned by a service account — ops-chat, api, scheduled runs), NOT
+    the credential principal: on managed channels (slack/telegram)
+    ``resolve_credential_principal`` deliberately swaps in the AGENT'S
+    OWN service account for external-tool credential minting, and
+    gating on that would exempt every Slack/Telegram buyer from
+    metering. Mirrors the browser guard, which queries the same
+    column. Otherwise: authorize holds against the sender's media
+    balance via the ops pre-flight endpoint; settle spends the same
+    hold with the generation's actual cost. Identity resolution
+    matches the browser guard: buy-page buyer first, embed end-user,
+    then the session's tenant user.
     """
     if not getattr(ctx, "media_credits_metered", False):
         return None, None
-    if platform_client is None or service_account_id is not None:
+    if platform_client is None:
+        return None, None
+    if getattr(session, "service_account_id", None) is not None:
         return None, None
 
     from surogates.runtime.platform_client import MediaCreditsExhaustedError
@@ -1527,7 +1534,6 @@ async def run_worker(settings: Settings) -> None:
         media_budget_authorize, media_budget_settle = _build_media_budget_hooks(
             ctx=ctx,
             session=session,
-            service_account_id=credential.service_account_id,
             platform_client=platform_client,
         )
         media_gen_config = MediaGenConfig(

--- a/surogates/runtime/context.py
+++ b/surogates/runtime/context.py
@@ -214,6 +214,15 @@ class AgentRuntimeContext:
     # agents or when ops has no public frontend URL configured.
     commerce_buy_url: str | None = None
 
+    # Per-buyer media metering: when True generate_image/generate_video
+    # authorize a hold against the sender's media-credit balance before
+    # generating and settle the actual cost after.  False (the default,
+    # and the read for payloads predating the field) skips the hop.
+    media_credits_metered: bool = False
+    # Flat per-image price in media cents the runtime holds and settles
+    # for one generate_image call (ops's image_billing_media_cents).
+    media_image_cents: int = 4
+
     @property
     def asset_root(self) -> str:
         """Path to the tenant's on-disk asset directory.

--- a/surogates/runtime/entitlements.py
+++ b/surogates/runtime/entitlements.py
@@ -31,7 +31,9 @@ _SLASH_CAPABILITIES = frozenset({
 })
 
 #: Everything a package can restrict (mirrors ops CAPABILITY_VOCAB).
-_SELLABLE_CAPABILITIES = _SLASH_CAPABILITIES | {"browser", "brainstorming"}
+_SELLABLE_CAPABILITIES = _SLASH_CAPABILITIES | {
+    "browser", "brainstorming", "image", "video",
+}
 
 
 def pinned_entitlements(session_config: dict | None) -> dict | None:

--- a/surogates/runtime/platform_client.py
+++ b/surogates/runtime/platform_client.py
@@ -711,17 +711,9 @@ class PlatformClient:
         }
         if reservation_id:
             payload["reservation_id"] = reservation_id
-        resp = await self._client.post(
-            f"/api/agents/agents/{agent_id}/media/settle",
-            json=payload,
+        return await self._post_commerce(
+            f"/api/agents/agents/{agent_id}/media/settle", payload,
         )
-        if resp.status_code == 401:
-            raise PlatformAuthError(
-                "surogate-ops rejected runtime token (401); "
-                "is the token revoked or missing the 'runtime' scope?",
-            )
-        resp.raise_for_status()
-        return resp.json()
 
     async def allowance_debit(
         self,

--- a/surogates/runtime/platform_client.py
+++ b/surogates/runtime/platform_client.py
@@ -78,6 +78,18 @@ class BrowserMinutesExhaustedError(RuntimeError):
         self.detail = detail
 
 
+class MediaCreditsExhaustedError(RuntimeError):
+    """Ops refused a media generation authorization with 402.
+
+    The sender has no media credits left on a metered agent;
+    ``detail`` is the machine sentinel (``media_credits_exhausted``).
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
 class PlatformClient:
     """Async HTTP client for surogate-ops.
 
@@ -614,6 +626,95 @@ class PlatformClient:
             raise BrowserMinutesExhaustedError(
                 detail or "browser_minutes_exhausted",
             )
+        if resp.status_code == 401:
+            raise PlatformAuthError(
+                "surogate-ops rejected runtime token (401); "
+                "is the token revoked or missing the 'runtime' scope?",
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def media_authorize(
+        self,
+        agent_id: str,
+        *,
+        session_id: str | None = None,
+        firebase_uid: str | None = None,
+        end_user_id: str | None = None,
+        requested_cents: int | None = None,
+    ) -> dict:
+        """Pre-flight hold before a media generation.
+
+        Called per generate_image/generate_video call on agents whose
+        runtime config reports ``media_credits_metered``. Images pass
+        their exact flat price as ``requested_cents``; video jobs omit
+        it and get the platform reserve chunk. Returns ``{metered,
+        reservation_id, balance_id, reserved_cents, owner_kind,
+        owner_id}``. Raises:
+
+        * :class:`MediaCreditsExhaustedError` on 402 — the sender has
+          no media credits left (or no identity that could hold a
+          balance).
+        * :class:`PlatformAuthError` on 401 — operations problem.
+        * ``httpx.HTTPStatusError`` on any other non-2xx.
+        """
+        payload: dict = {}
+        if session_id:
+            payload["session_id"] = session_id
+        if firebase_uid:
+            payload["firebase_uid"] = firebase_uid
+        if end_user_id:
+            payload["end_user_id"] = end_user_id
+        if requested_cents:
+            payload["requested_cents"] = requested_cents
+        resp = await self._client.post(
+            f"/api/agents/agents/{agent_id}/media/authorize",
+            json=payload,
+        )
+        if resp.status_code == 402:
+            detail = ""
+            try:
+                detail = str(resp.json().get("detail") or "")
+            except ValueError:
+                pass
+            raise MediaCreditsExhaustedError(
+                detail or "media_credits_exhausted",
+            )
+        if resp.status_code == 401:
+            raise PlatformAuthError(
+                "surogate-ops rejected runtime token (401); "
+                "is the token revoked or missing the 'runtime' scope?",
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def media_settle(
+        self,
+        agent_id: str,
+        *,
+        balance_id: str,
+        reserved_cents: int,
+        actual_cents: int,
+        external_ref: str,
+        reservation_id: str | None = None,
+    ) -> dict:
+        """Spend a media hold after the generation finished (or failed).
+
+        ``actual_cents=0`` releases the hold without spending.
+        Idempotent on ``external_ref`` — safe to retry.
+        """
+        payload: dict = {
+            "balance_id": balance_id,
+            "reserved_cents": reserved_cents,
+            "actual_cents": actual_cents,
+            "external_ref": external_ref,
+        }
+        if reservation_id:
+            payload["reservation_id"] = reservation_id
+        resp = await self._client.post(
+            f"/api/agents/agents/{agent_id}/media/settle",
+            json=payload,
+        )
         if resp.status_code == 401:
             raise PlatformAuthError(
                 "surogate-ops rejected runtime token (401); "

--- a/surogates/runtime/resolver.py
+++ b/surogates/runtime/resolver.py
@@ -125,6 +125,10 @@ def build_agent_runtime_context(payload: dict) -> AgentRuntimeContext:
         bundle_version=payload.get("bundle_version") or None,
         commerce_mode=str(payload.get("commerce_mode") or "free"),
         commerce_buy_url=payload.get("commerce_buy_url") or None,
+        media_credits_metered=bool(payload.get("media_credits_metered")),
+        media_image_cents=max(
+            0, int(payload.get("media_image_cents") or 4),
+        ),
     )
 
 

--- a/surogates/runtime/resolver.py
+++ b/surogates/runtime/resolver.py
@@ -126,9 +126,12 @@ def build_agent_runtime_context(payload: dict) -> AgentRuntimeContext:
         commerce_mode=str(payload.get("commerce_mode") or "free"),
         commerce_buy_url=payload.get("commerce_buy_url") or None,
         media_credits_metered=bool(payload.get("media_credits_metered")),
-        media_image_cents=max(
-            0, int(payload.get("media_image_cents") or 4),
-        ),
+        # ``is None`` (not falsy) so an explicit 0 — metered but free
+        # images — survives; only an absent field takes the default.
+        media_image_cents=max(0, int(
+            4 if payload.get("media_image_cents") is None
+            else payload.get("media_image_cents"),
+        )),
     )
 
 

--- a/surogates/tools/builtin/media_gen.py
+++ b/surogates/tools/builtin/media_gen.py
@@ -21,6 +21,7 @@ import base64
 import binascii
 import json
 import logging
+import math
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -82,6 +83,15 @@ class MediaGenConfig:
     ``image_client`` is an ``AsyncOpenAI`` (or duck-typed equivalent)
     already pointed at the image endpoint; video carries raw endpoint
     fields because the ``/videos`` job API is called over httpx.
+
+    ``budget_authorize`` / ``budget_settle`` are the per-buyer media
+    metering hooks the worker wires for metered agents (absent =
+    unmetered, generate exactly as before). Authorize takes the media
+    cents to hold (``None`` = platform chunk, for videos) and returns
+    a receipt dict or ``None``; it raises
+    :class:`MediaBudgetExhaustedError` when the sender has no credits.
+    Settle takes ``(receipt, actual_cents, external_ref)`` and spends
+    the hold — zero releases it without spending.
     """
 
     image_client: Any | None = None
@@ -91,6 +101,81 @@ class MediaGenConfig:
     video_api_key: str = ""
     video_timeout: int = 600
     video_poll_interval: int = 10
+    budget_authorize: Any | None = None
+    budget_settle: Any | None = None
+    # Flat per-image price in media cents (mirrors ops's
+    # image_billing_media_cents through the runtime config).
+    image_cents: int = 4
+
+
+class MediaBudgetExhaustedError(RuntimeError):
+    """The sender's media-credit balance can't cover a generation."""
+
+    def __init__(self, detail: str, *, buy_url: str | None = None) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.buy_url = buy_url
+
+
+def _media_buy_prompt(buy_url: str | None) -> str:
+    """Buyer-facing budget-exhausted tool error (mirrors the browser
+    pool's buy prompt): actionable, and explicit that nothing ran."""
+    message = (
+        "media_credits_exhausted: this user has no media generation "
+        "credits left, so the request was refused before anything was "
+        "charged. Tell the user to top up or upgrade to keep "
+        "generating images and videos"
+    )
+    if buy_url:
+        message += f" — they can purchase more at {buy_url}"
+    message += ". Do not retry until they have more credits."
+    return message
+
+
+async def _authorize_media_budget(
+    cfg: Any, requested_cents: int | None,
+) -> tuple[dict | None, str | None]:
+    """Run the worker-wired authorize hook, if any.
+
+    Returns ``(receipt, error)`` — exactly one is set when metered.
+    Fails CLOSED on an unreachable metering plane: a paid generation
+    must not run free because ops blinked.
+    """
+    authorize = getattr(cfg, "budget_authorize", None)
+    if authorize is None:
+        return None, None
+    try:
+        return await authorize(requested_cents), None
+    except MediaBudgetExhaustedError as exc:
+        return None, _media_buy_prompt(exc.buy_url)
+    except Exception as exc:  # noqa: BLE001 — degrade to a tool error
+        return None, (
+            f"media budget check unavailable: {exc} — nothing was "
+            "generated or charged; try again shortly"
+        )
+
+
+async def _settle_media_budget(
+    cfg: Any, billing: dict | None, actual_cents: int, external_ref: str,
+) -> None:
+    """Best-effort spend of the authorize hold; zero releases it.
+
+    Never fails the tool call — the generation already happened (or
+    already failed); an unreachable settle is logged and the ops-side
+    reservation reaper eventually releases the hold.
+    """
+    settle = getattr(cfg, "budget_settle", None)
+    if billing is None or settle is None:
+        return
+    try:
+        await settle(billing, actual_cents, external_ref)
+    except Exception:  # noqa: BLE001 — audit trail only
+        logger.warning(
+            "media budget settle failed (ref=%s, cents=%s)",
+            external_ref,
+            actual_cents,
+            exc_info=True,
+        )
 
 
 GENERATE_IMAGE_SCHEMA = ToolSchema(
@@ -258,6 +343,12 @@ async def _generate_image_handler(arguments: dict[str, Any], **kwargs: Any) -> s
         if value:
             extra_body[field_name] = value
 
+    image_cents = max(1, int(getattr(cfg, "image_cents", 4) or 4))
+    billing, budget_error = await _authorize_media_budget(cfg, image_cents)
+    if budget_error is not None:
+        return _json_error(budget_error)
+    media_ref = f"img-{uuid4().hex}"
+
     try:
         response = await client.chat.completions.create(
             model=model,
@@ -265,9 +356,15 @@ async def _generate_image_handler(arguments: dict[str, Any], **kwargs: Any) -> s
             extra_body=extra_body,
         )
     except Exception as exc:  # noqa: BLE001 — provider errors become tool errors
+        # The provider refused: release the buyer hold without spending.
+        await _settle_media_budget(cfg, billing, 0, media_ref)
         if _is_insufficient_credits(exc):
             return _json_error(_MEDIA_BUDGET_ERROR)
         return _json_error(f"Image generation failed: {exc}")
+    # The provider accepted and charged for the generation — the buyer
+    # spend mirrors the owner-plane debit regardless of what we manage
+    # to do with the payload afterwards.
+    await _settle_media_budget(cfg, billing, image_cents, media_ref)
 
     image_url = _first_generated_image_url(response)
     if not image_url.startswith("data:image/"):
@@ -370,6 +467,11 @@ async def _generate_video_handler(arguments: dict[str, Any], **kwargs: Any) -> s
             }
         ]
 
+    billing, budget_error = await _authorize_media_budget(cfg, None)
+    if budget_error is not None:
+        return _json_error(budget_error)
+    media_ref = f"vid-{uuid4().hex}"
+
     videos_url = f"{base_url.rstrip('/')}/videos"
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     try:
@@ -388,6 +490,7 @@ async def _generate_video_handler(arguments: dict[str, Any], **kwargs: Any) -> s
             deadline = asyncio.get_running_loop().time() + timeout
             while str(status_data.get("status") or "") not in {"completed", "failed"}:
                 if asyncio.get_running_loop().time() >= deadline:
+                    await _settle_media_budget(cfg, billing, 0, media_ref)
                     return _json_error(
                         f"Video generation timed out after {timeout}s; job "
                         f"{job_id} may still complete upstream ({polling_url})"
@@ -398,6 +501,7 @@ async def _generate_video_handler(arguments: dict[str, Any], **kwargs: Any) -> s
                 status_data = poll_response.json()
 
             if status_data.get("status") == "failed":
+                await _settle_media_budget(cfg, billing, 0, media_ref)
                 detail = (
                     status_data.get("error")
                     or status_data.get("failure_reason")
@@ -405,6 +509,19 @@ async def _generate_video_handler(arguments: dict[str, Any], **kwargs: Any) -> s
                 )
                 return _json_error(f"Video generation failed: {detail}")
 
+            usage_cost = (status_data.get("usage") or {}).get("cost")
+            if usage_cost is not None:
+                actual_cents = max(0, math.ceil(float(usage_cost) * 100))
+            else:
+                # Completed but no reported cost: mirror the ops-side
+                # "debiting 0" stance rather than guessing a price.
+                logger.warning(
+                    "completed video job %s reported no usage.cost — "
+                    "settling buyer 0",
+                    job_id,
+                )
+                actual_cents = 0
+            await _settle_media_budget(cfg, billing, actual_cents, media_ref)
             urls = status_data.get("unsigned_urls") or []
             if not urls:
                 return _json_error(
@@ -412,6 +529,7 @@ async def _generate_video_handler(arguments: dict[str, Any], **kwargs: Any) -> s
                 )
             data = await _download_video(client, str(urls[0]))
     except httpx.HTTPStatusError as exc:
+        await _settle_media_budget(cfg, billing, 0, media_ref)
         if _is_insufficient_credits(exc):
             return _json_error(_MEDIA_BUDGET_ERROR)
         detail = _upstream_error_detail(exc)
@@ -420,8 +538,10 @@ async def _generate_video_handler(arguments: dict[str, Any], **kwargs: Any) -> s
             + (f" — upstream said: {detail}" if detail else "")
         )
     except httpx.HTTPError as exc:
+        await _settle_media_budget(cfg, billing, 0, media_ref)
         return _json_error(f"Video generation request failed: {exc}")
     except ValueError as exc:
+        await _settle_media_budget(cfg, billing, 0, media_ref)
         return _json_error(str(exc))
 
     saved = await _save_media_bytes(

--- a/surogates/tools/builtin/media_gen.py
+++ b/surogates/tools/builtin/media_gen.py
@@ -70,10 +70,9 @@ def _is_insufficient_credits(exc: Exception) -> bool:
     provider's own 402 matches too; either way the honest tool answer
     is "no budget", not a stack trace the model can't act on.
     """
-    status = getattr(exc, "status_code", None)
-    if status is None:
-        status = getattr(getattr(exc, "response", None), "status_code", None)
-    return status == 402
+    from surogates.harness.error_classifier import extract_status_code
+
+    return extract_status_code(exc) == 402
 
 
 @dataclass(frozen=True)
@@ -497,7 +496,6 @@ async def _generate_video_handler(arguments: dict[str, Any], **kwargs: Any) -> s
             deadline = asyncio.get_running_loop().time() + timeout
             while str(status_data.get("status") or "") not in {"completed", "failed"}:
                 if asyncio.get_running_loop().time() >= deadline:
-                    await _settle_media_budget(cfg, billing, 0, media_ref)
                     return _json_error(
                         f"Video generation timed out after {timeout}s; job "
                         f"{job_id} may still complete upstream ({polling_url})"
@@ -508,7 +506,6 @@ async def _generate_video_handler(arguments: dict[str, Any], **kwargs: Any) -> s
                 status_data = poll_response.json()
 
             if status_data.get("status") == "failed":
-                await _settle_media_budget(cfg, billing, 0, media_ref)
                 detail = (
                     status_data.get("error")
                     or status_data.get("failure_reason")
@@ -540,7 +537,6 @@ async def _generate_video_handler(arguments: dict[str, Any], **kwargs: Any) -> s
                 )
             data = await _download_video(client, str(urls[0]))
     except httpx.HTTPStatusError as exc:
-        await _settle_media_budget(cfg, billing, 0, media_ref)
         if _is_insufficient_credits(exc):
             return _json_error(_MEDIA_BUDGET_ERROR)
         detail = _upstream_error_detail(exc)
@@ -549,11 +545,16 @@ async def _generate_video_handler(arguments: dict[str, Any], **kwargs: Any) -> s
             + (f" — upstream said: {detail}" if detail else "")
         )
     except httpx.HTTPError as exc:
-        await _settle_media_budget(cfg, billing, 0, media_ref)
         return _json_error(f"Video generation request failed: {exc}")
     except ValueError as exc:
-        await _settle_media_budget(cfg, billing, 0, media_ref)
         return _json_error(str(exc))
+    finally:
+        # Single release point for every exit that never reached the
+        # real settle — timeout, failed job, transport errors, and
+        # even exceptions nothing above catches. After a successful
+        # settle ``billing`` is None and this no-ops, so success paths
+        # can't be contradicted.
+        await _settle_media_budget(cfg, billing, 0, media_ref)
 
     saved = await _save_media_bytes(
         data,

--- a/surogates/tools/builtin/media_gen.py
+++ b/surogates/tools/builtin/media_gen.py
@@ -343,10 +343,17 @@ async def _generate_image_handler(arguments: dict[str, Any], **kwargs: Any) -> s
         if value:
             extra_body[field_name] = value
 
-    image_cents = max(1, int(getattr(cfg, "image_cents", 4) or 4))
-    billing, budget_error = await _authorize_media_budget(cfg, image_cents)
-    if budget_error is not None:
-        return _json_error(budget_error)
+    raw_cents = getattr(cfg, "image_cents", 4)
+    image_cents = max(0, int(4 if raw_cents is None else raw_cents))
+    billing = None
+    if image_cents > 0:
+        # A zero price means metered-but-free images: no hold to take,
+        # nothing to settle — skip the metering hop entirely.
+        billing, budget_error = await _authorize_media_budget(
+            cfg, image_cents,
+        )
+        if budget_error is not None:
+            return _json_error(budget_error)
     media_ref = f"img-{uuid4().hex}"
 
     try:
@@ -522,6 +529,10 @@ async def _generate_video_handler(arguments: dict[str, Any], **kwargs: Any) -> s
                 )
                 actual_cents = 0
             await _settle_media_budget(cfg, billing, actual_cents, media_ref)
+            # The hold is spent: a download failure below must not
+            # settle again (the ledger's external_ref idempotency would
+            # absorb it, but relying on that hides intent).
+            billing = None
             urls = status_data.get("unsigned_urls") or []
             if not urls:
                 return _json_error(

--- a/tests/test_entitlement_enforcement.py
+++ b/tests/test_entitlement_enforcement.py
@@ -117,7 +117,23 @@ def test_capability_exclusions_drop_browser_and_coding():
         tool_registry=_registry_with(*_REGISTRY_ENTRIES),
         mcp_scope=None,
     )
-    assert excluded == {"browser_navigate", "browser_click", "run_coding_agent"}
+    assert excluded == {
+        "browser_navigate", "browser_click", "run_coding_agent",
+        "generate_image", "generate_video",
+    }
+
+
+def test_capability_exclusions_keep_entitled_media_tools():
+    excluded = _entitlement_tool_exclusions(
+        session_config={
+            "entitlements": {"capabilities": ["mission", "image", "video"]},
+        },
+        tool_registry=_registry_with(*_REGISTRY_ENTRIES),
+        mcp_scope=None,
+    )
+    assert excluded == {
+        "browser_navigate", "browser_click", "run_coding_agent",
+    }
 
 
 def test_mcp_servers_filtered_by_resolved_scope():

--- a/tests/test_media_gen_tools.py
+++ b/tests/test_media_gen_tools.py
@@ -844,11 +844,12 @@ def _hook_ctx(metered=True, cents=4, buy_url="https://buy.example/a"):
     )
 
 
-def _hook_session(config=None, user_id="u-1"):
+def _hook_session(config=None, user_id="u-1", service_account_id=None):
     return SimpleNamespace(
         id="11111111-1111-1111-1111-111111111111",
         config=config or {},
         user_id=user_id,
+        service_account_id=service_account_id,
     )
 
 
@@ -858,22 +859,37 @@ def test_media_hooks_none_when_unmetered():
     a, s = _build_media_budget_hooks(
         ctx=_hook_ctx(metered=False),
         session=_hook_session(),
-        service_account_id=None,
         platform_client=object(),
     )
     assert a is None and s is None
 
 
 def test_media_hooks_none_for_service_account_sessions():
+    """Exemption keys on the SESSION row's service_account_id — the
+    credential principal is the agent's own SA on managed channels
+    and must not exempt Slack/Telegram buyers."""
     from surogates.orchestrator.worker import _build_media_budget_hooks
 
     a, s = _build_media_budget_hooks(
         ctx=_hook_ctx(),
-        session=_hook_session(),
-        service_account_id="sa-1",
+        session=_hook_session(user_id=None, service_account_id="sa-1"),
         platform_client=object(),
     )
     assert a is None and s is None
+
+
+def test_media_hooks_built_for_managed_channel_end_users():
+    """A slack/telegram end-user session (human user_id, no session
+    SA) gets metering hooks even though the CREDENTIAL principal for
+    such sessions is the agent's own service account."""
+    from surogates.orchestrator.worker import _build_media_budget_hooks
+
+    a, s = _build_media_budget_hooks(
+        ctx=_hook_ctx(),
+        session=_hook_session(user_id="u-slack-1"),
+        platform_client=object(),
+    )
+    assert a is not None and s is not None
 
 
 @pytest.mark.asyncio
@@ -884,7 +900,6 @@ async def test_media_hooks_anonymous_sender_raises_buy_prompt():
     authorize, _ = _build_media_budget_hooks(
         ctx=_hook_ctx(),
         session=_hook_session(user_id=None),
-        service_account_id=None,
         platform_client=object(),
     )
     with pytest.raises(MediaBudgetExhaustedError) as exc_info:
@@ -920,7 +935,6 @@ async def test_media_hooks_authorize_and_settle_call_platform():
         session=_hook_session(
             config={"commerce_buyer": {"firebase_uid": "fb-1"}},
         ),
-        service_account_id=None,
         platform_client=client,
     )
     receipt = await authorize(4)
@@ -951,7 +965,6 @@ async def test_media_hooks_exhausted_maps_to_buy_prompt_error():
     authorize, _ = _build_media_budget_hooks(
         ctx=_hook_ctx(),
         session=_hook_session(),
-        service_account_id=None,
         platform_client=_BrokeClient(),
     )
     with pytest.raises(MediaBudgetExhaustedError) as exc_info:

--- a/tests/test_media_gen_tools.py
+++ b/tests/test_media_gen_tools.py
@@ -697,3 +697,298 @@ def test_media_tool_exclusions_video_needs_both_model_and_url():
     assert "generate_video" in _media_tool_exclusions(
         _cfg(video_base_url="http://proxy.test/v1"),
     )
+
+
+# ── per-buyer budget hooks ──────────────────────────────────────────
+
+
+class _HookRecorder:
+    def __init__(self, receipt=None, authorize_exc=None):
+        self.receipt = receipt
+        self.authorize_exc = authorize_exc
+        self.authorize_calls = []
+        self.settle_calls = []
+
+    async def authorize(self, requested_cents=None):
+        self.authorize_calls.append(requested_cents)
+        if self.authorize_exc is not None:
+            raise self.authorize_exc
+        return self.receipt
+
+    async def settle(self, receipt, actual_cents, external_ref):
+        self.settle_calls.append((receipt, actual_cents, external_ref))
+
+
+def _billed_image_cfg(client, hooks, image_cents=4):
+    from surogates.tools.builtin.media_gen import MediaGenConfig
+
+    return MediaGenConfig(
+        image_client=client,
+        image_model="google/gemini-2.5-flash-image",
+        budget_authorize=hooks.authorize,
+        budget_settle=hooks.settle,
+        image_cents=image_cents,
+    )
+
+
+@pytest.mark.asyncio
+async def test_image_metered_holds_and_settles_flat_price(tmp_path):
+    from surogates.tools.builtin.media_gen import _generate_image_handler
+
+    hooks = _HookRecorder(receipt={"balance_id": "b1", "reserved_cents": 4})
+    client = _FakeImageClient(
+        images=[{"image_url": {"url": f"data:image/png;base64,{_PNG_B64}"}}],
+    )
+    result = json.loads(await _generate_image_handler(
+        {"prompt": "a red square"},
+        media_gen=_billed_image_cfg(client, hooks),
+        workspace_path=str(tmp_path),
+    ))
+    assert "error" not in result
+    assert hooks.authorize_calls == [4]
+    assert len(hooks.settle_calls) == 1
+    receipt, cents, ref = hooks.settle_calls[0]
+    assert receipt == {"balance_id": "b1", "reserved_cents": 4}
+    assert cents == 4
+    assert ref.startswith("img-")
+
+
+@pytest.mark.asyncio
+async def test_image_budget_exhausted_blocks_before_provider(tmp_path):
+    from surogates.tools.builtin.media_gen import (
+        MediaBudgetExhaustedError,
+        _generate_image_handler,
+    )
+
+    hooks = _HookRecorder(
+        authorize_exc=MediaBudgetExhaustedError(
+            "media_credits_exhausted", buy_url="https://buy.example/x",
+        ),
+    )
+    client = _FakeImageClient(images=[])
+    result = json.loads(await _generate_image_handler(
+        {"prompt": "a red square"},
+        media_gen=_billed_image_cfg(client, hooks),
+        workspace_path=str(tmp_path),
+    ))
+    assert result["error"].startswith("media_credits_exhausted")
+    assert "https://buy.example/x" in result["error"]
+    assert client.last_create_kwargs is None  # provider never called
+    assert hooks.settle_calls == []
+
+
+@pytest.mark.asyncio
+async def test_image_metering_plane_down_fails_closed(tmp_path):
+    from surogates.tools.builtin.media_gen import _generate_image_handler
+
+    hooks = _HookRecorder(authorize_exc=RuntimeError("ops unreachable"))
+    client = _FakeImageClient(images=[])
+    result = json.loads(await _generate_image_handler(
+        {"prompt": "a red square"},
+        media_gen=_billed_image_cfg(client, hooks),
+        workspace_path=str(tmp_path),
+    ))
+    assert result["error"].startswith("media budget check unavailable")
+    assert client.last_create_kwargs is None
+
+
+@pytest.mark.asyncio
+async def test_image_provider_failure_releases_hold(tmp_path):
+    from surogates.tools.builtin.media_gen import (
+        MediaGenConfig,
+        _generate_image_handler,
+    )
+
+    hooks = _HookRecorder(receipt={"balance_id": "b1", "reserved_cents": 4})
+    cfg = MediaGenConfig(
+        image_client=_Broke402Client(),
+        image_model="google/gemini-2.5-flash-image",
+        budget_authorize=hooks.authorize,
+        budget_settle=hooks.settle,
+    )
+    result = json.loads(await _generate_image_handler(
+        {"prompt": "a red square"},
+        media_gen=cfg,
+        workspace_path=str(tmp_path),
+    ))
+    assert "error" in result
+    assert len(hooks.settle_calls) == 1
+    assert hooks.settle_calls[0][1] == 0  # released, not spent
+
+
+@pytest.mark.asyncio
+async def test_image_unmetered_without_hooks_stays_free(tmp_path):
+    """No hooks configured (the default) = exactly the old behavior."""
+    from surogates.tools.builtin.media_gen import _generate_image_handler
+
+    client = _FakeImageClient(
+        images=[{"image_url": {"url": f"data:image/png;base64,{_PNG_B64}"}}],
+    )
+    result = json.loads(await _generate_image_handler(
+        {"prompt": "a red square"},
+        media_gen=_image_cfg(client),
+        workspace_path=str(tmp_path),
+    ))
+    assert "error" not in result
+
+
+# ── worker media budget hook factory ────────────────────────────────
+
+
+def _hook_ctx(metered=True, cents=4, buy_url="https://buy.example/a"):
+    return SimpleNamespace(
+        media_credits_metered=metered,
+        media_image_cents=cents,
+        commerce_buy_url=buy_url,
+        agent_id="agent-1",
+    )
+
+
+def _hook_session(config=None, user_id="u-1"):
+    return SimpleNamespace(
+        id="11111111-1111-1111-1111-111111111111",
+        config=config or {},
+        user_id=user_id,
+    )
+
+
+def test_media_hooks_none_when_unmetered():
+    from surogates.orchestrator.worker import _build_media_budget_hooks
+
+    a, s = _build_media_budget_hooks(
+        ctx=_hook_ctx(metered=False),
+        session=_hook_session(),
+        service_account_id=None,
+        platform_client=object(),
+    )
+    assert a is None and s is None
+
+
+def test_media_hooks_none_for_service_account_sessions():
+    from surogates.orchestrator.worker import _build_media_budget_hooks
+
+    a, s = _build_media_budget_hooks(
+        ctx=_hook_ctx(),
+        session=_hook_session(),
+        service_account_id="sa-1",
+        platform_client=object(),
+    )
+    assert a is None and s is None
+
+
+@pytest.mark.asyncio
+async def test_media_hooks_anonymous_sender_raises_buy_prompt():
+    from surogates.orchestrator.worker import _build_media_budget_hooks
+    from surogates.tools.builtin.media_gen import MediaBudgetExhaustedError
+
+    authorize, _ = _build_media_budget_hooks(
+        ctx=_hook_ctx(),
+        session=_hook_session(user_id=None),
+        service_account_id=None,
+        platform_client=object(),
+    )
+    with pytest.raises(MediaBudgetExhaustedError) as exc_info:
+        await authorize(4)
+    assert exc_info.value.buy_url == "https://buy.example/a"
+
+
+@pytest.mark.asyncio
+async def test_media_hooks_authorize_and_settle_call_platform():
+    from surogates.orchestrator.worker import _build_media_budget_hooks
+
+    class _Client:
+        def __init__(self):
+            self.authorize_kwargs = None
+            self.settle_kwargs = None
+
+        async def media_authorize(self, agent_id, **kwargs):
+            self.authorize_kwargs = {"agent_id": agent_id, **kwargs}
+            return {
+                "metered": True,
+                "reservation_id": "r1",
+                "balance_id": "b1",
+                "reserved_cents": 4,
+            }
+
+        async def media_settle(self, agent_id, **kwargs):
+            self.settle_kwargs = {"agent_id": agent_id, **kwargs}
+            return {"settled": True}
+
+    client = _Client()
+    authorize, settle = _build_media_budget_hooks(
+        ctx=_hook_ctx(),
+        session=_hook_session(
+            config={"commerce_buyer": {"firebase_uid": "fb-1"}},
+        ),
+        service_account_id=None,
+        platform_client=client,
+    )
+    receipt = await authorize(4)
+    assert client.authorize_kwargs["firebase_uid"] == "fb-1"
+    assert client.authorize_kwargs["requested_cents"] == 4
+    assert receipt["balance_id"] == "b1"
+    await settle(receipt, 4, "img-x")
+    assert client.settle_kwargs == {
+        "agent_id": "agent-1",
+        "balance_id": "b1",
+        "reserved_cents": 4,
+        "actual_cents": 4,
+        "external_ref": "img-x",
+        "reservation_id": "r1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_media_hooks_exhausted_maps_to_buy_prompt_error():
+    from surogates.orchestrator.worker import _build_media_budget_hooks
+    from surogates.runtime.platform_client import MediaCreditsExhaustedError
+    from surogates.tools.builtin.media_gen import MediaBudgetExhaustedError
+
+    class _BrokeClient:
+        async def media_authorize(self, agent_id, **kwargs):
+            raise MediaCreditsExhaustedError("media_credits_exhausted")
+
+    authorize, _ = _build_media_budget_hooks(
+        ctx=_hook_ctx(),
+        session=_hook_session(),
+        service_account_id=None,
+        platform_client=_BrokeClient(),
+    )
+    with pytest.raises(MediaBudgetExhaustedError) as exc_info:
+        await authorize(None)
+    assert exc_info.value.buy_url == "https://buy.example/a"
+
+
+# ── package capability exclusions for media tools ───────────────────
+
+
+def test_entitlement_exclusions_drop_media_tools():
+    from surogates.orchestrator.worker import _entitlement_tool_exclusions
+
+    class _Registry:
+        tool_names = ("generate_image", "generate_video")
+
+        def get_all(self):
+            return []
+
+    session_config = {
+        "entitlements": {"capabilities": ["code", "browser"]},
+    }
+    excluded = _entitlement_tool_exclusions(
+        session_config=session_config,
+        tool_registry=_Registry(),
+        mcp_scope=None,
+    )
+    assert "generate_image" in excluded
+    assert "generate_video" in excluded
+
+    session_config = {
+        "entitlements": {"capabilities": ["image", "video"]},
+    }
+    excluded = _entitlement_tool_exclusions(
+        session_config=session_config,
+        tool_registry=_Registry(),
+        mcp_scope=None,
+    )
+    assert "generate_image" not in excluded
+    assert "generate_video" not in excluded

--- a/web/src/features/settings/plan-usage-tab.tsx
+++ b/web/src/features/settings/plan-usage-tab.tsx
@@ -30,6 +30,8 @@ interface CommerceOffer {
   token_amount: number;
   /** Metered browser time the offer sells, in minutes (0 = none). */
   browser_minutes_amount?: number;
+  /** Metered media the offer sells, in media cents (0 = none). */
+  media_credits_amount?: number;
   description?: string | null;
   /** Buyer-facing labels for a custom package; [] or absent = full
    * access (subscriptions) / pure extra usage (packs). */
@@ -46,6 +48,11 @@ interface CommerceOverview {
     period_token_remaining: number;
     topup_token_remaining: number;
     browser_minutes?: {
+      metered: boolean;
+      period_remaining: number;
+      topup_remaining: number;
+    };
+    media_credits?: {
       metered: boolean;
       period_remaining: number;
       topup_remaining: number;
@@ -207,6 +214,24 @@ export function PlanUsageTab() {
                   </span>
                 </div>
               ) : null}
+              {ent.media_credits?.metered ? (
+                <div
+                  className="flex items-center justify-between"
+                  data-testid="plan-tab-media-credits"
+                >
+                  <span className="text-muted-foreground">
+                    Media generation left
+                  </span>
+                  <span className="font-medium tabular-nums">
+                    $
+                    {(
+                      (ent.media_credits.period_remaining +
+                        ent.media_credits.topup_remaining) /
+                      100
+                    ).toFixed(2)}
+                  </span>
+                </div>
+              ) : null}
               {(ent.included?.length ?? 0) > 0 ? (
                 <div
                   className="flex items-start justify-between gap-4"
@@ -254,13 +279,17 @@ export function PlanUsageTab() {
                     <span className="text-sm font-medium">{offer.name}</span>
                     <span className="text-xs text-muted-foreground">
                       {offer.token_amount > 0 ||
-                      (offer.browser_minutes_amount ?? 0) > 0
+                      (offer.browser_minutes_amount ?? 0) > 0 ||
+                      (offer.media_credits_amount ?? 0) > 0
                         ? `${[
                             offer.token_amount > 0
                               ? approxMessagesLabel(offer.token_amount)
                               : "",
                             (offer.browser_minutes_amount ?? 0) > 0
                               ? `${offer.browser_minutes_amount} min browsing`
+                              : "",
+                            (offer.media_credits_amount ?? 0) > 0
+                              ? `$${((offer.media_credits_amount ?? 0) / 100).toFixed(2)} media`
                               : "",
                           ]
                             .filter(Boolean)

--- a/web/src/features/settings/plan-usage-tab.tsx
+++ b/web/src/features/settings/plan-usage-tab.tsx
@@ -223,12 +223,11 @@ export function PlanUsageTab() {
                     Media generation left
                   </span>
                   <span className="font-medium tabular-nums">
-                    $
-                    {(
-                      (ent.media_credits.period_remaining +
-                        ent.media_credits.topup_remaining) /
-                      100
-                    ).toFixed(2)}
+                    {formatPrice(
+                      ent.media_credits.period_remaining +
+                        ent.media_credits.topup_remaining,
+                      "usd",
+                    )}
                   </span>
                 </div>
               ) : null}
@@ -289,7 +288,7 @@ export function PlanUsageTab() {
                               ? `${offer.browser_minutes_amount} min browsing`
                               : "",
                             (offer.media_credits_amount ?? 0) > 0
-                              ? `$${((offer.media_credits_amount ?? 0) / 100).toFixed(2)} media`
+                              ? `${formatPrice(offer.media_credits_amount ?? 0, "usd")} media`
                               : "",
                           ]
                             .filter(Boolean)


### PR DESCRIPTION
## What

Phase 2 runtime half (**stacked on #166** — merge that first; companion: surogate-ops feat/media-offers): buyers of a monetized agent spend their own media credits when the agent generates images or videos.

- `platform_client.media_authorize` / `media_settle` (mirrors the browser authorize contract; typed `MediaCreditsExhaustedError`).
- `MediaGenConfig` gains `budget_authorize`/`budget_settle`/`image_cents` hooks, built per session by `_build_media_budget_hooks` — operator-plane sessions exempt (service-account principals), identity resolution matches the browser guard (buy-page buyer → embed end-user → session user), fails closed when the metering plane is unreachable.
- Images hold and settle the exact flat price ops projects (`media_image_cents`); video jobs hold the platform chunk and settle `ceil(usage.cost × 100)` at completion. Every failure path (provider refusal, failed job, timeout, download error) releases the hold by settling zero.
- Exhausted credits return an actionable buy prompt with the agent's buy URL **before** anything is generated or charged.
- Packages can gate `image`/`video` capabilities (tool exclusions + sellable vocabulary); the web plan tab shows media balances and per-offer amounts.

## Tests

`test_media_gen_tools.py` 43 passed (hook matrix: hold/settle, buy prompt pre-provider, fail-closed, zero-release, unmetered default); entitlement exclusion matrix updated; full-suite failure set byte-identical to the master baseline (93 pre-existing).