### PR TITLE
fix(api): monetization hardening — typed answers to pending questions, resilient tenant resolution

### DIFF
--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -528,68 +528,29 @@ async def _resolve_pending_question(
 ) -> int | None:
     """Convert ``text`` into the answer of a live pending question.
 
-    Returns the response event id when the message resolved a pending
-    ``ask_user_question``, ``None`` when nothing live is pending (no
-    row, the row is older than the tool's wait window, or another
-    surface claimed it first) — the caller then treats the text as a
-    normal message. Never raises: a resolution failure must not block
-    the message path.
+    Thin route-side wrapper over
+    :func:`surogates.session.interactive_input.try_resolve_text_answer`
+    — the shared helper carries the guard set (freshness, already-
+    answered probe, atomic claim). Returns the response event id, or
+    ``None`` when the text should be delivered as a normal message.
+    Never raises: a resolution failure must not block the message path.
     """
-    from datetime import timezone
-
-    from surogates.channels.platforms.telegram_interactive import (
-        resolve_text_answer,
-    )
-    from surogates.session.events import EventType as _EventType
-    from surogates.session.interactive_input import (
-        pending_input_for_session,
-        resolve_input_response,
-    )
+    from surogates.session.interactive_input import try_resolve_text_answer
     from surogates.tools.builtin.ask_user_question import (
         ASK_USER_QUESTION_MAX_WAIT_SECONDS,
     )
 
-    # Refuse anything close to the tool's own deadline: the row's DB
-    # timestamp and the worker's monotonic deadline run on different
-    # clocks, and near the boundary the safe error is treating a live
-    # question as expired (the message falls through as a normal one),
-    # never the reverse (the message would be swallowed).
-    freshness_cap = ASK_USER_QUESTION_MAX_WAIT_SECONDS - 60
-
     try:
