### PR TITLE
fix(session-search): make the agent-side search reach what it claims to search

### DIFF
--- a/surogates/audit/types.py
+++ b/surogates/audit/types.py
@@ -66,3 +66,13 @@ class AuditType(str, Enum):
     # payload (which subsystems were cleaned up successfully).
     AGENT_CREATED = "agent.created"
     AGENT_DELETED = "agent.deleted"
+
+    # An operator searched or read end-user conversation content across
+    # sessions (Studio console, platform copilot).  Unlike every other
+    # entry here this records a *read*, because bulk operator access to
+    # end-user conversations is exactly what a controller has to be able
+    # to account for: who searched, over which agent and users, for what,
+    # and how much came back.  Emitters must treat a failed write as a
+    # failed read rather than swallowing it — an unlogged bulk read is
+    # the thing the log exists to make impossible.
+    SESSION_CONTENT_SEARCH = "session.content_search"

--- a/surogates/db/narrative.py
+++ b/surogates/db/narrative.py
@@ -6,7 +6,7 @@
 Two consumers need to agree, byte for byte, on what "the searchable text
 of an event" means:
 
-* the ``idx_events_narrative_fts`` GIN index declared in
+* the ``idx_events_narrative_fts_v2`` GIN index declared in
   ``observability.sql``, and
 * every query that wants that index used — the ``session_search`` builtin
   here, and the control plane's cross-session search, which imports these
@@ -69,15 +69,35 @@ _NARRATIVE_TEXT_PATHS: tuple[str, ...] = (
     "data->>'summary'",
 )
 
+# Hard ceiling on the text handed to ``to_tsvector``.
+#
+# A tsvector may hold at most 1,048,575 bytes of lexeme data, and exceeding
+# it is an ERROR, not a truncation. ``user.message`` bodies are unbounded —
+# the API takes ``content: str`` with no ``max_length`` — so without this cap
+# a single very long message has two failure modes, both on paths that must
+# not fail: the INSERT of that event is rejected once the index exists
+# (breaking the hot append path for a live session), and ``CREATE INDEX``
+# aborts if such a row already exists, which rolls back the whole
+# ``observability.sql`` transaction and fails the migration.
+#
+# 500k characters is far past any real message and leaves room for the
+# worst realistic lexeme-storage ratio, where every token is distinct.
+# Search quality is unaffected: nothing near that length is a conversation.
+NARRATIVE_TEXT_LIMIT = 500_000
+
 
 def narrative_text_sql(prefix: str = "") -> str:
     """Render the concatenated searchable-text expression.
 
     *prefix* qualifies the column reference: ``""`` for a ``CREATE INDEX``
     on ``events``, ``"e."`` inside a query that aliases the table.
+
+    The result is capped at :data:`NARRATIVE_TEXT_LIMIT` — see there for why
+    an uncapped expression can refuse writes and abort migrations.
     """
     parts = [f"COALESCE({prefix}{path}, '')" for path in _NARRATIVE_TEXT_PATHS]
-    return " || ' ' || ".join(parts)
+    joined = " || ' ' || ".join(parts)
+    return f"left({joined}, {NARRATIVE_TEXT_LIMIT})"
 
 
 def narrative_tsvector_sql(prefix: str = "") -> str:

--- a/surogates/db/narrative.py
+++ b/surogates/db/narrative.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+"""The narrative slice of the event log, and how to search it.
+
+Two consumers need to agree, byte for byte, on what "the searchable text
+of an event" means:
+
+* the ``idx_events_narrative_fts`` GIN index declared in
+  ``observability.sql``, and
+* every query that wants that index used — the ``session_search`` builtin
+  here, and the control plane's cross-session search, which imports these
+  helpers rather than re-deriving them.
+
+Postgres only uses an expression index when the query's expression parses
+to the same tree, and only uses a *partial* index when the query carries a
+predicate the planner can prove implies the index's ``WHERE``. A drifting
+copy of either does not fail loudly — it silently reverts to a sequential
+scan over a table that is ~90% streamed ``llm.delta`` chunks. Hence one
+module, two rendered strings, and a test that pins the ``.sql`` file
+against :func:`narrative_tsvector_sql`.
+
+Text keys, and why each is here:
+
+``content``
+    ``user.message`` prompts and ``tool.result`` payloads.
+``message.content``
+    ``llm.response`` assistant text. Always nested under ``message`` — a
+    flat ``data->>'content'`` read returns NULL for every assistant turn,
+    which is why the original search could not match the agent's own words.
+``recap``
+    ``turn.summary`` — the per-turn recap. The densest narrative the
+    platform stores, and the corpus the report engine already summarises.
+``summary``
+    ``iteration.summary`` — the one-line-per-iteration fallback that keeps
+    flowing when recap generation degrades.
+"""
+from __future__ import annotations
+
+# Event types whose payloads carry human-readable narrative text.
+#
+# Deliberately excludes ``llm.delta``: deltas are persisted one row per
+# streamed token chunk and carry a ``content`` key, so including them both
+# dominates the index and lets per-token fragments outrank whole messages.
+NARRATIVE_SEARCH_TYPES: tuple[str, ...] = (
+    "user.message",
+    "llm.response",
+    "tool.result",
+    "turn.summary",
+    "iteration.summary",
+)
+
+# Event types per ``role_filter`` value accepted by the search tools.
+NARRATIVE_ROLE_TYPES: dict[str, tuple[str, ...]] = {
+    "user": ("user.message",),
+    "assistant": ("llm.response",),
+    "tool": ("tool.result",),
+    "summary": ("turn.summary", "iteration.summary"),
+}
+
+# Text-search configuration for both the index and every query.
+#
+# ``simple`` lowercases and splits without stemming or a stopword list.
+# ``english`` would stem English a little better, but it is actively wrong
+# for the Romanian deployments this platform serves first: it applies
+# English suffix rules to Romanian tokens. Since one shared configuration
+# has to back one shared index, language-neutral exact-token matching is
+# the honest choice — callers OR the morphological variants they want, and
+# the tool descriptions say so.
+NARRATIVE_FTS_CONFIG = "simple"
+
+# JSONB paths concatenated into the searchable text, in index order.
+_NARRATIVE_TEXT_PATHS: tuple[str, ...] = (
+    "data->>'content'",
+    "data->'message'->>'content'",
+    "data->>'recap'",
+    "data->>'summary'",
+)
+
+
+def narrative_text_sql(prefix: str = "") -> str:
+    """Render the concatenated searchable-text expression.
+
+    *prefix* qualifies the column reference: ``""`` for a ``CREATE INDEX``
+    on ``events``, ``"e."`` inside a query that aliases the table.
+    """
+    parts = [f"COALESCE({prefix}{path}, '')" for path in _NARRATIVE_TEXT_PATHS]
+    return " || ' ' || ".join(parts)
+
+
+def narrative_tsvector_sql(prefix: str = "") -> str:
+    """Render the indexed ``tsvector`` expression."""
+    return f"to_tsvector('{NARRATIVE_FTS_CONFIG}', {narrative_text_sql(prefix)})"
+
+
+def narrative_tsquery_sql(param: str = "query") -> str:
+    """Render the query-side ``tsquery`` expression.
+
+    ``websearch_to_tsquery`` is what makes the documented syntax real: it
+    honours ``OR``, quoted phrases and leading ``-`` negation. The previous
+    ``plainto_tsquery`` discarded every operator and ANDed the remaining
+    lexemes, so the tool's own advice ("use OR between keywords, FTS
+    defaults to AND which misses sessions") produced the exact failure it
+    warned about.
+    """
+    return f"websearch_to_tsquery('{NARRATIVE_FTS_CONFIG}', :{param})"
+
+
+def narrative_type_list_sql() -> str:
+    """Render the type predicate that lets the partial index apply."""
+    return ", ".join(f"'{t}'" for t in NARRATIVE_SEARCH_TYPES)

--- a/surogates/db/narrative.py
+++ b/surogates/db/narrative.py
@@ -20,22 +20,14 @@ scan over a table that is ~90% streamed ``llm.delta`` chunks. Hence one
 module, two rendered strings, and a test that pins the ``.sql`` file
 against :func:`narrative_tsvector_sql`.
 
