### PR TITLE
fix(harness): bound the partial-tool-call recovery retry

### DIFF
--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -117,6 +117,7 @@ from surogates.harness.loop_constants import (
     _MAX_CONSECUTIVE_INVALID_TOOL_CALLS,
     _MAX_EMPTY_RESPONSE_RETRIES,
     _MAX_LENGTH_CONTINUATIONS,
+    _MAX_PARTIAL_TOOL_CALL_RETRIES,
     _PRE_WAKE_HUB_TIMEOUT_SECONDS,
 )
 from surogates.harness.loop_deep_research import (
@@ -1438,6 +1439,7 @@ class AgentHarness(
         thinking_prefill_retries = 0  # retries for thinking-only responses
         incomplete_scratchpad_retries = 0  # retries for unclosed REASONING_SCRATCHPAD
         empty_response_retries = 0  # retries for empty LLM responses (no content, no tools, no reasoning)
+        partial_tool_call_retries = 0  # retries for truncated tool-call arguments
         # One-shot safety net for the deep-research planner.  Fires when
         # the planner ends a turn with no tool calls AND has never
         # called ``delegate_task(agent_type="research-writer")`` in any
@@ -2032,19 +2034,51 @@ class AgentHarness(
             )
 
             if tool_calls_raw and usage_data.get("partial_tool_call"):
-                logger.warning(
-                    "Session %s: partial tool-call arguments for %s; "
-                    "returning recovery tool results instead of executing",
+                # This retry refunds the iteration, so the cap is the only
+                # thing bounding it.  Never reset a sibling counter here: a
+                # provider alternating truncated and unparseable arguments
+                # would otherwise keep both streaks below their own caps
+                # forever.
+                if partial_tool_call_retries < _MAX_PARTIAL_TOOL_CALL_RETRIES:
+                    partial_tool_call_retries += 1
+                    logger.warning(
+                        "Session %s: partial tool-call arguments for %s; "
+                        "returning recovery tool results instead of executing "
+                        "(%d/%d)",
+                        session.id,
+                        usage_data.get("partial_tool_names") or [],
+                        partial_tool_call_retries,
+                        _MAX_PARTIAL_TOOL_CALL_RETRIES,
+                    )
+                    if streaming_executor is not None:
+                        streaming_executor.discard()
+                    self._budget.refund()
+                    messages.append(assistant_message)
+                    messages.extend(
+                        build_partial_tool_call_recovery_results(tool_calls_raw)
+                    )
+                    continue
+
+                logger.error(
+                    "Session %s: partial tool-call arguments after %d retries; "
+                    "ending the turn with a summary",
                     session.id,
-                    usage_data.get("partial_tool_names") or [],
+                    _MAX_PARTIAL_TOOL_CALL_RETRIES,
                 )
                 if streaming_executor is not None:
                     streaming_executor.discard()
-                self._budget.refund()
                 messages.append(assistant_message)
-                messages.extend(build_partial_tool_call_recovery_results(tool_calls_raw))
-                invalid_json_retries = 0
-                continue
+                messages.extend(
+                    build_partial_tool_call_recovery_results(tool_calls_raw)
+                )
+                await self._request_final_summary(
+                    session, messages, system_prompt, lease,
+                    cost_tracker=cost_tracker,
+                    turn_id=turn_id,
+                    iteration_index=turn_iteration_index,
+                )
+                return
+            partial_tool_call_retries = 0  # reset on a turn with complete args
 
             # 4a. Length continuation with prefix accumulation.
             # When finish_reason == "length", the response was truncated. We

--- a/surogates/harness/loop_constants.py
+++ b/surogates/harness/loop_constants.py
@@ -42,6 +42,12 @@ _ADVISOR_PREFLIGHT_TIMEOUT_SECONDS: float = 20.0
 _MAX_LENGTH_CONTINUATIONS: int = 3
 _MAX_CONSECUTIVE_INVALID_TOOL_CALLS: int = 3
 _MAX_EMPTY_RESPONSE_RETRIES: int = 3
+# Retries for a provider that ends a response before the tool-call JSON is
+# complete.  This retry refunds the iteration budget, so without a cap the
+# wake loop's ``remaining > 0`` guard never advances and a provider stuck
+# truncating spins the worker forever — there is no wall-clock deadline in
+# the loop to catch it.
+_MAX_PARTIAL_TOOL_CALL_RETRIES: int = 3
 _LENGTH_CONTINUATION_PROMPT: str = (
     "[System: Your previous response was truncated by the output "
     "length limit. Continue exactly where you left off. Do not "

--- a/tests/test_partial_tool_call_bound.py
+++ b/tests/test_partial_tool_call_bound.py
@@ -1,0 +1,283 @@
+"""The partial-tool-call recovery path must terminate.
+
+``_run_loop`` refunds the iteration budget when a provider ends a response
+before the tool-call arguments are complete, so the wake loop's
+``while self._budget.remaining > 0`` guard never advances on that path.  A
+provider that keeps truncating therefore spins forever: there is no
+wall-clock deadline anywhere in the wake loop.
+
+These tests pin the bound. They drive the real ``_run_loop`` body with a
+provider that always truncates, and fail loudly instead of hanging.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from surogates.harness.budget import IterationBudget
+from surogates.session.events import EventType
+
+from tests.test_loop_turn_id import _make_loop_harness, _make_session
+
+# Far above any legitimate retry ceiling, low enough that a runaway loop
+# trips it in well under a second.
+_RUNAWAY_THRESHOLD = 40
+
+
+def _partial_tool_call_response() -> tuple[dict[str, Any], dict[str, Any]]:
+    """A response whose tool-call arguments were cut off mid-JSON."""
+    return (
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "write_file", "arguments": '{"path": "a'},
+                }
+            ],
+        },
+        {
+            "model": "test-model",
+            "finish_reason": "tool_calls",
+            "partial_tool_call": True,
+            "partial_tool_names": ["write_file"],
+            "input_tokens": 1,
+            "output_tokens": 1,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_repeated_partial_tool_calls_terminate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider that always truncates must not spin the wake loop forever."""
+    store = AsyncMock()
+    store.emit_event = AsyncMock(side_effect=range(100, 100 + 4 * _RUNAWAY_THRESHOLD))
+    store.get_events = AsyncMock(return_value=[])
+
+    harness = _make_loop_harness(
+        session_store=store, budget=IterationBudget(max_total=5),
+    )
+
+    calls = 0
+
+    async def always_partial(**_kwargs: Any) -> tuple[dict, dict]:
+        nonlocal calls
+        calls += 1
+        if calls > _RUNAWAY_THRESHOLD:
+            raise AssertionError(
+                f"_run_loop made {calls} LLM calls on the partial-tool-call "
+                "path — the recovery retry is unbounded",
+            )
+        return _partial_tool_call_response()
+
+    monkeypatch.setattr(
+        "surogates.harness.loop.call_llm_with_retry", always_partial,
+    )
+
+    session = _make_session()
+    lease = SimpleNamespace(lease_token=uuid4())
+
+    await asyncio.wait_for(
+        harness._run_loop(
+            session,
+            [{"role": "user", "content": "write the file"}],
+            "system",
+            lease,
+            all_events=[],
+        ),
+        timeout=10.0,
+    )
+
+    assert calls <= _RUNAWAY_THRESHOLD, "recovery retry is unbounded"
+
+
+@pytest.mark.asyncio
+async def test_partial_tool_call_exhaustion_ends_the_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once the retries are spent the turn ends with a final response.
+
+    The session must not be left mid-turn with nothing emitted — the user
+    is owed an answer explaining why the work stopped.
+    """
+    store = AsyncMock()
+    store.emit_event = AsyncMock(side_effect=range(100, 100 + 4 * _RUNAWAY_THRESHOLD))
+    store.get_events = AsyncMock(return_value=[])
+
+    harness = _make_loop_harness(
+        session_store=store, budget=IterationBudget(max_total=50),
+    )
+
+    calls = 0
+
+    async def always_partial(**_kwargs: Any) -> tuple[dict, dict]:
+        nonlocal calls
+        calls += 1
+        if calls > _RUNAWAY_THRESHOLD:
+            raise AssertionError("recovery retry is unbounded")
+        return _partial_tool_call_response()
+
+    monkeypatch.setattr(
+        "surogates.harness.loop.call_llm_with_retry", always_partial,
+    )
+    harness._request_final_summary = AsyncMock(return_value=None)
+
+    session = _make_session()
+    lease = SimpleNamespace(lease_token=uuid4())
+
+    await asyncio.wait_for(
+        harness._run_loop(
+            session,
+            [{"role": "user", "content": "write the file"}],
+            "system",
+            lease,
+            all_events=[],
+        ),
+        timeout=10.0,
+    )
+
+    assert harness._request_final_summary.await_count == 1, (
+        "exhausting the partial-tool-call retries must end the turn with a "
+        "final summary, not fall through to tool execution"
+    )
+    # The budget is never the thing that stopped it — the retry cap is.
+    assert harness._budget.remaining > 0
+
+
+@pytest.mark.asyncio
+async def test_partial_tool_call_does_not_clear_the_invalid_json_streak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider alternating the two malformed-args failures must terminate.
+
+    The partial-tool-call branch used to reset ``invalid_json_retries``, so a
+    provider that alternated truncated arguments with unparseable arguments
+    kept each counter below its own cap indefinitely.
+    """
+    store = AsyncMock()
+    store.emit_event = AsyncMock(side_effect=range(100, 100 + 4 * _RUNAWAY_THRESHOLD))
+    store.get_events = AsyncMock(return_value=[])
+
+    harness = _make_loop_harness(
+        session_store=store, budget=IterationBudget(max_total=50),
+    )
+
+    calls = 0
+
+    async def alternating(**_kwargs: Any) -> tuple[dict, dict]:
+        nonlocal calls
+        calls += 1
+        if calls > _RUNAWAY_THRESHOLD:
+            raise AssertionError(
+                f"_run_loop made {calls} LLM calls alternating truncated and "
+                "unparseable tool arguments — the two counters reset each other",
+            )
+        if calls % 2:
+            return _partial_tool_call_response()
+        return (
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": f"call_{calls}",
+                        "type": "function",
+                        "function": {"name": "write_file", "arguments": "not json"},
+                    }
+                ],
+            },
+            {
+                "model": "test-model",
+                "finish_reason": "tool_calls",
+                "input_tokens": 1,
+                "output_tokens": 1,
+            },
+        )
+
+    monkeypatch.setattr(
+        "surogates.harness.loop.call_llm_with_retry", alternating,
+    )
+    harness._request_final_summary = AsyncMock(return_value=None)
+
+    session = _make_session()
+    lease = SimpleNamespace(lease_token=uuid4())
+
+    await asyncio.wait_for(
+        harness._run_loop(
+            session,
+            [{"role": "user", "content": "write the file"}],
+            "system",
+            lease,
+            all_events=[],
+        ),
+        timeout=10.0,
+    )
+
+    assert calls <= _RUNAWAY_THRESHOLD
+
+
+@pytest.mark.asyncio
+async def test_one_partial_tool_call_still_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cap must not break the recovery it bounds.
+
+    A single truncated response is a transient provider hiccup: the loop
+    still refunds the iteration, hands the model a recovery tool result and
+    carries on to a successful turn.
+    """
+    store = AsyncMock()
+    store.emit_event = AsyncMock(side_effect=range(100, 200))
+    store.get_events = AsyncMock(return_value=[])
+
+    harness = _make_loop_harness(
+        session_store=store, budget=IterationBudget(max_total=5),
+    )
+
+    calls = 0
+
+    async def partial_then_ok(**_kwargs: Any) -> tuple[dict, dict]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return _partial_tool_call_response()
+        return (
+            {"role": "assistant", "content": "Wrote the file.", "tool_calls": None},
+            {"model": "test-model", "finish_reason": "stop",
+             "input_tokens": 1, "output_tokens": 2},
+        )
+
+    monkeypatch.setattr(
+        "surogates.harness.loop.call_llm_with_retry", partial_then_ok,
+    )
+
+    session = _make_session()
+    lease = SimpleNamespace(lease_token=uuid4())
+
+    emits: list[Any] = []
+    await asyncio.wait_for(
+        harness._run_loop(
+            session,
+            [{"role": "user", "content": "write the file"}],
+            "system",
+            lease,
+            all_events=[],
+        ),
+        timeout=10.0,
+    )
+    emits = [c.args[1] for c in store.emit_event.await_args_list]
+
+    assert calls == 2, "the truncated response must be retried, not fatal"
+    assert EventType.LLM_RESPONSE in emits
+    # The refund kept the retry off the budget.
+    assert harness._budget.used == 1


### PR DESCRIPTION
## The bug

`_run_loop` refunds the iteration budget when a provider ends a response before the tool-call JSON is complete (`surogates/harness/loop.py:2034`), so the loop guard `while self._budget.remaining > 0` never advances on that path. There is no wall-clock deadline anywhere in the wake loop, so a provider stuck truncating spins the worker **indefinitely**.

Every sibling recovery path is capped — `incomplete_scratchpad_retries <= 2`, `thinking_prefill_retries <= 2`, `empty_response_retries < _MAX_EMPTY_RESPONSE_RETRIES`, `invalid_json_retries < 3`. This one was not.

The path also reset `invalid_json_retries = 0`, so a provider alternating truncated arguments with unparseable arguments kept **both** streaks below their own caps forever.

Reproduced in test: **41 LLM calls against a `max_total=5` budget** before the runaway guard fired.

## The fix

- Cap at `_MAX_PARTIAL_TOOL_CALL_RETRIES = 3`, matching the sibling constants.
- Stop clearing `invalid_json_retries` — the two counters are now independently bounded.
- Reset the new counter on a turn with complete args, mirroring `invalid_json_retries` at :2399.
- On exhaustion, end the turn via `_request_final_summary` rather than falling through to tool execution with truncated arguments.

## Tests

Four tests in `tests/test_partial_tool_call_bound.py`, each written and watched fail first:

| Test | Pins |
|---|---|
| `test_repeated_partial_tool_calls_terminate` | the loop is bounded at all |
| `test_partial_tool_call_exhaustion_ends_the_turn` | the user gets an answer, and the budget is not what stopped it |
| `test_partial_tool_call_does_not_clear_the_invalid_json_streak` | the alternating ping-pong terminates |
| `test_one_partial_tool_call_still_retries` | the cap does not break the recovery it bounds — a single hiccup still refunds and continues |

Unit suite: `28 failed / 4952 passed` on master → `28 failed / 4956 passed` with this branch. Identical failure set (the 28 are pre-existing environment gaps). Ruff: no new findings.