### PR TITLE
fix(harness): parse fenced JSON so turn recaps survive gateway behaviour changes

### DIFF
--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -20,7 +20,6 @@ import asyncio
 import json
 import logging
 import os
-import re
 import traceback
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -69,7 +69,7 @@ from surogates.harness.slash_skill import (
 )
 from surogates.harness.subdirectory_hints import SubdirectoryHintTracker
 from surogates.harness.streaming_executor import StreamingToolExecutor
-from surogates.harness.structured_output import generate_structured
+from surogates.harness.structured_output import generate_structured, parse_json_object
 from surogates.harness.tool_exec import execute_tool_calls
 from surogates.harness.tool_guardrails import ToolGuardrailConfig, ToolGuardrails
 from surogates.harness.tool_schemas import filter_schemas_for_tenant
@@ -3376,20 +3376,12 @@ class AgentHarness(
 
     @staticmethod
     def _parse_json_object(content: str) -> dict[str, Any]:
-        text = content.strip()
-        if text.startswith("```"):
-            text = re.sub(r"^```(?:json)?\s*", "", text)
-            text = re.sub(r"\s*```$", "", text)
-        if not text:
-            raise ValueError("User-action rescue judge returned empty content")
-        if not text.startswith("{"):
-            start = text.find("{")
-            end = text.rfind("}")
-            if start >= 0 and end > start:
-                text = text[start:end + 1]
-        parsed = json.loads(text)
-        if not isinstance(parsed, dict):
-            raise ValueError("User-action rescue judge returned non-object JSON")
+        parsed = parse_json_object(content)
+        if parsed is None:
+            raise ValueError(
+                "User-action rescue judge returned non-object or "
+                "unparsable JSON",
+            )
         return parsed
 
     @staticmethod

--- a/surogates/harness/loop_mission_evaluator.py
+++ b/surogates/harness/loop_mission_evaluator.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import json
 import logging
-import re
 from typing import Any, Literal
 from uuid import UUID
 
@@ -329,7 +327,7 @@ def _build_mission_judge(
             # sees the documented shape (or a parse error, never a
             # silently-malformed dict).
             return _MissionVerdict.model_validate(parsed).model_dump()
-        except (json.JSONDecodeError, ValueError) as exc:
+        except ValueError as exc:
             raise MissionJudgeParseError(str(exc)) from exc
 
     return judge

--- a/surogates/harness/loop_mission_evaluator.py
+++ b/surogates/harness/loop_mission_evaluator.py
@@ -10,7 +10,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
-from surogates.harness.structured_output import generate_structured
+from surogates.harness.structured_output import generate_structured, parse_json_object
 from surogates.session.events import EventType
 
 logger = logging.getLogger(__name__)
@@ -215,29 +215,14 @@ async def _research_report_task_done(session_factory: Any, mission_id: Any) -> b
 def _parse_judge_json(raw: str) -> dict[str, Any]:
     """Tolerant JSON extraction for the mission judge.
 
-    Mirrors :meth:`AgentHarness._parse_json_object`: strips Markdown
-    fences, falls back to the first ``{...}`` block in prose, and
-    raises ``ValueError`` on empty / non-object payloads so the caller
-    can surface the error as a ``MissionJudgeParseError``.
+    Delegates to :func:`parse_json_object` (fences, prose around the
+    object, reasoning-model preambles) and raises ``ValueError`` when
+    no object can be extracted so the caller can surface the error as
+    a ``MissionJudgeParseError``.
     """
-    text = raw.strip()
-    if text.startswith("```"):
-        text = re.sub(r"^```(?:json)?\s*", "", text)
-        text = re.sub(r"\s*```$", "", text)
-    text = text.strip()
-    if not text:
-        raise ValueError("empty payload")
-    # Some reasoning models prefix the JSON with their thought process.
-    # Find the first balanced ``{ ... }`` block if the payload isn't
-    # already a JSON object.
-    if not text.startswith("{"):
-        start = text.find("{")
-        end = text.rfind("}")
-        if start >= 0 and end > start:
-            text = text[start:end + 1]
-    parsed = json.loads(text)
-    if not isinstance(parsed, dict):
-        raise ValueError(f"judge returned non-object JSON: {type(parsed).__name__}")
+    parsed = parse_json_object(raw)
+    if parsed is None:
+        raise ValueError("judge returned non-object or unparsable JSON")
     return parsed
 
 

--- a/surogates/harness/outcomes.py
+++ b/surogates/harness/outcomes.py
@@ -7,11 +7,12 @@ helpers.
 
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import asdict, dataclass
 from typing import Any
 from uuid import uuid4
+
+from surogates.harness.structured_output import parse_json_object
 
 DEFAULT_MAX_ITERATIONS = 20
 MAX_MAX_ITERATIONS = 20
@@ -22,7 +23,6 @@ DEFAULT_OUTCOME_RUBRIC = (
 )
 
 _RUBRIC_RE = re.compile(r"\n\s*(?:rubric|criteria)\s*:\s*\n", re.IGNORECASE)
-_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
 
 EVALUATOR_SYSTEM_PROMPT = (
     "You are a strict outcome evaluator for an agent harness. Evaluate the "
@@ -246,24 +246,7 @@ def parse_outcome_evaluation(raw: str) -> OutcomeEvaluation:
             parse_failed=True,
         )
 
-    text = raw.strip()
-    if text.startswith("```"):
-        text = text.strip("`")
-        newline = text.find("\n")
-        if newline >= 0:
-            text = text[newline + 1 :]
-
-    data: Any = None
-    try:
-        data = json.loads(text)
-    except Exception:
-        match = _JSON_OBJECT_RE.search(text)
-        if match is not None:
-            try:
-                data = json.loads(match.group(0))
-            except Exception:
-                data = None
-
+    data: Any = parse_json_object(raw)
     if not isinstance(data, dict):
         return OutcomeEvaluation(
             result="needs_revision",

--- a/surogates/harness/structured_output.py
+++ b/surogates/harness/structured_output.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterator
 from typing import Any, TypeVar
 
 from pydantic import BaseModel
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseModel)
 
 
-def iter_json_objects(content: Any):
+def iter_json_objects(content: Any) -> Iterator[dict[str, Any]]:
     """Yield every decodable JSON object embedded in raw model text.
 
     Providers that ignore ``response_format={"type": "json_object"}``
@@ -24,6 +25,10 @@ def iter_json_objects(content: Any):
     caller wants a mapping.  A truncated outer object can still yield
     complete objects nested inside it; callers that validate against a
     schema should keep scanning past candidates that fail validation.
+
+    ``content`` is deliberately ``Any``: callers pass provider response
+    attributes straight in, and a missing/None channel means "nothing
+    here", not a programming error.
     """
     if not isinstance(content, str):
         return
@@ -51,7 +56,6 @@ def iter_json_objects(content: Any):
             idx = text.find("{", end)
         else:
             idx = text.find("{", idx + 1)
-    return
 
 
 def parse_json_object(content: Any) -> dict[str, Any] | None:
@@ -255,7 +259,7 @@ def _coerce_structured_result(value: Any, output_model: type[T]) -> T:
         return value
     if isinstance(value, dict):
         return output_model.model_validate(value)
-    parsed = parse_json_object(str(value or ""))
+    parsed = parse_json_object(value if isinstance(value, str) else str(value))
     if parsed is None:
         raise ValueError("model output contains no JSON object")
     return output_model.model_validate(parsed)

--- a/surogates/harness/structured_output.py
+++ b/surogates/harness/structured_output.py
@@ -13,42 +13,55 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseModel)
 
 
-def parse_json_object(content: Any) -> dict[str, Any] | None:
-    """Best-effort extraction of one JSON object from raw model text.
+def iter_json_objects(content: Any):
+    """Yield every decodable JSON object embedded in raw model text.
 
     Providers that ignore ``response_format={"type": "json_object"}``
     (Claude via OpenAI-compatible gateways, notably) return the object
     wrapped in markdown fences and sometimes surrounded by prose.
-    Accepts the text as-is, fenced, or embedded in prose; returns the
-    first JSON *object* found, or ``None`` when no complete object can
-    be decoded.  Valid JSON that is not an object (array, string, ...)
-    is rejected -- every caller wants a mapping.
+    Accepts the text as-is, fenced, or embedded in prose.  Valid JSON
+    that is not an object (array, string, ...) is skipped -- every
+    caller wants a mapping.  A truncated outer object can still yield
+    complete objects nested inside it; callers that validate against a
+    schema should keep scanning past candidates that fail validation.
     """
     if not isinstance(content, str):
-        return None
+        return
     text = content.strip()
     if not text:
-        return None
+        return
     try:
         parsed = json.loads(text)
     except json.JSONDecodeError:
-        parsed = None
-    if isinstance(parsed, dict):
-        return parsed
-    if parsed is not None:
-        return None
+        pass
+    else:
+        if isinstance(parsed, dict):
+            yield parsed
+        return
     decoder = json.JSONDecoder()
     idx = text.find("{")
     while idx != -1:
         try:
-            candidate, _ = decoder.raw_decode(text, idx)
+            candidate, end = decoder.raw_decode(text, idx)
         except json.JSONDecodeError:
             idx = text.find("{", idx + 1)
             continue
         if isinstance(candidate, dict):
-            return candidate
-        idx = text.find("{", idx + 1)
-    return None
+            yield candidate
+            idx = text.find("{", end)
+        else:
+            idx = text.find("{", idx + 1)
+    return
+
+
+def parse_json_object(content: Any) -> dict[str, Any] | None:
+    """First JSON object embedded in raw model text, or ``None``.
+
+    See :func:`iter_json_objects` for the extraction rules.  First
+    object wins by design -- without a schema there is no way to rank
+    candidates, and clean fenced output has exactly one.
+    """
+    return next(iter_json_objects(content), None)
 
 
 async def generate_structured(
@@ -198,18 +211,18 @@ async def _try_openai_json_mode(
     # ``message.content`` and the JSON we asked for in
     # ``message.reasoning_content`` -- empty content alone isn't a failure
     # if the JSON is sitting in the reasoning channel.  Both channels are
-    # tried: prose in ``content`` no longer masks an object parked in
-    # ``reasoning_content``.
+    # tried, and within each, every embedded object -- leaked reasoning
+    # can contain draft objects before the real answer, and the schema
+    # is the only reliable way to tell them apart.
     for attr in ("content", "reasoning_content"):
-        parsed = parse_json_object(getattr(message, attr, None))
-        if parsed is None:
-            continue
-        try:
-            return output_model.model_validate(parsed)
-        except Exception as exc:
-            logger.debug(
-                "JSON-mode fallback validation failed on %s: %s", attr, exc,
-            )
+        for parsed in iter_json_objects(getattr(message, attr, None)):
+            try:
+                return output_model.model_validate(parsed)
+            except Exception as exc:
+                logger.debug(
+                    "JSON-mode fallback validation failed on %s: %s",
+                    attr, exc,
+                )
     return None
 
 

--- a/surogates/harness/structured_output.py
+++ b/surogates/harness/structured_output.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from typing import Any, TypeVar
 
 from pydantic import BaseModel
@@ -12,6 +11,44 @@ from pydantic import BaseModel
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
+
+
+def parse_json_object(content: Any) -> dict[str, Any] | None:
+    """Best-effort extraction of one JSON object from raw model text.
+
+    Providers that ignore ``response_format={"type": "json_object"}``
+    (Claude via OpenAI-compatible gateways, notably) return the object
+    wrapped in markdown fences and sometimes surrounded by prose.
+    Accepts the text as-is, fenced, or embedded in prose; returns the
+    first JSON *object* found, or ``None`` when no complete object can
+    be decoded.  Valid JSON that is not an object (array, string, ...)
+    is rejected -- every caller wants a mapping.
+    """
+    if not isinstance(content, str):
+        return None
+    text = content.strip()
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        return parsed
+    if parsed is not None:
+        return None
+    decoder = json.JSONDecoder()
+    idx = text.find("{")
+    while idx != -1:
+        try:
+            candidate, _ = decoder.raw_decode(text, idx)
+        except json.JSONDecodeError:
+            idx = text.find("{", idx + 1)
+            continue
+        if isinstance(candidate, dict):
+            return candidate
+        idx = text.find("{", idx + 1)
+    return None
 
 
 async def generate_structured(
@@ -160,35 +197,20 @@ async def _try_openai_json_mode(
     # with enable_thinking=True) often put visible text in
     # ``message.content`` and the JSON we asked for in
     # ``message.reasoning_content`` -- empty content alone isn't a failure
-    # if the JSON is sitting in the reasoning channel.
-    text = _extract_json_text(message)
-    if not text:
-        return None
-
-    try:
-        return output_model.model_validate_json(text)
-    except Exception as exc:
-        logger.debug("JSON-mode fallback validation failed: %s", exc)
-        return None
-
-
-def _extract_json_text(message: Any) -> str:
-    """Pull a JSON candidate string from ``message.content`` or
-    ``message.reasoning_content`` (in that order), stripping markdown
-    fences if present.  Returns an empty string when neither field
-    holds anything usable.
-    """
-    if message is None:
-        return ""
+    # if the JSON is sitting in the reasoning channel.  Both channels are
+    # tried: prose in ``content`` no longer masks an object parked in
+    # ``reasoning_content``.
     for attr in ("content", "reasoning_content"):
-        raw = getattr(message, attr, None)
-        if isinstance(raw, str) and raw.strip():
-            text = raw.strip()
-            if text.startswith("```"):
-                text = re.sub(r"^```(?:json)?\s*", "", text)
-                text = re.sub(r"\s*```$", "", text)
-            return text.strip()
-    return ""
+        parsed = parse_json_object(getattr(message, attr, None))
+        if parsed is None:
+            continue
+        try:
+            return output_model.model_validate(parsed)
+        except Exception as exc:
+            logger.debug(
+                "JSON-mode fallback validation failed on %s: %s", attr, exc,
+            )
+    return None
 
 
 def _make_outlines_model(
@@ -220,8 +242,7 @@ def _coerce_structured_result(value: Any, output_model: type[T]) -> T:
         return value
     if isinstance(value, dict):
         return output_model.model_validate(value)
-    text = str(value or "").strip()
-    if text.startswith("```"):
-        text = re.sub(r"^```(?:json)?\s*", "", text)
-        text = re.sub(r"\s*```$", "", text)
-    return output_model.model_validate_json(text)
+    parsed = parse_json_object(str(value or ""))
+    if parsed is None:
+        raise ValueError("model output contains no JSON object")
+    return output_model.model_validate(parsed)

--- a/surogates/harness/turn_summarizer.py
+++ b/surogates/harness/turn_summarizer.py
@@ -22,10 +22,11 @@ expected to omit the summary event rather than fail the turn.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from dataclasses import dataclass, field
 from typing import Any, Literal
+
+from surogates.harness.structured_output import parse_json_object
 
 logger = logging.getLogger(__name__)
 
@@ -261,16 +262,16 @@ class TurnSummarizer:
         if not content:
             return None
 
-        try:
-            parsed = json.loads(content)
-        except (json.JSONDecodeError, TypeError):
+        # Fence-tolerant: gateways that ignore ``response_format``
+        # (Claude via yunwu killed every recap fleet-wide for two days)
+        # return the object wrapped in ```json fences.
+        parsed = parse_json_object(content)
+        if parsed is None:
             logger.warning(
                 "turn summary returned non-JSON for %s: %r",
                 turn_id,
                 content[:200],
             )
-            return None
-        if not isinstance(parsed, dict):
             return None
 
         recap = str(parsed.get("recap") or "").strip()

--- a/surogates/harness/turn_summarizer.py
+++ b/surogates/harness/turn_summarizer.py
@@ -263,12 +263,12 @@ class TurnSummarizer:
             return None
 
         # Fence-tolerant: gateways that ignore ``response_format``
-        # (Claude via yunwu killed every recap fleet-wide for two days)
-        # return the object wrapped in ```json fences.
+        # return the object wrapped in ```json fences — a strict parse
+        # here once silenced recaps entirely.
         parsed = parse_json_object(content)
         if parsed is None:
             logger.warning(
-                "turn summary returned non-JSON for %s: %r",
+                "turn summary returned no JSON object for %s: %r",
                 turn_id,
                 content[:200],
             )

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -7,7 +7,10 @@ from unittest.mock import AsyncMock, patch
 from openai import AsyncOpenAI
 from pydantic import BaseModel
 
-from surogates.harness.structured_output import generate_structured
+from surogates.harness.structured_output import (
+    generate_structured,
+    parse_json_object,
+)
 
 
 class RoutingDecision(BaseModel):
@@ -331,3 +334,86 @@ async def test_fallback_skipped_for_empty_messages() -> None:
 
     assert decision is None
     create_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# parse_json_object
+# ---------------------------------------------------------------------------
+
+
+def test_parse_json_object_accepts_raw_object() -> None:
+    assert parse_json_object('{"a": 1}') == {"a": 1}
+
+
+def test_parse_json_object_accepts_fenced_object() -> None:
+    fenced = '```json\n{"recap": "done", "artifacts": []}\n```'
+    assert parse_json_object(fenced) == {"recap": "done", "artifacts": []}
+
+
+def test_parse_json_object_accepts_bare_fence_without_language_tag() -> None:
+    assert parse_json_object('```\n{"a": true}\n```') == {"a": True}
+
+
+def test_parse_json_object_accepts_prose_around_fence() -> None:
+    text = (
+        "Sure! Here is the JSON:\n```json\n"
+        '{"a": {"nested": "with a } brace in a string"}}\n'
+        "```\nHope this helps."
+    )
+    assert parse_json_object(text) == {
+        "a": {"nested": "with a } brace in a string"},
+    }
+
+
+def test_parse_json_object_skips_false_brace_starts() -> None:
+    assert parse_json_object('{oops — real one: {"a": 1}') == {"a": 1}
+
+
+def test_parse_json_object_rejects_non_object_json() -> None:
+    assert parse_json_object("[1, 2, 3]") is None
+    assert parse_json_object('"just a string"') is None
+
+
+def test_parse_json_object_rejects_truncated_object() -> None:
+    assert parse_json_object('```json\n{"recap": "cut off mid') is None
+
+
+def test_parse_json_object_rejects_empty_and_non_string() -> None:
+    assert parse_json_object("") is None
+    assert parse_json_object("   ") is None
+    assert parse_json_object(None) is None
+    assert parse_json_object(42) is None
+
+
+async def test_fallback_reads_json_from_reasoning_content() -> None:
+    """Prose in ``content`` must not mask the object a reasoning-mode
+    model parked in ``reasoning_content``."""
+    llm_client = AsyncOpenAI(api_key="test-key")
+    llm_client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="I thought about it and answered below.",
+                        reasoning_content=json.dumps(
+                            {"route": "final", "confidence": 0.9}
+                        ),
+                        refusal=None,
+                    )
+                )
+            ]
+        )
+    )
+
+    with patch(
+        "surogates.harness.structured_output._try_outlines",
+        AsyncMock(return_value=None),
+    ):
+        decision = await generate_structured(
+            llm_client=llm_client,
+            model="deepseek-r1",
+            messages=[{"role": "user", "content": "Route this."}],
+            output_model=RoutingDecision,
+        )
+
+    assert decision == RoutingDecision(route="final", confidence=0.9)

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 from surogates.harness.structured_output import (
     generate_structured,
+    iter_json_objects,
     parse_json_object,
 )
 
@@ -417,3 +418,49 @@ async def test_fallback_reads_json_from_reasoning_content() -> None:
         )
 
     assert decision == RoutingDecision(route="final", confidence=0.9)
+
+
+def test_iter_json_objects_yields_every_embedded_object() -> None:
+    text = 'draft {"a": 1} then final ```json\n{"a": 2}\n```'
+    assert list(iter_json_objects(text)) == [{"a": 1}, {"a": 2}]
+
+
+def test_iter_json_objects_does_not_rescan_nested_objects() -> None:
+    # The outer object is complete, so its members must not be yielded
+    # again as separate candidates.
+    text = 'noise {"outer": {"inner": 1}} tail'
+    assert list(iter_json_objects(text)) == [{"outer": {"inner": 1}}]
+
+
+async def test_fallback_skips_draft_objects_that_fail_the_schema() -> None:
+    """Leaked reasoning can park a draft object ahead of the answer;
+    the schema is what tells them apart."""
+    llm_client = AsyncOpenAI(api_key="test-key")
+    leaked = (
+        'Let me think. Maybe {"route": "unsure"} — no. Final answer:\n'
+        "```json\n"
+        + json.dumps({"route": "final", "confidence": 0.6})
+        + "\n```"
+    )
+    llm_client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content=leaked, refusal=None)
+                )
+            ]
+        )
+    )
+
+    with patch(
+        "surogates.harness.structured_output._try_outlines",
+        AsyncMock(return_value=None),
+    ):
+        decision = await generate_structured(
+            llm_client=llm_client,
+            model="gemma-4-31B",
+            messages=[{"role": "user", "content": "Route this."}],
+            output_model=RoutingDecision,
+        )
+
+    assert decision == RoutingDecision(route="final", confidence=0.6)

--- a/tests/test_turn_summarizer.py
+++ b/tests/test_turn_summarizer.py
@@ -338,3 +338,74 @@ async def test_summarize_turn_drops_internal_workspace_paths() -> None:
     # recap survives; the internal file does not.
     assert result is not None
     assert result.artifacts == []
+
+
+@pytest.mark.asyncio
+async def test_summarize_turn_parses_markdown_fenced_json() -> None:
+    # Exact failure shape observed in prod 2026-07-27..30: Claude via an
+    # OpenAI-compatible gateway ignores response_format=json_object and
+    # wraps the object in a ```json fence. The recap must still land.
+    payload = (
+        "```json\n"
+        '{\n  "recap": "Quizzed the user on 5 Greek verbs and updated '
+        'the progress tracker.",\n  "artifacts": []\n}\n'
+        "```"
+    )
+    client = _StubClient(payload)
+    summarizer = _turn_summarizer(client)
+
+    result = await summarizer.summarize_turn(
+        turn_id="t1",
+        user_message="help me practice greek verbs",
+        iteration_summaries=["Quiz user on verbs"],
+        candidate_artifacts=[],
+    )
+
+    assert isinstance(result, TurnSummary)
+    assert result.recap.startswith("Quizzed the user")
+    assert result.artifacts == []
+
+
+@pytest.mark.asyncio
+async def test_summarize_turn_parses_json_with_surrounding_prose() -> None:
+    payload = (
+        "Here is the summary you asked for:\n"
+        "```json\n"
+        '{"recap": "Built the report.", "artifacts": '
+        '[{"kind": "file", "label": "report.pdf", "ref": "report.pdf"}]}\n'
+        "```\n"
+        "Let me know if you need anything else."
+    )
+    client = _StubClient(payload)
+    summarizer = _turn_summarizer(client)
+
+    result = await summarizer.summarize_turn(
+        turn_id="t1",
+        user_message="make me a report",
+        iteration_summaries=["Write report"],
+        candidate_artifacts=[
+            TurnArtifact(kind="file", label="report.pdf", ref="report.pdf"),
+        ],
+    )
+
+    assert isinstance(result, TurnSummary)
+    assert result.recap == "Built the report."
+    assert [a.ref for a in result.artifacts] == ["report.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_summarize_turn_returns_none_on_truncated_fenced_json() -> None:
+    # A max_tokens cutoff mid-object stays unparseable — no recap
+    # beats a silently wrong one.
+    payload = '```json\n{"recap": "The agent loaded the PostHog analytics'
+    client = _StubClient(payload)
+    summarizer = _turn_summarizer(client)
+
+    result = await summarizer.summarize_turn(
+        turn_id="t1",
+        user_message="stats please",
+        iteration_summaries=["Run queries"],
+        candidate_artifacts=[],
+    )
+
+    assert result is None

--- a/tests/test_turn_summarizer.py
+++ b/tests/test_turn_summarizer.py
@@ -342,9 +342,10 @@ async def test_summarize_turn_drops_internal_workspace_paths() -> None:
 
 @pytest.mark.asyncio
 async def test_summarize_turn_parses_markdown_fenced_json() -> None:
-    # Exact failure shape observed in prod 2026-07-27..30: Claude via an
-    # OpenAI-compatible gateway ignores response_format=json_object and
-    # wraps the object in a ```json fence. The recap must still land.
+    # The exact failure shape that silenced recaps in production:
+    # Claude via an OpenAI-compatible gateway ignores
+    # response_format=json_object and wraps the object in a ```json
+    # fence. The recap must still land.
     payload = (
         "```json\n"
         '{\n  "recap": "Quizzed the user on 5 Greek verbs and updated '


### PR DESCRIPTION
## What broke

Every `turn.summary` recap stopped being emitted fleet-wide after **2026-07-27 09:04** (the last recap ever recorded). The summarizer asks for `response_format: {"type": "json_object"}` and parses the reply with a bare `json.loads`. When prod's base model moved to `claude-sonnet-5` through the OpenAI-compatible gateway on 07-26, the provider began ignoring `response_format` and wrapping the object in ` ```json ` fences — valid JSON inside a fence, discarded on every turn.

Measured recap success rate (recaps emitted vs. turns attempted, prod `events`):

| Window | Success |
|---|---|
| through 07-26 | 78–100% |
| 07-27 | 6% |
| 07-28 onward | 0% |

Reproduced live against the gateway with the exact prod prompt: `claude-sonnet-5` **and** `claude-opus-4-8` fence 3/3, so rolling the model back would not have fixed it either. `turn_summarizer.py` itself hasn't changed since June — this is purely a provider behaviour shift.

Recaps are also what carry the curated artifact list behind chat download cards, and they are the narrative source the Users-page activity reports read, so the blast radius is wider than summaries alone (see surogate-ops#PENDING).

## The fix

One shared extractor in `harness/structured_output.py`:

- `iter_json_objects()` yields every decodable JSON object in raw model text — accepting it plain, fenced, or wrapped in prose — using `JSONDecoder.raw_decode`, which handles braces inside strings that regex-slicing gets wrong. Non-object JSON is skipped; a truncated object still fails closed.
- `parse_json_object()` is the first-object-wins convenience over it.

Every LLM-JSON parse site now goes through it: the turn summarizer, the JSON-mode structured-output fallback, the Outlines result coercion, the user-action rescue judge, the mission judge, and the outcome evaluator (which kept a greedy `{.*}` regex spanning from the first brace in prose to the last one anywhere).

Two behaviours improve as a consequence:

- the structured-output fallback now scans **past** candidates that fail schema validation, and checks `reasoning_content` even when `content` holds prose — the same gateway is known to inline extended-thinking text, which can park a draft object ahead of the real answer;
- the three judges stop maintaining three divergent fence-strippers.

## Verification

- New tests cover the exact prod failure shape (fenced), prose-wrapped objects, braces inside strings, multi-object scanning, non-object rejection, and truncation failing closed.
- The real `TurnSummarizer` was run against the live gateway on `claude-sonnet-5`: it now emits a recap where prod currently drops 100% of them.
- Full suite matches the clean-`master` baseline exactly (93 pre-existing failures, unchanged), with 15 more tests passing.