-Text keys, and why each is here:
-
-``content``
-    ``user.message`` prompts and ``tool.result`` payloads.
-``message.content``
-    ``llm.response`` assistant text. Always nested under ``message`` — a
-    flat ``data->>'content'`` read returns NULL for every assistant turn,
-    which is why the original search could not match the agent's own words.
-``recap``
-    ``turn.summary`` — the per-turn recap. The densest narrative the
-    platform stores, and the corpus the report engine already summarises.
-``summary``
-    ``iteration.summary`` — the one-line-per-iteration fallback that keeps
-    flowing when recap generation degrades.
+One text key is worth calling out: ``llm.response`` assistant text is
+always nested under ``message``, so a flat ``data->>'content'`` read
+returns NULL for every assistant turn — which is why the original search
+could not match the agent's own words.
 """
 from __future__ import annotations
+
+from typing import Iterable, Optional, Sequence
 
 # Event types whose payloads carry human-readable narrative text.
 #
@@ -106,6 +98,50 @@ def narrative_tsquery_sql(param: str = "query") -> str:
     return f"websearch_to_tsquery('{NARRATIVE_FTS_CONFIG}', :{param})"
 
 
-def narrative_type_list_sql() -> str:
-    """Render the type predicate that lets the partial index apply."""
-    return ", ".join(f"'{t}'" for t in NARRATIVE_SEARCH_TYPES)
+def narrative_type_list_sql(
+    types: Sequence[str] = NARRATIVE_SEARCH_TYPES,
+) -> str:
+    """Render the ``IN`` list of event types for a query's type predicate.
+
+    Spelled as literals rather than a bound array because the planner has to
+    *see* the values to prove they imply the partial index's ``WHERE``; a
+    bound ``= ANY(:types)`` leaves it unable to, and the index goes unused.
+    *types* is always a subset of :data:`NARRATIVE_SEARCH_TYPES` chosen
+    server-side, never caller text.
+    """
+    return ", ".join(f"'{t}'" for t in types)
+
+
+def narrative_types_for_roles(roles: Optional[Iterable[str]]) -> tuple[str, ...]:
+    """Map caller role names to the event types they select.
+
+    Shared because both search implementations accept the same ``role``
+    vocabulary, and a role added on one side but not the other is a silent
+    difference in what each will find.
+
+    Raises :class:`ValueError` naming the unknown roles; callers render that
+    however their surface requires. An empty or all-blank selection means
+    "no preference" and yields the full narrative slice, so a query is never
+    accidentally narrowed to nothing.
+    """
+    if not roles:
+        return NARRATIVE_SEARCH_TYPES
+    selected: list[str] = []
+    unknown: list[str] = []
+    for raw_role in roles:
+        role = (raw_role or "").strip().lower()
+        if not role:
+            continue
+        mapped = NARRATIVE_ROLE_TYPES.get(role)
+        if mapped is None:
+            unknown.append(role)
+            continue
+        selected.extend(t for t in mapped if t not in selected)
+    if unknown:
+        raise ValueError(
+            "unknown role(s): "
+            + ", ".join(sorted(set(unknown)))
+            + ". Valid roles: "
+            + ", ".join(sorted(NARRATIVE_ROLE_TYPES))
+        )
+    return tuple(selected) or NARRATIVE_SEARCH_TYPES

--- a/surogates/db/observability.sql
+++ b/surogates/db/observability.sql
@@ -59,9 +59,22 @@ CREATE INDEX IF NOT EXISTS idx_events_feedback_dedupe
 -- index when the query's predicate implies this WHERE clause.  Drift is
 -- silent — it just stops using the index.  ``tests/db/test_narrative_index.py``
 -- pins this statement against the helpers.
-CREATE INDEX IF NOT EXISTS idx_events_narrative_fts
+--
+-- CHANGING THE EXPRESSION REQUIRES A NEW INDEX NAME.  ``IF NOT EXISTS``
+-- matches on name alone, so an edited expression under the same name is a
+-- no-op on every database that already has the index: the tests pass (they
+-- run against a fresh schema) while production keeps the old definition and
+-- quietly stops using it.  Bump the ``_v2`` suffix and drop the previous
+-- index once the new one is built.
+--
+-- ``left(..., 500000)`` is not cosmetic: a tsvector may hold at most
+-- 1,048,575 bytes of lexemes and overflowing it is an ERROR.  ``user.message``
+-- bodies are unbounded, so without the cap one long message makes its own
+-- INSERT fail once this index exists, and makes this CREATE INDEX abort —
+-- rolling back every statement in this file — if such a row already exists.
+CREATE INDEX IF NOT EXISTS idx_events_narrative_fts_v2
     ON events USING gin (
-        to_tsvector('simple', COALESCE(data->>'content', '') || ' ' || COALESCE(data->'message'->>'content', '') || ' ' || COALESCE(data->>'recap', '') || ' ' || COALESCE(data->>'summary', ''))
+        to_tsvector('simple', left(COALESCE(data->>'content', '') || ' ' || COALESCE(data->'message'->>'content', '') || ' ' || COALESCE(data->>'recap', '') || ' ' || COALESCE(data->>'summary', ''), 500000))
     )
     WHERE type IN ('user.message', 'llm.response', 'tool.result', 'turn.summary', 'iteration.summary');
 

--- a/surogates/db/observability.sql
+++ b/surogates/db/observability.sql
@@ -48,6 +48,23 @@ CREATE INDEX IF NOT EXISTS idx_events_feedback_dedupe
     )
     WHERE type IN ('user.feedback', 'expert.endorse', 'expert.override');
 
+-- Backing index for cross-session narrative search (the ``session_search``
+-- builtin and the control plane's operator-facing search).  Without it the
+-- query evaluates ``to_tsvector`` per row over a table that is ~90%
+-- streamed ``llm.delta`` chunks — a full sequential scan per search.
+--
+-- The expression and the type predicate MUST stay identical to
+-- ``surogates.db.narrative``: Postgres only uses an expression index when
+-- the query's expression parses to the same tree, and only uses a partial
+-- index when the query's predicate implies this WHERE clause.  Drift is
+-- silent — it just stops using the index.  ``tests/db/test_narrative_index.py``
+-- pins this statement against the helpers.
+CREATE INDEX IF NOT EXISTS idx_events_narrative_fts
+    ON events USING gin (
+        to_tsvector('simple', COALESCE(data->>'content', '') || ' ' || COALESCE(data->'message'->>'content', '') || ' ' || COALESCE(data->>'recap', '') || ' ' || COALESCE(data->>'summary', ''))
+    )
+    WHERE type IN ('user.message', 'llm.response', 'tool.result', 'turn.summary', 'iteration.summary');
+
 -- Per-tenant audit attribution.
 -- ``agent_id`` is nullable so emitters with no per-tenant context
 -- (e.g. platform-wide events) can leave it NULL.  The

--- a/surogates/tools/builtin/session_search.py
+++ b/surogates/tools/builtin/session_search.py
@@ -28,11 +28,12 @@ from uuid import UUID
 
 from surogates.tools.owner_scope import is_owner_scoped as _is_owner_scoped
 from surogates.db.narrative import (
-    NARRATIVE_ROLE_TYPES,
-    NARRATIVE_SEARCH_TYPES,
     narrative_tsquery_sql,
     narrative_tsvector_sql,
+    narrative_type_list_sql,
+    narrative_types_for_roles,
 )
+from surogates.session.events import EventType
 from surogates.tools.registry import ToolRegistry, ToolSchema
 
 logger = logging.getLogger(__name__)
@@ -148,8 +149,16 @@ def _format_conversation(events: List[Dict[str, Any]]) -> str:
             if recap:
                 parts.append(f"[RECAP]: {recap}")
 
-        elif event_type == "llm.thinking":
-            # Skip thinking events in transcript
+        elif event_type in ("llm.thinking", "llm.delta"):
+            # Thinking is not conversation.  Deltas are the same assistant
+            # text as ``llm.response``, but persisted one row per streamed
+            # chunk — they carry a ``content`` key, so without this branch
+            # they fall through to the generic case and re-emit every reply
+            # as hundreds of per-token lines.  On a busy session that is the
+            # majority of the transcript, and since the 100k-char window is
+            # centred on the first match, the real conversation is what gets
+            # truncated away.  ``surogates.db.narrative`` excludes them from
+            # the search index for the same reason.
             pass
 
         else:
@@ -478,34 +487,16 @@ async def session_search(
     query = query.strip()
 
     try:
-        # Narrow the searched event types to the caller's roles, defaulting
-        # to the whole narrative slice.  The type predicate is not optional
-        # decoration: it is what keeps streamed ``llm.delta`` chunks out of
-        # the results AND what lets the partial GIN index apply.
-        type_filter: tuple[str, ...] = NARRATIVE_SEARCH_TYPES
-        unknown_roles: list[str] = []
-        if role_filter and role_filter.strip():
-            selected: list[str] = []
-            for raw_role in role_filter.split(","):
-                role = raw_role.strip().lower()
-                if not role:
-                    continue
-                mapped = NARRATIVE_ROLE_TYPES.get(role)
-                if mapped is None:
-                    unknown_roles.append(role)
-                    continue
-                selected.extend(t for t in mapped if t not in selected)
-            if unknown_roles:
-                return json.dumps({
-                    "success": False,
-                    "error": (
-                        "Unknown role_filter value(s): "
-                        f"{', '.join(sorted(set(unknown_roles)))}. "
-                        f"Valid roles: {', '.join(sorted(NARRATIVE_ROLE_TYPES))}."
-                    ),
-                })
-            if selected:
-                type_filter = tuple(selected)
+        # Narrow the searched event types to the caller's roles.  The type
+        # predicate is not optional decoration: it is what keeps streamed
+        # ``llm.delta`` chunks out of the results AND what lets the partial
+        # GIN index apply.
+        try:
+            type_filter = narrative_types_for_roles(
+                role_filter.split(",") if role_filter else None
+            )
+        except ValueError as exc:
+            return json.dumps({"success": False, "error": str(exc)})
 
         # Full-text search across events for this org's sessions.
         from sqlalchemy import text as sa_text
@@ -533,17 +524,12 @@ async def session_search(
                 hidden_clause = "AND s.channel NOT IN ({})".format(
                     ", ".join(f"'{c}'" for c in _HIDDEN_SESSION_CHANNELS)
                 )
-                # The type predicate is spelled as a literal IN list rather
-                # than a bound array so the planner can prove it implies the
-                # partial index's WHERE clause.  Values come from a closed
-                # constant, never from caller input.
                 type_clause = "AND e.type IN ({})".format(
-                    ", ".join(f"'{t}'" for t in type_filter)
+                    narrative_type_list_sql(type_filter)
                 )
-                # Full-text search over the narrative slice of the event log.
-                # The tsvector expression and the type predicate are rendered
-                # from surogates.db.narrative so they stay identical to the
-                # backing GIN index — see that module for why drift is silent.
+                # Rendered from surogates.db.narrative so they stay identical
+                # to the backing GIN index — see that module for why drift is
+                # silent.
                 tsvector_sql = narrative_tsvector_sql("e.")
                 tsquery_sql = narrative_tsquery_sql("query")
                 fts_query = sa_text(
@@ -665,7 +651,15 @@ async def session_search(
         tasks: list[tuple[UUID, dict[str, Any], str, dict[str, Any]]] = []
         for sid, match_info in seen_sessions.items():
             try:
-                events = await session_store.get_events(sid)
+                # Deltas are ~90% of the log and carry no text the transcript
+                # does not already get from ``llm.response``; excluding them
+                # in SQL keeps a long session from being loaded into memory
+                # almost entirely as token fragments.
+                from surogates.session.events import EventType
+
+                events = await session_store.get_events(
+                    sid, exclude_types=[EventType.LLM_DELTA],
+                )
                 if not events:
                     continue
                 # Convert Event pydantic models to dicts for formatting

--- a/surogates/tools/builtin/session_search.py
+++ b/surogates/tools/builtin/session_search.py
@@ -27,6 +27,12 @@ from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
 from surogates.tools.owner_scope import is_owner_scoped as _is_owner_scoped
+from surogates.db.narrative import (
+    NARRATIVE_ROLE_TYPES,
+    NARRATIVE_SEARCH_TYPES,
+    narrative_tsquery_sql,
+    narrative_tsvector_sql,
+)
 from surogates.tools.registry import ToolRegistry, ToolSchema
 
 logger = logging.getLogger(__name__)
@@ -96,8 +102,18 @@ def _format_conversation(events: List[Dict[str, Any]]) -> str:
             parts.append(f"[USER]: {content}")
 
         elif event_type == "llm.response":
-            content = data.get("content", "")
+            # Assistant text is nested under ``message`` on every emit path;
+            # the flat read this used to do returned "" for every turn, so
+            # the transcript handed to the summarizer contained user messages
+            # and bare tool names and no agent replies at all.
+            message = data.get("message")
+            if isinstance(message, dict):
+                content = message.get("content") or ""
+            else:
+                content = data.get("content") or ""
             tool_calls = data.get("tool_calls")
+            if not tool_calls and isinstance(message, dict):
+                tool_calls = message.get("tool_calls")
             if tool_calls and isinstance(tool_calls, list):
                 tc_names = []
                 for tc in tool_calls:
@@ -118,21 +134,33 @@ def _format_conversation(events: List[Dict[str, Any]]) -> str:
 
         elif event_type == "tool.result":
             tool_name = data.get("name", "unknown")
-            content = str(data.get("result", ""))
+            # Result payloads carry ``content``; the ``result`` key this used
+            # to read has never been written, so every tool output rendered
+            # as an empty line.
+            content = str(data.get("content") or "")
             # Truncate long tool outputs
             if len(content) > 500:
                 content = content[:250] + "\n...[truncated]...\n" + content[-250:]
             parts.append(f"[TOOL:{tool_name}]: {content}")
+
+        elif event_type in ("turn.summary", "iteration.summary"):
+            recap = data.get("recap") or data.get("summary") or ""
+            if recap:
+                parts.append(f"[RECAP]: {recap}")
 
         elif event_type == "llm.thinking":
             # Skip thinking events in transcript
             pass
 
         else:
-            # Include other event types generically
-            content = str(data.get("content", data.get("message", "")))
-            if content:
-                parts.append(f"[{event_type.upper()}]: {content}")
+            # Include other event types generically.  ``message`` is a dict on
+            # LLM-shaped payloads, so only render it when it is plain text.
+            raw = data.get("content")
+            if raw is None:
+                candidate = data.get("message")
+                raw = candidate if isinstance(candidate, str) else None
+            if raw:
+                parts.append(f"[{event_type.upper()}]: {raw}")
 
     return "\n\n".join(parts)
 
@@ -450,29 +478,37 @@ async def session_search(
     query = query.strip()
 
     try:
-        # Parse role filter
-        role_list: list[str] | None = None
+        # Narrow the searched event types to the caller's roles, defaulting
+        # to the whole narrative slice.  The type predicate is not optional
+        # decoration: it is what keeps streamed ``llm.delta`` chunks out of
+        # the results AND what lets the partial GIN index apply.
+        type_filter: tuple[str, ...] = NARRATIVE_SEARCH_TYPES
+        unknown_roles: list[str] = []
         if role_filter and role_filter.strip():
-            role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
-
-        # Map role filter to event types
-        type_filter: list[str] | None = None
-        if role_list:
-            type_map = {
-                "user": "user.message",
-                "assistant": "llm.response",
-                "tool": "tool.result",
-            }
-            type_filter = [type_map[r] for r in role_list if r in type_map]
+            selected: list[str] = []
+            for raw_role in role_filter.split(","):
+                role = raw_role.strip().lower()
+                if not role:
+                    continue
+                mapped = NARRATIVE_ROLE_TYPES.get(role)
+                if mapped is None:
+                    unknown_roles.append(role)
+                    continue
+                selected.extend(t for t in mapped if t not in selected)
+            if unknown_roles:
+                return json.dumps({
+                    "success": False,
+                    "error": (
+                        "Unknown role_filter value(s): "
+                        f"{', '.join(sorted(set(unknown_roles)))}. "
+                        f"Valid roles: {', '.join(sorted(NARRATIVE_ROLE_TYPES))}."
+                    ),
+                })
+            if selected:
+                type_filter = tuple(selected)
 
         # Full-text search across events for this org's sessions.
-        # Query all sessions for the authenticated user (same org_id).
-        from surogates.session.events import EventType
-        from sqlalchemy import select, text as sa_text
-        from surogates.db.models import (
-            Event as EventRow,
-            Session as SessionRow,
-        )
+        from sqlalchemy import text as sa_text
 
         raw_results: list[dict[str, Any]] = []
         try:
@@ -497,8 +533,19 @@ async def session_search(
                 hidden_clause = "AND s.channel NOT IN ({})".format(
                     ", ".join(f"'{c}'" for c in _HIDDEN_SESSION_CHANNELS)
                 )
-                # Build full-text search query using PostgreSQL ts_vector
-                # Search event data->>'content' across all sessions for this org
+                # The type predicate is spelled as a literal IN list rather
+                # than a bound array so the planner can prove it implies the
+                # partial index's WHERE clause.  Values come from a closed
+                # constant, never from caller input.
+                type_clause = "AND e.type IN ({})".format(
+                    ", ".join(f"'{t}'" for t in type_filter)
+                )
+                # Full-text search over the narrative slice of the event log.
+                # The tsvector expression and the type predicate are rendered
+                # from surogates.db.narrative so they stay identical to the
+                # backing GIN index — see that module for why drift is silent.
+                tsvector_sql = narrative_tsvector_sql("e.")
+                tsquery_sql = narrative_tsquery_sql("query")
                 fts_query = sa_text(
                     f"""
                     SELECT e.id AS event_id,
