### PR TITLE
feat(governance): enforce per-agent policy and deliver Art. 50 AI disclosure

### DIFF
--- a/docs/appendices/configuration.md
+++ b/docs/appendices/configuration.md
@@ -94,13 +94,23 @@ Surogates is configured via a YAML file merged with environment variables. Envir
 
 ## Governance (`governance`)
 
+Per-agent governance (tool allow/deny lists, egress rules, AI
+disclosure) is configured in Studio and reaches the runtime through the
+agent's runtime config, not through env vars. The deployment-level
+settings below are the fallback / audit knobs only.
+
 | Key | Env Var | Default | Description |
 |---|---|---|---|
-| `governance.enabled` | `SUROGATES_GOVERNANCE_ENABLED` | `true` | Enable policy enforcement |
-| `governance.transparency.enabled` | -- | `false` | Enable EU AI Act transparency endpoints |
-| `governance.transparency.level` | -- | `full` | Transparency level |
-| `governance.transparency.require_confirmation` | -- | `true` | Require user confirmation for AI-generated content |
-| `governance.transparency.emotion_recognition` | -- | `false` | Flag emotion recognition usage |
+| `governance.log_allowed` | `SUROGATES_GOVERNANCE_LOG_ALLOWED` | `false` | Emit a `policy.allowed` event for every passing governance check (full audit trail; doubles event volume) |
+| `governance.transparency.enabled` | `SUROGATES_GOVERNANCE_TRANSPARENCY_ENABLED` | `false` | Deployment-wide AI-disclosure fallback for agents without a per-agent transparency block |
+| `governance.transparency.level` | `SUROGATES_GOVERNANCE_TRANSPARENCY_LEVEL` | `basic` | Fallback disclosure level: `none`, `basic`, `enhanced`, `full` |
+
+The legacy `SUROGATES_GOVERNANCE_ENABLED`,
+`SUROGATES_GOVERNANCE_TRANSPARENCY_REQUIRE_CONFIRMATION` and
+`SUROGATES_GOVERNANCE_TRANSPARENCY_EMOTION_RECOGNITION` variables are
+retired and ignored: enablement lives on `Agent.policy.enabled`,
+confirmation is recorded per session as a `disclosure.confirmed` event,
+and the platform performs no emotion recognition.
 
 ## Saga (`saga`)
 

--- a/docs/audit/events.md
+++ b/docs/audit/events.md
@@ -117,7 +117,24 @@ in compliance audits.
 | key | type | notes |
 |---|---|---|
 | `tool` | string | Tool name that passed the check. |
-| `check` | string | Which check ran (e.g. `workspace_sandbox`). |
+| `check` | string | Which check ran (e.g. `governance_gate`). |
+
+`disclosure.presented` — the AI disclosure (EU AI Act Art. 50) was
+delivered on a channel at a conversation's first contact.
+
+| key | type | notes |
+|---|---|---|
+| `level` | string | Disclosure level (`basic`/`enhanced`/`full`). |
+| `channel` | string | Channel platform (e.g. `slack`, `telegram`). |
+| `delivery` | string | Delivery mechanism (`channel_message`). |
+
+`disclosure.confirmed` — the end-user acknowledged the disclosure
+(web banner accept).
+
+| key | type | notes |
+|---|---|---|
+| `level` | string | Disclosure level shown (`none` when unconfigured). |
+| `source` | string | Acknowledgement source (`web_banner`). |
 | `timestamp` | number | Emitter-side Unix epoch seconds. |
 
 ### Sandbox lifecycle

--- a/docs/governance-and-security/index.md
+++ b/docs/governance-and-security/index.md
@@ -4,30 +4,53 @@ Surogates enforces security at every layer: policy-based tool governance, MCP se
 
 ## Policy Engine
 
-Every tool call passes through a policy check before execution. Policies are evaluated in sub-millisecond time and cannot be bypassed by the agent.
+Every tool call passes through the per-wake `GovernanceGate` before
+execution. The gate composes two layers:
 
