### PR TITLE
feat(channels): WhatsApp needs no per-kind enable flag

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -128,9 +128,10 @@ as a free-form answer. There are no tappable buttons on this channel.
 
 ## Ops notes
 
-- Enable the platform on the channels deployment via the runtime config
-  (`channels.whatsapp.enabled: true`); routing rows control which numbers
-  are live.
+- The platform needs no runtime-config flag — it is on by default, because
+  routing rows are the only gate that matters: without one the channel does
+  nothing, and an unknown number fast-acks 200. Set
+  `channels.whatsapp.enabled: false` only to switch it off deliberately.
 - Delivery is a durable outbox: transient failures retry every 30s and
   dead-letter after 30 minutes or on permanent errors.
 - Unknown phone number ids are fast-acked with 200 and no side effects, so

--- a/docs/superpowers/specs/2026-07-29-whatsapp-cloud-channel-design.md
+++ b/docs/superpowers/specs/2026-07-29-whatsapp-cloud-channel-design.md
@@ -733,8 +733,19 @@ Agent env vars: `SUROGATES_WHATSAPP_ENABLED` (the `enabled_env` gate checked at
 than the forms: `_DISPLAY_PHONE` (the Studio `derivedKey`) and `_VERIFY_TOKEN`
 (so the manage view can render the value the operator pastes into Meta).
 
-Process enablement: `channels.whatsapp.enabled: true` in the runtime config. In
-PROD this is the **hand-applied** ConfigMap `surogates-runtime-config`
+**Process enablement: none required.** `WhatsAppChannelSettings.enabled`
+defaults to `True`, unlike every other kind. The per-kind flag is a second gate
+on top of `channel_routing`, and for a BYO-per-tenant channel the routing table
+is already the only gate that matters: without a row the channel does nothing,
+and an unknown `phone_number_id` fast-acks 200 with no side effects by design.
+Requiring the flag bought no safety and cost a hand-applied ConfigMap edit per
+environment — a step easy to forget whose only symptom is a webhook Meta reports
+as unverifiable. Being on costs one mounted route and one 2-second outbox poll
+that finds nothing. `SUROGATES_CHANNELS_WHATSAPP_ENABLED=false` (or
+`channels.whatsapp.enabled: false`) still switches it off.
+
+For reference, the runtime config in PROD is the **hand-applied** ConfigMap
+`surogates-runtime-config`
 (`k8s/surogates-runtime/production/30-runtime-configmap.yaml:189-195`), not a
 chart template. The per-kind `channels.*.enabled` keys in
 `k8s/surogates-runtime/values.yaml:187-190` are inert — no template consumes

--- a/surogates/config.py
+++ b/surogates/config.py
@@ -603,7 +603,25 @@ class WebsiteChannelSettings(ChannelKindSettings):
 
 
 class WhatsAppChannelSettings(ChannelKindSettings):
+    """WhatsApp is on by default — unlike the other kinds.
+
+    The per-kind flag is a *second* gate on top of ``channel_routing``, and
+    for WhatsApp the routing table is already the only gate that matters:
+    every tenant brings their own Meta app, so the channel does nothing at
+    all until a routing row exists, and an unknown ``phone_number_id``
+    fast-acks 200 with no side effects by design.  Requiring the flag as
+    well bought no safety and cost a hand-applied ConfigMap edit per
+    environment — a step easy to forget, whose only symptom is a webhook
+    Meta reports as unverifiable.
+
+    Being on costs one mounted route and one outbox poll every 2 s that
+    finds nothing.  ``SUROGATES_CHANNELS_WHATSAPP_ENABLED=false`` still
+    turns it off if a deployment ever needs to.
+    """
+
     model_config = {"env_prefix": "SUROGATES_CHANNELS_WHATSAPP_"}
+
+    enabled: bool = True
 
 
 class ChannelsSettings(BaseSettings):

--- a/tests/test_channel_constants.py
+++ b/tests/test_channel_constants.py
@@ -6,6 +6,8 @@ join.  Omission fails silently at runtime, so the guards live here.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import surogates.channels.platforms  # noqa: F401  (registers every platform)
 from surogates.channels.constants import (
     ADAPTER_CHANNELS,
@@ -38,3 +40,46 @@ def test_whatsapp_has_a_memory_boundary():
     # Fail-open otherwise: session_memory_boundary returns None and WhatsApp
     # conversations share the per-user memory partition with web sessions.
     assert "whatsapp" in MANAGED_CHANNELS
+
+
+def test_whatsapp_is_enabled_without_any_config():
+    # WhatsApp needs no per-kind flag: the routing table is the only gate
+    # that matters, so a deployment must not have to hand-apply a
+    # ConfigMap edit to turn the channel on.
+    from surogates.channels.registry import ChannelRegistry
+    from surogates.config import ChannelsSettings
+    from surogates.channels.platforms.whatsapp import WhatsAppPlatform
+
+    reg = ChannelRegistry()
+    reg.register(WhatsAppPlatform())
+
+    settings = SimpleNamespace(channels=ChannelsSettings())
+    kinds = {p.kind for p in reg.enabled_platforms(settings)}
+    assert "whatsapp" in kinds
+
+
+def test_whatsapp_can_still_be_switched_off():
+    # The escape hatch survives: enabled-by-default is not un-disableable.
+    from surogates.channels.registry import ChannelRegistry
+    from surogates.config import ChannelsSettings, WhatsAppChannelSettings
+    from surogates.channels.platforms.whatsapp import WhatsAppPlatform
+
+    reg = ChannelRegistry()
+    reg.register(WhatsAppPlatform())
+
+    settings = SimpleNamespace(
+        channels=ChannelsSettings(whatsapp=WhatsAppChannelSettings(enabled=False)),
+    )
+    kinds = {p.kind for p in reg.enabled_platforms(settings)}
+    assert "whatsapp" not in kinds
+
+
+def test_other_kinds_still_default_off():
+    # Only WhatsApp changes; Slack/Telegram/Website keep opt-in semantics.
+    from surogates.config import ChannelsSettings
+
+    cfg = ChannelsSettings()
+    assert cfg.slack.enabled is False
+    assert cfg.telegram.enabled is False
+    assert cfg.website.enabled is False
+    assert cfg.whatsapp.enabled is True


### PR DESCRIPTION
`WhatsAppChannelSettings.enabled` now defaults to `True`, unlike every other kind. One line of behaviour, plus the tests and docs that were telling operators otherwise.

## Why

The per-kind flag is a **second** gate on top of `channel_routing`, and for a BYO-per-tenant channel the routing table is already the only gate that matters:

- without a routing row the channel does nothing at all — every tenant brings their own Meta app
- an unknown `phone_number_id` fast-acks 200 with no side effects, which is deliberate (the no-enumeration-oracle property)

So requiring the flag bought no safety. What it cost was a hand-applied ConfigMap edit per environment — a step that is easy to forget and whose only symptom is a webhook Meta reports as unverifiable, with nothing in our logs pointing at the cause.

## Is being on actually free?

Checked rather than assumed. The only per-platform startup work in `run_channels` is `_delivery_loop(platform)` — an outbox poll that finds nothing when no rows exist. There is no credential validation and no network call at boot, and the webhook reconciler skips `manual`-registration platforms, so it never touches WhatsApp. Net cost: one mounted route and one 2-second poll.

## Escape hatch preserved

`SUROGATES_CHANNELS_WHATSAPP_ENABLED=false` (or `channels.whatsapp.enabled: false`) still switches it off. Three tests pin the semantics: an empty `ChannelsSettings` yields an enabled WhatsApp, an explicit `false` disables it, and Slack/Telegram/Website keep their opt-in defaults.

## Verification

Measured against `origin/master`, comparing failure sets by name:

| | master | this branch |
|---|---|---|
| pytest | 34 failed / 5287 passed | 34 failed / **5434 passed** |

Identical failure set (all 34 pre-exist), +147 passing.

## Follow-up to #168

This removes the one deployment step that PR left behind. WhatsApp now works in any environment as soon as a tenant is provisioned through Studio, with no cluster-side edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