@@ -512,19 +559,16 @@ async def session_search(
                            s.title,
                            s.parent_id,
                            s.user_id,
-                           ts_rank(
-                               to_tsvector('english', COALESCE(e.data->>'content', '') || ' ' || COALESCE(e.data->>'result', '')),
-                               plainto_tsquery('english', :query)
-                           ) AS rank
+                           ts_rank({tsvector_sql}, {tsquery_sql}) AS rank
                     FROM events e
                     JOIN sessions s ON s.id = e.session_id
                     WHERE s.org_id = :org_id
                       {principal_clause}
                       {hidden_clause}
+                      {type_clause}
                       AND s.agent_id = :agent_id
                       AND s.status != 'archived'
-                      AND to_tsvector('english', COALESCE(e.data->>'content', '') || ' ' || COALESCE(e.data->>'result', ''))
-                          @@ plainto_tsquery('english', :query)
+                      AND {tsvector_sql} @@ {tsquery_sql}
                     ORDER BY rank DESC
                     LIMIT :limit
                     """
@@ -742,10 +786,15 @@ SESSION_SEARCH_SCHEMA = ToolSchema(
         "Don't hesitate to search when it is actually cross-session -- it's fast and cheap. "
         "Better to search and confirm than to guess or ask the user to repeat themselves.\n\n"
         "Search syntax: keywords joined with OR for broad recall (elevenlabs OR baseten OR funding), "
-        "phrases for exact match (\"docker networking\"), boolean (python NOT java), prefix (deploy*). "
-        "IMPORTANT: Use OR between keywords for best results — FTS5 defaults to AND which misses "
-        "sessions that only mention some terms. If a broad OR query returns nothing, try individual "
-        "keyword searches in parallel. Returns summaries of the top matching sessions.\n\n"
+        "quoted phrases for an exact sequence (\"docker networking\"), and a leading minus to exclude "
+        "a term (python -java). Bare keywords are ANDed, so use OR when a session only needs to "
+        "mention some of your terms.\n\n"
+        "Matching is exact-token and case-insensitive, with no stemming or wildcards: 'deploy' will "
+        "not find 'deployed' and 'deploy*' is not a prefix search. OR the word forms you care about "
+        "(deploy OR deployed OR deployment). This is deliberate — one shared index serves every "
+        "language the platform runs in, so no language's suffix rules are applied to another's.\n\n"
+        "Searches user messages, assistant replies, tool results, and per-turn recaps. "
+        "Returns summaries of the top matching sessions.\n\n"
         "In an ops console session, results span EVERY user of this agent and each result carries "
         "a user_id — attribute those conversations to that user, never to yourself or the person "
         "you are talking to."
@@ -764,8 +813,10 @@ SESSION_SEARCH_SCHEMA = ToolSchema(
             "role_filter": {
                 "type": "string",
                 "description": (
-                    "Optional: only search messages from specific roles (comma-separated). "
-                    "E.g. 'user,assistant' to skip tool outputs."
+                    "Optional: restrict the search to specific roles (comma-separated). "
+                    "One or more of 'user', 'assistant', 'tool', 'summary'. "
+                    "E.g. 'user,assistant' to skip tool outputs, or 'summary' to search "
+                    "only the per-turn recaps. Defaults to all four."
                 ),
             },
             "limit": {

--- a/surogates/tools/builtin/session_search.py
+++ b/surogates/tools/builtin/session_search.py
@@ -23,6 +23,7 @@ import asyncio
 import json
 import logging
 from datetime import datetime
+from shlex import split as shlex_split
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
@@ -162,10 +163,12 @@ def _format_conversation(events: List[Dict[str, Any]]) -> str:
             pass
 
         else:
-            # Include other event types generically.  ``message`` is a dict on
-            # LLM-shaped payloads, so only render it when it is plain text.
+            # Include other event types generically.  Both keys are dicts on
+            # LLM-shaped payloads, so render either only when it is plain
+            # text — otherwise the transcript grows a Python repr of the
+            # whole object and the summarizer reads that as conversation.
             raw = data.get("content")
-            if raw is None:
+            if not isinstance(raw, str):
                 candidate = data.get("message")
                 raw = candidate if isinstance(candidate, str) else None
             if raw:
@@ -179,6 +182,37 @@ def _format_conversation(events: List[Dict[str, Any]]) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _centering_terms(query: str) -> list[str]:
+    """The literal words to look for when centring the truncation window.
+
+    The query is ``websearch_to_tsquery`` syntax, so a plain ``.split()``
+    yields tokens that never appear in the transcript — the bare operator
+    ``OR``, the quote characters of a phrase, and the leading ``-`` of an
+    exclusion. Each of those either matches nothing (so the window falls
+    back to the start of the conversation and the summarizer is asked about
+    text it was not given) or, worse, matches incidentally: ``or`` occurs
+    inside "work order" within the first few hundred characters of almost
+    any transcript, which pins the window to the beginning every time.
+
+    So: drop the operator, unwrap phrases into their words, and discard
+    negated terms — a term the caller excluded is the last thing the window
+    should centre on.
+    """
+    try:
+        tokens = shlex_split(query)
+    except ValueError:
+        # Unbalanced quote — the tsquery parser tolerates it, so neither
+        # should this. Fall back to whitespace splitting with the quote
+        # characters stripped.
+        tokens = query.replace('"', " ").split()
+    terms: list[str] = []
+    for token in tokens:
+        if not token or token.upper() == "OR" or token.startswith("-"):
+            continue
+        terms.extend(word for word in token.lower().split() if word)
+    return terms
+
+
 def _truncate_around_matches(
     full_text: str, query: str, max_chars: int = MAX_SESSION_CHARS
 ) -> str:
@@ -188,8 +222,7 @@ def _truncate_around_matches(
     if len(full_text) <= max_chars:
         return full_text
 
-    # Find the first occurrence of any query term
-    query_terms = query.lower().split()
+    query_terms = _centering_terms(query)
     text_lower = full_text.lower()
     first_match = len(full_text)
     for term in query_terms:
@@ -354,7 +387,6 @@ async def _list_recent_sessions(
             # Build a preview from the first user message event
             preview = ""
             try:
-                from surogates.session.events import EventType
                 events = await session_store.get_events(
                     sid, types=[EventType.USER_MESSAGE], limit=1,
                 )
@@ -438,7 +470,9 @@ async def session_search(
     from results since the agent already has that context.
 
     Args:
-        query: Search terms (FTS5-style syntax: OR, NOT, phrases, prefix*).
+        query: Search terms in websearch syntax: bare words are ANDed,
+            OR between alternatives, "quoted phrases" for a sequence,
+            and a leading - to exclude. No stemming, no prefix wildcard.
         role_filter: Comma-separated roles to restrict search to.
         limit: Max sessions to summarize (capped at 5).
         session_store: The Surogates SessionStore instance.
@@ -655,7 +689,6 @@ async def session_search(
                 # does not already get from ``llm.response``; excluding them
                 # in SQL keeps a long session from being loaded into memory
                 # almost entirely as token fragments.
-                from surogates.session.events import EventType
 
                 events = await session_store.get_events(
                     sid, exclude_types=[EventType.LLM_DELTA],

--- a/tests/db/test_narrative_index.py
+++ b/tests/db/test_narrative_index.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+"""Pin the narrative FTS index DDL against the query-side helpers.
+
+Postgres uses an expression index only when the query's expression parses
+to the same tree, and a partial index only when the query's predicate
+implies the index's ``WHERE``. Neither mismatch raises — the planner just
+falls back to a sequential scan over the whole ``events`` table. These
+tests are the only thing standing between a one-character edit and a
+silent performance cliff.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from surogates.db.narrative import (
+    NARRATIVE_FTS_CONFIG,
+    NARRATIVE_ROLE_TYPES,
+    NARRATIVE_SEARCH_TYPES,
+    narrative_text_sql,
+    narrative_tsquery_sql,
+    narrative_tsvector_sql,
+    narrative_type_list_sql,
+)
+
+_SQL_PATH = Path(__file__).resolve().parents[2] / "surogates" / "db" / "observability.sql"
+_INDEX_NAME = "idx_events_narrative_fts"
+
+
+def _index_statement() -> str:
+    sql = _SQL_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        rf"CREATE INDEX IF NOT EXISTS {_INDEX_NAME}\b(.*?);",
+        sql,
+        re.DOTALL,
+    )
+    assert match, f"{_INDEX_NAME} is missing from {_SQL_PATH.name}"
+    return match.group(1)
+
+
+def _normalize(sql: str) -> str:
+    """Collapse whitespace so formatting differences don't fail the test."""
+    return re.sub(r"\s+", " ", sql).strip()
+
+
+def test_index_expression_matches_the_query_helper() -> None:
+    assert _normalize(narrative_tsvector_sql()) in _normalize(_index_statement())
+
+
+def test_index_predicate_matches_the_searchable_types() -> None:
+    statement = _normalize(_index_statement())
+    expected = _normalize(f"WHERE type IN ({narrative_type_list_sql()})")
+    assert expected in statement
+
+
+def test_index_is_gin() -> None:
+    assert "USING gin" in _normalize(_index_statement())
+
+
+def test_llm_delta_is_never_indexed() -> None:
+    """Deltas are one row per token chunk — indexing them is the cliff."""
+    assert "llm.delta" not in NARRATIVE_SEARCH_TYPES
+    assert "llm.delta" not in _index_statement()
+
+
+def test_assistant_text_is_reachable() -> None:
+    """``llm.response`` nests content under ``message``.
+
+    A flat ``data->>'content'`` read returns NULL for every assistant turn,
+    which is the defect that made ``role_filter="assistant"`` unmatchable.
+    """
+    assert "data->'message'->>'content'" in narrative_text_sql()
+
+
+def test_recaps_are_searchable() -> None:
+    text = narrative_text_sql()
+    assert "data->>'recap'" in text
+    assert "data->>'summary'" in text
+
+
+def test_dead_result_key_is_not_searched() -> None:
+    """``tool.result`` payloads carry ``content``; ``result`` never existed."""
+    assert "'result'" not in narrative_text_sql()
+
+
+def test_query_uses_websearch_to_tsquery() -> None:
+    """plainto_tsquery discards OR/phrase/negation the tools document."""
+    rendered = narrative_tsquery_sql("query")
+    assert rendered.startswith("websearch_to_tsquery(")
+    assert ":query" in rendered
+
+
+def test_config_is_shared_between_index_and_query() -> None:
+    assert f"'{NARRATIVE_FTS_CONFIG}'" in narrative_tsvector_sql()
+    assert f"'{NARRATIVE_FTS_CONFIG}'" in narrative_tsquery_sql()
+
+
+def test_prefix_qualifies_every_column_reference() -> None:
+    prefixed = narrative_text_sql("e.")
+    assert "e.data" in prefixed
+    assert re.search(r"(?<![\w.])data->", prefixed) is None
+
+
+def test_role_types_are_a_subset_of_searchable_types() -> None:
+    for role, types in NARRATIVE_ROLE_TYPES.items():
+        for event_type in types:
+            assert event_type in NARRATIVE_SEARCH_TYPES, (
+                f"role {role!r} maps to {event_type!r}, which the index "
+                "does not cover"
+            )

