### PR TITLE
fix(orchestrator): bound orphan-sweep recovery attempts

### DIFF
--- a/surogates/orchestrator/dispatcher.py
+++ b/surogates/orchestrator/dispatcher.py
@@ -86,6 +86,15 @@ _CRASH_LOOP_THRESHOLD: int = 3
 _CRASH_LOOP_KEY_PREFIX = "surogates:crash_loop:"
 _CRASH_LOOP_TTL_SECONDS: int = 6 * 3600
 
+# How many times the orphan sweeper re-enqueues one session before giving up.
+# The crash-loop breaker above only trips inside ``_process``'s ``except``
+# branch, and a SIGKILL (OOM, pod eviction) never reaches an ``except`` — so a
+# session that reproducibly kills its worker leaves no crash record at all and
+# the sweeper would re-enqueue it every cycle, forever.  The streak counting
+# these resets on any sign of life, so a session making real progress between
+# crashes never approaches the ceiling.
+_MAX_RECOVERY_ATTEMPTS: int = 3
+
 
 def _crash_fingerprint(exc: BaseException) -> str:
     """Stable identity for a crash: error category + hashed detail."""
@@ -873,6 +882,32 @@ class Orchestrator:
             if getattr(session, "channel", None) == "browser_setup":
                 continue
             try:
+                # Checked BEFORE the recovery emit: emit_event bumps
+                # ``sessions.updated_at``, which is the staleness signal that
+                # made this session visible to the sweeper in the first place.
+                # Emitting on the tripping pass would reset that clock.
+                #
+                # Fails open — a transient DB blip on this query must not
+                # strand a session, because ordinary crash recovery is the
+                # common case and the ceiling is only a backstop.
+                try:
+                    attempts = int(
+                        await self.session_store
+                        .count_recoveries_since_progress(session.id)
+                    )
+                except Exception:
+                    logger.warning(
+                        "Recovery-streak lookup failed for session %s; "
+                        "recovering anyway",
+                        session.id, exc_info=True,
+                    )
+                    attempts = 0
+                if attempts >= _MAX_RECOVERY_ATTEMPTS:
+                    await self._abandon_unrecoverable_session(
+                        session, attempts=attempts, reason=reason,
+                    )
+                    continue
+
                 await self.session_store.emit_event(
                     session.id,
                     EventType.HARNESS_RECOVERED,
@@ -882,35 +917,7 @@ class Orchestrator:
                     },
                 )
                 await self.session_store.release_stale_lease(session.id)
-                # Compensate the TurnConcurrencyGate.  A session that
-                # reaches the orphan sweeper got there because its
-                # previous owner died WITHOUT running the dispatcher's
-                # finally branch -- which is the only path that
-                # ``release()``s the gate slot.  Left unhandled, every
-                # debugger-stop / OOM / pod-eviction leaks one slot
-                # per in-flight session for this (org, agent); a few
-                # cycles of that drives the counter to its cap and
-                # every subsequent dequeue is rejected, leaving fresh
-                # sessions stuck in an endless re-enqueue loop with
-                # no diagnostic anywhere.
-                #
-                # Floor-at-zero in ``TurnGate.release()`` protects
-                # against double-release if this recovery races a
-                # late-arriving finally on the original owner (the
-                # owner is by definition gone at this point, but the
-                # floor keeps us honest).
-                if self._turn_gate is not None:
-                    try:
-                        await self._turn_gate.release(
-                            str(session.org_id), session.agent_id,
-                        )
-                    except Exception:
-                        logger.warning(
-                            "Failed to release turn gate slot for "
-                            "recovered session %s (org=%s agent=%s)",
-                            session.id, session.org_id, session.agent_id,
-                            exc_info=True,
-                        )
+                await self._release_dead_owner_gate_slot(session)
                 await enqueue_session(
                     self.redis,
                     org_id=str(session.org_id),
@@ -928,6 +935,70 @@ class Orchestrator:
                     session.id,
                 )
         return recovered