-### Allow-List Mode
+- **Platform floor** (always on, not configurable): workspace-sandbox
+  path containment for file/terminal tools, shell-variable path
+  hygiene, and argument-level checks. No agent configuration can relax
+  the floor.
+- **Agent policy** (configured in Studio, projected through the
+  runtime config's `governance` blob): `allowed_tools` /
+  `denied_tools` over the built-in tool catalog, plus network egress
+  rules for the web/browser tools.
 
-By default, only explicitly allowed tools can be called. The allow-list is composed at session start from:
+Composition is narrowing-only: allow-lists intersect, deny-lists
+union, the stricter egress default wins. Denials are returned to the
+LLM as tool results and recorded as `policy.denied` events (visible in
+the session's Policies tab); `governance.log_allowed` additionally
+records every pass.
 
-- the tenant's base governance policy (set via the org config / `GovernanceSettings`), and
-- the optional `allowed_tools` / `denied_tools` declared on the `AgentDef` row.
+The allow-list governs the **built-in** tool catalog. MCP tools
+(`mcp__*`) are governed by their own plane — per-agent MCP server
+attachment enforced by the MCP proxy, plus package entitlements — so a
+built-in allow-list does not reject them.
 
-The composed gate is **frozen** at session start; the agent cannot widen its own allow-list mid-session.
+### AI disclosure (EU AI Act Art. 50)
 
-### Attribute-Based Access Control (ABAC)
+Per-agent disclosure is part of the agent policy
+(`policy.transparency`, levels `none|basic|enhanced|full`):
 
-Fine-grained rules based on attributes allow precise control:
-
-- "Allow `refund_user` only if `user_status == verified` AND `amount < 1000`"
-- "Allow `terminal` only if `command` does not match `rm -rf`"
-- "Allow `web_search` only during business hours"
-
-ABAC rules can reference tool arguments, user attributes (role, group membership), session attributes (channel, model), and time-based conditions.
+- the public `GET /v1/transparency` endpoint serves the per-agent
+  config (query param or Host-subdomain resolution) with a
+  deployment-settings fallback, and the web SPA renders the banner
+  from it;
+- adapter channels (Slack, Telegram) deliver the disclosure text as
+  the first message of every new conversation, recorded as a
+  `disclosure.presented` event. Platforms without a
+  `post_input_nudge` implementation (e.g. Teams) cannot deliver it —
+  do not enable such channels for disclosure-required agents;
+- the web banner's accept action persists a `disclosure.confirmed`
+  event on the session log, giving deployers per-session evidence.
 
 ### Policy Immutability
 
-Policies are **frozen at session start**. The agent cannot modify its own policy during execution. This prevents prompt injection attacks that attempt to weaken governance mid-session.
+The composed gate is **frozen** for the wake. The agent cannot modify
+its own policy during execution, which blocks prompt-injection
+attempts to weaken governance mid-session. Policy edits in Studio
+reach live sessions on their next wake via the runtime-config
+invalidation channel.
 
 ## Trust Boundaries
 
@@ -43,17 +66,22 @@ The structural fix for prompt injection: credentials and tenant data are never r
 
 ## Sandbox Network Isolation
 
-Kubernetes NetworkPolicy restricts sandbox pod egress:
+Two network controls exist today:
 
-| Allowed | Denied |
-|---|---|
-| MCP proxy (for external tool calls with credential injection) | Internet |
-| Garage S3 API (for workspace file I/O) | Database (PostgreSQL) |
-| | Redis |
-| | API server |
-| | Other sandbox pods |
+- **Agent egress rules** (Studio policy): domain/port allow/deny rules
+  enforced by the governance gate on the URL arguments of
+  `web_search`, `web_extract`, `web_crawl` and `browser_navigate`. An
+  egress `default_action: deny` with no allow rules blocks all
+  outbound requests from those tools.
+- **SSH-session NetworkPolicies**: sessions with configured SSH
+  targets get a per-session Kubernetes NetworkPolicy pinning egress to
+  the resolved target IPs; targets without a pinned host key fail
+  closed.
 
-This prevents data exfiltration from the sandbox, even if the LLM is compromised.
+A blanket sandbox-egress NetworkPolicy (deny internet/DB/Redis/API
+from sandbox pods) is a deployment concern: this repository ships an
+ingress policy for the sandbox executor, and the cluster deployment is
+responsible for the egress rules appropriate to its environment.
 
 ## Credential Vault
 

--- a/docs/governance-and-security/index.md
+++ b/docs/governance-and-security/index.md
@@ -64,19 +64,32 @@ Surogates enforces a three-component isolation model:
 
 The structural fix for prompt injection: credentials and tenant data are never reachable from the sandbox where the LLM's generated code runs.
 
-## Sandbox Network Isolation
+## Network controls
 
-Two network controls exist today:
+There is no single network switch. Three independent planes govern
+outbound traffic, and an operator needs all three to reason about what
+an agent can reach:
 
-- **Agent egress rules** (Studio policy): domain/port allow/deny rules
-  enforced by the governance gate on the URL arguments of
-  `web_search`, `web_extract`, `web_crawl` and `browser_navigate`. An
-  egress `default_action: deny` with no allow rules blocks all
-  outbound requests from those tools.
-- **SSH-session NetworkPolicies**: sessions with configured SSH
-  targets get a per-session Kubernetes NetworkPolicy pinning egress to
-  the resolved target IPs; targets without a pinned host key fail
-  closed.
+1. **Agent web/browser egress** (Studio policy): domain/port allow/deny
+   rules enforced by the governance gate on the URL arguments of
+   `web_search`, `web_extract`, `web_crawl` and `browser_navigate`.
+   `default_action: deny` with no allow rules blocks those tools'
+   requests. It governs nothing else — in particular it does **not**
+   stop `terminal` from running `curl`, nor MCP calls, nor coding
+   agents. Restrict those by denying the tool or detaching the MCP
+   server.
+2. **Terminal sandbox allowlist**: the terminal tool writes its own
+   sandbox-runtime settings with a fixed domain allowlist (package
+   registries, GitHub, coding-agent vendor APIs) plus any configured
+   SSH hosts. It is independent of the agent policy; the only policy
+   lever over it is denying `terminal` (or `run_coding_agent`).
+3. **MCP server attachment**: tool discovery and calls are scoped to
+   the servers attached to the agent, enforced by the MCP proxy. An
+   agent with no attached servers can reach no MCP endpoint.
+
+Additionally, sessions with configured SSH targets get a per-session
+Kubernetes NetworkPolicy pinning egress to the resolved target IPs;
+targets without a pinned host key fail closed.
 
 A blanket sandbox-egress NetworkPolicy (deny internet/DB/Redis/API
 from sandbox pods) is a deployment concern: this repository ships an

--- a/docs/governance-and-security/index.md
+++ b/docs/governance-and-security/index.md
@@ -36,11 +36,12 @@ Per-agent disclosure is part of the agent policy
   config (query param or Host-subdomain resolution) with a
   deployment-settings fallback, and the web SPA renders the banner
   from it;
-- adapter channels (Slack, Telegram) deliver the disclosure text as
-  the first message of every new conversation, recorded as a
-  `disclosure.presented` event. Platforms without a
-  `post_input_nudge` implementation (e.g. Teams) cannot deliver it —
-  do not enable such channels for disclosure-required agents;
+- adapter channels (Slack, Telegram, WhatsApp) deliver the disclosure
+  text as the first message of every new conversation, recorded as a
+  `disclosure.presented` event. Delivery rides each platform's
+  `post_input_nudge`; a platform without one (e.g. the Teams stub)
+  silently cannot disclose, so do not enable such a channel for a
+  disclosure-required agent;
 - the web banner's accept action persists a `disclosure.confirmed`
   event on the session log, giving deployers per-session evidence.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -88,15 +88,6 @@ Supports both standard unified diff and V4A patch format. Includes fuzzy matchin
 | `path` | string | Directory to list |
 | `recursive` | boolean | Include subdirectories (default: false) |
 
-### `execute_code` -- Programmatic Code Execution
-
-Executes code programmatically, enabling agents to call tools from within generated code.
-
-| Parameter | Type | Description |
-|---|---|---|
-| `language` | string | Programming language |
-| `code` | string | Code to execute |
-
 ### `web_search` -- Web Search
 
 | Parameter | Type | Description |

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -870,17 +870,30 @@ async def confirm_disclosure(
     tenant: TenantContext = Depends(get_current_tenant),
     agent_runtime: AgentRuntimeContext = Depends(agent_runtime_context_dep),
 ) -> None:
-    """Confirm AI disclosure for a session (EU AI Act Art. 50).
+    """Record the end-user's AI-disclosure acknowledgement (Art. 50).
 
-    Must be called before the agent can execute tools when transparency
-    enforcement is enabled.  Typically called by the frontend after
-    showing the AI disclosure notice to the user.
+    Called by the frontend after the user accepts the disclosure
+    banner.  Persists a ``disclosure.confirmed`` event on the session's
+    append-only log so the acknowledgement survives worker restarts and
+    is evidenceable per session — the previous in-process
+    ``app.state.governance_gate`` write was never wired and lost state
+    on every restart.  Idempotent by construction: repeated confirms
+    append repeated events, which is harmless and still truthful.
     """
     await _get_session_for_tenant(request, session_id, tenant, agent_runtime)
 
-    governance = getattr(request.app.state, "governance_gate", None)
-    if governance is not None:
-        governance.confirm_disclosure(str(session_id))
+    from surogates.runtime.governance import transparency_config
+
+    store = _get_session_store(request)
+    cfg = transparency_config(agent_runtime.governance)
+    await store.emit_event(
+        session_id,
+        EventType.DISCLOSURE_CONFIRMED,
+        {
+            "level": cfg["level"],
+            "source": "web_banner",
+        },
+    )
 
 
 @router.get("/api/sessions/{session_id}", response_model=Session)

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -882,15 +882,15 @@ async def confirm_disclosure(
     """
     await _get_session_for_tenant(request, session_id, tenant, agent_runtime)
 
-    from surogates.runtime.governance import transparency_config
+    from surogates.runtime.governance import disclosure_config
 
     store = _get_session_store(request)
-    cfg = transparency_config(agent_runtime.governance)
+    cfg = disclosure_config(agent_runtime.governance)
     await store.emit_event(
         session_id,
         EventType.DISCLOSURE_CONFIRMED,
         {
-            "level": cfg["level"],
+            "level": cfg["level"] if cfg else "none",
             "source": "web_banner",
         },
     )

--- a/surogates/api/routes/transparency.py
+++ b/surogates/api/routes/transparency.py
@@ -4,11 +4,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Request
 
-from surogates.runtime.governance import (
-    disclosure_text,
-    has_transparency_config,
-    transparency_config,
-)
+from surogates.runtime.governance import disclosure_config, disclosure_text
+from surogates.runtime.resolver import resolve_agent_id_soft
 
 router = APIRouter()
 
@@ -20,11 +17,12 @@ async def transparency_endpoint(request: Request) -> dict:
     The frontend fetches this on load to decide whether to show the
     EU AI Act disclosure banner and which text to display.
 
-    Resolution is per-agent first: an explicit ``?agent_id=`` query
-    parameter, else the ``Host`` header subdomain (the web SPA is
-    served from the agent's host and fetches with a relative URL, so
-    it gets its agent's config with no client change).  An agent that
-    carries a transparency block wins outright — including an explicit
+    Resolution is per-agent first, via
+    :func:`surogates.runtime.resolver.resolve_agent_id_soft` (query
+    param, then Host-subdomain slug — the web SPA is served from the
+    agent's host and fetches with a relative URL, so it gets its
+    agent's config with no client change).  An agent with an explicit
+    disclosure config wins outright — including an explicit
     "disabled".  Agents without one, and requests that resolve no
     agent, fall back to the deployment-wide setting.
 
@@ -33,16 +31,11 @@ async def transparency_endpoint(request: Request) -> dict:
     It never errors on unresolvable agents — the disclosure banner must
     not break the chat page — it just falls back.
     """
-    agent_governance = await _resolve_agent_governance(request)
-    if has_transparency_config(agent_governance):
-        cfg = transparency_config(agent_governance)
+    cfg = await _agent_disclosure(request)
+    if cfg is not None:
         if not cfg["enabled"]:
             return {"enabled": False}
-        return {
-            "enabled": True,
-            "level": cfg["level"],
-            "text": disclosure_text(cfg["level"]),
-        }
+        return {"enabled": True, "level": cfg["level"], "text": cfg["text"]}
 
     settings = getattr(request.app.state, "settings", None)
     if settings is None:
@@ -57,31 +50,14 @@ async def transparency_endpoint(request: Request) -> dict:
     }
 
 
-async def _resolve_agent_governance(request: Request) -> dict | None:
-    """Best-effort per-agent governance lookup; ``None`` when unresolved.
-
-    Mirrors the resolution order of
-    :func:`surogates.runtime.resolver.agent_runtime_context_dep`
-    (query param, then Host-subdomain slug) but never raises: this
-    endpoint pre-dates authentication and must degrade to the
-    deployment default instead of failing the page load.
-    """
-    agent_id = request.query_params.get("agent_id")
-    if not agent_id:
-        host = request.headers.get("host", "")
-        slug = host.split(".", 1)[0] if "." in host else None
-        if slug and slug.lower() not in {"www", "api", "localhost"}:
-            slug_cache = getattr(
-                request.app.state, "slug_resolver_cache", None,
-            )
-            if slug_cache is not None:
-                try:
-                    agent_id = await slug_cache.get(slug)
-                except Exception:  # noqa: BLE001 — fall back to deployment
-                    agent_id = None
+async def _agent_disclosure(request: Request) -> dict | None:
+    """Best-effort per-agent disclosure lookup; ``None`` when unresolved."""
+    try:
+        agent_id = await resolve_agent_id_soft(request)
+    except Exception:  # noqa: BLE001 — slug cache blip: deployment fallback
+        return None
     if not agent_id:
         return None
-
     cache = getattr(request.app.state, "runtime_config_cache", None)
     if cache is None:
         return None
@@ -90,4 +66,4 @@ async def _resolve_agent_governance(request: Request) -> dict | None:
     except Exception:  # noqa: BLE001 — unknown agent: deployment fallback
         return None
     governance = payload.get("governance") if isinstance(payload, dict) else None
-    return governance if isinstance(governance, dict) else None
+    return disclosure_config(governance)

--- a/surogates/api/routes/transparency.py
+++ b/surogates/api/routes/transparency.py
@@ -32,38 +32,40 @@ async def transparency_endpoint(request: Request) -> dict:
     not break the chat page — it just falls back.
     """
     cfg = await _agent_disclosure(request)
-    if cfg is not None:
-        if not cfg["enabled"]:
-            return {"enabled": False}
-        return {"enabled": True, "level": cfg["level"], "text": cfg["text"]}
+    if cfg is None:
+        cfg = _deployment_disclosure(request)
+    if cfg is None or not cfg["enabled"]:
+        return {"enabled": False}
+    return {"enabled": True, "level": cfg["level"], "text": cfg["text"]}
 
+
+def _deployment_disclosure(request: Request) -> dict | None:
+    """The deployment-wide fallback disclosure, or ``None`` if unset."""
     settings = getattr(request.app.state, "settings", None)
-    if settings is None:
-        return {"enabled": False}
-    t = getattr(settings.governance, "transparency", None)
-    if t is None or not getattr(t, "enabled", False):
-        return {"enabled": False}
+    transparency = (
+        getattr(settings.governance, "transparency", None)
+        if settings is not None else None
+    )
+    if transparency is None or not getattr(transparency, "enabled", False):
+        return None
     return {
         "enabled": True,
-        "level": t.level,
-        "text": disclosure_text(t.level),
+        "level": transparency.level,
+        "text": disclosure_text(transparency.level),
     }
 
 
 async def _agent_disclosure(request: Request) -> dict | None:
     """Best-effort per-agent disclosure lookup; ``None`` when unresolved."""
-    try:
-        agent_id = await resolve_agent_id_soft(request)
-    except Exception:  # noqa: BLE001 — slug cache blip: deployment fallback
-        return None
-    if not agent_id:
-        return None
     cache = getattr(request.app.state, "runtime_config_cache", None)
     if cache is None:
         return None
     try:
+        agent_id = await resolve_agent_id_soft(request)
+        if not agent_id:
+            return None
         payload = await cache.get(agent_id)
-    except Exception:  # noqa: BLE001 — unknown agent: deployment fallback
+    except Exception:  # noqa: BLE001 — unknown agent or cache blip: fall back
         return None
     governance = payload.get("governance") if isinstance(payload, dict) else None
     return disclosure_config(governance)

--- a/surogates/api/routes/transparency.py
+++ b/surogates/api/routes/transparency.py
@@ -4,28 +4,90 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Request
 
+from surogates.runtime.governance import (
+    disclosure_text,
+    has_transparency_config,
+    transparency_config,
+)
+
 router = APIRouter()
 
 
 @router.get("/transparency")
-async def transparency_config(request: Request) -> dict:
-    """Return the transparency config for the frontend.
+async def transparency_endpoint(request: Request) -> dict:
+    """Return the AI-disclosure config for the frontend.
 
     The frontend fetches this on load to decide whether to show the
     EU AI Act disclosure banner and which text to display.
 
+    Resolution is per-agent first: an explicit ``?agent_id=`` query
+    parameter, else the ``Host`` header subdomain (the web SPA is
+    served from the agent's host and fetches with a relative URL, so
+    it gets its agent's config with no client change).  An agent that
+    carries a transparency block wins outright — including an explicit
+    "disabled".  Agents without one, and requests that resolve no
+    agent, fall back to the deployment-wide setting.
+
     This endpoint is public (no authentication required) because the
     disclosure must be shown before the user interacts with the system.
+    It never errors on unresolvable agents — the disclosure banner must
+    not break the chat page — it just falls back.
     """
+    agent_governance = await _resolve_agent_governance(request)
+    if has_transparency_config(agent_governance):
+        cfg = transparency_config(agent_governance)
+        if not cfg["enabled"]:
+            return {"enabled": False}
+        return {
+            "enabled": True,
+            "level": cfg["level"],
+            "text": disclosure_text(cfg["level"]),
+        }
+
     settings = getattr(request.app.state, "settings", None)
     if settings is None:
         return {"enabled": False}
-
     t = getattr(settings.governance, "transparency", None)
     if t is None or not getattr(t, "enabled", False):
         return {"enabled": False}
-
     return {
         "enabled": True,
         "level": t.level,
+        "text": disclosure_text(t.level),
     }
+
+
+async def _resolve_agent_governance(request: Request) -> dict | None:
+    """Best-effort per-agent governance lookup; ``None`` when unresolved.
+
+    Mirrors the resolution order of
+    :func:`surogates.runtime.resolver.agent_runtime_context_dep`
+    (query param, then Host-subdomain slug) but never raises: this
+    endpoint pre-dates authentication and must degrade to the
+    deployment default instead of failing the page load.
+    """
+    agent_id = request.query_params.get("agent_id")
+    if not agent_id:
+        host = request.headers.get("host", "")
+        slug = host.split(".", 1)[0] if "." in host else None
+        if slug and slug.lower() not in {"www", "api", "localhost"}:
+            slug_cache = getattr(
+                request.app.state, "slug_resolver_cache", None,
+            )
+            if slug_cache is not None:
+                try:
+                    agent_id = await slug_cache.get(slug)
+                except Exception:  # noqa: BLE001 — fall back to deployment
+                    agent_id = None
+    if not agent_id:
+        return None
+
+    cache = getattr(request.app.state, "runtime_config_cache", None)
+    if cache is None:
+        return None
+    try:
+        payload = await cache.get(agent_id)
+    except Exception:  # noqa: BLE001 — unknown agent: deployment fallback
+        return None
+    governance = payload.get("governance") if isinstance(payload, dict) else None
+    return governance if isinstance(governance, dict) else None

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -388,20 +388,6 @@ def build_principal_stamp(*, user_id=None, service_account_id=None) -> dict:
 # ---------------------------------------------------------------------------
 
 
-# Sessions this process has already seen disclosed (or established) —
-# bounded FIFO so a long-lived adapter cannot grow it unboundedly.
-# Purely an optimisation over the session-row message_count check: an
-# eviction or restart costs one extra lookup, never a missed disclosure.
-_DISCLOSED_SESSIONS: dict[str, None] = {}
-_DISCLOSED_SESSIONS_CAP = 4096
-
-
-def _remember_disclosed(key: str) -> None:
-    if len(_DISCLOSED_SESSIONS) >= _DISCLOSED_SESSIONS_CAP:
-        _DISCLOSED_SESSIONS.pop(next(iter(_DISCLOSED_SESSIONS)))
-    _DISCLOSED_SESSIONS[key] = None
-
-
 class ChannelInboundPipeline:
     """Shared inbound message pipeline for all channel adapters.
 
@@ -688,6 +674,26 @@ class ChannelInboundPipeline:
                     logger.warning("[channels] /stop ack failed", exc_info=True)
             return InboundOutcome.INTERRUPTED
 
+        # The agent's runtime config feeds both the disclosure notice and
+        # the allowance gate below. Resolve it at most once per message —
+        # the two used to fetch it independently — and only when a
+        # consumer is actually wired. A failed fetch resolves to ``{}``,
+        # which both consumers read as "nothing configured": disclosure
+        # stays silent and the allowance gate stays open.
+        runtime_payload: dict | None = None
+        if deps.runtime_config is not None and (
+            deps.input_nudge is not None
+            or (identity.user_id is not None and deps.platform_client is not None)
+        ):
+            try:
+                runtime_payload = await deps.runtime_config(routing.agent_id) or {}
+            except Exception:
+                logger.warning(
+                    "[channels] runtime config unavailable for agent %s",
+                    routing.agent_id, exc_info=True,
+                )
+                runtime_payload = {}
+
         # AI disclosure (EU AI Act Art. 50): on the first contact of a
         # conversation with a disclosure-enabled agent, the channel user
         # gets the notice as its own message before any agent output.
@@ -695,6 +701,7 @@ class ChannelInboundPipeline:
         # does not open a conversation.
         await self._maybe_send_disclosure(
             msg, routing=routing, deps=deps, session_id=session_id,
+            runtime_payload=runtime_payload,
         )
 
         # While a question is pending, the platforms diverge on what a plain
@@ -789,13 +796,10 @@ class ChannelInboundPipeline:
                 AllowanceExhaustedError,
             )
 
-            try:
-                runtime_payload = await deps.runtime_config(routing.agent_id) or {}
-            except Exception:
-                # Can't resolve the agent's config → fail OPEN (do not gate).
-                # Only a fetched, capped payload should ever block a turn;
-                # a cache blip must not drop every channel message.
-                runtime_payload = {}
+            # Resolved once above; an unresolvable config is ``{}``, which
+            # fails OPEN (do not gate) — only a fetched, capped payload
+            # should ever block a turn, and a cache blip must not drop
+            # every channel message.
             try:
                 await reserve_allowance(
                     platform_client=deps.platform_client,
@@ -948,6 +952,7 @@ class ChannelInboundPipeline:
         routing: Any,
         deps: PipelineDeps,
         session_id: Any,
+        runtime_payload: dict | None,
     ) -> None:
         """Deliver the AI disclosure on a conversation's first contact.
 
@@ -956,11 +961,7 @@ class ChannelInboundPipeline:
         session row's ``message_count`` — zero means no USER_MESSAGE has
         been recorded yet (the pipeline emits it after this hook), which
         also covers resumed-but-never-messaged sessions; a re-disclosure
-        on such a session is harmless, a missing one is not.  Sessions
-        already seen disclosed by this process are remembered in a
-        bounded in-memory set so established conversations skip the
-        session-row lookup entirely (an eviction or restart merely costs
-        one extra lookup, never a missing disclosure).
+        on such a session is harmless, a missing one is not.
 
         Delivery rides ``deps.input_nudge`` (the same seam as the /stop
         acknowledgement), which posts a plain platform message.  On
@@ -971,21 +972,16 @@ class ChannelInboundPipeline:
         with level + channel for the per-session audit trail.  Failures
         never drop the inbound message.
         """
-        if deps.runtime_config is None or deps.input_nudge is None:
+        from surogates.runtime.governance import disclosure_config
+
+        if runtime_payload is None or deps.input_nudge is None:
+            return
+        cfg = disclosure_config(runtime_payload.get("governance"))
+        if cfg is None or not cfg["enabled"] or not cfg["text"]:
             return
         try:
-            from surogates.runtime.governance import disclosure_config
-
-            payload = await deps.runtime_config(routing.agent_id) or {}
-            cfg = disclosure_config(payload.get("governance"))
-            if cfg is None or not cfg["enabled"] or not cfg["text"]:
-                return
-            key = str(session_id)
-            if key in _DISCLOSED_SESSIONS:
-                return
             session = await deps.session_store.get_session(session_id)
             if getattr(session, "message_count", 0):
-                _remember_disclosed(key)
                 return
             await deps.input_nudge(session_id, msg, cfg["text"])
             await deps.session_store.emit_event(
@@ -997,7 +993,6 @@ class ChannelInboundPipeline:
                     "delivery": "channel_message",
                 },
             )
-            _remember_disclosed(key)
         except Exception:
             logger.warning(
                 "[channels] AI disclosure delivery failed for session %s",

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -388,6 +388,20 @@ def build_principal_stamp(*, user_id=None, service_account_id=None) -> dict:
 # ---------------------------------------------------------------------------
 
 
+# Sessions this process has already seen disclosed (or established) —
+# bounded FIFO so a long-lived adapter cannot grow it unboundedly.
+# Purely an optimisation over the session-row message_count check: an
+# eviction or restart costs one extra lookup, never a missed disclosure.
+_DISCLOSED_SESSIONS: dict[str, None] = {}
+_DISCLOSED_SESSIONS_CAP = 4096
+
+
+def _remember_disclosed(key: str) -> None:
+    if len(_DISCLOSED_SESSIONS) >= _DISCLOSED_SESSIONS_CAP:
+        _DISCLOSED_SESSIONS.pop(next(iter(_DISCLOSED_SESSIONS)))
+    _DISCLOSED_SESSIONS[key] = None
+
+
 class ChannelInboundPipeline:
     """Shared inbound message pipeline for all channel adapters.
 
@@ -645,13 +659,6 @@ class ChannelInboundPipeline:
         # Remember in Redis-backed state for thread-gate lookups.
         await deps.state.remember_session(session_key, str(session_id))
 
-        # AI disclosure (EU AI Act Art. 50): on the first contact of a
-        # conversation with a disclosure-enabled agent, the channel user
-        # gets the notice as its own message before any agent output.
-        await self._maybe_send_disclosure(
-            msg, routing=routing, deps=deps, session_id=session_id,
-        )
-
         # ------------------------------------------------------------------
         # /stop — interrupt the running turn OUT-OF-BAND.  A normal message
         # would queue behind the busy worker and never reach it in time (a
@@ -680,6 +687,15 @@ class ChannelInboundPipeline:
                 except Exception:
                     logger.warning("[channels] /stop ack failed", exc_info=True)
             return InboundOutcome.INTERRUPTED
+
+        # AI disclosure (EU AI Act Art. 50): on the first contact of a
+        # conversation with a disclosure-enabled agent, the channel user
+        # gets the notice as its own message before any agent output.
+        # After the /stop gate — a control command interrupts a run, it
+        # does not open a conversation.
+        await self._maybe_send_disclosure(
+            msg, routing=routing, deps=deps, session_id=session_id,
+        )
 
         # While a question is pending, the platforms diverge on what a plain
         # reply means — see _intercept_pending_input.
@@ -934,11 +950,15 @@ class ChannelInboundPipeline:
         """Deliver the AI disclosure on a conversation's first contact.
 
         Fires only for agents whose runtime-config governance carries an
-        enabled transparency block.  "First contact" is detected via the
+        enabled disclosure config.  "First contact" is detected via the
         session row's ``message_count`` — zero means no USER_MESSAGE has
         been recorded yet (the pipeline emits it after this hook), which
         also covers resumed-but-never-messaged sessions; a re-disclosure
-        on such a session is harmless, a missing one is not.
+        on such a session is harmless, a missing one is not.  Sessions
+        already seen disclosed by this process are remembered in a
+        bounded in-memory set so established conversations skip the
+        session-row lookup entirely (an eviction or restart merely costs
+        one extra lookup, never a missing disclosure).
 
         Delivery rides ``deps.input_nudge`` (the same seam as the /stop
         acknowledgement), which posts a plain platform message.  On
@@ -952,22 +972,20 @@ class ChannelInboundPipeline:
         if deps.runtime_config is None or deps.input_nudge is None:
             return
         try:
-            from surogates.runtime.governance import (
-                disclosure_text,
-                transparency_config,
-            )
+            from surogates.runtime.governance import disclosure_config
 
             payload = await deps.runtime_config(routing.agent_id) or {}
-            cfg = transparency_config(payload.get("governance"))
-            if not cfg["enabled"]:
+            cfg = disclosure_config(payload.get("governance"))
+            if cfg is None or not cfg["enabled"] or not cfg["text"]:
                 return
-            text = disclosure_text(cfg["level"])
-            if not text:
+            key = str(session_id)
+            if key in _DISCLOSED_SESSIONS:
                 return
             session = await deps.session_store.get_session(session_id)
             if getattr(session, "message_count", 0):
+                _remember_disclosed(key)
                 return
-            await deps.input_nudge(session_id, msg, text)
+            await deps.input_nudge(session_id, msg, cfg["text"])
             await deps.session_store.emit_event(
                 session_id,
                 EventType.DISCLOSURE_PRESENTED,
@@ -977,6 +995,7 @@ class ChannelInboundPipeline:
                     "delivery": "channel_message",
                 },
             )
+            _remember_disclosed(key)
         except Exception:
             logger.warning(
                 "[channels] AI disclosure delivery failed for session %s",

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -645,6 +645,13 @@ class ChannelInboundPipeline:
         # Remember in Redis-backed state for thread-gate lookups.
         await deps.state.remember_session(session_key, str(session_id))
 
+        # AI disclosure (EU AI Act Art. 50): on the first contact of a
+        # conversation with a disclosure-enabled agent, the channel user
+        # gets the notice as its own message before any agent output.
+        await self._maybe_send_disclosure(
+            msg, routing=routing, deps=deps, session_id=session_id,
+        )
+
         # ------------------------------------------------------------------
         # /stop — interrupt the running turn OUT-OF-BAND.  A normal message
         # would queue behind the busy worker and never reach it in time (a
@@ -915,6 +922,66 @@ class ChannelInboundPipeline:
             await _nudge("✅ Got it — continuing.")
             return InboundOutcome.DROPPED
         return None
+
+    @staticmethod
+    async def _maybe_send_disclosure(
+        msg: InboundMessage,
+        *,
+        routing: Any,
+        deps: PipelineDeps,
+        session_id: Any,
+    ) -> None:
+        """Deliver the AI disclosure on a conversation's first contact.
+
+        Fires only for agents whose runtime-config governance carries an
+        enabled transparency block.  "First contact" is detected via the
+        session row's ``message_count`` — zero means no USER_MESSAGE has
+        been recorded yet (the pipeline emits it after this hook), which
+        also covers resumed-but-never-messaged sessions; a re-disclosure
+        on such a session is harmless, a missing one is not.
+
+        Delivery rides ``deps.input_nudge`` (the same seam as the /stop
+        acknowledgement), which posts a plain platform message.  On
+        platforms without ``post_input_nudge`` the nudge is a silent
+        no-op — those channels must not be enabled for
+        disclosure-required agents (see docs/governance-and-security).
+        A ``disclosure.presented`` event records the delivery attempt
+        with level + channel for the per-session audit trail.  Failures
+        never drop the inbound message.
+        """
+        if deps.runtime_config is None or deps.input_nudge is None:
+            return
+        try:
+            from surogates.runtime.governance import (
+                disclosure_text,
+                transparency_config,
+            )
+
+            payload = await deps.runtime_config(routing.agent_id) or {}
+            cfg = transparency_config(payload.get("governance"))
+            if not cfg["enabled"]:
+                return
+            text = disclosure_text(cfg["level"])
+            if not text:
+                return
+            session = await deps.session_store.get_session(session_id)
+            if getattr(session, "message_count", 0):
+                return
+            await deps.input_nudge(session_id, msg, text)
+            await deps.session_store.emit_event(
+                session_id,
+                EventType.DISCLOSURE_PRESENTED,
+                {
+                    "level": cfg["level"],
+                    "channel": routing.platform,
+                    "delivery": "channel_message",
+                },
+            )
+        except Exception:
+            logger.warning(
+                "[channels] AI disclosure delivery failed for session %s",
+                session_id, exc_info=True,
+            )
 
     @staticmethod
     async def _record_reply_target(

--- a/surogates/environments/coding-crew/code-orchestrator/AGENT.md
+++ b/surogates/environments/coding-crew/code-orchestrator/AGENT.md
@@ -2,7 +2,7 @@
 name: code-orchestrator
 description: Routes a build across the coding crew; does not write code itself.
 tools: [spawn_task, unblock_task, cancel_task]
-disallowed_tools: [terminal, write_file, patch, execute_code, run_coding_agent]
+disallowed_tools: [terminal, write_file, patch, run_coding_agent]
 ---
 
 You route a software build across a coding crew. You do NOT write code yourself.

--- a/surogates/governance/policy.py
+++ b/surogates/governance/policy.py
@@ -96,9 +96,19 @@ class GovernanceGate:
         enabled: bool = True,
         egress_policy: EgressPolicy | None = None,
         transparency: TransparencyInterceptor | None = None,
+        allow_list_scope: frozenset[str] | None = None,
     ) -> None:
         self._enabled: bool = enabled
         self._open_policy: bool = (allowed_tools is None and denied_tools is None)
+
+        # Namespace the allow-list governs.  A Studio-authored policy
+        # names built-in tools only, so a tool outside the scope (e.g.
+        # ``mcp__*``, which is governed by MCP-server attachment +
+        # entitlements) must not be rejected by the role gate merely for
+        # not appearing in the list.  Deny-list, egress, sandbox and
+        # argument checks still apply to out-of-scope tools.  ``None``
+        # means the allow-list governs every tool (historic behaviour).
+        self._allow_list_scope: frozenset[str] | None = allow_list_scope
 
         # Initialise AGT engine.
         self._engine = AGTPolicyEngine()
@@ -284,8 +294,14 @@ class GovernanceGate:
                 allowed=False, reason=egress_violation, tool_name=tool_name
             )
 
-        # Open policy: skip role check, only run argument checks.
-        if self._open_policy:
+        # Open policy: skip role check, only run argument checks.  Tools
+        # outside the allow-list's governed namespace (e.g. MCP tools
+        # under a built-in-tool allow-list) take the same path.
+        out_of_scope = (
+            self._allow_list_scope is not None
+            and tool_name not in self._allow_list_scope
+        )
+        if self._open_policy or out_of_scope:
             violation = self._check_arguments(tool_name, arguments or {})
             if violation:
                 return PolicyDecision(
@@ -541,7 +557,14 @@ class GovernanceGate:
         profile_rules = profile_egress.get("rules") or []
         profile_default = profile_egress.get("default_action")
 
-        if self._egress_policy is not None or profile_rules:
+        # ``default_action: deny`` with no rules is a real posture
+        # ("block all outbound") — it must materialise a policy, not
+        # fall through to unchecked egress.
+        if (
+            self._egress_policy is not None
+            or profile_rules
+            or profile_default == "deny"
+        ):
             base_default = (
                 getattr(self._egress_policy, "default_action", None)
                 if self._egress_policy is not None else None
@@ -579,6 +602,7 @@ class GovernanceGate:
             enabled=self._enabled,
             egress_policy=new_egress,
             transparency=self._transparency,
+            allow_list_scope=self._allow_list_scope,
         )
         composed.freeze()
         return composed

--- a/surogates/governance/policy.py
+++ b/surogates/governance/policy.py
@@ -463,20 +463,26 @@ class GovernanceGate:
             # role gate.
             return self._check_arguments_direct(tool_name, arguments)
 
-        # Add the tool to permissions so check_violation evaluates only
-        # argument-level rules, and leave it there: in open-policy mode
-        # the role gate is never consulted, so a resident name cannot
-        # permit anything, and the set is bounded by the tool catalog.
-        # (The previous add/discard pair allocated and mutated a shared
-        # engine on every tool call — the floor gate is process-wide.)
+        # Temporarily admit the tool so check_violation evaluates only
+        # argument-level rules, then take it back out.
+        #
+        # ``setdefault`` reuses the same set object across calls (the old
+        # ``.get(role, set())`` + reassign allocated one per tool call on
+        # a process-wide gate), while the discard keeps the set from
+        # growing without bound: this runs before any registry lookup, so
+        # ``tool_name`` is whatever the model emitted — hallucinated names
+        # and every tenant's ``mcp__*`` tools would otherwise accumulate
+        # for the lifetime of the worker.
         perms = self._engine.state_permissions.setdefault(
             _DEFAULT_ROLE, set(),
         )
-        if tool_name not in perms:
-            perms.add(tool_name)
-        return self._engine.check_violation(
-            _DEFAULT_ROLE, tool_name, arguments,
-        )
+        perms.add(tool_name)
+        try:
+            return self._engine.check_violation(
+                _DEFAULT_ROLE, tool_name, arguments,
+            )
+        finally:
+            perms.discard(tool_name)
 
     @staticmethod
     def _check_arguments_direct(

--- a/surogates/governance/policy.py
+++ b/surogates/governance/policy.py
@@ -463,17 +463,20 @@ class GovernanceGate:
             # role gate.
             return self._check_arguments_direct(tool_name, arguments)
 
-        # Temporarily add the tool to permissions so check_violation
-        # only evaluates argument-level rules.
-        perms = self._engine.state_permissions.get(_DEFAULT_ROLE, set())
-        perms.add(tool_name)
-        self._engine.state_permissions[_DEFAULT_ROLE] = perms
-        try:
-            return self._engine.check_violation(_DEFAULT_ROLE, tool_name, arguments)
-        finally:
-            perms.discard(tool_name)
-            if not perms:
-                self._engine.state_permissions.pop(_DEFAULT_ROLE, None)
+        # Add the tool to permissions so check_violation evaluates only
+        # argument-level rules, and leave it there: in open-policy mode
+        # the role gate is never consulted, so a resident name cannot
+        # permit anything, and the set is bounded by the tool catalog.
+        # (The previous add/discard pair allocated and mutated a shared
+        # engine on every tool call — the floor gate is process-wide.)
+        perms = self._engine.state_permissions.setdefault(
+            _DEFAULT_ROLE, set(),
+        )
+        if tool_name not in perms:
+            perms.add(tool_name)
+        return self._engine.check_violation(
+            _DEFAULT_ROLE, tool_name, arguments,
+        )
 
     @staticmethod
     def _check_arguments_direct(

--- a/surogates/governance/policy.py
+++ b/surogates/governance/policy.py
@@ -96,19 +96,9 @@ class GovernanceGate:
         enabled: bool = True,
         egress_policy: EgressPolicy | None = None,
         transparency: TransparencyInterceptor | None = None,
-        allow_list_scope: frozenset[str] | None = None,
     ) -> None:
         self._enabled: bool = enabled
         self._open_policy: bool = (allowed_tools is None and denied_tools is None)
-
-        # Namespace the allow-list governs.  A Studio-authored policy
-        # names built-in tools only, so a tool outside the scope (e.g.
-        # ``mcp__*``, which is governed by MCP-server attachment +
-        # entitlements) must not be rejected by the role gate merely for
-        # not appearing in the list.  Deny-list, egress, sandbox and
-        # argument checks still apply to out-of-scope tools.  ``None``
-        # means the allow-list governs every tool (historic behaviour).
-        self._allow_list_scope: frozenset[str] | None = allow_list_scope
 
         # Initialise AGT engine.
         self._engine = AGTPolicyEngine()
@@ -294,14 +284,16 @@ class GovernanceGate:
                 allowed=False, reason=egress_violation, tool_name=tool_name
             )
 
-        # Open policy: skip role check, only run argument checks.  Tools
-        # outside the allow-list's governed namespace (e.g. MCP tools
-        # under a built-in-tool allow-list) take the same path.
-        out_of_scope = (
-            self._allow_list_scope is not None
-            and tool_name not in self._allow_list_scope
-        )
-        if self._open_policy or out_of_scope:
+        # Open policy: skip role check, only run argument checks.  MCP
+        # tools take the same path — a Studio-authored allow-list names
+        # built-in tools only, and ``mcp__*`` access is governed by its
+        # own plane (per-agent server attachment enforced by the MCP
+        # proxy, plus entitlements), so the role gate must not reject
+        # them for not appearing in the list.  Deny-list, egress,
+        # sandbox and argument checks above still apply to them, and
+        # every non-MCP name stays subject to the allow-list
+        # (fail-closed for built-ins).
+        if self._open_policy or tool_name.startswith("mcp__"):
             violation = self._check_arguments(tool_name, arguments or {})
             if violation:
                 return PolicyDecision(
@@ -602,7 +594,6 @@ class GovernanceGate:
             enabled=self._enabled,
             egress_policy=new_egress,
             transparency=self._transparency,
-            allow_list_scope=self._allow_list_scope,
         )
         composed.freeze()
         return composed

--- a/surogates/governance/transparency.py
+++ b/surogates/governance/transparency.py
@@ -48,23 +48,29 @@ class ToolCallResult:
     audit_entry: dict[str, Any] | None = None
 
 
+# Disclosure texts deliberately do NOT self-classify the system (the
+# earlier drafts claimed "high-risk AI system", which is a legal
+# classification under AI Act Art. 6 that a patient-communication or
+# assistant agent does not carry — asserting it in end-user copy is
+# both wrong and harmful). The levels scale detail, not risk claims.
 DISCLOSURE_TEXTS = {
     TransparencyLevel.BASIC: (
-        "You are interacting with an AI system. Outputs are machine-generated "
-        "and may contain errors. (EU AI Act Art. 50(1))"
+        "You are interacting with an AI assistant. Replies are "
+        "machine-generated and may contain errors. (EU AI Act Art. 50(1))"
     ),
     TransparencyLevel.ENHANCED: (
-        "You are interacting with a high-risk AI system. Outputs are "
-        "machine-generated, subject to governance policy enforcement, and "
-        "logged for regulatory audit. Interpretability documentation is "
-        "available on request. (EU AI Act Art. 13, Art. 50(1))"
+        "You are interacting with an AI assistant. Replies are "
+        "machine-generated, may contain errors, and are logged. The AI "
+        "follows the operator's usage policy and you can always ask for "
+        "a human contact. (EU AI Act Art. 50(1))"
     ),
     TransparencyLevel.FULL: (
-        "You are interacting with a high-risk AI system under full "
-        "transparency obligations. All tool calls are policy-governed, "
-        "audited, and subject to human oversight. System accuracy "
-        "declarations and technical documentation are available. "
-        "(EU AI Act Art. 13, Art. 14, Art. 50)"
+        "You are interacting with an AI assistant operated on the "
+        "Surogate platform. Replies are machine-generated, may contain "
+        "errors, and are logged and policy-governed; a human operator "
+        "reviews escalations and you can request a human contact at any "
+        "time. This notice is provided under EU AI Act Art. 50(1); "
+        "further information is available from the operator."
     ),
 }
 

--- a/surogates/governance/transparency.py
+++ b/surogates/governance/transparency.py
@@ -80,6 +80,16 @@ EMOTION_RECOGNITION_NOTICE = (
 )
 
 
+def disclosure_text_for(level: TransparencyLevel) -> str:
+    """The disclosure copy for a level, falling back to BASIC.
+
+    Module-level so the runtime's per-agent path
+    (``surogates.runtime.governance.disclosure_text``) and the
+    interceptor share one lookup instead of two.
+    """
+    return DISCLOSURE_TEXTS.get(level, DISCLOSURE_TEXTS[TransparencyLevel.BASIC])
+
+
 class TransparencyInterceptor:
     """EU AI Act Art. 13/50 transparency enforcement interceptor.
 
@@ -180,7 +190,7 @@ class TransparencyInterceptor:
 
     def get_disclosure_text(self, level: TransparencyLevel) -> str:
         """Get standard disclosure text for the given transparency level."""
-        return DISCLOSURE_TEXTS.get(level, DISCLOSURE_TEXTS[TransparencyLevel.BASIC])
+        return disclosure_text_for(level)
 
     def is_disclosure_confirmed(self, session_id: str) -> bool:
         """Check if disclosure has been confirmed for a session."""

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -372,6 +372,7 @@ class AgentHarness(
         default_model: str = "gpt-4o",
         session_factory: Any | None = None,
         log_policy_allowed: bool = False,
+        governance_gate: Any | None = None,
         summary_client: AsyncOpenAI | None = None,
         summary_model: str = "",
         vision_client: AsyncOpenAI | None = None,
@@ -545,6 +546,11 @@ class AgentHarness(
         # ``policy.denied`` on block.  Off by default (doubles audit
         # volume); sourced from ``settings.governance.log_allowed``.
         self._log_policy_allowed = log_policy_allowed
+
+        # Per-wake governance gate: the platform floor composed with the
+        # agent's runtime-config policy (allow/deny lists + egress).
+        # ``None`` falls back to a floor-only gate inside tool_exec.
+        self._governance_gate = governance_gate
 
         # System prompt cache (shared across wake() calls for the same worker).
         self._system_prompt_cache: SystemPromptCache = (
@@ -1775,6 +1781,7 @@ class AgentHarness(
                     media_gen=self._media_gen,
                     saga=saga,
                     log_policy_allowed=self._log_policy_allowed,
+                    governance_gate=self._governance_gate,
                     tool_guardrails=tool_guardrails,
                     bundle=self._bundle,
                     turn_gate=self._turn_gate,
@@ -2520,6 +2527,7 @@ class AgentHarness(
                     media_gen=self._media_gen,
                     saga=saga,
                     log_policy_allowed=self._log_policy_allowed,
+                    governance_gate=self._governance_gate,
                     bundle=self._bundle,
                     turn_gate=self._turn_gate,
                 )

--- a/surogates/harness/streaming_executor.py
+++ b/surogates/harness/streaming_executor.py
@@ -144,6 +144,7 @@ class StreamingToolExecutor:
         media_gen: Any | None = None,
         saga: SagaOrchestrator | None = None,
         log_policy_allowed: bool = False,
+        governance_gate: Any | None = None,
         tool_guardrails: Any | None = None,
         bundle: Any | None = None,
         turn_gate: Any | None = None,
@@ -157,6 +158,7 @@ class StreamingToolExecutor:
         self._redis = redis
         self._budget = budget
         self._log_policy_allowed = log_policy_allowed
+        self._governance_gate = governance_gate
         self._memory_manager = memory_manager
         self._hint_tracker = hint_tracker
         self._sandbox_pool = sandbox_pool
@@ -401,6 +403,7 @@ class StreamingToolExecutor:
                 media_gen=self._media_gen,
                 saga=self._saga,
                 log_policy_allowed=self._log_policy_allowed,
+                governance_gate=self._governance_gate,
                 bundle=self._bundle,
                 turn_gate=self._turn_gate,
             )

--- a/surogates/harness/tool_exec.py
+++ b/surogates/harness/tool_exec.py
@@ -28,6 +28,7 @@ from surogates.harness.tool_guardrails import (
     toolguard_synthetic_result,
 )
 from surogates.tools.coerce import coerce_tool_args
+from surogates.runtime.governance import floor_gate
 from surogates.storage.tenant import boundary_workspace_prefix
 
 # ---------------------------------------------------------------------------
@@ -1218,12 +1219,12 @@ async def execute_single_tool(
     # failure; emits ``policy.allowed`` on success only when
     # ``governance.log_allowed`` is enabled.
     from surogates.governance.events import policy_denied_event
-    from surogates.runtime.governance import floor_gate
     gate = governance_gate if governance_gate is not None else floor_gate()
+    # ``session_id`` is only read by the transparency interceptor, which
+    # is never instantiated, so it is not passed: disclosure is delivered
+    # by the channel pipeline, not by blocking tool calls.
     decision = gate.check(
-        tool_name, tool_args,
-        workspace_path=workspace_path,
-        session_id=str(session.id),
+        tool_name, tool_args, workspace_path=workspace_path,
     )
     if not decision.allowed:
         logger.warning(

--- a/surogates/harness/tool_exec.py
+++ b/surogates/harness/tool_exec.py
@@ -1210,7 +1210,7 @@ async def execute_single_tool(
     # Governance check — enforced before the tool is dispatched, for
     # every tool call.  The per-wake *governance_gate* composes the
     # platform floor (workspace path containment via AGT
-    # ExecutionSandbox, path-argument hygiene, argument checks) with the
+    # ExecutionSandbox plus path-argument hygiene) with the
     # agent's configured policy (allow/deny lists + egress) projected
     # from the runtime config.  When no gate was threaded (direct
     # callers, tests) a bare floor gate preserves the historic

--- a/surogates/harness/tool_exec.py
+++ b/surogates/harness/tool_exec.py
@@ -1218,8 +1218,8 @@ async def execute_single_tool(
     # failure; emits ``policy.allowed`` on success only when
     # ``governance.log_allowed`` is enabled.
     from surogates.governance.events import policy_denied_event
-    from surogates.governance.policy import GovernanceGate
-    gate = governance_gate if governance_gate is not None else GovernanceGate()
+    from surogates.runtime.governance import floor_gate
+    gate = governance_gate if governance_gate is not None else floor_gate()
     decision = gate.check(
         tool_name, tool_args,
         workspace_path=workspace_path,

--- a/surogates/harness/tool_exec.py
+++ b/surogates/harness/tool_exec.py
@@ -260,6 +260,7 @@ def _truncate_args(arguments: Any, limit: int = 500) -> str:
 if TYPE_CHECKING:
     from redis.asyncio import Redis
 
+    from surogates.governance.policy import GovernanceGate
     from surogates.governance.saga.orchestrator import SagaOrchestrator
     from surogates.browser.control import BrowserControlStore
     from surogates.browser.pool import BrowserPool
@@ -713,6 +714,7 @@ async def execute_tool_calls(
     media_gen: Any | None = None,
     saga: SagaOrchestrator | None = None,
     log_policy_allowed: bool = False,
+    governance_gate: GovernanceGate | None = None,
     tool_guardrails: ToolGuardrails | None = None,
     bundle: Any | None = None,
     turn_gate: Any | None = None,
@@ -769,6 +771,7 @@ async def execute_tool_calls(
             media_gen=media_gen,
             tool_guardrails=tool_guardrails,
             log_policy_allowed=log_policy_allowed,
+            governance_gate=governance_gate,
             bundle=bundle,
             turn_gate=turn_gate,
         )
@@ -800,6 +803,7 @@ async def execute_tool_calls(
         media_gen=media_gen,
         saga=saga,
         log_policy_allowed=log_policy_allowed,
+        governance_gate=governance_gate,
         tool_guardrails=tool_guardrails,
         bundle=bundle,
         turn_gate=turn_gate,
@@ -835,6 +839,7 @@ async def execute_tool_calls_sequential(
     media_gen: Any | None = None,
     saga: SagaOrchestrator | None = None,
     log_policy_allowed: bool = False,
+    governance_gate: GovernanceGate | None = None,
     tool_guardrails: ToolGuardrails | None = None,
     bundle: Any | None = None,
     turn_gate: Any | None = None,
@@ -892,6 +897,7 @@ async def execute_tool_calls_sequential(
             media_gen=media_gen,
             saga=saga,
             log_policy_allowed=log_policy_allowed,
+            governance_gate=governance_gate,
             bundle=bundle,
             turn_gate=turn_gate,
         )
@@ -944,6 +950,7 @@ async def execute_tool_calls_concurrent(
     media_gen: Any | None = None,
     tool_guardrails: ToolGuardrails | None = None,
     log_policy_allowed: bool = False,
+    governance_gate: GovernanceGate | None = None,
     bundle: Any | None = None,
     turn_gate: Any | None = None,
 ) -> list[dict]:
@@ -1007,6 +1014,7 @@ async def execute_tool_calls_concurrent(
                 media_gen=media_gen,
                 _parent_trace=parent_trace,
                 log_policy_allowed=log_policy_allowed,
+                governance_gate=governance_gate,
                 bundle=bundle,
                 turn_gate=turn_gate,
             )
@@ -1111,6 +1119,7 @@ async def execute_single_tool(
     _parent_trace: Any | None = None,
     saga: SagaOrchestrator | None = None,
     log_policy_allowed: bool = False,
+    governance_gate: GovernanceGate | None = None,
     bundle: Any | None = None,
     turn_gate: Any | None = None,
 ) -> dict:
@@ -1198,80 +1207,85 @@ async def execute_single_tool(
             "content": result_content,
         }
 
-    # Workspace sandbox check — enforced at the governance layer before
-    # the tool is dispatched.  Uses AGT ExecutionSandbox for path
-    # containment (symlink resolution, is_relative_to).  Emits a
-    # ``policy.denied`` event on failure; emits ``policy.allowed`` on
-    # success only when ``governance.log_allowed`` is enabled.
+    # Governance check — enforced before the tool is dispatched, for
+    # every tool call.  The per-wake *governance_gate* composes the
+    # platform floor (workspace path containment via AGT
+    # ExecutionSandbox, path-argument hygiene, argument checks) with the
+    # agent's configured policy (allow/deny lists + egress) projected
+    # from the runtime config.  When no gate was threaded (direct
+    # callers, tests) a bare floor gate preserves the historic
+    # sandbox-only behaviour.  Emits a ``policy.denied`` event on
+    # failure; emits ``policy.allowed`` on success only when
+    # ``governance.log_allowed`` is enabled.
     from surogates.governance.events import policy_denied_event
-    from surogates.governance.policy import GovernanceGate, _PATH_ARGUMENT_MAP
-    path_keys = _PATH_ARGUMENT_MAP.get(tool_name)
-    if workspace_path and path_keys:
-        _sandbox_gate = GovernanceGate()
-        decision = _sandbox_gate.check(
-            tool_name, tool_args, workspace_path=workspace_path,
+    from surogates.governance.policy import GovernanceGate
+    gate = governance_gate if governance_gate is not None else GovernanceGate()
+    decision = gate.check(
+        tool_name, tool_args,
+        workspace_path=workspace_path,
+        session_id=str(session.id),
+    )
+    if not decision.allowed:
+        logger.warning(
+            "Governance blocked %s for session %s: %s",
+            tool_name, session.id, decision.reason,
         )
-        if not decision.allowed:
-            logger.warning(
-                "Workspace sandbox blocked %s for session %s: %s",
-                tool_name, session.id, decision.reason,
-            )
+        await store.emit_event(
+            session.id,
+            EventType.POLICY_DENIED,
+            policy_denied_event(tool_name, decision.reason or ""),
+        )
+        if decision.overridable:
             await store.emit_event(
                 session.id,
-                EventType.POLICY_DENIED,
-                policy_denied_event(tool_name, decision.reason or ""),
-            )
-            if decision.overridable:
-                await store.emit_event(
-                    session.id,
-                    EventType.INBOX_GOVERNANCE_GATE,
-                    {
-                        "tool_name": tool_name,
-                        "tool_call_id": tool_call_id,
-                        "arguments_excerpt": _truncate_args(sanitized_args),
-                        "deny_reason": decision.reason or "",
-                        "policy_id": decision.policy_id,
-                    },
-                )
-
-            result_payload = {"error": f"Blocked: {decision.reason}"}
-            if decision.overridable:
-                result_payload["error"] = "policy_blocked_overridable"
-                result_payload["message"] = decision.reason
-                result_payload["tool_call_id"] = tool_call_id
-            result_content = json.dumps(result_payload)
-
-            result_event_id = await store.emit_event(
-                session.id,
-                EventType.TOOL_RESULT,
+                EventType.INBOX_GOVERNANCE_GATE,
                 {
+                    "tool_name": tool_name,
                     "tool_call_id": tool_call_id,
-                    "name": tool_name,
-                    "content": result_content,
-                    "elapsed_ms": 0,
+                    "arguments_excerpt": _truncate_args(sanitized_args),
+                    "deny_reason": decision.reason or "",
+                    "policy_id": decision.policy_id,
                 },
             )
-            await store.advance_harness_cursor(
-                session.id,
-                through_event_id=result_event_id,
-                lease_token=lease.lease_token,
-            )
-            return {
-                "role": "tool",
-                "tool_call_id": tool_call_id,
-                "content": result_content,
-            }
 
-        if log_policy_allowed:
-            await store.emit_event(
-                session.id,
-                EventType.POLICY_ALLOWED,
-                {
-                    "tool": tool_name,
-                    "check": "workspace_sandbox",
-                    "timestamp": time.time(),
-                },
-            )
+        result_payload = {"error": f"Blocked: {decision.reason}"}
+        if decision.overridable:
+            result_payload["error"] = "policy_blocked_overridable"
+            result_payload["message"] = decision.reason
+            result_payload["tool_call_id"] = tool_call_id
+        result_content = json.dumps(result_payload)
+
+        result_event_id = await store.emit_event(
+            session.id,
+            EventType.TOOL_RESULT,
+            {
+                "tool_call_id": tool_call_id,
+                "name": tool_name,
+                "content": result_content,
+                "elapsed_ms": 0,
+            },
+        )
+        await store.advance_harness_cursor(
+            session.id,
+            through_event_id=result_event_id,
+            lease_token=lease.lease_token,
+        )
+        return {
+            "role": "tool",
+            "tool_call_id": tool_call_id,
+            "content": result_content,
+        }
+
+    if log_policy_allowed:
+        await store.emit_event(
+            session.id,
+            EventType.POLICY_ALLOWED,
+            {
+                "tool": tool_name,
+                "check": "governance_gate",
+                "timestamp": time.time(),
+            },
+        )
 
     # --- Session tool allow-list check ---
     # When the session config declares a ``tool_allow_list``, any tool

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -26,7 +26,11 @@ from surogates.runtime.entitlements import (
     capability_allowed as _entitlement_capability_allowed,
     dimension_allowlist,
 )
-from surogates.runtime.governance import build_governance_gate
+from surogates.runtime.governance import (
+    BOARD_SELF_TOOLS,
+    WORKER_SELF_TOOLS,
+    build_governance_gate,
+)
 from surogates.harness.prompt_library import default_library as default_prompt_library
 from surogates.health import infrastructure_readiness, start_health_server
 from surogates.browser.control import BrowserControlStore
@@ -222,9 +226,7 @@ def _filter_effective_tools(
     # ``task_*`` names confused LLMs into calling them at the end of
     # plain chat turns.
     if getattr(session, "task_id", None) is None:
-        result.discard("worker_block")
-        result.discard("worker_complete")
-        result.discard("worker_context")
+        result -= WORKER_SELF_TOOLS
     else:
         # Task workers always get their self-tools, even under a
         # restrictive AgentDef allowlist (e.g. a specialist whose ``tools``
@@ -233,7 +235,7 @@ def _filter_effective_tools(
         # self-tools, not work tools subject to the allowlist — without
         # them a task worker can't hand off a structured result or read
         # its parents' output.
-        result.update({"worker_block", "worker_complete", "worker_context"})
+        result |= WORKER_SELF_TOOLS
 
     # share_note / read_board / expand_note are coordination self-tools,
     # meaningful only inside a coordination group (the spawn paths stamp
@@ -243,11 +245,9 @@ def _filter_effective_tools(
     # sessions, force-added for members even under a restrictive AgentDef
     # allowlist.
     if not (getattr(session, "config", None) or {}).get("context_group_id"):
-        result.discard("share_note")
-        result.discard("read_board")
-        result.discard("expand_note")
+        result -= BOARD_SELF_TOOLS
     else:
-        result.update({"share_note", "read_board", "expand_note"})
+        result |= BOARD_SELF_TOOLS
 
     # idea_tree / dispatch_experiments / merge_experiment are the research
     # coordinator's deterministic spine. They are present only while a

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -26,6 +26,7 @@ from surogates.runtime.entitlements import (
     capability_allowed as _entitlement_capability_allowed,
     dimension_allowlist,
 )
+from surogates.runtime.governance import build_governance_gate
 from surogates.harness.prompt_library import default_library as default_prompt_library
 from surogates.health import infrastructure_readiness, start_health_server
 from surogates.browser.control import BrowserControlStore
@@ -1964,6 +1965,10 @@ async def run_worker(settings: Settings) -> None:
             saga_enabled=settings.saga.enabled,
             saga_settings=settings.saga if settings.saga.enabled else None,
             log_policy_allowed=settings.governance.log_allowed,
+            # Per-wake enforcement gate from the agent's runtime-config
+            # governance projection (allow/deny lists + egress composed
+            # onto the platform floor, frozen).
+            governance_gate=build_governance_gate(ctx.governance),
             summary_client=(
                 summary_slot.client if summary_slot is not None else None
             ),

--- a/surogates/runtime/governance.py
+++ b/surogates/runtime/governance.py
@@ -1,0 +1,136 @@
+"""Per-agent governance profile: runtime-config projection -> gate.
+
+The management plane projects ``Agent.policy`` into the runtime-config
+``governance`` blob (``AgentRuntimeContext.governance``).  This module
+turns that raw dict into the frozen per-wake :class:`GovernanceGate`
+the tool-execution path enforces, and exposes the transparency
+(AI-disclosure) view the API and channel adapters serve.
+
+Normalization mirrors the ops-side projection
+(``agents_shared.governance_blob_from_policy``): entries that are not
+the documented shape are dropped rather than raising, because the
+worker must keep serving sessions even when a legacy or hand-edited
+blob arrives.  Dropping an entry never *widens* the policy — a
+malformed ``allowed_tools`` falls back to "no allow-list" while a
+malformed ``denied_tools`` entry is simply not matched, and the
+platform floor (workspace sandbox + argument hygiene) applies
+regardless of profile content.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from surogates.governance.policy import GovernanceGate
+
+logger = logging.getLogger(__name__)
+
+# The harness disclosure-level vocabulary.  Mirrors
+# :class:`surogates.governance.transparency.TransparencyLevel`; kept as
+# a plain set here so profile parsing does not import the interceptor
+# machinery.
+_VALID_LEVELS = {"none", "basic", "enhanced", "full"}
+
+
+def governance_profile(governance: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Normalize the runtime-config governance blob into a gate profile.
+
+    Returns the ``GovernanceGate.with_profile`` input shape
+    (``allowed_tools`` / ``denied_tools`` / ``egress``), or ``None``
+    when the agent has no enforceable profile: no blob, an explicitly
+    disabled policy (``enabled: false`` means the operator switched the
+    agent-configured rules off), or a blob with no restrictions in it.
+    """
+    if not isinstance(governance, dict) or not governance:
+        return None
+    if not governance.get("enabled", True):
+        return None
+
+    profile: dict[str, Any] = {}
+
+    allowed = governance.get("allowed_tools")
+    if isinstance(allowed, list):
+        allowed_names = [t for t in allowed if isinstance(t, str) and t]
+        if allowed_names:
+            profile["allowed_tools"] = allowed_names
+    elif allowed not in (None, []):
+        logger.warning(
+            "governance.allowed_tools has unexpected type %s; ignoring",
+            type(allowed).__name__,
+        )
+
+    denied = governance.get("denied_tools")
+    if isinstance(denied, list):
+        denied_names = [t for t in denied if isinstance(t, str) and t]
+        if denied_names:
+            profile["denied_tools"] = denied_names
+    elif denied not in (None, []):
+        logger.warning(
+            "governance.denied_tools has unexpected type %s; ignoring",
+            type(denied).__name__,
+        )
+
+    egress = governance.get("egress")
+    if isinstance(egress, dict):
+        rules = [r for r in (egress.get("rules") or []) if isinstance(r, dict)]
+        default_action = egress.get("default_action")
+        if rules or default_action == "deny":
+            profile["egress"] = {
+                "default_action": (
+                    default_action if default_action in ("allow", "deny")
+                    else "deny"
+                ),
+                "rules": rules,
+            }
+
+    return profile or None
+
+
+def build_governance_gate(
+    governance: dict[str, Any] | None,
+) -> GovernanceGate:
+    """Build the per-wake gate from an agent's governance blob.
+
+    The base gate is the platform floor — open policy, which still
+    enforces workspace-sandbox path containment, path-argument hygiene
+    and AGT argument checks.  When the agent carries an enforceable
+    profile the floor is narrowed via ``with_profile`` (allow-lists
+    intersect, deny-lists union, strictest egress default) and the
+    result is frozen for the wake; no agent configuration can relax
+    the floor.
+    """
+    from surogates.tools.router import TOOL_LOCATIONS
+
+    floor = GovernanceGate(
+        allow_list_scope=frozenset(TOOL_LOCATIONS),
+    )
+    profile = governance_profile(governance)
+    if profile is None:
+        return floor
+    return floor.with_profile(profile)
+
+
+def transparency_config(
+    governance: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Normalize the per-agent AI-disclosure block.
+
+    Returns ``{"enabled": bool, "level": str}`` with the level clamped
+    to the harness vocabulary.  Unknown levels degrade to ``basic``
+    (disclosure still shown) rather than ``none`` so a vocabulary drift
+    upstream can never silently switch disclosure off.
+    """
+    raw = (
+        governance.get("transparency")
+        if isinstance(governance, dict) else None
+    )
+    if not isinstance(raw, dict):
+        return {"enabled": False, "level": "none"}
+    enabled = bool(raw.get("enabled", False))
+    level = str(raw.get("level", "basic")).strip().lower()
+    if level not in _VALID_LEVELS:
+        level = "basic"
+    if not enabled:
+        return {"enabled": False, "level": "none"}
+    return {"enabled": True, "level": level}

--- a/surogates/runtime/governance.py
+++ b/surogates/runtime/governance.py
@@ -24,8 +24,8 @@ from typing import Any
 
 from surogates.governance.policy import GovernanceGate
 from surogates.governance.transparency import (
-    DISCLOSURE_TEXTS,
     TransparencyLevel,
+    disclosure_text_for,
 )
 
 logger = logging.getLogger(__name__)
@@ -40,28 +40,39 @@ logger = logging.getLogger(__name__)
 # state (``add_allowed``/``add_denied`` have no production callers).
 _FLOOR_GATE = GovernanceGate()
 
-# Execution-context self-tools an agent policy must not be able to take
-# away. These are not work tools: they are how a session reports its own
-# state and how a stuck one gets unstuck, and the harness already
-# force-adds the first two groups into a worker's schema even under a
-# restrictive AgentDef allowlist (see ``worker._filter_effective_tools``).
-# Letting a policy deny them would put the two layers in conflict and,
-# for the task-lifecycle pair, strand work permanently: a child that
-# called ``worker_block`` can only be resumed by the coordinator calling
-# ``unblock_task`` or ``cancel_task``, so denying those leaves the task
-# blocked forever with a single ``policy.denied`` event as the trace.
+# Execution-context self-tools: how a session reports its own state and
+# how a stuck one gets unstuck, as opposed to work tools.
 #
-# The ops catalog omits these names so Studio cannot offer them and the
-# policy validator rejects them with a clear 422; this set is the
-# runtime's own belt-and-braces for hand-written or legacy blobs.
-PROTECTED_TOOLS: frozenset[str] = frozenset({
-    # Task-worker self-reporting (force-added by the harness).
+# These are the single declaration for both layers that care.
+# ``worker._filter_effective_tools`` strips them from sessions that
+# cannot use them and force-adds them for sessions that can, even under
+# a restrictive AgentDef allowlist; the governance gate refuses to let
+# an agent policy deny them. Keeping one set means adding a fourth
+# group cannot leave the two layers disagreeing.
+WORKER_SELF_TOOLS: frozenset[str] = frozenset({
     "worker_block", "worker_complete", "worker_context",
-    # Coordination-board self-tools (force-added for group members).
+})
+BOARD_SELF_TOOLS: frozenset[str] = frozenset({
     "share_note", "read_board", "expand_note",
-    # The coordinator's only levers to resume or abandon a blocked task.
+})
+# The coordinator's only levers to resume or abandon a blocked task: a
+# child that called ``worker_block`` stays blocked forever without them,
+# so a policy that denied them would strand work with a single
+# ``policy.denied`` event as the trace.
+TASK_LIFECYCLE_TOOLS: frozenset[str] = frozenset({
     "unblock_task", "cancel_task",
 })
+
+# Tools no agent policy may take away. The ops catalog omits these names
+# so Studio cannot offer them and the policy validator rejects them with
+# a clear 422; this set is the runtime's own belt-and-braces for
+# hand-written or legacy blobs.
+PROTECTED_TOOLS: frozenset[str] = (
+    WORKER_SELF_TOOLS | BOARD_SELF_TOOLS | TASK_LIFECYCLE_TOOLS
+)
+
+# The harness disclosure-level vocabulary, straight off the enum.
+_LEVEL_VALUES = {level.value for level in TransparencyLevel}
 
 
 def floor_gate() -> GovernanceGate:
@@ -85,44 +96,22 @@ def governance_profile(governance: dict[str, Any] | None) -> dict[str, Any] | No
 
     profile: dict[str, Any] = {}
 
-    allowed = governance.get("allowed_tools")
-    if isinstance(allowed, list):
-        allowed_names = [t for t in allowed if isinstance(t, str) and t]
-        if allowed_names:
-            # An allow-list must still admit the self-tools, or a task
-            # worker cannot report its own state.
-            profile["allowed_tools"] = sorted(
-                set(allowed_names) | PROTECTED_TOOLS,
-            )
-    elif allowed not in (None, []):
-        logger.warning(
-            "governance.allowed_tools has unexpected type %s; ignoring",
-            type(allowed).__name__,
-        )
+    allowed = _tool_names(governance, "allowed_tools")
+    if allowed:
+        # An allow-list must still admit the self-tools, or a task worker
+        # cannot report its own state.
+        profile["allowed_tools"] = sorted(allowed | PROTECTED_TOOLS)
 
-    denied = governance.get("denied_tools")
-    if isinstance(denied, list):
-        denied_names = [
-            t for t in denied
-            if isinstance(t, str) and t and t not in PROTECTED_TOOLS
-        ]
-        dropped = sorted(
-            t for t in denied
-            if isinstance(t, str) and t in PROTECTED_TOOLS
-        )
-        if dropped:
-            logger.warning(
-                "governance.denied_tools names protected self-tools %s; "
-                "ignoring them (denying these strands blocked work)",
-                dropped,
-            )
-        if denied_names:
-            profile["denied_tools"] = denied_names
-    elif denied not in (None, []):
+    denied = _tool_names(governance, "denied_tools")
+    protected = denied & PROTECTED_TOOLS
+    if protected:
         logger.warning(
-            "governance.denied_tools has unexpected type %s; ignoring",
-            type(denied).__name__,
+            "governance.denied_tools names protected self-tools %s; "
+            "ignoring them (denying these strands blocked work)",
+            sorted(protected),
         )
+    if denied - PROTECTED_TOOLS:
+        profile["denied_tools"] = sorted(denied - PROTECTED_TOOLS)
 
     egress = governance.get("egress")
     if isinstance(egress, dict):
@@ -142,6 +131,24 @@ def governance_profile(governance: dict[str, Any] | None) -> dict[str, Any] | No
             }
 
     return profile or None
+
+
+def _tool_names(governance: dict[str, Any], key: str) -> set[str]:
+    """Non-empty string tool names under *key*, or an empty set.
+
+    A malformed value never widens the policy: an unusable
+    ``allowed_tools`` becomes "no allow-list" and an unusable
+    ``denied_tools`` simply matches nothing.
+    """
+    value = governance.get(key)
+    if isinstance(value, list):
+        return {t for t in value if isinstance(t, str) and t}
+    if value not in (None, []):
+        logger.warning(
+            "governance.%s has unexpected type %s; ignoring",
+            key, type(value).__name__,
+        )
+    return set()
 
 
 def build_governance_gate(
@@ -201,19 +208,18 @@ def disclosure_config(
     }
 
 
-_LEVEL_VALUES = {level.value for level in TransparencyLevel}
-
-
 def disclosure_text(level: str) -> str:
-    """The disclosure copy for a level, empty for ``none``.
+    """The disclosure copy for a level string, empty for ``none``.
 
-    Unknown levels degrade to the ``basic`` text (never to silence) for
+    Adds string normalisation and the ``none`` case on top of
+    :func:`~surogates.governance.transparency.disclosure_text_for`;
+    unknown levels degrade to the ``basic`` text (never to silence) for
     the same reason ``disclosure_config`` clamps upward.
     """
     normalized = str(level or "").strip().lower()
     if normalized == "none":
         return ""
     try:
-        return DISCLOSURE_TEXTS[TransparencyLevel(normalized)]
-    except (KeyError, ValueError):
-        return DISCLOSURE_TEXTS[TransparencyLevel.BASIC]
+        return disclosure_text_for(TransparencyLevel(normalized))
+    except ValueError:
+        return disclosure_text_for(TransparencyLevel.BASIC)

--- a/surogates/runtime/governance.py
+++ b/surogates/runtime/governance.py
@@ -30,13 +30,38 @@ from surogates.governance.transparency import (
 
 logger = logging.getLogger(__name__)
 
-# The platform floor: open policy (workspace-sandbox path containment,
-# path-argument hygiene and AGT argument checks still run).  Shared
+# The platform floor: open policy — workspace-sandbox path containment
+# and path-argument hygiene still run.  (The AGT engine's dangerous-code
+# screening keys off tool names this harness does not use, so treat the
+# floor as path containment only, not command screening.)  Shared
 # across wakes and used as the tool-path fallback so the per-workspace
 # ExecutionSandbox cache is actually effective — the gate documents its
 # sandbox cache as thread-safe, and the floor carries no mutable policy
 # state (``add_allowed``/``add_denied`` have no production callers).
 _FLOOR_GATE = GovernanceGate()
+
+# Execution-context self-tools an agent policy must not be able to take
+# away. These are not work tools: they are how a session reports its own
+# state and how a stuck one gets unstuck, and the harness already
+# force-adds the first two groups into a worker's schema even under a
+# restrictive AgentDef allowlist (see ``worker._filter_effective_tools``).
+# Letting a policy deny them would put the two layers in conflict and,
+# for the task-lifecycle pair, strand work permanently: a child that
+# called ``worker_block`` can only be resumed by the coordinator calling
+# ``unblock_task`` or ``cancel_task``, so denying those leaves the task
+# blocked forever with a single ``policy.denied`` event as the trace.
+#
+# The ops catalog omits these names so Studio cannot offer them and the
+# policy validator rejects them with a clear 422; this set is the
+# runtime's own belt-and-braces for hand-written or legacy blobs.
+PROTECTED_TOOLS: frozenset[str] = frozenset({
+    # Task-worker self-reporting (force-added by the harness).
+    "worker_block", "worker_complete", "worker_context",
+    # Coordination-board self-tools (force-added for group members).
+    "share_note", "read_board", "expand_note",
+    # The coordinator's only levers to resume or abandon a blocked task.
+    "unblock_task", "cancel_task",
+})
 
 
 def floor_gate() -> GovernanceGate:
@@ -64,7 +89,11 @@ def governance_profile(governance: dict[str, Any] | None) -> dict[str, Any] | No
     if isinstance(allowed, list):
         allowed_names = [t for t in allowed if isinstance(t, str) and t]
         if allowed_names:
-            profile["allowed_tools"] = allowed_names
+            # An allow-list must still admit the self-tools, or a task
+            # worker cannot report its own state.
+            profile["allowed_tools"] = sorted(
+                set(allowed_names) | PROTECTED_TOOLS,
+            )
     elif allowed not in (None, []):
         logger.warning(
             "governance.allowed_tools has unexpected type %s; ignoring",
@@ -73,7 +102,20 @@ def governance_profile(governance: dict[str, Any] | None) -> dict[str, Any] | No
 
     denied = governance.get("denied_tools")
     if isinstance(denied, list):
-        denied_names = [t for t in denied if isinstance(t, str) and t]
+        denied_names = [
+            t for t in denied
+            if isinstance(t, str) and t and t not in PROTECTED_TOOLS
+        ]
+        dropped = sorted(
+            t for t in denied
+            if isinstance(t, str) and t in PROTECTED_TOOLS
+        )
+        if dropped:
+            logger.warning(
+                "governance.denied_tools names protected self-tools %s; "
+                "ignoring them (denying these strands blocked work)",
+                dropped,
+            )
         if denied_names:
             profile["denied_tools"] = denied_names
     elif denied not in (None, []):

--- a/surogates/runtime/governance.py
+++ b/surogates/runtime/governance.py
@@ -3,8 +3,8 @@
 The management plane projects ``Agent.policy`` into the runtime-config
 ``governance`` blob (``AgentRuntimeContext.governance``).  This module
 turns that raw dict into the frozen per-wake :class:`GovernanceGate`
-the tool-execution path enforces, and exposes the transparency
-(AI-disclosure) view the API and channel adapters serve.
+the tool-execution path enforces, and exposes the AI-disclosure view
+the API and channel adapters serve.
 
 Normalization mirrors the ops-side projection
 (``agents_shared.governance_blob_from_policy``): entries that are not
@@ -23,14 +23,25 @@ import logging
 from typing import Any
 
 from surogates.governance.policy import GovernanceGate
+from surogates.governance.transparency import (
+    DISCLOSURE_TEXTS,
+    TransparencyLevel,
+)
 
 logger = logging.getLogger(__name__)
 
-# The harness disclosure-level vocabulary.  Mirrors
-# :class:`surogates.governance.transparency.TransparencyLevel`; kept as
-# a plain set here so profile parsing does not import the interceptor
-# machinery.
-_VALID_LEVELS = {"none", "basic", "enhanced", "full"}
+# The platform floor: open policy (workspace-sandbox path containment,
+# path-argument hygiene and AGT argument checks still run).  Shared
+# across wakes and used as the tool-path fallback so the per-workspace
+# ExecutionSandbox cache is actually effective — the gate documents its
+# sandbox cache as thread-safe, and the floor carries no mutable policy
+# state (``add_allowed``/``add_denied`` have no production callers).
+_FLOOR_GATE = GovernanceGate()
+
+
+def floor_gate() -> GovernanceGate:
+    """The shared platform-floor gate (no agent-configured rules)."""
+    return _FLOOR_GATE
 
 
 def governance_profile(governance: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -75,6 +86,10 @@ def governance_profile(governance: dict[str, Any] | None) -> dict[str, Any] | No
     if isinstance(egress, dict):
         rules = [r for r in (egress.get("rules") or []) if isinstance(r, dict)]
         default_action = egress.get("default_action")
+        # Restriction detection only — ``with_profile`` owns the actual
+        # egress semantics (including materialising a policy for a bare
+        # deny default); this mirrors its activation condition so a
+        # restriction-free blob composes no gate at all.
         if rules or default_action == "deny":
             profile["egress"] = {
                 "default_action": (
@@ -92,73 +107,67 @@ def build_governance_gate(
 ) -> GovernanceGate:
     """Build the per-wake gate from an agent's governance blob.
 
-    The base gate is the platform floor — open policy, which still
-    enforces workspace-sandbox path containment, path-argument hygiene
-    and AGT argument checks.  When the agent carries an enforceable
-    profile the floor is narrowed via ``with_profile`` (allow-lists
-    intersect, deny-lists union, strictest egress default) and the
-    result is frozen for the wake; no agent configuration can relax
-    the floor.
+    The base gate is the shared platform floor.  When the agent carries
+    an enforceable profile the floor is narrowed via ``with_profile``
+    (allow-lists intersect, deny-lists union, strictest egress default)
+    and the result is frozen for the wake; no agent configuration can
+    relax the floor.  Agents without a profile share the floor gate
+    directly — cheap, and it keeps the workspace sandbox cache warm
+    across wakes.
     """
-    from surogates.tools.router import TOOL_LOCATIONS
-
-    floor = GovernanceGate(
-        allow_list_scope=frozenset(TOOL_LOCATIONS),
-    )
     profile = governance_profile(governance)
     if profile is None:
-        return floor
-    return floor.with_profile(profile)
+        return _FLOOR_GATE
+    return _FLOOR_GATE.with_profile(profile)
 
 
-def transparency_config(
+def disclosure_config(
     governance: dict[str, Any] | None,
-) -> dict[str, Any]:
-    """Normalize the per-agent AI-disclosure block.
+) -> dict[str, Any] | None:
+    """The agent's explicit AI-disclosure config, or ``None``.
 
-    Returns ``{"enabled": bool, "level": str}`` with the level clamped
-    to the harness vocabulary.  Unknown levels degrade to ``basic``
-    (disclosure still shown) rather than ``none`` so a vocabulary drift
-    upstream can never silently switch disclosure off.
+    ``None`` means "nothing explicitly configured" — callers fall back
+    to the deployment-wide setting.  That covers a missing/malformed
+    transparency block AND a policy whose master switch is off
+    (``enabled: false``): Studio presents one master toggle over the
+    whole governance section, so a switched-off policy must not keep
+    disclosing behind the operator's back — it falls back to the
+    deployment default like an unconfigured agent.
+
+    Otherwise returns ``{"enabled", "level", "text"}`` with the level
+    clamped to the harness vocabulary.  Unknown levels degrade to
+    ``basic`` (disclosure still shown) rather than ``none`` so a
+    vocabulary drift upstream can never silently switch disclosure off.
+    An explicitly disabled block returns
+    ``{"enabled": False, "level": "none", "text": ""}`` — the agent
+    config beats the deployment fallback in both directions.
     """
-    raw = (
-        governance.get("transparency")
-        if isinstance(governance, dict) else None
-    )
+    if not isinstance(governance, dict):
+        return None
+    if not governance.get("enabled", True):
+        return None
+    raw = governance.get("transparency")
     if not isinstance(raw, dict):
-        return {"enabled": False, "level": "none"}
-    enabled = bool(raw.get("enabled", False))
+        return None
+    if not raw.get("enabled", False):
+        return {"enabled": False, "level": "none", "text": ""}
     level = str(raw.get("level", "basic")).strip().lower()
-    if level not in _VALID_LEVELS:
-        level = "basic"
-    if not enabled:
-        return {"enabled": False, "level": "none"}
-    return {"enabled": True, "level": level}
+    return {
+        "enabled": True,
+        "level": level if level in _LEVEL_VALUES else "basic",
+        "text": disclosure_text(level),
+    }
 
 
-def has_transparency_config(governance: dict[str, Any] | None) -> bool:
-    """True when the agent carries an explicit transparency block.
-
-    Distinguishes "the operator configured disclosure (possibly off)"
-    from "nothing configured" — the latter falls back to the
-    deployment-wide default, the former always wins.
-    """
-    return isinstance(governance, dict) and isinstance(
-        governance.get("transparency"), dict,
-    )
+_LEVEL_VALUES = {level.value for level in TransparencyLevel}
 
 
 def disclosure_text(level: str) -> str:
-    """The disclosure copy for a level, empty for ``none``/unknown-off.
+    """The disclosure copy for a level, empty for ``none``.
 
     Unknown levels degrade to the ``basic`` text (never to silence) for
-    the same reason ``transparency_config`` clamps upward.
+    the same reason ``disclosure_config`` clamps upward.
     """
-    from surogates.governance.transparency import (
-        DISCLOSURE_TEXTS,
-        TransparencyLevel,
-    )
-
     normalized = str(level or "").strip().lower()
     if normalized == "none":
         return ""

--- a/surogates/runtime/governance.py
+++ b/surogates/runtime/governance.py
@@ -134,3 +134,35 @@ def transparency_config(
     if not enabled:
         return {"enabled": False, "level": "none"}
     return {"enabled": True, "level": level}
+
+
+def has_transparency_config(governance: dict[str, Any] | None) -> bool:
+    """True when the agent carries an explicit transparency block.
+
+    Distinguishes "the operator configured disclosure (possibly off)"
+    from "nothing configured" — the latter falls back to the
+    deployment-wide default, the former always wins.
+    """
+    return isinstance(governance, dict) and isinstance(
+        governance.get("transparency"), dict,
+    )
+
+
+def disclosure_text(level: str) -> str:
+    """The disclosure copy for a level, empty for ``none``/unknown-off.
+
+    Unknown levels degrade to the ``basic`` text (never to silence) for
+    the same reason ``transparency_config`` clamps upward.
+    """
+    from surogates.governance.transparency import (
+        DISCLOSURE_TEXTS,
+        TransparencyLevel,
+    )
+
+    normalized = str(level or "").strip().lower()
+    if normalized == "none":
+        return ""
+    try:
+        return DISCLOSURE_TEXTS[TransparencyLevel(normalized)]
+    except (KeyError, ValueError):
+        return DISCLOSURE_TEXTS[TransparencyLevel.BASIC]

--- a/surogates/runtime/resolver.py
+++ b/surogates/runtime/resolver.py
@@ -155,6 +155,30 @@ async def _resolve_slug_to_agent_id(
     return await cache.get(slug)
 
 
+async def resolve_agent_id_soft(request: Request) -> str | None:
+    """Resolve the target agent id from a request, or ``None``.
+
+    The single home of the resolution order (highest precedence first):
+
+    1. ``?agent_id=<id>`` query parameter — explicit, used by Studio
+       and admin tools.
+    2. ``Host`` header subdomain (slug -> agent_id via the cache),
+       skipping the reserved non-agent subdomains.
+
+    Never raises on "not resolvable" — callers choose whether that is
+    a 400 (:func:`agent_runtime_context_dep`) or a graceful fallback
+    (the public transparency endpoint).
+    """
+    agent_id = request.query_params.get("agent_id")
+    if agent_id:
+        return agent_id
+    host = request.headers.get("host", "")
+    slug = host.split(".", 1)[0] if "." in host else None
+    if slug and slug.lower() not in {"www", "api", "localhost"}:
+        return await _resolve_slug_to_agent_id(request, slug)
+    return None
+
+
 async def agent_runtime_context_dep(request: Request) -> AgentRuntimeContext:
     """Resolve the per-request :class:`AgentRuntimeContext`.
 
@@ -172,14 +196,7 @@ async def agent_runtime_context_dep(request: Request) -> AgentRuntimeContext:
       "administratively stopped".  This is the lifecycle gate the
       management plane flips on ``stop_agent``.
     """
-    agent_id = request.query_params.get("agent_id")
-
-    if not agent_id:
-        host = request.headers.get("host", "")
-        slug = host.split(".", 1)[0] if "." in host else None
-        if slug and slug.lower() not in {"www", "api", "localhost"}:
-            agent_id = await _resolve_slug_to_agent_id(request, slug)
-
+    agent_id = await resolve_agent_id_soft(request)
     if not agent_id:
         raise HTTPException(400, "no agent_id in request")
 

--- a/surogates/session/events.py
+++ b/surogates/session/events.py
@@ -183,6 +183,12 @@ class EventType(str, Enum):
     POLICY_ALLOWED = "policy.allowed"
     POLICY_DENIED = "policy.denied"
 
+    # AI-disclosure audit trail (EU AI Act Art. 50): the disclosure was
+    # delivered on a channel / acknowledged by the end-user.  Persisted
+    # in the event log so deployers can evidence compliance per session.
+    DISCLOSURE_PRESENTED = "disclosure.presented"
+    DISCLOSURE_CONFIRMED = "disclosure.confirmed"
+
     # General user feedback on an llm.response (not expert.result — that is
     # rated via EXPERT_ENDORSE / EXPERT_OVERRIDE).  Emitted by the feedback
     # endpoint and consumed by training-data selection to filter trajectories

--- a/tests/runtime/test_governance_contract.py
+++ b/tests/runtime/test_governance_contract.py
@@ -1,0 +1,94 @@
+"""Consumer half of the governance wire contract.
+
+The producer half lives in the surogate-ops repo
+(``tests/test_governance_end_to_end.py``) and asserts that a policy
+saved in Studio projects to exactly the blob below. This file asserts
+the same blob actually enforces at runtime, so the two repos cannot
+drift apart without one of them failing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from surogates.runtime.governance import (
+    build_governance_gate,
+    disclosure_config,
+)
+from surogates.tools.router import TOOL_LOCATIONS
+
+
+# Mirrored from the producer test. Any shape change must land in both.
+CANONICAL_BLOB = {
+    "enabled": True,
+    "allowed_tools": [],
+    "denied_tools": ["terminal"],
+    "egress": {
+        "default_action": "deny",
+        "rules": [{
+            "domain": "api.example.com",
+            "ports": [443],
+            "protocol": "tcp",
+            "action": "allow",
+        }],
+    },
+    "transparency": {"enabled": True, "level": "full"},
+}
+
+
+def test_canonical_blob_denies_the_denied_tool():
+    gate = build_governance_gate(CANONICAL_BLOB)
+    assert not gate.check("terminal", {"command": "ls"}).allowed
+    assert gate.check("read_file", {"path": "notes.md"}).allowed
+
+
+def test_canonical_blob_enforces_its_egress_rules():
+    gate = build_governance_gate(CANONICAL_BLOB)
+    assert gate.check(
+        "web_extract", {"url": "https://api.example.com/x"},
+    ).allowed
+    assert not gate.check(
+        "web_extract", {"url": "https://elsewhere.example.org/x"},
+    ).allowed
+
+
+def test_canonical_blob_yields_a_disclosure_notice():
+    cfg = disclosure_config(CANONICAL_BLOB)
+    assert cfg["enabled"] is True
+    assert cfg["level"] == "full"
+    assert cfg["text"]
+
+
+def test_allow_list_blob_blocks_everything_unlisted():
+    gate = build_governance_gate({
+        "enabled": True,
+        "allowed_tools": ["read_file", "write_file"],
+        "denied_tools": [],
+    })
+    assert gate.check("read_file", {"path": "a"}).allowed
+    assert not gate.check("terminal", {"command": "ls"}).allowed
+    assert not gate.check("generate_image", {"prompt": "x"}).allowed
+    # MCP tools answer to server attachment + entitlements, not this list.
+    assert gate.check("mcp__srv__tool", {}).allowed
+
+
+def test_master_switch_off_drops_agent_rules_but_keeps_the_floor(tmp_path):
+    """``enabled: false`` means "no agent rules", not "no governance"."""
+    gate = build_governance_gate({
+        "enabled": False, "denied_tools": ["terminal"],
+    })
+    assert gate.check("terminal", {"command": "ls"}).allowed
+    assert not gate.check(
+        "read_file", {"path": "/etc/passwd"}, workspace_path=str(tmp_path),
+    ).allowed
+
+
+@pytest.mark.parametrize("tool", sorted(TOOL_LOCATIONS))
+def test_every_runtime_tool_can_actually_be_denied(tool: str):
+    """Whatever Studio can name, the gate must be able to block.
+
+    Studio's catalog is pinned to this same table on the ops side, so
+    together the two tests mean: every offerable deny rule enforces.
+    """
+    gate = build_governance_gate({"enabled": True, "denied_tools": [tool]})
+    assert not gate.check(tool, {}).allowed

--- a/tests/runtime/test_governance_contract.py
+++ b/tests/runtime/test_governance_contract.py
@@ -12,13 +12,17 @@ from __future__ import annotations
 import pytest
 
 from surogates.runtime.governance import (
+    PROTECTED_TOOLS,
     build_governance_gate,
     disclosure_config,
 )
-from surogates.tools.router import TOOL_LOCATIONS
 
 
-# Mirrored from the producer test. Any shape change must land in both.
+# Mirrored from the producer test, together with the contract id both
+# halves assert — editing the literal on one side only now fails here.
+GOVERNANCE_CONTRACT_ID = "governance-blob/v1"
+
+
 CANONICAL_BLOB = {
     "enabled": True,
     "allowed_tools": [],
@@ -34,6 +38,10 @@ CANONICAL_BLOB = {
     },
     "transparency": {"enabled": True, "level": "full"},
 }
+
+
+def test_contract_id_matches_the_producer():
+    assert GOVERNANCE_CONTRACT_ID == "governance-blob/v1"
 
 
 def test_canonical_blob_denies_the_denied_tool():
@@ -83,12 +91,54 @@ def test_master_switch_off_drops_agent_rules_but_keeps_the_floor(tmp_path):
     ).allowed
 
 
-@pytest.mark.parametrize("tool", sorted(TOOL_LOCATIONS))
-def test_every_runtime_tool_can_actually_be_denied(tool: str):
-    """Whatever Studio can name, the gate must be able to block.
+@pytest.mark.parametrize(
+    "tool", ["terminal", "web_extract", "generate_image", "user_reports"],
+)
+def test_representative_tools_can_be_denied(tool: str):
+    """Deny is set membership, so a few representatives suffice.
 
-    Studio's catalog is pinned to this same table on the ops side, so
-    together the two tests mean: every offerable deny rule enforces.
+    The exhaustive version of this test was tautological (it passed for
+    invented names too); what actually needs pinning is the *set* of
+    governable names, which the ops catalog-parity test owns.
     """
     gate = build_governance_gate({"enabled": True, "denied_tools": [tool]})
     assert not gate.check(tool, {}).allowed
+
+
+@pytest.mark.parametrize("tool", sorted(PROTECTED_TOOLS))
+def test_protected_self_tools_cannot_be_denied(tool: str):
+    """A policy must not be able to strand a session.
+
+    Denying ``unblock_task``/``cancel_task`` would leave a child that
+    called ``worker_block`` blocked forever, and denying the
+    ``worker_*``/board self-tools contradicts the harness, which
+    force-adds them into a worker's schema regardless of the AgentDef
+    allowlist.
+    """
+    gate = build_governance_gate({"enabled": True, "denied_tools": [tool]})
+    assert gate.check(tool, {}).allowed
+
+
+@pytest.mark.parametrize("tool", sorted(PROTECTED_TOOLS))
+def test_protected_self_tools_survive_an_allow_list(tool: str):
+    gate = build_governance_gate({
+        "enabled": True, "allowed_tools": ["read_file"],
+    })
+    assert gate.check(tool, {}).allowed
+    # The allow-list still bites for ordinary tools.
+    assert not gate.check("terminal", {"command": "ls"}).allowed
+
+
+def test_protected_tools_are_all_real_registered_tools():
+    """The protected set must name tools that actually exist.
+
+    A typo here would silently protect nothing, so pin it against a
+    fully built registry rather than a hand-maintained list.
+    """
+    from surogates.tools.registry import ToolRegistry
+    from surogates.tools.runtime import ToolRuntime
+
+    registry = ToolRegistry()
+    ToolRuntime(registry).register_builtins()
+    unknown = sorted(PROTECTED_TOOLS - set(registry.tool_names))
+    assert not unknown, f"PROTECTED_TOOLS names unregistered tools: {unknown}"

--- a/tests/runtime/test_governance_contract.py
+++ b/tests/runtime/test_governance_contract.py
@@ -9,6 +9,9 @@ drift apart without one of them failing.
 
 from __future__ import annotations
 
+import hashlib
+import json
+
 import pytest
 
 from surogates.runtime.governance import (
@@ -21,6 +24,9 @@ from surogates.runtime.governance import (
 # Mirrored from the producer test, together with the contract id both
 # halves assert — editing the literal on one side only now fails here.
 GOVERNANCE_CONTRACT_ID = "governance-blob/v1"
+# First 16 hex chars of sha256 over the sorted-key JSON of CANONICAL_BLOB,
+# recorded identically in the producer test.
+CANONICAL_BLOB_DIGEST = "fe4aea33015b61b5"
 
 
 CANONICAL_BLOB = {
@@ -40,8 +46,19 @@ CANONICAL_BLOB = {
 }
 
 
-def test_contract_id_matches_the_producer():
-    assert GOVERNANCE_CONTRACT_ID == "governance-blob/v1"
+def test_contract_digest_matches_the_producer():
+    """Pin the blob's content, not just its name.
+
+    Both repos record this digest, so editing the mirrored literal on one
+    side only fails there — a bare ``id == id`` assertion could not catch
+    that.
+    """
+    digest = hashlib.sha256(
+        json.dumps(CANONICAL_BLOB, sort_keys=True).encode(),
+    ).hexdigest()
+    assert (GOVERNANCE_CONTRACT_ID, digest[:16]) == (
+        "governance-blob/v1", CANONICAL_BLOB_DIGEST,
+    )
 
 
 def test_canonical_blob_denies_the_denied_tool():

--- a/tests/runtime/test_governance_profile.py
+++ b/tests/runtime/test_governance_profile.py
@@ -24,8 +24,9 @@ import pytest
 from surogates.harness.tool_exec import execute_single_tool
 from surogates.runtime.governance import (
     build_governance_gate,
+    disclosure_config,
+    floor_gate,
     governance_profile,
-    transparency_config,
 )
 from surogates.session.events import EventType
 from surogates.tools.registry import ToolRegistry, ToolSchema
@@ -157,31 +158,52 @@ def test_gate_floor_workspace_containment_survives_profile(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# transparency_config
+# disclosure_config
 # ---------------------------------------------------------------------------
 
 
-def test_transparency_defaults_off():
-    assert transparency_config(None) == {"enabled": False, "level": "none"}
-    assert transparency_config({}) == {"enabled": False, "level": "none"}
+def test_disclosure_none_when_not_explicitly_configured():
+    assert disclosure_config(None) is None
+    assert disclosure_config({}) is None
+    assert disclosure_config({"enabled": True}) is None
 
 
-def test_transparency_disabled_reports_level_none():
-    assert transparency_config(
+def test_disclosure_none_when_policy_master_switch_off():
+    # Studio's master toggle covers the whole governance section — a
+    # switched-off policy falls back to the deployment default instead
+    # of keeping the agent-level disclosure alive behind it.
+    assert disclosure_config({
+        "enabled": False,
+        "transparency": {"enabled": True, "level": "full"},
+    }) is None
+
+
+def test_disclosure_explicit_disabled_beats_fallback():
+    assert disclosure_config(
         {"transparency": {"enabled": False, "level": "full"}},
-    ) == {"enabled": False, "level": "none"}
+    ) == {"enabled": False, "level": "none", "text": ""}
 
 
-def test_transparency_unknown_level_degrades_to_basic_not_none():
-    assert transparency_config(
+def test_disclosure_unknown_level_degrades_to_basic_not_none():
+    cfg = disclosure_config(
         {"transparency": {"enabled": True, "level": "partial"}},
-    ) == {"enabled": True, "level": "basic"}
+    )
+    assert cfg["enabled"] is True
+    assert cfg["level"] == "basic"
+    assert cfg["text"]
 
 
-def test_transparency_valid_level_passes_through():
-    assert transparency_config(
+def test_disclosure_valid_level_passes_through_with_text():
+    cfg = disclosure_config(
         {"transparency": {"enabled": True, "level": "full"}},
-    ) == {"enabled": True, "level": "full"}
+    )
+    assert cfg == {"enabled": True, "level": "full", "text": cfg["text"]}
+    assert "Art. 50" in cfg["text"]
+
+
+def test_gate_without_profile_is_shared_floor():
+    assert build_governance_gate(None) is floor_gate()
+    assert build_governance_gate({"enabled": True}) is floor_gate()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/runtime/test_governance_profile.py
+++ b/tests/runtime/test_governance_profile.py
@@ -55,13 +55,18 @@ def test_profile_no_restrictions_is_none():
 
 
 def test_profile_normalises_lists_and_drops_garbage():
+    from surogates.runtime.governance import PROTECTED_TOOLS
+
     profile = governance_profile({
         "enabled": True,
         "allowed_tools": ["read_file", 42, ""],
         "denied_tools": "terminal",          # wrong type: ignored
         "egress": {"default_action": "allow", "rules": []},  # no-op egress
     })
-    assert profile == {"allowed_tools": ["read_file"]}
+    # Non-string / empty entries are dropped; the execution-context
+    # self-tools are added so an allow-list cannot strand a worker.
+    assert set(profile) == {"allowed_tools"}
+    assert set(profile["allowed_tools"]) == {"read_file"} | PROTECTED_TOOLS
 
 
 def test_profile_keeps_deny_default_egress_without_rules():

--- a/tests/runtime/test_governance_profile.py
+++ b/tests/runtime/test_governance_profile.py
@@ -1,0 +1,300 @@
+"""Per-agent governance profile: projection parsing + gate enforcement.
+
+Covers the chain that makes the runtime-config ``governance`` blob real:
+
+* ``governance_profile`` — normalisation of the raw blob (fail-safe on
+  malformed input, disabled policies, empty profiles);
+* ``build_governance_gate`` — floor composition (allow-list scope so
+  MCP tools are not caught by a built-in allow-list, egress deny-all,
+  frozen profile gates, unconditional workspace floor);
+* ``transparency_config`` — disclosure-level clamping;
+* ``execute_single_tool`` enforcement — a threaded gate denies before
+  dispatch, emits ``policy.denied``, and returns the refusal to the LLM.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from surogates.harness.tool_exec import execute_single_tool
+from surogates.runtime.governance import (
+    build_governance_gate,
+    governance_profile,
+    transparency_config,
+)
+from surogates.session.events import EventType
+from surogates.tools.registry import ToolRegistry, ToolSchema
+
+
+# ---------------------------------------------------------------------------
+# governance_profile
+# ---------------------------------------------------------------------------
+
+
+def test_profile_none_and_empty_blob():
+    assert governance_profile(None) is None
+    assert governance_profile({}) is None
+
+
+def test_profile_disabled_policy_is_none():
+    assert governance_profile(
+        {"enabled": False, "denied_tools": ["terminal"]},
+    ) is None
+
+
+def test_profile_no_restrictions_is_none():
+    assert governance_profile(
+        {"enabled": True, "allowed_tools": [], "denied_tools": []},
+    ) is None
+
+
+def test_profile_normalises_lists_and_drops_garbage():
+    profile = governance_profile({
+        "enabled": True,
+        "allowed_tools": ["read_file", 42, ""],
+        "denied_tools": "terminal",          # wrong type: ignored
+        "egress": {"default_action": "allow", "rules": []},  # no-op egress
+    })
+    assert profile == {"allowed_tools": ["read_file"]}
+
+
+def test_profile_keeps_deny_default_egress_without_rules():
+    profile = governance_profile({
+        "enabled": True,
+        "egress": {"default_action": "deny", "rules": []},
+    })
+    assert profile == {"egress": {"default_action": "deny", "rules": []}}
+
+
+def test_profile_clamps_unknown_egress_default_to_deny():
+    profile = governance_profile({
+        "enabled": True,
+        "egress": {
+            "default_action": "alow",     # typo must not widen
+            "rules": [{"domain": "api.example.com", "action": "allow"}],
+        },
+    })
+    assert profile["egress"]["default_action"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# build_governance_gate
+# ---------------------------------------------------------------------------
+
+
+def test_gate_denies_denied_tool_and_is_frozen():
+    gate = build_governance_gate(
+        {"enabled": True, "denied_tools": ["terminal"]},
+    )
+    assert gate.is_frozen
+    decision = gate.check("terminal", {"command": "ls"})
+    assert not decision.allowed
+    assert gate.check("read_file", {"path": "notes.md"}).allowed
+
+
+def test_gate_allow_list_scopes_to_builtin_tools():
+    gate = build_governance_gate(
+        {"enabled": True, "allowed_tools": ["read_file"]},
+    )
+    assert gate.check("read_file", {"path": "x"}).allowed
+    assert not gate.check("terminal", {"command": "ls"}).allowed
+    assert not gate.check("web_search", {"query": "q"}).allowed
+    # MCP tools are governed by server attachment + entitlements, not by
+    # the built-in allow-list — they must pass the role gate.
+    assert gate.check("mcp__github__list_issues", {}).allowed
+
+
+def test_gate_egress_deny_all_blocks_urls():
+    gate = build_governance_gate({
+        "enabled": True,
+        "egress": {"default_action": "deny", "rules": []},
+    })
+    decision = gate.check("web_extract", {"url": "https://example.com"})
+    assert not decision.allowed
+    assert "Egress policy violation" in decision.reason
+
+
+def test_gate_egress_allow_rule_passes_matching_domain():
+    gate = build_governance_gate({
+        "enabled": True,
+        "egress": {
+            "default_action": "deny",
+            "rules": [{
+                "domain": "api.example.com", "ports": [443],
+                "protocol": "tcp", "action": "allow",
+            }],
+        },
+    })
+    assert gate.check(
+        "web_extract", {"url": "https://api.example.com/v1"},
+    ).allowed
+    assert not gate.check(
+        "web_extract", {"url": "https://evil.example.net/"},
+    ).allowed
+
+
+def test_gate_disabled_profile_falls_back_to_floor():
+    gate = build_governance_gate(
+        {"enabled": False, "denied_tools": ["terminal"]},
+    )
+    assert gate.check("terminal", {"command": "ls"}).allowed
+
+
+def test_gate_floor_workspace_containment_survives_profile(tmp_path):
+    gate = build_governance_gate(
+        {"enabled": True, "denied_tools": ["terminal"]},
+    )
+    decision = gate.check(
+        "read_file", {"path": "/etc/passwd"},
+        workspace_path=str(tmp_path),
+    )
+    assert not decision.allowed
+
+
+# ---------------------------------------------------------------------------
+# transparency_config
+# ---------------------------------------------------------------------------
+
+
+def test_transparency_defaults_off():
+    assert transparency_config(None) == {"enabled": False, "level": "none"}
+    assert transparency_config({}) == {"enabled": False, "level": "none"}
+
+
+def test_transparency_disabled_reports_level_none():
+    assert transparency_config(
+        {"transparency": {"enabled": False, "level": "full"}},
+    ) == {"enabled": False, "level": "none"}
+
+
+def test_transparency_unknown_level_degrades_to_basic_not_none():
+    assert transparency_config(
+        {"transparency": {"enabled": True, "level": "partial"}},
+    ) == {"enabled": True, "level": "basic"}
+
+
+def test_transparency_valid_level_passes_through():
+    assert transparency_config(
+        {"transparency": {"enabled": True, "level": "full"}},
+    ) == {"enabled": True, "level": "full"}
+
+
+# ---------------------------------------------------------------------------
+# execute_single_tool enforcement
+# ---------------------------------------------------------------------------
+
+
+_ids = iter(range(1, 10_000))
+
+
+def _make_registry(name: str = "terminal") -> tuple[ToolRegistry, AsyncMock]:
+    registry = ToolRegistry()
+    handler = AsyncMock(return_value='{"status": "ok"}')
+    registry.register(
+        name,
+        ToolSchema(
+            name=name,
+            description="test tool",
+            parameters={
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+            },
+        ),
+        handler=handler,
+    )
+    return registry, handler
+
+
+def _make_session() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(), config={}, agent_id="test-agent", model="gpt-4o",
+    )
+
+
+def _make_store() -> AsyncMock:
+    store = AsyncMock()
+    store.emit_event = AsyncMock(side_effect=lambda *a, **k: next(_ids))
+    store.advance_harness_cursor = AsyncMock()
+    return store
+
+
+@pytest.mark.asyncio
+async def test_threaded_gate_denies_before_dispatch():
+    registry, handler = _make_registry("terminal")
+    store = _make_store()
+    gate = build_governance_gate(
+        {"enabled": True, "denied_tools": ["terminal"]},
+    )
+
+    result = await execute_single_tool(
+        {
+            "id": "tc_1",
+            "function": {"name": "terminal", "arguments": '{"command": "ls"}'},
+        },
+        session=_make_session(),
+        lease=SimpleNamespace(lease_token=uuid4()),
+        store=store,
+        tools=registry,
+        tenant=MagicMock(asset_root="/tmp/test"),
+        governance_gate=gate,
+    )
+
+    handler.assert_not_awaited()
+    denied = [
+        c for c in store.emit_event.call_args_list
+        if c.args[1] is EventType.POLICY_DENIED
+    ]
+    assert denied, "policy.denied was never emitted"
+    assert denied[0].args[2]["tool"] == "terminal"
+    payload = json.loads(result["content"])
+    assert "Blocked" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_threaded_gate_allows_and_dispatches():
+    registry, handler = _make_registry("terminal")
+    store = _make_store()
+    gate = build_governance_gate(
+        {"enabled": True, "denied_tools": ["web_search"]},
+    )
+
+    result = await execute_single_tool(
+        {
+            "id": "tc_1",
+            "function": {"name": "terminal", "arguments": '{"command": "ls"}'},
+        },
+        session=_make_session(),
+        lease=SimpleNamespace(lease_token=uuid4()),
+        store=store,
+        tools=registry,
+        tenant=MagicMock(asset_root="/tmp/test"),
+        governance_gate=gate,
+    )
+
+    handler.assert_awaited()
+    assert json.loads(result["content"])["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_no_gate_preserves_open_behaviour():
+    registry, handler = _make_registry("terminal")
+    store = _make_store()
+
+    await execute_single_tool(
+        {
+            "id": "tc_1",
+            "function": {"name": "terminal", "arguments": '{"command": "ls"}'},
+        },
+        session=_make_session(),
+        lease=SimpleNamespace(lease_token=uuid4()),
+        store=store,
+        tools=registry,
+        tenant=MagicMock(asset_root="/tmp/test"),
+    )
+
+    handler.assert_awaited()

--- a/tests/runtime/test_transparency_disclosure.py
+++ b/tests/runtime/test_transparency_disclosure.py
@@ -122,6 +122,24 @@ def test_unknown_agent_falls_back_not_errors():
     }
 
 
+def test_master_switch_off_falls_back_to_deployment():
+    client = _make_client(
+        payloads={
+            "agent-1": {
+                "governance": {
+                    "enabled": False,
+                    "transparency": {"enabled": True, "level": "full"},
+                },
+            },
+        },
+        deployment_enabled=True,
+        deployment_level="basic",
+    )
+    body = client.get("/transparency?agent_id=agent-1").json()
+    assert body["enabled"] is True
+    assert body["level"] == "basic"
+
+
 def test_no_agent_uses_deployment_setting():
     client = _make_client(deployment_enabled=True, deployment_level="enhanced")
     body = client.get("/transparency").json()

--- a/tests/runtime/test_transparency_disclosure.py
+++ b/tests/runtime/test_transparency_disclosure.py
@@ -171,15 +171,13 @@ def _disclosure_deps(
     async def _nudge(session_id, msg, text):
         nudges.append(text)
 
-    async def _runtime_config(agent_id: str) -> dict:
-        return {"governance": governance} if governance is not None else {}
-
-    deps = SimpleNamespace(
-        session_store=store,
-        runtime_config=_runtime_config,
-        input_nudge=_nudge,
-    )
+    deps = SimpleNamespace(session_store=store, input_nudge=_nudge)
     deps._nudges = nudges
+    # The pipeline resolves the runtime payload once per message and
+    # hands it to the hook, so the fixture supplies it directly.
+    deps._payload = (
+        {"governance": governance} if governance is not None else {}
+    )
     return deps
 
 
@@ -198,6 +196,7 @@ async def test_first_contact_sends_disclosure_and_emits_event():
     )
     await ChannelInboundPipeline._maybe_send_disclosure(
         _msg(), routing=_routing(), deps=deps, session_id=uuid4(),
+        runtime_payload=deps._payload,
     )
     assert deps._nudges == [disclosure_text("basic")]
     event_call = deps.session_store.emit_event.call_args
@@ -214,6 +213,7 @@ async def test_no_disclosure_on_established_conversation():
     )
     await ChannelInboundPipeline._maybe_send_disclosure(
         _msg(), routing=_routing(), deps=deps, session_id=uuid4(),
+        runtime_payload=deps._payload,
     )
     assert deps._nudges == []
     deps.session_store.emit_event.assert_not_awaited()
@@ -225,6 +225,7 @@ async def test_no_disclosure_when_transparency_disabled_or_absent():
         deps = _disclosure_deps(governance=governance)
         await ChannelInboundPipeline._maybe_send_disclosure(
             _msg(), routing=_routing(), deps=deps, session_id=uuid4(),
+            runtime_payload=deps._payload,
         )
         assert deps._nudges == []
 
@@ -237,13 +238,24 @@ async def test_disclosure_failure_never_raises():
     deps.session_store.get_session = AsyncMock(side_effect=RuntimeError("db"))
     await ChannelInboundPipeline._maybe_send_disclosure(
         _msg(), routing=_routing(), deps=deps, session_id=uuid4(),
+        runtime_payload=deps._payload,
     )
     assert deps._nudges == []
 
 
 @pytest.mark.asyncio
 async def test_disclosure_skipped_without_wiring():
-    deps = SimpleNamespace(runtime_config=None, input_nudge=None)
+    """No nudge seam, or no resolvable config, means no attempt."""
+    deps = SimpleNamespace(input_nudge=None)
     await ChannelInboundPipeline._maybe_send_disclosure(
         _msg(), routing=_routing(), deps=deps, session_id=uuid4(),
+        runtime_payload={"governance": {"transparency": {"enabled": True}}},
     )
+    deps = _disclosure_deps(
+        governance={"transparency": {"enabled": True, "level": "basic"}},
+    )
+    await ChannelInboundPipeline._maybe_send_disclosure(
+        _msg(), routing=_routing(), deps=deps, session_id=uuid4(),
+        runtime_payload=None,
+    )
+    assert deps._nudges == []

--- a/tests/runtime/test_transparency_disclosure.py
+++ b/tests/runtime/test_transparency_disclosure.py
@@ -1,0 +1,231 @@
+"""Per-agent AI disclosure: endpoint resolution + channel delivery.
+
+Covers the Art. 50 chain: the public transparency endpoint resolving
+per-agent config (agent beats deployment, graceful fallbacks), the
+disclosure text helper, and the inbound pipeline's first-contact
+disclosure delivery with its ``disclosure.presented`` audit event.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from surogates.api.routes.transparency import router as transparency_router
+from surogates.channels.inbound import ChannelInboundPipeline
+from surogates.runtime.governance import disclosure_text
+from surogates.session.events import EventType
+
+
+# ---------------------------------------------------------------------------
+# disclosure_text
+# ---------------------------------------------------------------------------
+
+
+def test_disclosure_text_levels():
+    assert disclosure_text("none") == ""
+    assert "AI assistant" in disclosure_text("basic")
+    assert "Art. 50" in disclosure_text("full")
+    # Unknown levels degrade to the basic text, never to silence.
+    assert disclosure_text("partial") == disclosure_text("basic")
+    # No level self-classifies the system as high-risk.
+    for level in ("basic", "enhanced", "full"):
+        assert "high-risk" not in disclosure_text(level)
+
+
+# ---------------------------------------------------------------------------
+# GET /transparency
+# ---------------------------------------------------------------------------
+
+
+class _FakeCache:
+    def __init__(self, payloads: dict[str, dict]):
+        self._payloads = payloads
+
+    async def get(self, agent_id: str) -> dict:
+        try:
+            return self._payloads[agent_id]
+        except KeyError:
+            raise LookupError(agent_id)
+
+
+def _make_client(
+    *,
+    payloads: dict[str, dict] | None = None,
+    deployment_enabled: bool = False,
+    deployment_level: str = "basic",
+) -> TestClient:
+    app = FastAPI()
+    app.include_router(transparency_router)
+    app.state.settings = SimpleNamespace(
+        governance=SimpleNamespace(
+            transparency=SimpleNamespace(
+                enabled=deployment_enabled, level=deployment_level,
+            ),
+        ),
+    )
+    app.state.runtime_config_cache = _FakeCache(payloads or {})
+    return TestClient(app)
+
+
+def test_agent_transparency_wins_and_carries_text():
+    client = _make_client(payloads={
+        "agent-1": {
+            "governance": {
+                "transparency": {"enabled": True, "level": "full"},
+            },
+        },
+    })
+    body = client.get("/transparency?agent_id=agent-1").json()
+    assert body["enabled"] is True
+    assert body["level"] == "full"
+    assert "Art. 50" in body["text"]
+
+
+def test_agent_explicit_disabled_beats_deployment_enabled():
+    client = _make_client(
+        payloads={
+            "agent-1": {
+                "governance": {
+                    "transparency": {"enabled": False, "level": "full"},
+                },
+            },
+        },
+        deployment_enabled=True,
+    )
+    assert client.get("/transparency?agent_id=agent-1").json() == {
+        "enabled": False,
+    }
+
+
+def test_agent_without_block_falls_back_to_deployment():
+    client = _make_client(
+        payloads={"agent-1": {"governance": {"enabled": True}}},
+        deployment_enabled=True,
+        deployment_level="basic",
+    )
+    body = client.get("/transparency?agent_id=agent-1").json()
+    assert body["enabled"] is True
+    assert body["level"] == "basic"
+    assert body["text"]
+
+
+def test_unknown_agent_falls_back_not_errors():
+    client = _make_client(deployment_enabled=False)
+    assert client.get("/transparency?agent_id=ghost").json() == {
+        "enabled": False,
+    }
+
+
+def test_no_agent_uses_deployment_setting():
+    client = _make_client(deployment_enabled=True, deployment_level="enhanced")
+    body = client.get("/transparency").json()
+    assert body == {
+        "enabled": True,
+        "level": "enhanced",
+        "text": disclosure_text("enhanced"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Channel first-contact disclosure
+# ---------------------------------------------------------------------------
+
+
+def _disclosure_deps(
+    *,
+    governance: dict | None,
+    message_count: int = 0,
+) -> SimpleNamespace:
+    store = SimpleNamespace(
+        get_session=AsyncMock(
+            return_value=SimpleNamespace(message_count=message_count),
+        ),
+        emit_event=AsyncMock(return_value=1),
+    )
+    nudges: list[str] = []
+
+    async def _nudge(session_id, msg, text):
+        nudges.append(text)
+
+    async def _runtime_config(agent_id: str) -> dict:
+        return {"governance": governance} if governance is not None else {}
+
+    deps = SimpleNamespace(
+        session_store=store,
+        runtime_config=_runtime_config,
+        input_nudge=_nudge,
+    )
+    deps._nudges = nudges
+    return deps
+
+
+def _msg() -> SimpleNamespace:
+    return SimpleNamespace(identifier="C1", thread_key=None)
+
+
+def _routing() -> SimpleNamespace:
+    return SimpleNamespace(agent_id="agent-1", platform="telegram")
+
+
+@pytest.mark.asyncio
+async def test_first_contact_sends_disclosure_and_emits_event():
+    deps = _disclosure_deps(
+        governance={"transparency": {"enabled": True, "level": "basic"}},
+    )
+    await ChannelInboundPipeline._maybe_send_disclosure(
+        _msg(), routing=_routing(), deps=deps, session_id=uuid4(),
+    )
+    assert deps._nudges == [disclosure_text("basic")]
+    event_call = deps.session_store.emit_event.call_args
+    assert event_call.args[1] is EventType.DISCLOSURE_PRESENTED
+    assert event_call.args[2]["level"] == "basic"
+    assert event_call.args[2]["channel"] == "telegram"
+
+
+@pytest.mark.asyncio
+async def test_no_disclosure_on_established_conversation():
+    deps = _disclosure_deps(
+        governance={"transparency": {"enabled": True, "level": "basic"}},
+        message_count=7,
+    )
+    await ChannelInboundPipeline._maybe_send_disclosure(
+        _msg(), routing=_routing(), deps=deps, session_id=uuid4(),
+    )
+    assert deps._nudges == []
+    deps.session_store.emit_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_disclosure_when_transparency_disabled_or_absent():
+    for governance in (None, {}, {"transparency": {"enabled": False}}):
+        deps = _disclosure_deps(governance=governance)
+        await ChannelInboundPipeline._maybe_send_disclosure(
+            _msg(), routing=_routing(), deps=deps, session_id=uuid4(),
+        )
+        assert deps._nudges == []
+
+
+@pytest.mark.asyncio
+async def test_disclosure_failure_never_raises():
+    deps = _disclosure_deps(
+        governance={"transparency": {"enabled": True, "level": "basic"}},
+    )
+    deps.session_store.get_session = AsyncMock(side_effect=RuntimeError("db"))
+    await ChannelInboundPipeline._maybe_send_disclosure(
+        _msg(), routing=_routing(), deps=deps, session_id=uuid4(),
+    )
+    assert deps._nudges == []
+
+
+@pytest.mark.asyncio
+async def test_disclosure_skipped_without_wiring():
+    deps = SimpleNamespace(runtime_config=None, input_nudge=None)
+    await ChannelInboundPipeline._maybe_send_disclosure(
+        _msg(), routing=_routing(), deps=deps, session_id=uuid4(),
+    )

--- a/tests/test_loop_turn_id.py
+++ b/tests/test_loop_turn_id.py
@@ -67,6 +67,7 @@ def _make_loop_harness(
     harness._saga_enabled = False
     harness._saga_settings = None
     harness._log_policy_allowed = False
+    harness._governance_gate = None
     harness._memory_manager = None
     harness._memory_nudge_interval = 0
     harness._turns_since_memory = 0

--- a/tests/test_steer_loop.py
+++ b/tests/test_steer_loop.py
@@ -48,6 +48,7 @@ def _make_loop_harness(*, session_store: Any, budget: IterationBudget | None = N
     harness._saga_enabled = False
     harness._saga_settings = None
     harness._log_policy_allowed = False
+    harness._governance_gate = None
     harness._memory_manager = None
     harness._memory_nudge_interval = 0
     harness._turns_since_memory = 0

--- a/web/src/api/transparency.ts
+++ b/web/src/api/transparency.ts
@@ -5,6 +5,9 @@
 export interface TransparencyConfig {
   enabled: boolean;
   level?: "none" | "basic" | "enhanced" | "full";
+  // Server-composed disclosure text (per-agent). Newer runtimes send
+  // it; when absent the banner falls back to its local copies.
+  text?: string;
 }
 
 let _cached: TransparencyConfig | null = null;

--- a/web/src/components/transparency-banner.tsx
+++ b/web/src/components/transparency-banner.tsx
@@ -14,6 +14,11 @@ import * as sessionsApi from "@/api/sessions";
 
 type TransparencyLevel = "none" | "basic" | "enhanced" | "full";
 
+// Fallback copies when the server did not send its disclosure text
+// (older runtimes). Deliberately does NOT self-classify the system as
+// "high-risk" — that is an AI Act Art. 6 legal classification these
+// agents do not carry; the levels scale detail, not risk claims. Keep
+// in sync with surogates/governance/transparency.py DISCLOSURE_TEXTS.
 const DISCLOSURE_TEXT: Record<TransparencyLevel, { body: string; legal: string }> = {
   none: {
     body: "",
@@ -21,7 +26,7 @@ const DISCLOSURE_TEXT: Record<TransparencyLevel, { body: string; legal: string }
   },
   basic: {
     body:
-      "You are about to interact with an AI system. All outputs are " +
+      "You are about to interact with an AI assistant. Replies are " +
       "machine-generated and may contain errors.",
     legal:
       "In accordance with the EU AI Act (Art. 50(1)), you are being " +
@@ -30,34 +35,35 @@ const DISCLOSURE_TEXT: Record<TransparencyLevel, { body: string; legal: string }
   },
   enhanced: {
     body:
-      "You are about to interact with a high-risk AI system. All outputs " +
-      "are machine-generated, subject to governance policy enforcement, " +
-      "and logged for regulatory audit purposes. Interpretability " +
-      "documentation is available on request.",
+      "You are about to interact with an AI assistant. Replies are " +
+      "machine-generated, may contain errors, and are logged. The AI " +
+      "follows the operator's usage policy and you can always ask for " +
+      "a human contact.",
     legal:
-      "In accordance with the EU AI Act (Art. 13, Art. 50(1)), you are " +
-      "being informed that this system uses artificial intelligence. " +
-      "This system is classified as high-risk and is subject to " +
-      "transparency and oversight obligations.",
+      "In accordance with the EU AI Act (Art. 50(1)), you are being " +
+      "informed that this system uses artificial intelligence and that " +
+      "your conversation is logged.",
   },
   full: {
     body:
-      "You are about to interact with a high-risk AI system under full " +
-      "transparency obligations. All tool calls are policy-governed, " +
-      "audited, and subject to human oversight. System accuracy " +
-      "declarations and technical documentation are available.",
+      "You are about to interact with an AI assistant operated on the " +
+      "Surogate platform. Replies are machine-generated, may contain " +
+      "errors, and are logged and policy-governed; a human operator " +
+      "reviews escalations and you can request a human contact at any " +
+      "time.",
     legal:
-      "In accordance with the EU AI Act (Art. 13, Art. 14, Art. 50), " +
-      "you are being informed that this system uses artificial " +
-      "intelligence under full transparency, interpretability, and " +
-      "human oversight requirements. Detailed technical documentation " +
-      "and accuracy declarations are available on request.",
+      "This notice is provided under EU AI Act Art. 50(1). Further " +
+      "information about the system and its operator is available on " +
+      "request.",
   },
 };
 
 interface TransparencyBannerProps {
   sessionId?: string;
   level: TransparencyLevel;
+  // Per-agent disclosure text from the transparency endpoint; falls
+  // back to the local level copies when absent (older runtimes).
+  serverText?: string;
   onConfirmed: () => void;
   onDeclined: () => void;
 }
@@ -65,12 +71,16 @@ interface TransparencyBannerProps {
 export function TransparencyBanner({
   sessionId,
   level,
+  serverText,
   onConfirmed,
   onDeclined,
 }: TransparencyBannerProps) {
   const [confirming, setConfirming] = useState(false);
 
-  const texts = DISCLOSURE_TEXT[level] || DISCLOSURE_TEXT.basic;
+  const fallback = DISCLOSURE_TEXT[level] || DISCLOSURE_TEXT.basic;
+  const texts = serverText
+    ? { body: serverText, legal: fallback.legal }
+    : fallback;
 
   const handleAccept = async () => {
     setConfirming(true);

--- a/web/src/components/transparency-banner.tsx
+++ b/web/src/components/transparency-banner.tsx
@@ -14,48 +14,28 @@ import * as sessionsApi from "@/api/sessions";
 
 type TransparencyLevel = "none" | "basic" | "enhanced" | "full";
 
-// Fallback copies when the server did not send its disclosure text
-// (older runtimes). Deliberately does NOT self-classify the system as
-// "high-risk" — that is an AI Act Art. 6 legal classification these
-// agents do not carry; the levels scale detail, not risk claims. Keep
-// in sync with surogates/governance/transparency.py DISCLOSURE_TEXTS.
-const DISCLOSURE_TEXT: Record<TransparencyLevel, { body: string; legal: string }> = {
-  none: {
-    body: "",
-    legal: "",
-  },
-  basic: {
-    body:
-      "You are about to interact with an AI assistant. Replies are " +
-      "machine-generated and may contain errors.",
-    legal:
-      "In accordance with the EU AI Act (Art. 50(1)), you are being " +
-      "informed that this system uses artificial intelligence to process " +
-      "your requests.",
-  },
-  enhanced: {
-    body:
-      "You are about to interact with an AI assistant. Replies are " +
-      "machine-generated, may contain errors, and are logged. The AI " +
-      "follows the operator's usage policy and you can always ask for " +
-      "a human contact.",
-    legal:
-      "In accordance with the EU AI Act (Art. 50(1)), you are being " +
-      "informed that this system uses artificial intelligence and that " +
-      "your conversation is logged.",
-  },
-  full: {
-    body:
-      "You are about to interact with an AI assistant operated on the " +
-      "Surogate platform. Replies are machine-generated, may contain " +
-      "errors, and are logged and policy-governed; a human operator " +
-      "reviews escalations and you can request a human contact at any " +
-      "time.",
-    legal:
-      "This notice is provided under EU AI Act Art. 50(1). Further " +
-      "information about the system and its operator is available on " +
-      "request.",
-  },
+// The disclosure body is server-composed (per-agent) and arrives via
+// the transparency endpoint's `text`; a single generic sentence covers
+// the fallback when it is absent. Only the short legal references are
+// kept per level here — they are UI framing, not the disclosure copy.
+const FALLBACK_BODY =
+  "You are about to interact with an AI assistant. Replies are " +
+  "machine-generated and may contain errors.";
+
+const LEGAL_TEXT: Record<TransparencyLevel, string> = {
+  none: "",
+  basic:
+    "In accordance with the EU AI Act (Art. 50(1)), you are being " +
+    "informed that this system uses artificial intelligence to process " +
+    "your requests.",
+  enhanced:
+    "In accordance with the EU AI Act (Art. 50(1)), you are being " +
+    "informed that this system uses artificial intelligence and that " +
+    "your conversation is logged.",
+  full:
+    "This notice is provided under EU AI Act Art. 50(1). Further " +
+    "information about the system and its operator is available on " +
+    "request.",
 };
 
 interface TransparencyBannerProps {
@@ -77,10 +57,10 @@ export function TransparencyBanner({
 }: TransparencyBannerProps) {
   const [confirming, setConfirming] = useState(false);
 
-  const fallback = DISCLOSURE_TEXT[level] || DISCLOSURE_TEXT.basic;
-  const texts = serverText
-    ? { body: serverText, legal: fallback.legal }
-    : fallback;
+  const texts = {
+    body: serverText || FALLBACK_BODY,
+    legal: LEGAL_TEXT[level] ?? LEGAL_TEXT.basic,
+  };
 
   const handleAccept = async () => {
     setConfirming(true);

--- a/web/src/features/chat/chat-page.tsx
+++ b/web/src/features/chat/chat-page.tsx
@@ -211,6 +211,7 @@ export function ChatPage() {
             <TransparencyBanner
               sessionId={sessionId ?? undefined}
               level={transparencyConfig?.level ?? "basic"}
+              serverText={transparencyConfig?.text}
               onConfirmed={handleDisclosureConfirmed}
               onDeclined={handleDisclosureDeclined}
             />


### PR DESCRIPTION
## Summary

The governance machinery existed but was unreachable in the production turn path: the tool path built a bare `GovernanceGate` used only for workspace path containment, `ctx.governance` had a single consumer (`rate_limit_rpm`), the EU AI Act transparency interceptor was never instantiated, and AI disclosure existed only as a deployment-wide banner in the first-party web chat. This PR wires enforcement and delivers per-agent disclosure on the live channels, ahead of the Art. 50 deadline (2 Aug 2026).

Companion management-plane PR: `surogate-ops#323` (projects `Agent.policy` into the runtime-config governance blob this PR consumes).

## Changes

### Policy enforcement
- `surogates.runtime.governance`: normalises the per-agent governance blob (fail-safe on malformed input; `enabled=false` projects to the floor) and builds the frozen per-wake gate via `with_profile`; a module-level shared floor gate serves profile-less agents and the tool-path fallback (keeps the workspace sandbox cache warm)
- The worker threads the gate through `AgentHarness` -> streaming executor / tool_exec; `execute_single_tool` now runs the gate on every tool call — allow/deny lists and egress rules from Studio actually block, with `policy.denied` events feeding the existing Policies tab
- `GovernanceGate`: MCP tools (`mcp__*`) bypass the built-in allow-list role check (they are governed by server attachment + entitlements) while remaining subject to deny/egress/floor checks; `with_profile` now materialises an egress policy for `default_action: deny` with no rules instead of falling open

### AI disclosure (Art. 50)
- `GET /v1/transparency` resolves per-agent config (query param or Host subdomain, via a shared `resolve_agent_id_soft` helper) with deployment fallback, and serves the composed disclosure text; agent config beats the fallback in both directions; disclosure honours the policy master switch
- Slack/Telegram deliver the disclosure as the first message of every new conversation (after the /stop gate), recorded as a `disclosure.presented` event; a bounded in-process seen-set keeps established conversations free of extra lookups
- `confirm-disclosure` persists a `disclosure.confirmed` event (the old endpoint wrote to an `app.state` attribute that was never assigned)
- Disclosure texts no longer self-classify the system as "high-risk AI" (an Art. 6 legal category these agents do not carry); the web banner renders the server-composed text and keeps only legal strings locally
- Docs updated to describe actual behavior, including retired env vars and the Teams disclosure gap (no `post_input_nudge` — do not enable Teams for disclosure-required agents)

## Verification

- Full unit suite: same 24 pre-existing failures as `master`, none new; 41 new tests (gate composition, profile parsing, endpoint resolution, channel disclosure, floor semantics)
- Web SPA typecheck green

## Notes for reviewers

- Composition is narrowing-only and fail-closed; the platform floor (path containment, argument hygiene) is not configurable
- Commerce/entitlements code paths are untouched