--- a/tests/db/test_narrative_index.py
+++ b/tests/db/test_narrative_index.py
@@ -26,7 +26,7 @@ from surogates.db.narrative import (
 )
 
 _SQL_PATH = Path(__file__).resolve().parents[2] / "surogates" / "db" / "observability.sql"
-_INDEX_NAME = "idx_events_narrative_fts"
+_INDEX_NAME = "idx_events_narrative_fts_v2"
 
 
 def _index_statement() -> str:
@@ -110,3 +110,30 @@ def test_role_types_are_a_subset_of_searchable_types() -> None:
                 f"role {role!r} maps to {event_type!r}, which the index "
                 "does not cover"
             )
+
+
+def test_every_searchable_type_is_a_real_event_type() -> None:
+    """The type lists are plain strings, and nothing else checks them.
+
+    A typo applied consistently to ``narrative.py`` and ``observability.sql``
+    passes the parity test and the EXPLAIN test — the index and the query
+    agree perfectly on a predicate that matches no row that was ever
+    written. Tying the vocabulary to the enum that produces it is the only
+    thing that catches that.
+    """
+    from surogates.db.narrative import NARRATIVE_ROLE_TYPES, NARRATIVE_SEARCH_TYPES
+    from surogates.session.events import EventType
+
+    emitted = {e.value for e in EventType}
+    assert set(NARRATIVE_SEARCH_TYPES) <= emitted
+    for types in NARRATIVE_ROLE_TYPES.values():
+        assert set(types) <= emitted
+
+
+def test_role_types_are_all_searchable() -> None:
+    """A role that selects a type outside the index's WHERE clause would
+    silently fall off the index."""
+    from surogates.db.narrative import NARRATIVE_ROLE_TYPES, NARRATIVE_SEARCH_TYPES
+
+    for role, types in NARRATIVE_ROLE_TYPES.items():
+        assert set(types) <= set(NARRATIVE_SEARCH_TYPES), role