-        pending = await pending_input_for_session(
-            store, session_id=session_id,
-        )
-        if pending is None:
-            return None
-        created_at = pending.get("created_at")
-        if created_at is not None:
-            now = datetime.now(timezone.utc)
-            if created_at.tzinfo is None:
-                now = now.replace(tzinfo=None)
-            if (now - created_at).total_seconds() > freshness_cap:
-                return None
-        tool_call_id = pending.get("tool_call_id", "")
-        # The form's respond route emits its response event BEFORE its
-        # best-effort inbox claim; a row left pending after a form
-        # answer must not eat the user's next message.
-        prior = await store.get_events(
-            session_id,
-            after=0,
-            types=[_EventType.ASK_USER_QUESTION_RESPONSE],
-        )
-        if any(
-            (event.data or {}).get("tool_call_id") == tool_call_id
-            for event in prior
-        ):
-            return None
-        return await resolve_input_response(
+        return await try_resolve_text_answer(
             store,
             session_id=session_id,
-            tool_call_id=tool_call_id,
-            responses=resolve_text_answer(
-                pending.get("questions") or [], text,
-            ),
+            text=text,
+            # Refuse anything close to the tool's own deadline: the
+            # row's DB timestamp and the worker's monotonic deadline
+            # run on different clocks, and near the boundary the safe
+            # error is treating a live question as expired (the message
+            # falls through as a normal one), never the reverse.
+            max_age_seconds=ASK_USER_QUESTION_MAX_WAIT_SECONDS - 60,
         )
     except Exception:
         logger.warning(

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -523,6 +523,61 @@ async def create_api_session(
     )
 
 
+async def _resolve_pending_question(
+    store, session_id: UUID, text: str,
+) -> int | None:
+    """Convert ``text`` into the answer of a live pending question.
+
+    Returns the response event id when the message resolved a pending
+    ``ask_user_question``, ``None`` when nothing live is pending (no
+    row, the row is older than the tool's wait window, or another
+    surface claimed it first) — the caller then treats the text as a
+    normal message. Never raises: a resolution failure must not block
+    the message path.
+    """
+    from datetime import timezone
+
+    from surogates.channels.platforms.telegram_interactive import (
+        resolve_text_answer,
+    )
+    from surogates.session.interactive_input import (
+        pending_input_for_session,
+        resolve_input_response,
+    )
+    from surogates.tools.builtin.ask_user_question import (
+        ASK_USER_QUESTION_MAX_WAIT_SECONDS,
+    )
+
+    try:
+        pending = await pending_input_for_session(
+            store, session_id=session_id,
+        )
+        if pending is None:
+            return None
+        created_at = pending.get("created_at")
+        if created_at is not None:
+            now = datetime.now(timezone.utc)
+            if created_at.tzinfo is None:
+                now = now.replace(tzinfo=None)
+            age = (now - created_at).total_seconds()
+            if age > ASK_USER_QUESTION_MAX_WAIT_SECONDS:
+                return None
+        return await resolve_input_response(
+            store,
+            session_id=session_id,
+            tool_call_id=pending.get("tool_call_id", ""),
+            responses=resolve_text_answer(
+                pending.get("questions") or [], text,
+            ),
+        )
+    except Exception:
+        logger.warning(
+            "Pending-question resolution failed for session %s; "
+            "delivering as a normal message",
+            session_id,
+            exc_info=True,
+        )
+        return None
 
 
 @router.post(
@@ -586,6 +641,23 @@ async def send_message(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=(f"Message blocked: {injection_result.explanation}"),
             )
+
+    # A message typed while the agent is blocked on ask_user_question IS
+    # that question's answer.  The slack/telegram inbound pipeline already
+    # resolves this; without the same treatment here a web user who types
+    # instead of using the question form leaves the wake parked on the
+    # tool until its timeout.  Only pure text converts — images and
+    # attachments are new material for the next turn.  The inbox-row
+    # claim is atomic, so racing the form's respond route yields exactly
+    # one response event, and a row older than the tool's own wait
+    # window is ignored (the tool has already timed out; the expire
+    # sweeper only clears terminal sessions).
+    if body.content.strip() and not body.images and not body.attachments:
+        answered = await _resolve_pending_question(
+            store, session_id, body.content,
+        )
+        if answered is not None:
+            return SendMessageResponse(event_id=answered)
 
     # Resolve any attachments against the session workspace.  Filenames
     # are user-controlled too, so they go through the same prompt-

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -540,6 +540,7 @@ async def _resolve_pending_question(
     from surogates.channels.platforms.telegram_interactive import (
         resolve_text_answer,
     )
+    from surogates.session.events import EventType as _EventType
     from surogates.session.interactive_input import (
         pending_input_for_session,
         resolve_input_response,
@@ -547,6 +548,13 @@ async def _resolve_pending_question(
     from surogates.tools.builtin.ask_user_question import (
         ASK_USER_QUESTION_MAX_WAIT_SECONDS,
     )
+
+    # Refuse anything close to the tool's own deadline: the row's DB
+    # timestamp and the worker's monotonic deadline run on different
+    # clocks, and near the boundary the safe error is treating a live
+    # question as expired (the message falls through as a normal one),
+    # never the reverse (the message would be swallowed).
+    freshness_cap = ASK_USER_QUESTION_MAX_WAIT_SECONDS - 60
 
     try:
         pending = await pending_input_for_session(
@@ -559,13 +567,26 @@ async def _resolve_pending_question(
             now = datetime.now(timezone.utc)
             if created_at.tzinfo is None:
                 now = now.replace(tzinfo=None)
-            age = (now - created_at).total_seconds()
-            if age > ASK_USER_QUESTION_MAX_WAIT_SECONDS:
+            if (now - created_at).total_seconds() > freshness_cap:
                 return None
+        tool_call_id = pending.get("tool_call_id", "")
+        # The form's respond route emits its response event BEFORE its
+        # best-effort inbox claim; a row left pending after a form
+        # answer must not eat the user's next message.
+        prior = await store.get_events(
+            session_id,
+            after=0,
+            types=[_EventType.ASK_USER_QUESTION_RESPONSE],
+        )
+        if any(
+            (event.data or {}).get("tool_call_id") == tool_call_id
+            for event in prior
+        ):
+            return None
         return await resolve_input_response(
             store,
             session_id=session_id,
-            tool_call_id=pending.get("tool_call_id", ""),
+            tool_call_id=tool_call_id,
             responses=resolve_text_answer(
                 pending.get("questions") or [], text,
             ),
@@ -619,6 +640,12 @@ async def send_message(
     # UI reports "stopped" while deltas for the new turn stream in,
     # regardless of whether the previous terminal state was pause, fail,
     # or completed.
+    # Captured BEFORE the resume below: a pending question on a session
+    # that went terminal belongs to a tool call that already cancelled
+    # itself (pause/fail/complete exit its wait loop), so a message
+    # that resumes the session must be a NORMAL message — converting it
+    # into an answer would feed a consumer that no longer exists.
+    was_active = session.status == "active"
     if session.status in ("failed", "paused", "completed"):
         await store.update_session_status(session_id, "active")
         await store.emit_event(session_id, EventType.SESSION_RESUME, {})
@@ -643,16 +670,27 @@ async def send_message(
             )
 
     # A message typed while the agent is blocked on ask_user_question IS
-    # that question's answer.  The slack/telegram inbound pipeline already
-    # resolves this; without the same treatment here a web user who types
-    # instead of using the question form leaves the wake parked on the
-    # tool until its timeout.  Only pure text converts — images and
-    # attachments are new material for the next turn.  The inbox-row
-    # claim is atomic, so racing the form's respond route yields exactly
-    # one response event, and a row older than the tool's own wait
-    # window is ignored (the tool has already timed out; the expire
-    # sweeper only clears terminal sessions).
-    if body.content.strip() and not body.images and not body.attachments:
+    # that question's answer — the same call the Telegram inbound
+    # pipeline makes for plain replies (Slack instead nudges toward its
+    # modal; the web composer stays enabled under the question widget,
+    # so typing must work here or the wake stays parked on the tool
+    # until its timeout).  Guards, in order: only genuinely-active
+    # sessions (a terminal session's tool already cancelled itself);
+    # only real web users (an API service-account client cannot detect
+    # the reinterpretation); only pure text (images/attachments are new
+    # material for the next turn).  The claim is atomic among
+    # claim-first callers; the form's respond route emits first and
+    # claims best-effort, so the helper also refuses when a response
+    # event already exists for the tool call.  Commerce/allowance gates
+    # are deliberately not re-run: the resumed turn spends the
+    # reservation its original message already authorized.
+    if (
+        was_active
+        and not request.url.path.startswith("/v1/api/")
+        and body.content.strip()
+        and not body.images
+        and not body.attachments
+    ):
         answered = await _resolve_pending_question(
             store, session_id, body.content,
         )

--- a/surogates/runtime/cache.py
+++ b/surogates/runtime/cache.py
@@ -32,10 +32,6 @@ from surogates.runtime.platform_client import PlatformAuthError
 
 logger = logging.getLogger(__name__)
 
-# Sentinel far in the monotonic past so "never failed" never matches
-# the backoff window.
-_FAR_PAST = 1e12
-
 __all__ = ["RuntimeConfigCache"]
 
 
@@ -84,13 +80,14 @@ class RuntimeConfigCache:
         """
         now = time.monotonic()
         cached = self._entries.get(agent_id)
-        if cached is not None and (now - cached[0]) < self._ttl:
+        if cached is not None and self._fresh(cached[0], now):
             return cached[1]
+        last_failure = self._last_failure.get(agent_id)
         if (
             cached is not None
-            and (now - cached[0]) < self._ttl + self._stale_grace
-            and (now - self._last_failure.get(agent_id, -_FAR_PAST))
-            < self._failure_backoff
+            and self._fresh(cached[0], now, grace=self._stale_grace)
+            and last_failure is not None
+            and (now - last_failure) < self._failure_backoff
         ):
             return cached[1]
 
@@ -99,7 +96,7 @@ class RuntimeConfigCache:
             # Double-checked after taking the lock — a peer may have
             # already loaded while we waited.
             cached = self._entries.get(agent_id)
-            if cached is not None and (time.monotonic() - cached[0]) < self._ttl:
+            if cached is not None and self._fresh(cached[0], time.monotonic()):
                 return cached[1]
             try:
                 cfg = await self._loader(agent_id)
@@ -111,10 +108,8 @@ class RuntimeConfigCache:
                 raise
             except Exception:
                 self._last_failure[agent_id] = time.monotonic()
-                if (
-                    cached is not None
-                    and (time.monotonic() - cached[0])
-                    < self._ttl + self._stale_grace
+                if cached is not None and self._fresh(
+                    cached[0], time.monotonic(), grace=self._stale_grace,
                 ):
                     logger.warning(
                         "runtime-config refresh failed for agent %s — "
@@ -127,6 +122,9 @@ class RuntimeConfigCache:
             self._last_failure.pop(agent_id, None)
             self._entries[agent_id] = (time.monotonic(), cfg)
             return cfg
+
+    def _fresh(self, loaded_at: float, now: float, grace: float = 0.0) -> bool:
+        return (now - loaded_at) < self._ttl + grace
 
     def invalidate(self, agent_id: str) -> None:
         """Drop the cache entry for ``agent_id`` if present.

--- a/surogates/runtime/cache.py
+++ b/surogates/runtime/cache.py
@@ -4,7 +4,9 @@ Pure cache fronting :class:`~surogates.runtime.PlatformClient`.  The
 management plane is the source of truth; the cache exists to absorb
 read load on the hot path.  Eviction policies:
 
-* **TTL** — every entry expires ``ttl_seconds`` after its load.
+* **TTL** — every entry expires ``ttl_seconds`` after its load, but a
+  transient loader failure may serve the expired entry for up to
+  ``stale_grace_seconds`` longer (stale-on-failure, see :meth:`get`).
 * **Explicit invalidate** — :meth:`invalidate` drops a single key,
   driven by the Redis pub/sub listener when surogate-ops
   publishes ``agent.runtime_config_changed:<agent_id>``.
@@ -26,7 +28,13 @@ import logging
 import time
 from typing import Awaitable, Callable
 
+from surogates.runtime.platform_client import PlatformAuthError
+
 logger = logging.getLogger(__name__)
+
+# Sentinel far in the monotonic past so "never failed" never matches
+# the backoff window.
+_FAR_PAST = 1e12
 
 __all__ = ["RuntimeConfigCache"]
 
@@ -45,11 +53,14 @@ class RuntimeConfigCache:
         loader: Callable[[str], Awaitable[dict]],
         ttl_seconds: float = 1.0,
         stale_grace_seconds: float = 300.0,
+        failure_backoff_seconds: float = 2.0,
     ) -> None:
         self._loader = loader
         self._ttl = ttl_seconds
         self._stale_grace = stale_grace_seconds
+        self._failure_backoff = failure_backoff_seconds
         self._entries: dict[str, tuple[float, dict]] = {}
+        self._last_failure: dict[str, float] = {}
         self._locks: dict[str, asyncio.Lock] = {}
         self._global = asyncio.Lock()
 
@@ -60,15 +71,27 @@ class RuntimeConfigCache:
         network blip, a version bump racing this request) serves the
         expired entry for up to ``stale_grace_seconds`` past its TTL
         instead of failing the request — the platform client surfaces
-        network errors unchanged for exactly this policy. The stale
-        entry's timestamp is NOT refreshed, so the next call retries
-        the loader immediately. ``LookupError`` (a definitive 404) is
-        never absorbed: the agent is gone, and it also purges any
-        cached entry so a deleted agent cannot be served stale.
+        network errors unchanged for exactly this policy. After a
+        failure, further calls within ``failure_backoff_seconds`` serve
+        the stale copy WITHOUT re-entering the loader, so an ops outage
+        does not serialize every request behind a timing-out fetch;
+        past the backoff the loader is retried (the stale timestamp is
+        never refreshed). Two errors are definitive and never absorbed:
+        ``LookupError`` (404 — the agent is gone; also purges the entry
+        so a deleted agent cannot be served stale) and
+        ``PlatformAuthError`` (the runtime token is rejected — a
+        condition that never self-heals and must page, not retry).
         """
         now = time.monotonic()
         cached = self._entries.get(agent_id)
         if cached is not None and (now - cached[0]) < self._ttl:
+            return cached[1]
+        if (
+            cached is not None
+            and (now - cached[0]) < self._ttl + self._stale_grace
+            and (now - self._last_failure.get(agent_id, -_FAR_PAST))
+            < self._failure_backoff
+        ):
             return cached[1]
 
         lock = await self._lock(agent_id)
@@ -82,8 +105,12 @@ class RuntimeConfigCache:
                 cfg = await self._loader(agent_id)
             except LookupError:
                 self._entries.pop(agent_id, None)
+                self._last_failure.pop(agent_id, None)
+                raise
+            except PlatformAuthError:
                 raise
             except Exception:
+                self._last_failure[agent_id] = time.monotonic()
                 if (
                     cached is not None
                     and (time.monotonic() - cached[0])
@@ -97,6 +124,7 @@ class RuntimeConfigCache:
                     )
                     return cached[1]
                 raise
+            self._last_failure.pop(agent_id, None)
             self._entries[agent_id] = (time.monotonic(), cfg)
             return cfg
 

--- a/surogates/runtime/cache.py
+++ b/surogates/runtime/cache.py
@@ -22,8 +22,11 @@ would need a separate negative-TTL story.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from typing import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
 
 __all__ = ["RuntimeConfigCache"]
 
@@ -41,15 +44,28 @@ class RuntimeConfigCache:
         self,
         loader: Callable[[str], Awaitable[dict]],
         ttl_seconds: float = 1.0,
+        stale_grace_seconds: float = 300.0,
     ) -> None:
         self._loader = loader
         self._ttl = ttl_seconds
+        self._stale_grace = stale_grace_seconds
         self._entries: dict[str, tuple[float, dict]] = {}
         self._locks: dict[str, asyncio.Lock] = {}
         self._global = asyncio.Lock()
 
     async def get(self, agent_id: str) -> dict:
-        """Return the cached config, fetching through the loader on miss."""
+        """Return the cached config, fetching through the loader on miss.
+
+        Stale-on-failure: a transient loader error (ops redeploying,
+        network blip, a version bump racing this request) serves the
+        expired entry for up to ``stale_grace_seconds`` past its TTL
+        instead of failing the request — the platform client surfaces
+        network errors unchanged for exactly this policy. The stale
+        entry's timestamp is NOT refreshed, so the next call retries
+        the loader immediately. ``LookupError`` (a definitive 404) is
+        never absorbed: the agent is gone, and it also purges any
+        cached entry so a deleted agent cannot be served stale.
+        """
         now = time.monotonic()
         cached = self._entries.get(agent_id)
         if cached is not None and (now - cached[0]) < self._ttl:
@@ -62,7 +78,25 @@ class RuntimeConfigCache:
             cached = self._entries.get(agent_id)
             if cached is not None and (time.monotonic() - cached[0]) < self._ttl:
                 return cached[1]
-            cfg = await self._loader(agent_id)
+            try:
+                cfg = await self._loader(agent_id)
+            except LookupError:
+                self._entries.pop(agent_id, None)
+                raise
+            except Exception:
+                if (
+                    cached is not None
+                    and (time.monotonic() - cached[0])
+                    < self._ttl + self._stale_grace
+                ):
+                    logger.warning(
+                        "runtime-config refresh failed for agent %s — "
+                        "serving the cached copy",
+                        agent_id,
+                        exc_info=True,
+                    )
+                    return cached[1]
+                raise
             self._entries[agent_id] = (time.monotonic(), cfg)
             return cfg
 

--- a/surogates/runtime/resolver.py
+++ b/surogates/runtime/resolver.py
@@ -14,6 +14,8 @@ This module bridges two layers:
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import HTTPException, Request
 
 from surogates.runtime.context import (
@@ -21,6 +23,8 @@ from surogates.runtime.context import (
     LLMEndpoint,
     SlashCommandConfig,
 )
+
+logger = logging.getLogger(__name__)
 
 __all__ = ["agent_runtime_context_dep", "build_agent_runtime_context"]
 
@@ -191,6 +195,30 @@ async def agent_runtime_context_dep(request: Request) -> AgentRuntimeContext:
             404,
             f"agent {agent_id} not configured",
         )
+    except Exception:
+        # Transient control-plane failure with no cached copy to serve
+        # (cold start racing an ops redeploy / a runtime-config version
+        # bump). One immediate retry covers the sub-second blip; a
+        # second failure is the client's problem to retry — surface a
+        # retryable 503, never an anonymous 500.
+        logger.warning(
+            "runtime-config fetch failed for agent %s — retrying once",
+            agent_id,
+            exc_info=True,
+        )
+        try:
+            payload = await cache.get(agent_id)
+        except LookupError:
+            raise HTTPException(
+                404,
+                f"agent {agent_id} not configured",
+            )
+        except Exception:
+            raise HTTPException(
+                503,
+                "runtime configuration temporarily unavailable — "
+                "retry shortly",
+            )
 
     ctx = build_agent_runtime_context(payload)
     if not ctx.enabled:

--- a/surogates/runtime/resolver.py
+++ b/surogates/runtime/resolver.py
@@ -194,56 +194,45 @@ async def agent_runtime_context_dep(request: Request) -> AgentRuntimeContext:
         raise HTTPException(400, "no agent_id in request")
 
     cache = request.app.state.runtime_config_cache
-    try:
-        payload = await cache.get(agent_id)
-    except LookupError:
-        raise HTTPException(
-            404,
-            f"agent {agent_id} not configured",
-        )
-    except PlatformAuthError:
-        # The runtime token was rejected — an operations problem that
-        # never self-heals, so no retry (the platform client's error
-        # taxonomy says page, don't retry). Still a 503 for clients,
-        # but named so nobody mistakes it for a transient blip.
-        logger.error(
-            "surogate-ops rejected the runtime token while resolving "
-            "agent %s — check the token's scope/rotation",
-            agent_id,
-        )
-        raise HTTPException(
-            503,
-            "runtime authentication misconfigured — contact the operator",
-        )
-    except Exception:
-        # Transient control-plane failure with no cached copy to serve
-        # (cold start racing an ops redeploy / a runtime-config version
-        # bump). One immediate retry covers the sub-second blip; a
-        # second failure is the client's problem to retry — surface a
-        # retryable 503, never an anonymous 500.
-        logger.warning(
-            "runtime-config fetch failed for agent %s — retrying once",
-            agent_id,
-            exc_info=True,
-        )
+    # Two attempts: an immediate retry covers a transient control-plane
+    # blip with no cached copy to serve (cold start racing an ops
+    # redeploy / a runtime-config version bump); a second failure is
+    # the client's problem to retry — a retryable 503, never an
+    # anonymous 500. LookupError (definitive 404) and PlatformAuthError
+    # (a rejected runtime token never self-heals — the platform
+    # client's error taxonomy says page, don't retry) short-circuit.
+    payload = None
+    for attempt in (0, 1):
         try:
             payload = await cache.get(agent_id)
+            break
         except LookupError:
             raise HTTPException(
                 404,
                 f"agent {agent_id} not configured",
             )
         except PlatformAuthError:
+            logger.error(
+                "surogate-ops rejected the runtime token while resolving "
+                "agent %s — check the token's scope/rotation",
+                agent_id,
+            )
             raise HTTPException(
                 503,
                 "runtime authentication misconfigured — contact the "
                 "operator",
             )
         except Exception:
-            raise HTTPException(
-                503,
-                "runtime configuration temporarily unavailable — "
-                "retry shortly",
+            if attempt == 1:
+                raise HTTPException(
+                    503,
+                    "runtime configuration temporarily unavailable — "
+                    "retry shortly",
+                )
+            logger.warning(
+                "runtime-config fetch failed for agent %s — retrying once",
+                agent_id,
+                exc_info=True,
             )
 
     ctx = build_agent_runtime_context(payload)

--- a/surogates/runtime/resolver.py
+++ b/surogates/runtime/resolver.py
@@ -23,6 +23,7 @@ from surogates.runtime.context import (
     LLMEndpoint,
     SlashCommandConfig,
 )
+from surogates.runtime.platform_client import PlatformAuthError
 
 logger = logging.getLogger(__name__)
 
@@ -175,6 +176,11 @@ async def agent_runtime_context_dep(request: Request) -> AgentRuntimeContext:
     * ``503`` when the agent exists but ``enabled == False`` —
       "administratively stopped".  This is the lifecycle gate the
       management plane flips on ``stop_agent``.
+    * ``503`` (distinct details) when the runtime config cannot be
+      fetched: "temporarily unavailable" for a transient control-plane
+      failure that survived one retry (retry-worthy), or
+      "authentication misconfigured" when ops rejects the runtime
+      token (not retry-worthy — operations must rotate/rescope it).
     """
     agent_id = request.query_params.get("agent_id")
 
@@ -195,6 +201,20 @@ async def agent_runtime_context_dep(request: Request) -> AgentRuntimeContext:
             404,
             f"agent {agent_id} not configured",
         )
+    except PlatformAuthError:
+        # The runtime token was rejected — an operations problem that
+        # never self-heals, so no retry (the platform client's error
+        # taxonomy says page, don't retry). Still a 503 for clients,
+        # but named so nobody mistakes it for a transient blip.
+        logger.error(
+            "surogate-ops rejected the runtime token while resolving "
+            "agent %s — check the token's scope/rotation",
+            agent_id,
+        )
+        raise HTTPException(
+            503,
+            "runtime authentication misconfigured — contact the operator",
+        )
     except Exception:
         # Transient control-plane failure with no cached copy to serve
         # (cold start racing an ops redeploy / a runtime-config version
@@ -212,6 +232,12 @@ async def agent_runtime_context_dep(request: Request) -> AgentRuntimeContext:
             raise HTTPException(
                 404,
                 f"agent {agent_id} not configured",
+            )
+        except PlatformAuthError:
+            raise HTTPException(
+                503,
+                "runtime authentication misconfigured — contact the "
+                "operator",
             )
         except Exception:
             raise HTTPException(

--- a/surogates/session/interactive_input.py
+++ b/surogates/session/interactive_input.py
@@ -48,6 +48,11 @@ async def pending_input_for_session(
         "tool_call_id": (row.action_ref or {}).get("tool_call_id", ""),
         "questions": payload.get("questions") or [],
         "context": payload.get("context", ""),
+        # The blocked tool waits at most its own timeout; callers that
+        # convert free-text messages into answers use this to ignore
+        # rows orphaned by a tool timeout on a still-active session
+        # (the expire sweeper only clears terminal sessions).
+        "created_at": row.created_at,
     }
 
 
@@ -57,10 +62,17 @@ async def resolve_input_response(
     session_id,
     tool_call_id: str,
     responses: list[dict],
-) -> bool:
+) -> int | None:
+    """Claim the pending inbox item and emit the response event.
+
+    Returns the emitted event id (truthy) when this call resolved the
+    question, ``None`` when there was nothing pending to resolve — the
+    inbox-row update is the atomic claim, so two surfaces racing on the
+    same answer produce exactly one response event.
+    """
     tc_id = valid_tool_call_id(tool_call_id)
     if tc_id is None:
-        return False
+        return None
 
     async with store._sf() as db:
         result = await db.execute(
@@ -81,11 +93,10 @@ async def resolve_input_response(
         updated = bool(getattr(result, "rowcount", 0))
 
     if not updated:
-        return False
+        return None
 
-    await store.emit_event(
+    return await store.emit_event(
         session_id,
         EventType.ASK_USER_QUESTION_RESPONSE,
         {"tool_call_id": tc_id, "responses": responses},
     )
-    return True

--- a/surogates/session/interactive_input.py
+++ b/surogates/session/interactive_input.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+
 from sqlalchemy import func, select, update
 
 from surogates.db.models import InboxItem
 from surogates.session.events import EventType
+
+logger = logging.getLogger(__name__)
 
 
 def valid_tool_call_id(tool_call_id: str) -> str | None:
@@ -95,8 +99,42 @@ async def resolve_input_response(
     if not updated:
         return None
 
-    return await store.emit_event(
-        session_id,
-        EventType.ASK_USER_QUESTION_RESPONSE,
-        {"tool_call_id": tc_id, "responses": responses},
-    )
+    try:
+        return await store.emit_event(
+            session_id,
+            EventType.ASK_USER_QUESTION_RESPONSE,
+            {"tool_call_id": tc_id, "responses": responses},
+        )
+    except Exception:
+        # The claim committed but the response event did not: without a
+        # revert the row reads "responded" while the tool keeps waiting
+        # and no later attempt can convert — a wedged question. Putting
+        # the row back lets the caller fall back to a normal message
+        # and the user answer again via any surface.
+        try:
+            async with store._sf() as db:
+                await db.execute(
+                    update(InboxItem)
+                    .where(
+                        InboxItem.session_id == session_id,
+                        InboxItem.kind == "input_required",
+                        InboxItem.action_ref["tool_call_id"].as_string()
+                        == tc_id,
+                        InboxItem.status == "responded",
+                    )
+                    .values(
+                        status="pending",
+                        responded_at=None,
+                        updated_at=func.now(),
+                    ),
+                )
+                await db.commit()
+        except Exception:
+            logger.warning(
+                "Failed to revert claim for tool_call_id=%s after emit "
+                "failure; the question stays claimed until answered via "
+                "the form",
+                tc_id,
+                exc_info=True,
+            )
+        raise

--- a/surogates/session/interactive_input.py
+++ b/surogates/session/interactive_input.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 
 from sqlalchemy import func, select, update
 
-from surogates.db.models import InboxItem
+from surogates.db.models import Event, InboxItem
 from surogates.session.events import EventType
 
 logger = logging.getLogger(__name__)
@@ -138,3 +139,75 @@ async def resolve_input_response(
                 exc_info=True,
             )
         raise
+
+
+async def response_event_exists(
+    store,
+    *,
+    session_id,
+    tool_call_id: str,
+) -> bool:
+    """Whether a response event was already recorded for the tool call.
+
+    The form's respond route emits its event BEFORE its best-effort
+    inbox claim, so a row can read ``pending`` although the question is
+    answered — converters must not eat the next message for it. One
+    indexed probe (``idx_events_session_type``) instead of scanning the
+    session's response history.
+    """
+    async with store._sf() as db:
+        row = await db.execute(
+            select(Event.id)
+            .where(
+                Event.session_id == session_id,
+                Event.type == EventType.ASK_USER_QUESTION_RESPONSE.value,
+                Event.data["tool_call_id"].as_string() == tool_call_id,
+            )
+            .limit(1),
+        )
+        return row.scalar_one_or_none() is not None
+
+
+async def try_resolve_text_answer(
+    store,
+    *,
+    session_id,
+    text: str,
+    max_age_seconds: float | None = None,
+) -> int | None:
+    """Resolve free-form *text* as the answer to the live pending question.
+
+    The full guard set for surfaces that convert typed messages into
+    answers: nothing pending → ``None``; the pending row older than
+    ``max_age_seconds`` → ``None`` (the blocked tool has timed out, and
+    converting would feed a consumer that no longer exists); a response
+    event already recorded for the tool call → ``None`` (see
+    :func:`response_event_exists`). On success returns the response
+    event id. Callers treat ``None`` as "deliver the text as a normal
+    message".
+    """
+    pending = await pending_input_for_session(store, session_id=session_id)
+    if pending is None:
+        return None
+    created_at = pending.get("created_at")
+    if created_at is not None and max_age_seconds is not None:
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        age = (datetime.now(timezone.utc) - created_at).total_seconds()
+        if age > max_age_seconds:
+            return None
+    tool_call_id = pending.get("tool_call_id", "")
+    if await response_event_exists(
+        store, session_id=session_id, tool_call_id=tool_call_id,
+    ):
+        return None
+    from surogates.channels.platforms.telegram_interactive import (
+        resolve_text_answer,
+    )
+
+    return await resolve_input_response(
+        store,
+        session_id=session_id,
+        tool_call_id=tool_call_id,
+        responses=resolve_text_answer(pending.get("questions") or [], text),
+    )

--- a/surogates/tools/builtin/ask_user_question.py
+++ b/surogates/tools/builtin/ask_user_question.py
@@ -48,7 +48,11 @@ _POLL_INTERVAL_SECONDS = 1.0
 _LEASE_RENEW_INTERVAL_SECONDS = 30.0
 # Hard cap on how long we keep the worker parked on a single ask call.
 # Past this, we emit a timeout response so the LLM can move on.
-_MAX_WAIT_SECONDS = 30 * 60  # 30 minutes
+# Public: channel/web surfaces that convert free-text messages into
+# answers bound their staleness window to this — an inbox row older
+# than the wait cannot belong to a live tool call.
+ASK_USER_QUESTION_MAX_WAIT_SECONDS = 30 * 60  # 30 minutes
+_MAX_WAIT_SECONDS = ASK_USER_QUESTION_MAX_WAIT_SECONDS
 
 
 ASK_USER_QUESTION_DESCRIPTION = (

--- a/tests/runtime/test_cache_stale_on_failure.py
+++ b/tests/runtime/test_cache_stale_on_failure.py
@@ -1,0 +1,112 @@
+"""Stale-on-failure policy of RuntimeConfigCache and the resolver's
+retry-then-503 handling of transient control-plane failures."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from surogates.runtime.cache import RuntimeConfigCache
+from surogates.runtime.resolver import agent_runtime_context_dep
+
+
+class _Loader:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = 0
+
+    async def __call__(self, agent_id: str) -> dict:
+        self.calls += 1
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+async def test_serves_stale_entry_when_refresh_fails():
+    cfg = {"agent_id": "a1", "enabled": True}
+    loader = _Loader([cfg, RuntimeError("ops redeploying")])
+    cache = RuntimeConfigCache(loader, ttl_seconds=0.0, stale_grace_seconds=60)
+    assert await cache.get("a1") == cfg
+    # TTL 0: the next call must refresh, the refresh fails, the stale
+    # copy is served instead of the error.
+    assert await cache.get("a1") == cfg
+    assert loader.calls == 2
+
+
+async def test_failure_with_no_cached_copy_propagates():
+    loader = _Loader([RuntimeError("cold start blip")])
+    cache = RuntimeConfigCache(loader, ttl_seconds=0.0)
+    with pytest.raises(RuntimeError):
+        await cache.get("a1")
+
+
+async def test_lookup_error_purges_and_propagates():
+    cfg = {"agent_id": "a1", "enabled": True}
+    loader = _Loader([cfg, LookupError("gone"), LookupError("gone")])
+    cache = RuntimeConfigCache(loader, ttl_seconds=0.0, stale_grace_seconds=60)
+    assert await cache.get("a1") == cfg
+    # A definitive 404 must never be masked by a stale copy.
+    with pytest.raises(LookupError):
+        await cache.get("a1")
+    with pytest.raises(LookupError):
+        await cache.get("a1")
+
+
+async def test_stale_grace_expires():
+    cfg = {"agent_id": "a1", "enabled": True}
+    loader = _Loader([cfg, RuntimeError("down"), RuntimeError("down")])
+    cache = RuntimeConfigCache(loader, ttl_seconds=0.0, stale_grace_seconds=0.0)
+    assert await cache.get("a1") == cfg
+    with pytest.raises(RuntimeError):
+        await cache.get("a1")
+
+
+class _Request:
+    def __init__(self, cache, agent_id="a1"):
+        class _App:
+            pass
+
+        class _State:
+            pass
+
+        self.app = _App()
+        self.app.state = _State()
+        self.app.state.runtime_config_cache = cache
+        self.query_params = {"agent_id": agent_id}
+        self.headers = {}
+
+
+_ENABLED_PAYLOAD = {
+    "agent_id": "a1",
+    "org_id": "o1",
+    "project_id": "p1",
+    "enabled": True,
+    "version": 1,
+    "storage_key_prefix": "p1/a1",
+}
+
+
+async def test_resolver_retries_once_and_succeeds():
+    loader = _Loader([RuntimeError("blip"), _ENABLED_PAYLOAD])
+    cache = RuntimeConfigCache(loader, ttl_seconds=0.0)
+    ctx = await agent_runtime_context_dep(_Request(cache))
+    assert ctx.agent_id == "a1"
+    assert loader.calls == 2
+
+
+async def test_resolver_returns_503_after_second_failure():
+    loader = _Loader([RuntimeError("down"), RuntimeError("still down")])
+    cache = RuntimeConfigCache(loader, ttl_seconds=0.0)
+    with pytest.raises(HTTPException) as exc:
+        await agent_runtime_context_dep(_Request(cache))
+    assert exc.value.status_code == 503
+    assert "temporarily unavailable" in exc.value.detail
+
+
+async def test_resolver_404_on_lookup_error_during_retry():
+    loader = _Loader([RuntimeError("blip"), LookupError("gone")])
+    cache = RuntimeConfigCache(loader, ttl_seconds=0.0)
+    with pytest.raises(HTTPException) as exc:
+        await agent_runtime_context_dep(_Request(cache))
+    assert exc.value.status_code == 404

--- a/tests/runtime/test_cache_stale_on_failure.py
+++ b/tests/runtime/test_cache_stale_on_failure.py
@@ -110,3 +110,41 @@ async def test_resolver_404_on_lookup_error_during_retry():
     with pytest.raises(HTTPException) as exc:
         await agent_runtime_context_dep(_Request(cache))
     assert exc.value.status_code == 404
+
+
+from surogates.runtime.platform_client import PlatformAuthError  # noqa: E402
+
+
+async def test_auth_error_is_never_stale_served():
+    cfg = {"agent_id": "a1", "enabled": True}
+    loader = _Loader([cfg, PlatformAuthError("token revoked")])
+    cache = RuntimeConfigCache(loader, ttl_seconds=0.0, stale_grace_seconds=60)
+    assert await cache.get("a1") == cfg
+    with pytest.raises(PlatformAuthError):
+        await cache.get("a1")
+
+
+async def test_resolver_maps_auth_error_to_named_503_without_retry():
+    loader = _Loader([PlatformAuthError("token revoked")])
+    cache = RuntimeConfigCache(loader, ttl_seconds=0.0)
+    with pytest.raises(HTTPException) as exc:
+        await agent_runtime_context_dep(_Request(cache))
+    assert exc.value.status_code == 503
+    assert "authentication misconfigured" in exc.value.detail
+    assert loader.calls == 1  # no retry: the condition never self-heals
+
+
+async def test_failure_backoff_serves_stale_without_reloading():
+    cfg = {"agent_id": "a1", "enabled": True}
+    loader = _Loader([cfg, RuntimeError("down"), RuntimeError("down")])
+    cache = RuntimeConfigCache(
+        loader, ttl_seconds=0.0, stale_grace_seconds=60,
+        failure_backoff_seconds=30.0,
+    )
+    assert await cache.get("a1") == cfg
+    assert await cache.get("a1") == cfg  # refresh fails -> stale served
+    assert loader.calls == 2
+    # Within the backoff window the loader is not re-entered at all.
+    for _ in range(5):
+        assert await cache.get("a1") == cfg
+    assert loader.calls == 2

--- a/tests/test_interactive_input.py
+++ b/tests/test_interactive_input.py
@@ -61,6 +61,7 @@ async def test_pending_input_returns_payload_for_newest_pending_item():
     row = SimpleNamespace(
         action_ref={"tool_call_id": "tc1"},
         payload={"questions": [{"prompt": "q"}], "context": "ctx"},
+        created_at=None,
     )
     store = _Store(_DB(_ExecuteResult(row=row)))
 
@@ -70,6 +71,7 @@ async def test_pending_input_returns_payload_for_newest_pending_item():
         "tool_call_id": "tc1",
         "questions": [{"prompt": "q"}],
         "context": "ctx",
+        "created_at": None,
     }
 
 
@@ -83,7 +85,7 @@ async def test_resolve_emits_when_pending_row_claimed():
         responses=[{"question": "q", "answer": "a", "is_other": False}],
     )
 
-    assert ok is True
+    assert ok == 42
     assert store._db.committed is True
     assert store.emitted == [
         (
@@ -107,5 +109,5 @@ async def test_resolve_skips_emit_when_no_pending_row_claimed():
         responses=[],
     )
 
-    assert ok is False
+    assert ok is None
     assert store.emitted == []

--- a/tests/test_send_message_pending_question.py
+++ b/tests/test_send_message_pending_question.py
@@ -40,10 +40,9 @@ class _DB:
 
 
 class _Store:
-    def __init__(self, db, prior_responses=()):
+    def __init__(self, db):
         self._db = db
         self.emitted = []
-        self.prior_responses = list(prior_responses)
 
     def _sf(self):
         return self._db
@@ -51,9 +50,6 @@ class _Store:
     async def emit_event(self, session_id, event_type, data):
         self.emitted.append((session_id, event_type, data))
         return 77
-
-    async def get_events(self, session_id, after=0, types=None):
-        return self.prior_responses
 
 
 def _pending_row(*, age_seconds: int = 0):
@@ -73,6 +69,7 @@ async def test_fresh_pending_question_consumes_the_message():
     store = _Store(
         _DB(
             _ExecuteResult(row=_pending_row(age_seconds=60)),
+            _ExecuteResult(row=None),  # no prior response event
             _ExecuteResult(rowcount=1),  # inbox claim
         ),
     )
@@ -113,6 +110,7 @@ async def test_lost_claim_race_returns_none():
     store = _Store(
         _DB(
             _ExecuteResult(row=_pending_row(age_seconds=5)),
+            _ExecuteResult(row=None),  # no prior response event
             _ExecuteResult(rowcount=0),  # someone else claimed it
         ),
     )
@@ -124,10 +122,11 @@ async def test_already_answered_question_is_not_reclaimed():
     """The form's respond route emits before its best-effort claim; a
     row left pending after a form answer must not eat the next typed
     message."""
-    prior = SimpleNamespace(data={"tool_call_id": "tc-live"})
     store = _Store(
-        _DB(_ExecuteResult(row=_pending_row(age_seconds=10))),
-        prior_responses=[prior],
+        _DB(
+            _ExecuteResult(row=_pending_row(age_seconds=10)),
+            _ExecuteResult(row=object()),  # a prior response event exists
+        ),
     )
     assert await _resolve_pending_question(store, "s1", "hello") is None
     assert store.emitted == []

--- a/tests/test_send_message_pending_question.py
+++ b/tests/test_send_message_pending_question.py
@@ -1,0 +1,126 @@
+"""The web message route converts typed replies into pending-question
+answers (mirrors the slack/telegram inbound behavior)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from surogates.api.routes.sessions import _resolve_pending_question
+from surogates.session.events import EventType
+
+
+class _ExecuteResult:
+    def __init__(self, *, rowcount=0, row=None):
+        self.rowcount = rowcount
+        self._row = row
+
+    def scalar_one_or_none(self):
+        return self._row
+
+
+class _DB:
+    def __init__(self, *results):
+        self.results = list(results)
+        self.committed = False
+
+    async def execute(self, *args, **kwargs):
+        if not self.results:
+            return _ExecuteResult()
+        return self.results.pop(0)
+
+    async def commit(self):
+        self.committed = True
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class _Store:
+    def __init__(self, db):
+        self._db = db
+        self.emitted = []
+
+    def _sf(self):
+        return self._db
+
+    async def emit_event(self, session_id, event_type, data):
+        self.emitted.append((session_id, event_type, data))
+        return 77
+
+
+def _pending_row(*, age_seconds: int = 0):
+    return SimpleNamespace(
+        action_ref={"tool_call_id": "tc-live"},
+        payload={
+            "questions": [{"prompt": "What subjects do you like?"}],
+            "context": "",
+        },
+        created_at=(
+            datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+        ),
+    )
+
+
+async def test_fresh_pending_question_consumes_the_message():
+    store = _Store(
+        _DB(
+            _ExecuteResult(row=_pending_row(age_seconds=60)),
+            _ExecuteResult(rowcount=1),  # inbox claim
+        ),
+    )
+    event_id = await _resolve_pending_question(store, "s1", "biology mostly")
+    assert event_id == 77
+    (session_id, event_type, data) = store.emitted[0]
+    assert event_type is EventType.ASK_USER_QUESTION_RESPONSE
+    assert data["tool_call_id"] == "tc-live"
+    assert data["responses"] == [
+        {
+            "question": "What subjects do you like?",
+            "answer": "biology mostly",
+            "is_other": True,
+        },
+    ]
+
+
+async def test_no_pending_question_returns_none():
+    store = _Store(_DB(_ExecuteResult(row=None)))
+    assert await _resolve_pending_question(store, "s1", "hello") is None
+    assert store.emitted == []
+
+
+async def test_stale_pending_row_is_ignored():
+    """A row older than the tool's wait window belongs to a timed-out
+    call — converting would swallow the message with nothing consuming
+    the answer."""
+    store = _Store(
+        _DB(_ExecuteResult(row=_pending_row(age_seconds=31 * 60))),
+    )
+    assert await _resolve_pending_question(store, "s1", "hello") is None
+    assert store.emitted == []
+
+
+async def test_lost_claim_race_returns_none():
+    """The form's respond route claimed the row first: exactly one
+    response event, and the message falls through as a normal one."""
+    store = _Store(
+        _DB(
+            _ExecuteResult(row=_pending_row(age_seconds=5)),
+            _ExecuteResult(rowcount=0),  # someone else claimed it
+        ),
+    )
+    assert await _resolve_pending_question(store, "s1", "hello") is None
+    assert store.emitted == []
+
+
+async def test_resolution_failure_falls_back_to_normal_message():
+    class _BrokenStore:
+        def _sf(self):
+            raise RuntimeError("db down")
+
+    assert (
+        await _resolve_pending_question(_BrokenStore(), "s1", "hello")
+    ) is None

--- a/tests/test_send_message_pending_question.py
+++ b/tests/test_send_message_pending_question.py
@@ -40,9 +40,10 @@ class _DB:
 
 
 class _Store:
-    def __init__(self, db):
+    def __init__(self, db, prior_responses=()):
         self._db = db
         self.emitted = []
+        self.prior_responses = list(prior_responses)
 
     def _sf(self):
         return self._db
@@ -50,6 +51,9 @@ class _Store:
     async def emit_event(self, session_id, event_type, data):
         self.emitted.append((session_id, event_type, data))
         return 77
+
+    async def get_events(self, session_id, after=0, types=None):
+        return self.prior_responses
 
 
 def _pending_row(*, age_seconds: int = 0):
@@ -111,6 +115,19 @@ async def test_lost_claim_race_returns_none():
             _ExecuteResult(row=_pending_row(age_seconds=5)),
             _ExecuteResult(rowcount=0),  # someone else claimed it
         ),
+    )
+    assert await _resolve_pending_question(store, "s1", "hello") is None
+    assert store.emitted == []
+
+
+async def test_already_answered_question_is_not_reclaimed():
+    """The form's respond route emits before its best-effort claim; a
+    row left pending after a form answer must not eat the next typed
+    message."""
+    prior = SimpleNamespace(data={"tool_call_id": "tc-live"})
+    store = _Store(
+        _DB(_ExecuteResult(row=_pending_row(age_seconds=10))),
+        prior_responses=[prior],
     )
     assert await _resolve_pending_question(store, "s1", "hello") is None
     assert store.emitted == []


### PR DESCRIPTION
Implements items D and F of invergent-ai/surogate-ops#319 (findings from the full live test of the monetization mechanism), plus the adversarial-review and simplify rounds.

## D — A typed web message answers a pending `ask_user_question`
The ask-tool wait loop resolves only on `ASK_USER_QUESTION_RESPONSE` events; a plain `user.message` sent while a question was pending sat unconsumed while the wake stayed parked on the tool until its 30-minute timeout (observed live — Ludwig's onboarding asks a question nearly every turn, so any user who typed instead of using the form saw a hung agent).

The web `send_message` route now converts a pure-text message into the question's answer through a new shared helper `interactive_input.try_resolve_text_answer` carrying the full guard set:
- **atomic claim** of the pending inbox row (exactly one response event among claim-first callers), with **claim revert** if the response event fails to emit;
- **freshness cap** a minute short of the tool's own deadline — near the boundary the safe error is treating a live question as expired (message falls through as normal), never the reverse (message swallowed);
- **already-answered probe** (one indexed event lookup) because the form's respond route emits before its best-effort claim;
- **terminal-session guard**: a session resumed from paused/failed/completed has a dead tool consumer — its first message stays a normal message;
- service-account `/v1/api` alias excluded (an API client cannot detect the reinterpretation); images/attachments stay normal messages;
- commerce/allowance gates deliberately not re-run: the resumed turn spends the reservation its original message already authorized.

Telegram/Slack already had their own conversion paths; the new helper is the shared home they can migrate to.

## F — Resilient tenant resolution
A transient control-plane failure during per-request tenant resolution surfaced as an anonymous 500 on every `/v1` route (observed live: login 500 right after a runtime-config version bump). Now:
- `RuntimeConfigCache` implements the **stale-on-failure policy** the platform client's error taxonomy was written against: an expired entry is served for a grace window when the refresh fails, with a **failure backoff** so an ops outage doesn't serialize requests behind timing-out fetches;
- `LookupError` (404) stays definitive and purges the entry; `PlatformAuthError` (rejected runtime token) is **never absorbed and never retried** — named 503 so nobody mistakes it for a blip;
- the resolver retries a cold-start miss once, then answers a retryable 503.

## Tests
Full suite: **4690 passed** (the 24 failures are the pre-existing baseline, verified identical on untouched master). New coverage: pending-question conversion guards (6), cache stale-on-failure/backoff/auth taxonomy + resolver retry (10), interactive-input claim/revert.

Refs invergent-ai/surogate-ops#319