+
+    async def _release_dead_owner_gate_slot(self, session: Any) -> None:
+        """Compensate the TurnConcurrencyGate for a session's dead owner.
+
+        A session that reaches the orphan sweeper got there because its
+        previous owner died WITHOUT running the dispatcher's finally branch --
+        which is the only path that ``release()``s the gate slot.  Left
+        unhandled, every debugger-stop / OOM / pod-eviction leaks one slot per
+        in-flight session for this (org, agent); a few cycles of that drives
+        the counter to its cap and every subsequent dequeue is rejected,
+        leaving fresh sessions stuck in an endless re-enqueue loop with no
+        diagnostic anywhere.
+
+        The slot leaked whether or not we go on to retry the session, so both
+        the recovery and the abandon path call this.
+
+        Floor-at-zero in ``TurnGate.release()`` protects against
+        double-release if this races a late-arriving finally on the original
+        owner (the owner is by definition gone at this point, but the floor
+        keeps us honest).
+        """
+        if self._turn_gate is None:
+            return
+        try:
+            await self._turn_gate.release(
+                str(session.org_id), session.agent_id,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to release turn gate slot for "
+                "recovered session %s (org=%s agent=%s)",
+                session.id, session.org_id, session.agent_id,
+                exc_info=True,
+            )
+
+    async def _abandon_unrecoverable_session(
+        self, session: Any, *, attempts: int, reason: str,
+    ) -> None:
+        """Terminate a session the sweeper has failed to recover.
+
+        Failing the session is what actually breaks the loop: ``session.fail``
+        is one of ``find_orphaned_sessions``'s session-ending event types AND
+        the status filter drops non-``active`` rows, so the session leaves the
+        orphan-eligible set on both counts.  Merely skipping the re-enqueue
+        would leave it to be re-examined every sweep forever.
+        """
+        logger.error(
+            "Session %s hit the recovery ceiling (%d attempts with no "
+            "progress, %s) — abandoning instead of re-enqueueing",
+            session.id, attempts, reason,
+        )
+        await self.session_store.release_stale_lease(session.id)
+        await self._release_dead_owner_gate_slot(session)
+        await self.session_store.emit_event(
+            session.id,
+            EventType.SESSION_FAIL,
+            {
+                "reason": "recovery_loop",
+                "attempts": attempts,
+                "recovered_by": reason,
+                "retryable": False,
+            },
+        )
+        await self.session_store.update_session_status(session.id, "failed")
 
     async def _sweep_orphans_on_boot(self) -> None:
         """One-shot aggressive sweep right after worker start.

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -1419,6 +1419,46 @@ class SessionStore:
             row = result.first()
         return row[0] if row is not None else None
 
+    async def count_recoveries_since_progress(self, session_id: UUID) -> int:
+        """Count ``harness.recovered`` events since the session last progressed.
+
+        The orphan sweeper re-enqueues any stale, leaseless active session.
+        ``harness.recovered`` is not a session-ending event, so a session that
+        reproducibly kills its worker before emitting anything stays eligible
+        forever and takes a worker down on every sweep.  This is the streak
+        that bounds those attempts.
+
+        "Progress" is a sign of life the sweep itself cannot fake: a model
+        answered, a tool returned, or the user said something new.  An
+        ``llm.request`` deliberately does not count — it only proves the wake
+        started, which a session that dies during context replay never gets
+        past.  Any of the three resets the streak, so a session doing real
+        work between crashes is never mistaken for a poison one.
+        """
+        progress_types = (
+            EventType.LLM_RESPONSE.value,
+            EventType.TOOL_RESULT.value,
+            EventType.USER_MESSAGE.value,
+        )
+        last_progress_id = (
+            select(func.max(EventRow.id))
+            .where(
+                EventRow.session_id == session_id,
+                EventRow.type.in_(progress_types),
+            )
+            .scalar_subquery()
+        )
+        stmt = select(func.count()).select_from(EventRow).where(
+            EventRow.session_id == session_id,
+            EventRow.type == EventType.HARNESS_RECOVERED.value,
+            or_(
+                last_progress_id.is_(None),
+                EventRow.id > last_progress_id,
+            ),
+        )
+        async with self._sf() as db:
+            return int((await db.execute(stmt)).scalar_one())
+
     async def list_inbox(
         self,
         *,

--- a/tests/integration/test_recovery_streak.py
+++ b/tests/integration/test_recovery_streak.py
@@ -1,0 +1,117 @@
+"""``count_recoveries_since_progress`` — the orphan sweeper's poison guard.
+
+The sweeper re-enqueues any stale, leaseless active session. ``harness.recovered``
+is not a session-ending event, so a session that reproducibly kills its worker
+before emitting anything stays orphan-eligible forever and takes a worker down
+every sweep. The crash-loop breaker cannot see it: that only trips inside an
+``except`` block, and a SIGKILL never reaches one.
+
+The streak counts recoveries since the session last showed a sign of life, so
+a session doing real work between crashes is never mistaken for a poison one.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from surogates.session.events import EventType
+
+from .conftest import create_org, create_user
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def _make_session(session_store, session_factory):
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+    return await session_store.create_session(
+        org_id=org_id, user_id=user_id, agent_id="agent-1", channel="web",
+    )
+
+
+async def test_streak_is_zero_for_a_session_that_never_crashed(
+    session_store, session_factory,
+):
+    session = await _make_session(session_store, session_factory)
+    await session_store.emit_event(
+        session.id, EventType.USER_MESSAGE, {"content": "hello"},
+    )
+
+    assert await session_store.count_recoveries_since_progress(session.id) == 0
+
+
+async def test_streak_counts_consecutive_recoveries(
+    session_store, session_factory,
+):
+    """Three sweeps that never produced a sign of life count as three."""
+    session = await _make_session(session_store, session_factory)
+    await session_store.emit_event(
+        session.id, EventType.USER_MESSAGE, {"content": "do it"},
+    )
+    for _ in range(3):
+        await session_store.emit_event(
+            session.id, EventType.HARNESS_RECOVERED, {"recovered_by": "sweeper"},
+        )
+
+    assert await session_store.count_recoveries_since_progress(session.id) == 3
+
+
+@pytest.mark.parametrize(
+    "progress_type",
+    [EventType.LLM_RESPONSE, EventType.TOOL_RESULT, EventType.USER_MESSAGE],
+)
+async def test_progress_after_a_recovery_resets_the_streak(
+    session_store, session_factory, progress_type,
+):
+    """A session that gets real work done between crashes is not poison."""
+    session = await _make_session(session_store, session_factory)
+    for _ in range(5):
+        await session_store.emit_event(
+            session.id, EventType.HARNESS_RECOVERED, {"recovered_by": "sweeper"},
+        )
+    await session_store.emit_event(session.id, progress_type, {})
+    await session_store.emit_event(
+        session.id, EventType.HARNESS_RECOVERED, {"recovered_by": "sweeper"},
+    )
+
+    assert await session_store.count_recoveries_since_progress(session.id) == 1
+
+
+async def test_streak_ignores_events_that_are_not_progress(
+    session_store, session_factory,
+):
+    """An ``llm.request`` means the wake started, not that it accomplished
+    anything — a session that OOMs after every request is still poison."""
+    session = await _make_session(session_store, session_factory)
+    for _ in range(3):
+        await session_store.emit_event(
+            session.id, EventType.HARNESS_RECOVERED, {"recovered_by": "sweeper"},
+        )
+        await session_store.emit_event(session.id, EventType.LLM_REQUEST, {})
+
+    assert await session_store.count_recoveries_since_progress(session.id) == 3
+
+
+async def test_streak_is_scoped_to_one_session(session_store, session_factory):
+    session_a = await _make_session(session_store, session_factory)
+    session_b = await _make_session(session_store, session_factory)
+    for _ in range(4):
+        await session_store.emit_event(
+            session_a.id, EventType.HARNESS_RECOVERED, {"recovered_by": "sweeper"},
+        )
+
+    assert await session_store.count_recoveries_since_progress(session_b.id) == 0
+
+
+async def test_streak_of_a_session_with_no_events_is_zero(
+    session_store, session_factory,
+):
+    session = await _make_session(session_store, session_factory)
+
+    assert await session_store.count_recoveries_since_progress(session.id) == 0
+
+
+async def test_unknown_session_has_no_streak(session_store):
+    assert await session_store.count_recoveries_since_progress(uuid.uuid4()) == 0