--- a/tests/integration/test_narrative_index_usage.py
+++ b/tests/integration/test_narrative_index_usage.py
@@ -30,7 +30,7 @@ from surogates.db.narrative import (
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
-_INDEX_NAME = "idx_events_narrative_fts"
+_INDEX_NAME = "idx_events_narrative_fts_v2"
 
 
 async def test_index_exists(session_factory) -> None:
@@ -100,6 +100,21 @@ async def test_planner_can_use_the_index_for_the_shared_query(
     assert _INDEX_NAME in plan, (
         "the planner cannot use the narrative index for the query the shared "
         f"helpers render — the expression or the type predicate has drifted:\n{plan}"
+    )
+    # The index name alone is not enough. This index is *partial*, so when
+    # only the tsvector expression drifts the planner still uses it — for the
+    # type predicate — and demotes the text match to a per-row ``Filter``.
+    # That plan reads every narrative row and re-evaluates ``to_tsvector`` on
+    # each, which is the sequential-scan cost this index exists to avoid, and
+    # it contains the index name. Require the text match to be an index
+    # condition, which is only true when the expressions agree.
+    index_cond = "\n".join(
+        line for line in plan_rows if "Index Cond" in line
+    )
+    assert "@@" in index_cond, (
+        "the tsvector expression has drifted from the index: the text match "
+        "was pushed to a per-row Filter instead of an Index Cond, so every "
+        f"narrative row is re-tokenised at query time:\n{plan}"
     )
 
 

--- a/tests/integration/test_narrative_index_usage.py
+++ b/tests/integration/test_narrative_index_usage.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+"""Prove the narrative FTS index is real and that queries can use it.
+
+The parity unit tests pin the DDL text against the helpers, but text
+matching cannot tell you whether Postgres agrees. These tests execute the
+real statements against the real schema and read the planner's mind:
+
+* the index exists after ``observability.sql`` has been applied,
+* a query rendered from the shared helpers is *satisfiable* by it, and
+* the searchable-text expression behaves as documented across the four
+  payload shapes it has to cover.
+
+A drifting expression does not raise — it just stops using the index — so
+without an ``EXPLAIN`` assertion the cliff is invisible until production.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy import text
+
+from surogates.db.narrative import (
+    NARRATIVE_SEARCH_TYPES,
+    narrative_tsquery_sql,
+    narrative_tsvector_sql,
+)
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+_INDEX_NAME = "idx_events_narrative_fts"
+
+
+async def test_index_exists(session_factory) -> None:
+    async with session_factory() as db:
+        found = (
+            await db.execute(
+                text(
+                    "SELECT indexname FROM pg_indexes "
+                    "WHERE tablename = 'events' AND indexname = :name"
+                ),
+                {"name": _INDEX_NAME},
+            )
+        ).scalar_one_or_none()
+
+    assert found == _INDEX_NAME, (
+        "observability.sql did not create the narrative FTS index"
+    )
+
+
+async def test_index_is_gin_and_partial(session_factory) -> None:
+    async with session_factory() as db:
+        definition = (
+            await db.execute(
+                text("SELECT indexdef FROM pg_indexes WHERE indexname = :name"),
+                {"name": _INDEX_NAME},
+            )
+        ).scalar_one()
+
+    assert "USING gin" in definition
+    assert "WHERE" in definition
+    for event_type in NARRATIVE_SEARCH_TYPES:
+        assert event_type in definition
+    assert "llm.delta" not in definition
+
+
+async def test_planner_can_use_the_index_for_the_shared_query(
+    session_factory,
+) -> None:
+    """The predicate the helpers render must be satisfiable by the index.
+
+    Postgres will not choose a bitmap index scan on an empty table, so this
+    asks the planner the narrower question it can always answer: does an
+    index-only path exist for this exact expression? ``enable_seqscan=off``
+    forces it to prove one or admit it cannot.
+    """
+    tsvector_sql = narrative_tsvector_sql("e.")
+    tsquery_sql = narrative_tsquery_sql("q")
+    type_list = ", ".join(f"'{t}'" for t in NARRATIVE_SEARCH_TYPES)
+
+    async with session_factory() as db:
+        await db.execute(text("SET LOCAL enable_seqscan = off"))
+        plan_rows = (
+            await db.execute(
+                text(
+                    f"""
+                    EXPLAIN SELECT e.id
+                    FROM events e
+                    WHERE e.type IN ({type_list})
+                      AND {tsvector_sql} @@ {tsquery_sql}
+                    """
+                ),
+                {"q": "reagent"},
+            )
+        ).scalars().all()
+
+    plan = "\n".join(plan_rows)
+    assert _INDEX_NAME in plan, (
+        "the planner cannot use the narrative index for the query the shared "
+        f"helpers render — the expression or the type predicate has drifted:\n{plan}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "needle"),
+    [
+        ({"content": "limiting reagent question"}, "reagent"),
+        (
+            {"message": {"role": "assistant", "content": "equivalence point"}},
+            "equivalence",
+        ),
+        ({"turn_id": "t1", "recap": "covered molar ratios"}, "molar"),
+        ({"turn_id": "t1", "summary": "checked the titration curve"}, "titration"),
+    ],
+    ids=["user-content", "assistant-nested", "recap", "iteration-summary"],
+)
+async def test_every_payload_shape_is_searchable(
+    session_factory, payload: dict, needle: str,
+) -> None:
+    """One row per shape the concatenated expression has to reach."""
+    tsvector_sql = narrative_tsvector_sql("")
+    tsquery_sql = narrative_tsquery_sql("q")
+
+    async with session_factory() as db:
+        matched = (
+            await db.execute(
+                text(
+                    f"SELECT {tsvector_sql} @@ {tsquery_sql} "
+                    "FROM (SELECT CAST(:payload AS jsonb) AS data) AS e"
+                ),
+                {"payload": json.dumps(payload), "q": needle},
+            )
+        ).scalar_one()
+
+    assert matched is True, f"{needle!r} not found in {payload!r}"
+
+
+async def test_dead_result_key_is_not_searched(session_factory) -> None:
+    """``tool.result`` carries ``content``; ``result`` was never written."""
+    tsvector_sql = narrative_tsvector_sql("")
+    tsquery_sql = narrative_tsquery_sql("q")
+
+    async with session_factory() as db:
+        matched = (
+            await db.execute(
+                text(
+                    f"SELECT {tsvector_sql} @@ {tsquery_sql} "
+                    "FROM (SELECT CAST(:payload AS jsonb) AS data) AS e"
+                ),
+                {"payload": '{"result": "orphaned text"}', "q": "orphaned"},
+            )
+        ).scalar_one()
+
+    assert matched is False

--- a/tests/integration/test_session_search.py
+++ b/tests/integration/test_session_search.py
@@ -456,6 +456,17 @@ async def test_streamed_deltas_never_match(session_store, session_factory):
     assert result["success"] is True
     assert result["count"] == 0
 
+    # Positive control: the same word in a searchable event type does match,
+    # so the assertion above is about deltas being out of scope and not about
+    # the search being broken.
+    await session_store.emit_event(
+        session.id, EventType.USER_MESSAGE, {"content": "electronegativity"},
+    )
+    control = await _search(
+        session_store, org_id, "agent-delta", issued.id, query="electronegativity",
+    )
+    assert control["count"] == 1
+
 
 async def test_role_filter_restricts_the_searched_events(
     session_store, session_factory,

--- a/tests/integration/test_session_search.py
+++ b/tests/integration/test_session_search.py
@@ -323,3 +323,267 @@ async def test_system_agent_session_stays_scoped(
     assert result["success"] is True
     assert result["count"] == 1
     assert result["results"][0]["session_id"] == str(own_session.id)
+
+
+# ---------------------------------------------------------------------------
+# What the search can actually reach
+#
+# Each test below pins one defect that made the shipped search silently
+# incomplete: assistant text unreachable, recaps unsearched, a dead result
+# key, role_filter ignored, streamed deltas ranked as matches, and a
+# documented query syntax the implementation discarded.
+# ---------------------------------------------------------------------------
+
+
+async def _search(session_store, org_id, agent_id, principal_id, **args):
+    return json.loads(
+        await _session_search_handler(
+            args,
+            session_store=session_store,
+            tenant=SimpleNamespace(
+                org_id=org_id, user_id=None, service_account_id=principal_id,
+            ),
+            agent_id=agent_id,
+        )
+    )
+
+
+async def _own_session(session_store, session_factory, org_id, agent_id):
+    issued = await issue_service_account_token(session_factory, org_id)
+    session = await session_store.create_session(
+        user_id=None,
+        service_account_id=issued.id,
+        org_id=org_id,
+        agent_id=agent_id,
+        channel="api",
+    )
+    return issued, session
+
+
+async def test_assistant_replies_are_searchable(session_store, session_factory):
+    """``llm.response`` nests text under ``message``.
+
+    The previous flat ``data->>'content'`` read made every assistant turn
+    invisible, so a query whose words only appear in the agent's own reply
+    returned nothing.
+    """
+    org_id = await create_org(session_factory)
+    issued, session = await _own_session(
+        session_store, session_factory, org_id, "agent-assistant",
+    )
+    await session_store.emit_event(
+        session.id, EventType.USER_MESSAGE, {"content": "and then?"},
+    )
+    await session_store.emit_event(
+        session.id,
+        EventType.LLM_RESPONSE,
+        {"message": {"role": "assistant", "content": "titration reaches equivalence"}},
+    )
+
+    result = await _search(
+        session_store, org_id, "agent-assistant", issued.id, query="equivalence",
+    )
+
+    assert result["success"] is True
+    assert result["count"] == 1
+    assert result["results"][0]["session_id"] == str(session.id)
+
+
+async def test_turn_recaps_are_searchable(session_store, session_factory):
+    """Recaps are the densest narrative stored and were never searched."""
+    org_id = await create_org(session_factory)
+    issued, session = await _own_session(
+        session_store, session_factory, org_id, "agent-recap",
+    )
+    await session_store.emit_event(
+        session.id, EventType.USER_MESSAGE, {"content": "ok"},
+    )
+    await session_store.emit_event(
+        session.id,
+        EventType.TURN_SUMMARY,
+        {"turn_id": "t1", "recap": "worked through stoichiometry limiting reagents"},
+        )
+
+    result = await _search(
+        session_store, org_id, "agent-recap", issued.id, query="reagents",
+    )
+
+    assert result["count"] == 1
+    assert result["results"][0]["session_id"] == str(session.id)
+
+
+async def test_tool_results_are_searchable_via_content(
+    session_store, session_factory,
+):
+    """Result payloads carry ``content``; the old ``result`` key never existed."""
+    org_id = await create_org(session_factory)
+    issued, session = await _own_session(
+        session_store, session_factory, org_id, "agent-tool",
+    )
+    await session_store.emit_event(
+        session.id, EventType.USER_MESSAGE, {"content": "check it"},
+    )
+    await session_store.emit_event(
+        session.id,
+        EventType.TOOL_RESULT,
+        {"tool_call_id": "c1", "name": "web_search", "content": "perchlorate solubility table"},
+    )
+
+    result = await _search(
+        session_store, org_id, "agent-tool", issued.id, query="perchlorate",
+    )
+
+    assert result["count"] == 1
+
+
+async def test_streamed_deltas_never_match(session_store, session_factory):
+    """``llm.delta`` is one row per token chunk — it must stay out of scope."""
+    org_id = await create_org(session_factory)
+    issued, session = await _own_session(
+        session_store, session_factory, org_id, "agent-delta",
+    )
+    await session_store.emit_event(
+        session.id, EventType.USER_MESSAGE, {"content": "unrelated prompt"},
+    )
+    await session_store.emit_event(
+        session.id, EventType.LLM_DELTA, {"content": "electronegativity"},
+    )
+
+    result = await _search(
+        session_store, org_id, "agent-delta", issued.id, query="electronegativity",
+    )
+
+    assert result["success"] is True
+    assert result["count"] == 0
+
+
+async def test_role_filter_restricts_the_searched_events(
+    session_store, session_factory,
+):
+    """``role_filter`` was parsed and then never applied."""
+    org_id = await create_org(session_factory)
+    issued, user_hit = await _own_session(
+        session_store, session_factory, org_id, "agent-roles",
+    )
+    await session_store.emit_event(
+        user_hit.id,
+        EventType.USER_MESSAGE,
+        {"content": "buffer capacity question"},
+    )
+
+    assistant_hit = await session_store.create_session(
+        user_id=None,
+        service_account_id=issued.id,
+        org_id=org_id,
+        agent_id="agent-roles",
+        channel="api",
+    )
+    await session_store.emit_event(
+        assistant_hit.id, EventType.USER_MESSAGE, {"content": "go on"},
+    )
+    await session_store.emit_event(
+        assistant_hit.id,
+        EventType.LLM_RESPONSE,
+        {"message": {"role": "assistant", "content": "buffer capacity peaks at the pKa"}},
+    )
+
+    only_user = await _search(
+        session_store, org_id, "agent-roles", issued.id,
+        query="buffer capacity", role_filter="user",
+    )
+    only_assistant = await _search(
+        session_store, org_id, "agent-roles", issued.id,
+        query="buffer capacity", role_filter="assistant",
+    )
+
+    assert {r["session_id"] for r in only_user["results"]} == {str(user_hit.id)}
+    assert {r["session_id"] for r in only_assistant["results"]} == {
+        str(assistant_hit.id)
+    }
+
+
+async def test_unknown_role_filter_is_rejected(session_store, session_factory):
+    org_id = await create_org(session_factory)
+    issued, _ = await _own_session(
+        session_store, session_factory, org_id, "agent-badrole",
+    )
+
+    result = await _search(
+        session_store, org_id, "agent-badrole", issued.id,
+        query="anything", role_filter="user,wizard",
+    )
+
+    assert result["success"] is False
+    assert "wizard" in result["error"]
+
+
+async def test_or_syntax_matches_partial_terms(session_store, session_factory):
+    """The tool documents OR; ``plainto_tsquery`` used to AND everything."""
+    org_id = await create_org(session_factory)
+    issued, session = await _own_session(
+        session_store, session_factory, org_id, "agent-or",
+    )
+    await session_store.emit_event(
+        session.id,
+        EventType.USER_MESSAGE,
+        {"content": "we settled on baseten for inference"},
+    )
+
+    result = await _search(
+        session_store, org_id, "agent-or", issued.id,
+        query="elevenlabs OR baseten OR funding",
+    )
+
+    assert result["count"] == 1
+
+
+async def test_quoted_phrase_requires_the_sequence(
+    session_store, session_factory,
+):
+    org_id = await create_org(session_factory)
+    issued, session = await _own_session(
+        session_store, session_factory, org_id, "agent-phrase",
+    )
+    await session_store.emit_event(
+        session.id,
+        EventType.USER_MESSAGE,
+        {"content": "networking inside docker was the blocker"},
+    )
+
+    exact = await _search(
+        session_store, org_id, "agent-phrase", issued.id,
+        query='"docker networking"',
+    )
+    loose = await _search(
+        session_store, org_id, "agent-phrase", issued.id,
+        query="docker networking",
+    )
+
+    assert exact["count"] == 0
+    assert loose["count"] == 1
+
+
+async def test_negation_excludes_a_term(session_store, session_factory):
+    org_id = await create_org(session_factory)
+    issued, python_only = await _own_session(
+        session_store, session_factory, org_id, "agent-neg",
+    )
+    await session_store.emit_event(
+        python_only.id, EventType.USER_MESSAGE, {"content": "ported the python parser"},
+    )
+    both = await session_store.create_session(
+        user_id=None,
+        service_account_id=issued.id,
+        org_id=org_id,
+        agent_id="agent-neg",
+        channel="api",
+    )
+    await session_store.emit_event(
+        both.id, EventType.USER_MESSAGE, {"content": "python and java interop notes"},
+    )
+
+    result = await _search(
+        session_store, org_id, "agent-neg", issued.id, query="python -java",
+    )
+
+    assert {r["session_id"] for r in result["results"]} == {str(python_only.id)}

--- a/tests/tools/test_session_search_transcript.py
+++ b/tests/tools/test_session_search_transcript.py
@@ -78,9 +78,15 @@ def test_a_dict_message_is_never_rendered_as_a_repr() -> None:
     """
     transcript = _format_conversation([
         {"type": "some.other", "data": {"message": {"content": "nested"}}},
+        {"type": "some.other", "data": {"content": {"nested": "dict"}}},
+        {"type": "some.other", "data": {"content": "plain text survives"}},
     ])
 
     assert "{" not in transcript
+    # Positive control: the branch still renders genuine text, so the
+    # assertion above is about repr suppression rather than the branch
+    # having stopped emitting anything at all.
+    assert "plain text survives" in transcript
 
 
 def test_tool_calls_are_named_from_either_nesting() -> None:
@@ -94,3 +100,72 @@ def test_tool_calls_are_named_from_either_nesting() -> None:
     ])
 
     assert "search_web" in transcript
+
+
+# ── Centring the truncation window ─────────────────────────────────
+
+
+def _long_transcript(needle: str) -> str:
+    """Filler either side of the needle, far enough out to matter.
+
+    Each half is comfortably wider than ``MAX_SESSION_CHARS``, so a window
+    anchored at the start of the transcript cannot reach the needle — which
+    is what makes these assertions fail when the centring is wrong rather
+    than passing by luck.
+
+    The filler says "work order" deliberately: it contains the substring
+    "or", which is what a naive split on the query turns the OR operator
+    into.
+    """
+    filler = "[USER]: we should coordinate on the work order.\n\n" * 6000
+    return filler + f"[USER]: {needle}\n\n" + filler
+
+
+def test_or_syntax_still_centres_on_the_match() -> None:
+    """The tool tells the model to use OR; the window has to understand it.
+
+    Splitting the query on whitespace makes "or" a search term, and "or"
+    occurs inside "work order" in the first hundred characters of almost
+    any transcript — pinning the window to the start and handing the
+    summarizer text that does not contain what it was asked about.
+    """
+    from surogates.tools.builtin.session_search import _truncate_around_matches
+
+    text = _long_transcript("we settled on baseten for inference")
+    out = _truncate_around_matches(text, "elevenlabs OR baseten OR funding")
+
+    assert "baseten" in out
+
+
+def test_a_quoted_phrase_still_centres_on_the_match() -> None:
+    from surogates.tools.builtin.session_search import _truncate_around_matches
+
+    text = _long_transcript("the docker networking setup broke")
+    out = _truncate_around_matches(text, '"docker networking"')
+
+    assert "docker networking" in out
+
+
+def test_operators_are_not_treated_as_search_terms() -> None:
+    """The centring terms are the words, never the query syntax.
+
+    ``OR`` is the operator, ``-java`` is an exclusion, and the quotes
+    around a phrase are not part of it. Each would otherwise be looked up
+    literally in the transcript — and "or" in particular matches inside
+    ordinary words like "order", which is what pins the window to the
+    start of the conversation.
+    """
+    from surogates.tools.builtin.session_search import _centering_terms
+
+    assert _centering_terms("elevenlabs OR baseten") == ["elevenlabs", "baseten"]
+    assert _centering_terms('"docker networking"') == ["docker", "networking"]
+    assert _centering_terms("python -java") == ["python"]
+    assert _centering_terms("-java") == []
+
+
+def test_an_unbalanced_quote_does_not_raise() -> None:
+    """tsquery tolerates it, so the window must too."""
+    from surogates.tools.builtin.session_search import _truncate_around_matches
+
+    text = _long_transcript("the reagent question")
+    _truncate_around_matches(text, '"reagent')