--- a/tests/test_orphan_recovery_ceiling.py
+++ b/tests/test_orphan_recovery_ceiling.py
@@ -1,0 +1,264 @@
+"""The orphan sweeper must stop re-enqueueing a session it cannot recover.
+
+``_sweep_orphans_once`` re-enqueues every stale, leaseless active session it
+finds. ``harness.recovered`` is not one of ``find_orphaned_sessions``'s
+session-ending event types, so a session that reproducibly kills its worker
+before emitting anything stays eligible forever: it takes a worker down on
+every sweep, indefinitely.
+
+The dispatcher's crash-loop breaker does not cover this — it only trips inside
+the ``except`` branch of ``_process``, and a SIGKILL (OOM, eviction) never
+reaches an ``except``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from surogates.orchestrator.dispatcher import (
+    _MAX_RECOVERY_ATTEMPTS,
+    Orchestrator,
+)
+from surogates.session.events import EventType
+
+from tests.test_orphan_sweep_gate_release import _FakeQueueRedis
+
+
+def _make_orphan(*, org_id: UUID, agent_id: str = "agent-X") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(), org_id=org_id, agent_id=agent_id, channel="web",
+    )
+
+
+def _make_store(*, orphans: list, streak: int) -> AsyncMock:
+    store = AsyncMock()
+    store.find_orphaned_sessions = AsyncMock(return_value=orphans)
+    store.emit_event = AsyncMock()
+    store.release_stale_lease = AsyncMock(return_value=True)
+    store.update_session_status = AsyncMock()
+    store.count_recoveries_since_progress = AsyncMock(return_value=streak)
+    return store
+
+
+def _make_orchestrator(*, session_store, redis, gate=None) -> Orchestrator:
+    return Orchestrator(
+        redis_client=redis,
+        session_store=session_store,
+        harness_factory=lambda _sid: None,
+        agent_id="agent-X",
+        queue_key="surogates:work_queue",
+        max_concurrent=1,
+        turn_gate=gate,
+    )
+
+
+def _emitted(store: AsyncMock, event_type: str) -> list:
+    return [
+        call.args[2]
+        for call in store.emit_event.await_args_list
+        if call.args[1] == event_type
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sweep_stops_re_enqueueing_at_the_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A session that has burned the recovery budget is not re-enqueued."""
+    enqueue = AsyncMock()
+    monkeypatch.setattr(
+        "surogates.orchestrator.dispatcher.enqueue_session", enqueue,
+    )
+
+    orphan = _make_orphan(org_id=uuid4())
+    store = _make_store(orphans=[orphan], streak=_MAX_RECOVERY_ATTEMPTS)
+
+    orchestrator = _make_orchestrator(
+        session_store=store, redis=_FakeQueueRedis(),
+    )
+    recovered = await orchestrator._sweep_orphans_once(
+        stale_seconds=60, reason="orchestrator_sweeper",
+    )
+
+    assert recovered == 0
+    assert enqueue.await_count == 0, (
+        "a session past the recovery ceiling must not be re-enqueued — "
+        "that is the loop this guard exists to break"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sweep_fails_the_session_at_the_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Tripping the ceiling terminates the session so it leaves the
+    orphan-eligible set instead of being swept again every cycle."""
+    monkeypatch.setattr(
+        "surogates.orchestrator.dispatcher.enqueue_session", AsyncMock(),
+    )
+
+    orphan = _make_orphan(org_id=uuid4())
+    store = _make_store(orphans=[orphan], streak=_MAX_RECOVERY_ATTEMPTS + 2)
+
+    orchestrator = _make_orchestrator(
+        session_store=store, redis=_FakeQueueRedis(),
+    )
+    await orchestrator._sweep_orphans_once(
+        stale_seconds=60, reason="orchestrator_sweeper",
+    )
+
+    fails = _emitted(store, EventType.SESSION_FAIL)
+    assert len(fails) == 1, "expected exactly one session.fail"
+    assert fails[0]["reason"] == "recovery_loop"
+    assert fails[0]["attempts"] == _MAX_RECOVERY_ATTEMPTS + 2
+    assert fails[0]["retryable"] is False
+    store.update_session_status.assert_awaited_once_with(orphan.id, "failed")
+
+
+@pytest.mark.asyncio
+async def test_ceiling_does_not_emit_harness_recovered(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The check runs before the recovery emit.
+
+    ``emit_event`` bumps ``sessions.updated_at``, which is the staleness
+    signal — emitting harness.recovered on the tripping pass would reset the
+    very clock that made the session visible to the sweeper.
+    """
+    monkeypatch.setattr(
+        "surogates.orchestrator.dispatcher.enqueue_session", AsyncMock(),
+    )
+
+    orphan = _make_orphan(org_id=uuid4())
+    store = _make_store(orphans=[orphan], streak=_MAX_RECOVERY_ATTEMPTS)
+
+    orchestrator = _make_orchestrator(
+        session_store=store, redis=_FakeQueueRedis(),
+    )
+    await orchestrator._sweep_orphans_once(
+        stale_seconds=60, reason="orchestrator_sweeper",
+    )
+
+    assert _emitted(store, EventType.HARNESS_RECOVERED) == []
+
+
+@pytest.mark.asyncio
+async def test_ceiling_still_releases_the_leaked_gate_slot(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The dead owner leaked its gate slot whether or not we retry.
+
+    Skipping the release here would drive the (org, agent) counter to its
+    cap and stall every unrelated session for that agent.
+    """
+    monkeypatch.setattr(
+        "surogates.orchestrator.dispatcher.enqueue_session", AsyncMock(),
+    )
+
+    org_id = uuid4()
+    orphan = _make_orphan(org_id=org_id)
+    store = _make_store(orphans=[orphan], streak=_MAX_RECOVERY_ATTEMPTS)
+    gate = AsyncMock()
+
+    orchestrator = _make_orchestrator(
+        session_store=store, redis=_FakeQueueRedis(), gate=gate,
+    )
+    await orchestrator._sweep_orphans_once(
+        stale_seconds=60, reason="orchestrator_sweeper",
+    )
+
+    gate.release.assert_awaited_once_with(str(org_id), orphan.agent_id)
+    store.release_stale_lease.assert_awaited_once_with(orphan.id)
+
+
+@pytest.mark.asyncio
+async def test_sweep_recovers_normally_below_the_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The guard must not break the recovery it bounds."""
+    enqueue = AsyncMock()
+    monkeypatch.setattr(
+        "surogates.orchestrator.dispatcher.enqueue_session", enqueue,
+    )
+
+    orphan = _make_orphan(org_id=uuid4())
+    store = _make_store(orphans=[orphan], streak=_MAX_RECOVERY_ATTEMPTS - 1)
+
+    orchestrator = _make_orchestrator(
+        session_store=store, redis=_FakeQueueRedis(),
+    )
+    recovered = await orchestrator._sweep_orphans_once(
+        stale_seconds=60, reason="orchestrator_sweeper",
+    )
+
+    assert recovered == 1
+    assert enqueue.await_count == 1
+    assert len(_emitted(store, EventType.HARNESS_RECOVERED)) == 1
+    assert _emitted(store, EventType.SESSION_FAIL) == []
+
+
+@pytest.mark.asyncio
+async def test_one_poison_session_does_not_block_its_neighbours(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A tripped session must not abort the rest of the sweep pass."""
+    enqueue = AsyncMock()
+    monkeypatch.setattr(
+        "surogates.orchestrator.dispatcher.enqueue_session", enqueue,
+    )
+
+    org_id = uuid4()
+    poison = _make_orphan(org_id=org_id)
+    healthy = _make_orphan(org_id=org_id)
+    store = _make_store(orphans=[poison, healthy], streak=0)
+    store.count_recoveries_since_progress = AsyncMock(
+        side_effect=lambda sid: (
+            _MAX_RECOVERY_ATTEMPTS if sid == poison.id else 0
+        )
+    )
+
+    orchestrator = _make_orchestrator(
+        session_store=store, redis=_FakeQueueRedis(),
+    )
+    recovered = await orchestrator._sweep_orphans_once(
+        stale_seconds=60, reason="orchestrator_sweeper",
+    )
+
+    assert recovered == 1
+    enqueued_ids = {c.kwargs["session_id"] for c in enqueue.await_args_list}
+    assert enqueued_ids == {healthy.id}
+
+
+@pytest.mark.asyncio
+async def test_streak_lookup_failure_falls_back_to_recovering(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A transient DB blip on the streak query must not strand a session.
+
+    The ceiling is a backstop against a rare poison session; failing open
+    keeps ordinary crash recovery — the common case — working.
+    """
+    enqueue = AsyncMock()
+    monkeypatch.setattr(
+        "surogates.orchestrator.dispatcher.enqueue_session", enqueue,
+    )
+
+    orphan = _make_orphan(org_id=uuid4())
+    store = _make_store(orphans=[orphan], streak=0)
+    store.count_recoveries_since_progress = AsyncMock(
+        side_effect=RuntimeError("connection reset")
+    )
+
+    orchestrator = _make_orchestrator(
+        session_store=store, redis=_FakeQueueRedis(),
+    )
+    recovered = await orchestrator._sweep_orphans_once(
+        stale_seconds=60, reason="orchestrator_sweeper",
+    )
+
+    assert recovered == 1
+    assert enqueue.await_count == 1


### PR DESCRIPTION
## The bug

`_sweep_orphans_once` re-enqueues every stale, leaseless active session it finds (`surogates/orchestrator/dispatcher.py:851`). `harness.recovered` is **not** one of `find_orphaned_sessions`'s `session_end_event_types` (`surogates/session/store.py:1822`), so a session that reproducibly kills its worker before emitting anything stays orphan-eligible forever — it takes a worker down on every sweep, indefinitely.

The crash-loop breaker does not cover this. `_crash_fingerprint` only trips inside the `except Exception` branch of `_process`, and a SIGKILL (OOM, pod eviction) never reaches an `except`. The Task layer's `max_attempts` is also inert: `attempt_count` increments on spawn, and a session that never terminates never finalises its task.

## The fix

New `SessionStore.count_recoveries_since_progress` counts `harness.recovered` events since the session last showed a **sign of life** — an `llm.response`, a `tool.result`, or a new `user.message`. The sweeper abandons the session once that streak reaches `_MAX_RECOVERY_ATTEMPTS = 3` (matching `_CRASH_LOOP_THRESHOLD`).

`llm.request` deliberately does **not** count as progress: it only proves the wake started, which a session dying during context replay never gets past. Any of the three real signals resets the streak, so a session making progress between crashes never approaches the ceiling.

Three details worth reviewing:

- **The check runs before the recovery emit.** `emit_event` bumps `sessions.updated_at`, which is the staleness signal that surfaced the session — emitting on the tripping pass would reset the very clock that made it visible.
- **Tripping fails the session** rather than just skipping the enqueue. `session.fail` drops it from the orphan-eligible set on *both* the status filter and the latest-event filter; skipping alone would leave it re-examined every sweep forever.
- **The gate slot is released on both paths.** The dead owner leaked it whether or not we retry; skipping the release would drive the (org, agent) counter to its cap and stall every unrelated session for that agent. Extracted to `_release_dead_owner_gate_slot` so both callers share it.

The streak lookup **fails open** — a transient DB blip must not strand a session, since ordinary crash recovery is the common case and this ceiling is only a backstop.

## Tests

7 dispatcher tests (`tests/test_orphan_recovery_ceiling.py`) and 9 store tests against real PostgreSQL (`tests/integration/test_recovery_streak.py`), each written and watched fail first. They pin: no re-enqueue at the ceiling, the terminal `session.fail`/`failed` status, no `harness.recovered` on the tripping pass, the gate release, normal recovery below the ceiling, one poison session not blocking its neighbours, and the fail-open.

## Verification

Unit suite: `28 failed / 4952 passed` on master → `28 failed / 4959 passed` with this branch. Identical failure set (the 28 are pre-existing environment gaps). Ruff clean.

**Not verified:** the full integration suite showed 13 failures on this branch, in areas unrelated to the sweeper (`test_api` scheduled-run, `test_inbox_progress_hook`, `test_attachment_history_replay`, `test_observability`, firebase auth). The master baseline run was stopped before completing, so these are *presumed* pre-existing but not confirmed. Worth a look if any of those are known-good locally.