--- a/tests/tools/test_session_search_transcript.py
+++ b/tests/tools/test_session_search_transcript.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+"""The transcript handed to the session-search summarizer.
+
+Every case here is a payload shape the formatter used to read from the
+wrong key, which is how a feature that looked like it worked produced
+summaries built from user messages and bare tool names.
+"""
+from __future__ import annotations
+
+from surogates.tools.builtin.session_search import _format_conversation
+
+
+def test_assistant_text_is_read_from_the_nested_message() -> None:
+    """``llm.response`` nests its text under ``message``.
+
+    A flat ``data["content"]`` read returns nothing for every assistant
+    turn, so the summarizer never saw a single agent reply.
+    """
+    transcript = _format_conversation([
+        {"type": "llm.response", "data": {"message": {"content": "Atoms vibrate."}}},
+    ])
+
+    assert "[ASSISTANT]: Atoms vibrate." in transcript
+
+
+def test_tool_output_is_read_from_content_not_result() -> None:
+    """``result`` has never been written; every tool line rendered empty."""
+    transcript = _format_conversation([
+        {"type": "tool.result", "data": {"name": "lookup", "content": "42 g/mol"}},
+    ])
+
+    assert "[TOOL:lookup]: 42 g/mol" in transcript
+
+
+def test_recaps_are_included() -> None:
+    transcript = _format_conversation([
+        {"type": "turn.summary", "data": {"recap": "Student grasped melting."}},
+        {"type": "iteration.summary", "data": {"summary": "Checked the answer."}},
+    ])
+
+    assert "[RECAP]: Student grasped melting." in transcript
+    assert "[RECAP]: Checked the answer." in transcript
+
+
+def test_streamed_deltas_are_not_in_the_transcript() -> None:
+    """Deltas repeat the assistant text one row per token chunk.
+
+    They carry a ``content`` key, so without an explicit skip they fall
+    through to the generic branch and re-emit the whole reply as hundreds
+    of fragments — which then dominate the character budget and push the
+    real conversation out of the truncation window.
+    """
+    transcript = _format_conversation([
+        {"type": "llm.response", "data": {"message": {"content": "Atoms vibrate."}}},
+        {"type": "llm.delta", "data": {"content": "Atoms "}},
+        {"type": "llm.delta", "data": {"content": "vibrate."}},
+    ])
+
+    assert "LLM.DELTA" not in transcript
+    assert transcript.count("Atoms vibrate.") == 1
+
+
+def test_thinking_is_not_in_the_transcript() -> None:
+    transcript = _format_conversation([
+        {"type": "llm.thinking", "data": {"content": "let me reason"}},
+    ])
+
+    assert transcript == ""
+
+
+def test_a_dict_message_is_never_rendered_as_a_repr() -> None:
+    """The generic branch used to fall back to ``data["message"]``.
+
+    On any LLM-shaped payload that is a dict, so the transcript grew a
+    Python repr of the whole message object.
+    """
+    transcript = _format_conversation([
+        {"type": "some.other", "data": {"message": {"content": "nested"}}},
+    ])
+
+    assert "{" not in transcript
+
+
+def test_tool_calls_are_named_from_either_nesting() -> None:
+    transcript = _format_conversation([
+        {"type": "llm.response", "data": {
+            "message": {
+                "content": "",
+                "tool_calls": [{"function": {"name": "search_web"}}],
+            },
+        }},
+    ])
+
+    assert "search_web" in transcript


### PR DESCRIPTION
The `session_search` builtin has been searching a fraction of what it advertises, silently. This fixes that and adds the index it needs.

**Merge this before the ops PR** ([invergent-ai/surogate-ops#… copilot session intelligence](https://github.com/invergent-ai/surogate-ops)) — that branch imports `surogates.db.narrative`, so it needs a release cut from this one and the wheel pin bumped. See "Release ordering" below.

## What was broken

| # | Defect | Effect |
|---|---|---|
| 1 | FTS read `data->>'content'`; `llm.response` nests text under `message` | `role_filter="assistant"` could never match, and no query whose words appear only in the agent's replies returned anything |
| 2 | `_format_conversation` read `content`/`result` flatly | The transcript handed to the summarizer had user messages and bare tool names, and no agent replies at all |
| 3 | `tool.result` read a `result` key that has never been written | Every tool line rendered empty |
| 4 | Documented syntax (`OR`, phrases, `-word`) vs `plainto_tsquery` | The tool's own advice produced the exact failure it warned about; `websearch_to_tsquery` honours it |
| 5 | No FTS index, and `llm.delta` in scope | Sequential scan with per-row `to_tsvector` over a table that is ~90% streamed token chunks; per-token fragments could outrank whole messages |
| 6 | `turn.summary` recaps never searched | The densest narrative the platform stores was invisible to the search that most needs it |
| 7 | `role_filter` computed a type filter and never used it | Documented behaviour did not exist |
| 8 | `llm.delta` fell through to the generic transcript branch | Every reply re-emitted as one line per chunk; since the 100k window centres on the first match, the real conversation is what got truncated away |

## The index

`idx_events_narrative_fts`, a partial GIN index on the narrative slice, declared in `db/observability.sql`.

Postgres only uses an expression index when the query's expression parses to the same tree, and only uses a partial index when the query carries a predicate the planner can prove implies its `WHERE`. Drift does not fail loudly — it silently reverts to a sequential scan. So the expression, the event types and the FTS configuration are defined once in the new `surogates/db/narrative.py`, rendered into both the DDL and every query, with a test pinning the `.sql` file against the helpers and an integration test that `EXPLAIN`s the real query and asserts the planner picks the index.

FTS config is `simple`, not `english`: one shared index has to serve Romanian too, and `english` applies English suffix rules to Romanian tokens. Callers OR the word forms they want; the tool description says so.

## Verified against a real corpus

Applied to a 311k-event database (11.4k narrative events) and confirmed by `EXPLAIN (ANALYZE)`:

```
Bitmap Heap Scan on events e
  Recheck Cond: ((to_tsvector('simple'::regconfig, ...) @@ '''chemistry'''::tsquery)
                 AND (type = ANY ('{user.message,llm.response,...}')))
```

~1 ms, index used, type predicate proven to imply the partial `WHERE`. Also verified with a role-narrowed subset, which still uses it.

## Also here

`AuditType.SESSION_CONTENT_SEARCH`, for operator reads of end-user conversation content. Unlike every other entry it records a *read*, because bulk operator access to end-user conversations is what a controller has to be able to account for. Emitters are told to treat a failed write as a failed read — the ops-side consumer does.

## Release ordering

1. Merge this.
2. Tag and release (`setuptools_scm` drives the version from the tag) so a wheel containing `surogates.db.narrative` exists.
3. Bump the pin in `surogate-ops/pyproject.toml` — the version appears twice in that URL — then `uv lock && uv sync`.
4. Merge the ops PR.

Note for step 3: the GIN index reaches production through `surogate-ops migrate upgrade`, which calls `run_migrations` from the *pinned wheel*, not the runtime image.

**One thing to decide before deploying:** `observability.sql` runs inside a single transaction, so `CREATE INDEX CONCURRENTLY` is not available, and a plain `CREATE INDEX` takes a `SHARE` lock — it permits `SELECT` but blocks every `INSERT` on `events`, the hot append path, for the duration. On this dev database it was instant; production `events` has not been measured. Either measure it first and run migrate in a quiet window, or build the index out-of-band with `CONCURRENTLY` so the `IF NOT EXISTS` in the script becomes a no-op. The four existing `events` indexes in that file don't exercise this — they were created when the table was empty.

## Tests

42 new (integration tests against real Postgres via testcontainers, plus transcript unit tests). Each of the eight defects is pinned behaviourally, not by asserting the SQL string.

Full suite: 5500 passed / 94 failed — the same 94 fail on a clean `master` checkout of `origin/master`, verified in a separate worktree. No new failures.