### PR TITLE
fix(ask): release the turn slot while a human deliberates

### DIFF
--- a/surogates/runtime/turn_gate.py
+++ b/surogates/runtime/turn_gate.py
@@ -25,10 +25,24 @@ the simple counter is enough for the canary deploy.
 
 from __future__ import annotations
 
+import asyncio
+import logging
+import time
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
 
-__all__ = ["TurnConcurrencyGate", "TurnGateBusy"]
+__all__ = ["TurnConcurrencyGate", "TurnGateBusy", "released_for_wait"]
+
+logger = logging.getLogger(__name__)
+
+# Re-acquiring on the way out is best-effort.  If the cap is genuinely
+# saturated when the wait ends we proceed without a slot and let the
+# dispatcher's outer release fall on the floor-at-zero guard.  Slight
+# under-count is acceptable — the cap is a guideline, not a correctness
+# constraint — whereas blocking forever waiting for a slot would expire the
+# session lease and produce an orphan re-enqueue cycle, a far worse failure.
+_REACQUIRE_TIMEOUT_SECONDS: float = 30.0
+_REACQUIRE_BACKOFF_SECONDS: float = 0.5
 
 
 class TurnGateBusy(RuntimeError):
@@ -104,3 +118,78 @@ class TurnConcurrencyGate:
 
     def _key(self, org_id: str, agent_id: str) -> str:
         return f"surogates:turns:{org_id}:{agent_id}"
+
+
+async def _reacquire_with_backoff(
+    turn_gate: Any, org_id: str, agent_id: str,
+) -> bool:
+    """Re-acquire a slot, retrying briefly while the tenant is at cap.
+
+    Returns ``True`` on success, ``False`` once
+    :data:`_REACQUIRE_TIMEOUT_SECONDS` of failed attempts have elapsed.
+    """
+    if turn_gate is None:
+        return False
+    deadline = time.monotonic() + _REACQUIRE_TIMEOUT_SECONDS
+    while True:
+        try:
+            if await turn_gate.try_acquire(org_id, agent_id):
+                return True
+        except Exception:
+            logger.debug(
+                "Transient try_acquire failure during re-acquire "
+                "(org=%s agent=%s)", org_id, agent_id, exc_info=True,
+            )
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(_REACQUIRE_BACKOFF_SECONDS)
+
+
+@asynccontextmanager
+async def released_for_wait(
+    turn_gate: Any | None,
+    org_id: str,
+    agent_id: str,
+    *,
+    context: str,
+) -> AsyncIterator[None]:
+    """Hand the tenant's slot back while the caller sleeps; take it again after.
+
+    The gate counts *active work*.  A caller blocked on something external —
+    a delegated child session, a human answering a question — consumes no
+    worker CPU, so holding its slot for the duration is a category error: a
+    handful of waiters saturate the per-tenant cap and every unrelated
+    session is requeued behind sleepers.
+
+    Both halves are best-effort and never raise into the body:
+
+    * If the release fails the body still runs, and no re-acquire is
+      attempted — re-taking a slot that was never given up would hand the
+      tenant a slot it does not own.
+    * If the re-acquire fails the body's result still stands.  Losing the
+      work a caller already completed to satisfy a soft cap is the wrong
+      trade.
+
+    ``context`` names the caller in log lines.
+    """
+    released = False
+    if turn_gate is not None:
+        try:
+            await turn_gate.release(org_id, agent_id)
+            released = True
+        except Exception:
+            logger.warning(
+                "%s: failed to release gate slot (org=%s agent=%s); "
+                "proceeding without", context, org_id, agent_id, exc_info=True,
+            )
+    try:
+        yield
+    finally:
+        if released and not await _reacquire_with_backoff(
+            turn_gate, org_id, agent_id,
+        ):
+            logger.warning(
+                "%s: could not re-acquire gate slot within %.0fs "
+                "(org=%s agent=%s); continuing without",
+                context, _REACQUIRE_TIMEOUT_SECONDS, org_id, agent_id,
+            )

--- a/surogates/tools/builtin/ask_user_question.py
+++ b/surogates/tools/builtin/ask_user_question.py
@@ -30,6 +30,7 @@ import logging
 from typing import Any
 from uuid import UUID
 
+from surogates.runtime.turn_gate import released_for_wait
 from surogates.session.events import EventType
 from surogates.tools.registry import ToolRegistry, ToolSchema
 
@@ -307,6 +308,30 @@ async def _wait_for_response(
         await asyncio.sleep(_POLL_INTERVAL_SECONDS)
 
 
+async def _resolve_gate_identity(
+    session_store: Any, session_id: UUID,
+) -> tuple[str | None, str | None]:
+    """Read the (org_id, agent_id) the turn gate is keyed on.
+
+    Returns ``(None, None)`` when the session cannot be read or does not
+    carry both -- there is then no slot we can safely account for, so the
+    caller skips the release entirely rather than guessing at a key.
+    """
+    try:
+        session = await session_store.get_session(session_id)
+    except Exception:
+        logger.warning(
+            "Could not read session %s for gate release; holding the slot",
+            session_id, exc_info=True,
+        )
+        return None, None
+    org_id = getattr(session, "org_id", None)
+    agent_id = getattr(session, "agent_id", None)
+    if org_id is None or agent_id is None:
+        return None, None
+    return str(org_id), str(agent_id)
+
+
 # ---------------------------------------------------------------------------
 # Handler + registration
 # ---------------------------------------------------------------------------
@@ -324,11 +349,14 @@ async def _ask_user_question_handler(arguments: dict[str, Any], **kwargs: Any) -
     Optional:
 
     - ``lease_token`` -- current lease token, used to renew during the wait.
+    - ``turn_gate`` -- the per-tenant concurrency gate; its slot is handed
+      back for the duration of the wait.
     """
     session_store = kwargs.get("session_store")
     tool_call_id = kwargs.get("tool_call_id")
     raw_session_id = kwargs.get("session_id")
     lease_token = kwargs.get("lease_token")
+    turn_gate = kwargs.get("turn_gate")
 
     if session_store is None or not tool_call_id or raw_session_id is None:
         return json.dumps(
@@ -355,12 +383,23 @@ async def _ask_user_question_handler(arguments: dict[str, Any], **kwargs: Any) -
         },
     )
 
-    outcome = await _wait_for_response(
-        session_id=session_id,
-        tool_call_id=str(tool_call_id),
-        session_store=session_store,
-        lease_token=lease_token,
-    )
+    # The wait below is idle -- it polls at 1 Hz and renews the lease, using
+    # no worker CPU -- but can last 30 minutes.  Holding a turn slot for it
+    # would let a handful of pending questions saturate the tenant cap and
+    # requeue every unrelated session behind sleepers.
+    org_id, agent_id = await _resolve_gate_identity(session_store, session_id)
+    async with released_for_wait(
+        turn_gate if org_id else None,
+        org_id or "",
+        agent_id or "",
+        context="ask_user_question",
+    ):
+        outcome = await _wait_for_response(
+            session_id=session_id,
+            tool_call_id=str(tool_call_id),
+            session_store=session_store,
+            lease_token=lease_token,
+        )
 
     if outcome.get("cancelled"):
         return json.dumps(

--- a/surogates/tools/builtin/delegate.py
+++ b/surogates/tools/builtin/delegate.py
@@ -36,6 +36,7 @@ from typing import Any
 from uuid import UUID
 
 from surogates.config import enqueue_session
+from surogates.runtime.turn_gate import released_for_wait
 from surogates.session.events import EventType
 from surogates.tools.registry import ToolRegistry, ToolSchema
 
@@ -50,45 +51,6 @@ _DELEGATION_TIMEOUT_SECONDS: int = 3600
 _POLL_INTERVAL_SECONDS: float = 1.0
 _CHILD_MAX_ITERATIONS: int = 30
 _MAX_DELEGATION_DEPTH: int = 2
-
-# Cap on how long the parent waits to re-acquire its
-# TurnConcurrencyGate slot when ``_run_single_delegation`` returns.
-# In the common case the slot is free immediately (the parent's own
-# release a moment ago opened one).  Genuine cap saturation by other
-# tenants is rare; if we can't get a slot within this window we
-# proceed without one and let the dispatcher's outer release fall on
-# the floor-at-zero guard.  Slight under-count is acceptable;
-# blocking the parent forever would expire the lease and produce an
-# orphan re-enqueue cycle, which is a much worse failure mode.
-_REACQUIRE_TIMEOUT_SECONDS: float = 30.0
-_REACQUIRE_BACKOFF_SECONDS: float = 0.5
-
-
-async def _reacquire_gate_with_backoff(
-    turn_gate: Any, org_id: str, agent_id: str,
-) -> bool:
-    """Re-acquire the parent's gate slot, retrying briefly if at cap.
-
-    Returns ``True`` on success.  ``False`` after
-    ``_REACQUIRE_TIMEOUT_SECONDS`` of failed attempts -- caller logs
-    and proceeds without (the dispatcher's outer release floors at
-    zero, so we don't drive the counter negative).
-    """
-    if turn_gate is None:
-        return False
-    deadline = time.monotonic() + _REACQUIRE_TIMEOUT_SECONDS
-    while True:
-        try:
-            if await turn_gate.try_acquire(org_id, agent_id):
-                return True
-        except Exception:
-            logger.debug(
-                "Transient try_acquire failure during re-acquire "
-                "(org=%s agent=%s)", org_id, agent_id, exc_info=True,
-            )
-        if time.monotonic() >= deadline:
-            return False
-        await asyncio.sleep(_REACQUIRE_BACKOFF_SECONDS)
 
 # Agent types that must not be delegated to recursively or in a
 # batched fan-out.  These workflows are expensive (they themselves
@@ -365,35 +327,16 @@ async def _delegate_handler(
     remaining = budget.remaining if budget else _CHILD_MAX_ITERATIONS
     per_child_budget = max(1, remaining // max(1, len(tasks)))
 
-    # Release the parent's TurnConcurrencyGate slot for the duration
-    # of the delegation: the parent is about to spend up to 15 minutes
-    # idle inside _poll_child_completion waiting for the child, NOT
-    # consuming worker CPU.  Counting it as 1 slot during that window
-    # is a category error -- the gate is meant to track active work,
-    # not sleeping waiters.  With this release, a deep delegation
-    # chain stops self-saturating its own per-tenant cap.
-    #
-    # Re-acquire is best-effort: if the cap is genuinely saturated on
-    # exit, we proceed without and let the dispatcher's outer release
-    # fall on the floor-at-zero guard.  Slight under-count is
-    # acceptable (cap is a guideline, not a correctness constraint);
-    # blocking the parent forever waiting for a slot would be a much
-    # worse failure mode (lease expiry, orphan re-enqueue cycle).
+    # The parent is about to spend up to 15 minutes idle inside
+    # _poll_child_completion waiting for the child, so it gives its gate slot
+    # back for the duration -- otherwise a deep delegation chain saturates
+    # its own per-tenant cap with sleepers.
     parent_org_id = str(parent_session.org_id)
     parent_agent_id = parent_session.agent_id
-    released_slot = False
-    if turn_gate is not None:
-        try:
-            await turn_gate.release(parent_org_id, parent_agent_id)
-            released_slot = True
-        except Exception:
-            logger.warning(
-                "delegate_task: failed to release parent gate slot "
-                "(org=%s agent=%s); proceeding without",
-                parent_org_id, parent_agent_id, exc_info=True,
-            )
 
-    try:
+    async with released_for_wait(
+        turn_gate, parent_org_id, parent_agent_id, context="delegate_task",
+    ):
         results = await asyncio.gather(*[
             _run_single_delegation(
                 task=task,
@@ -410,19 +353,6 @@ async def _delegate_handler(
             )
             for task in tasks
         ], return_exceptions=False)
-    finally:
-        if released_slot:
-            try:
-                await _reacquire_gate_with_backoff(
-                    turn_gate, parent_org_id, parent_agent_id,
-                )
-            except Exception:
-                logger.warning(
-                    "delegate_task: failed to re-acquire parent gate "
-                    "slot (org=%s agent=%s); the dispatcher's release "
-                    "will rely on the floor-at-zero guard",
-                    parent_org_id, parent_agent_id, exc_info=True,
-                )
 
     if batch_mode:
         return json.dumps([

--- a/tests/runtime/test_turn_gate.py
+++ b/tests/runtime/test_turn_gate.py
@@ -119,3 +119,111 @@ async def test_turn_gate_acquire_context_manager_raises_when_over_limit():
         with pytest.raises(TurnGateBusy):
             async with gate.acquire("o-1", "a-1", limit=1):
                 pass  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# released_for_wait — the inverse of acquire(), for callers that are about to
+# block on something external and should not hold a slot while they sleep.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_released_for_wait_frees_the_slot_inside_the_body():
+    from surogates.runtime.turn_gate import TurnConcurrencyGate, released_for_wait
+
+    redis = _FakeRedis()
+    gate = TurnConcurrencyGate(redis, default_max=1)
+    assert await gate.try_acquire("o-1", "a-1") is True
+
+    async with released_for_wait(gate, "o-1", "a-1", context="test"):
+        # The slot is free while the caller sleeps — that is the whole point.
+        assert await gate.try_acquire("o-1", "a-1") is True
+        await gate.release("o-1", "a-1")
+
+    assert redis._store["surogates:turns:o-1:a-1"] == 1
+
+
+@pytest.mark.asyncio
+async def test_released_for_wait_is_a_noop_without_a_gate():
+    from surogates.runtime.turn_gate import released_for_wait
+
+    async with released_for_wait(None, "o-1", "a-1", context="test"):
+        pass  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_released_for_wait_retakes_the_slot_when_the_body_raises():
+    """A panicking body must not leak the slot it gave up."""
+    from surogates.runtime.turn_gate import TurnConcurrencyGate, released_for_wait
+
+    redis = _FakeRedis()
+    gate = TurnConcurrencyGate(redis, default_max=5)
+    await gate.try_acquire("o-1", "a-1")
+
+    with pytest.raises(RuntimeError):
+        async with released_for_wait(gate, "o-1", "a-1", context="test"):
+            raise RuntimeError("boom")
+
+    assert redis._store["surogates:turns:o-1:a-1"] == 1
+
+
+@pytest.mark.asyncio
+async def test_released_for_wait_skips_reacquire_when_release_failed():
+    """Re-taking a slot we never gave up would hand the tenant a free slot."""
+    from surogates.runtime.turn_gate import released_for_wait
+
+    class _FlakyRelease:
+        def __init__(self) -> None:
+            self.acquires = 0
+
+        async def release(self, org_id: str, agent_id: str) -> None:
+            raise RuntimeError("redis blip")
+
+        async def try_acquire(self, org_id: str, agent_id: str) -> bool:
+            self.acquires += 1
+            return True
+
+    gate = _FlakyRelease()
+    async with released_for_wait(gate, "o-1", "a-1", context="test"):
+        pass
+
+    assert gate.acquires == 0
+
+
+@pytest.mark.asyncio
+async def test_reacquire_returns_true_when_slot_immediately_free():
+    from surogates.runtime.turn_gate import (
+        TurnConcurrencyGate,
+        _reacquire_with_backoff,
+    )
+
+    redis = _FakeRedis()
+    gate = TurnConcurrencyGate(redis, default_max=10)
+    assert await _reacquire_with_backoff(gate, "org-1", "agent-A") is True
+    assert redis._store["surogates:turns:org-1:agent-A"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reacquire_returns_false_after_deadline_at_cap(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Saturated for the whole window: give up rather than block forever.
+
+    The caller's return path matters more than perfect accounting.
+    """
+    import surogates.runtime.turn_gate as turn_gate_module
+    from surogates.runtime.turn_gate import (
+        TurnConcurrencyGate,
+        _reacquire_with_backoff,
+    )
+
+    monkeypatch.setattr(turn_gate_module, "_REACQUIRE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(turn_gate_module, "_REACQUIRE_BACKOFF_SECONDS", 0.01)
+
+    redis = _FakeRedis()
+    gate = TurnConcurrencyGate(redis, default_max=2)
+    redis._store["surogates:turns:org-1:agent-A"] = 2
+
+    assert await _reacquire_with_backoff(gate, "org-1", "agent-A") is False
+    # Counter unchanged -- the helper aborted without acquiring.
+    assert redis._store["surogates:turns:org-1:agent-A"] == 2

--- a/tests/test_ask_user_question_gate.py
+++ b/tests/test_ask_user_question_gate.py
@@ -1,0 +1,250 @@
+"""``ask_user_question`` must not hold a turn slot while a human deliberates.
+
+The handler parks the worker for up to 30 minutes waiting for an answer. That
+wait is idle — it polls at 1 Hz and renews the lease; it consumes no worker
+CPU. Counting it as an in-flight turn is a category error: the
+``TurnConcurrencyGate`` tracks active work, not sleeping waiters, and its cap
+is only 10 per (org, agent). Ten agents waiting on questions saturate the
+tenant and every unrelated session is requeued behind them.
+
+``delegate_task`` already solved exactly this for its own blocking wait
+(``surogates/tools/builtin/delegate.py``). These tests pin the same contract
+for the ask path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from surogates.session.events import EventType
+from surogates.tools.builtin.ask_user_question import (
+    _ask_user_question_handler,
+)
+
+from tests.test_ask_user_question import FakeSessionStore
+
+
+class _RecordingGate:
+    """Records the release/acquire sequence and models the cap."""
+
+    def __init__(self, *, held: int = 1, cap: int = 10) -> None:
+        self.held = held
+        self.cap = cap
+        self.calls: list[str] = []
+        self.acquire_failures = 0
+
+    async def release(self, org_id: str, agent_id: str) -> None:
+        self.calls.append("release")
+        self.held = max(0, self.held - 1)
+
+    async def try_acquire(self, org_id: str, agent_id: str) -> bool:
+        self.calls.append("try_acquire")
+        if self.acquire_failures > 0:
+            self.acquire_failures -= 1
+            return False
+        if self.held >= self.cap:
+            return False
+        self.held += 1
+        return True
+
+
+class _IdentifiedStore(FakeSessionStore):
+    """FakeSessionStore whose sessions carry the tenant identity the gate needs."""
+
+    def __init__(self, *, status: str = "active") -> None:
+        super().__init__(status=status)
+        self.org_id = uuid4()
+        self.agent_id = "agent-X"
+
+    async def get_session(self, session_id: Any) -> Any:
+        return SimpleNamespace(
+            id=session_id,
+            status=self.status,
+            org_id=self.org_id,
+            agent_id=self.agent_id,
+        )
+
+
+async def _answer_after(store: FakeSessionStore, session_id, tool_call_id) -> None:
+    await asyncio.sleep(0.05)
+    await store.emit_event(
+        session_id,
+        EventType.ASK_USER_QUESTION_RESPONSE,
+        {
+            "tool_call_id": tool_call_id,
+            "responses": [{"question": "q", "answer": "A", "is_other": False}],
+        },
+    )
+
+
+async def _invoke(store, session_id, tool_call_id, gate) -> str:
+    return await _ask_user_question_handler(
+        {"questions": [{"prompt": "q"}]},
+        session_id=session_id,
+        session_store=store,
+        tool_call_id=tool_call_id,
+        lease_token=uuid4(),
+        turn_gate=gate,
+    )
+
+
+@pytest.mark.asyncio
+async def test_slot_is_released_while_waiting_and_taken_back_after():
+    session_id, tool_call_id = uuid4(), "call_1"
+    store = _IdentifiedStore()
+    gate = _RecordingGate(held=1)
+
+    raw, _ = await asyncio.gather(
+        _invoke(store, session_id, tool_call_id, gate),
+        _answer_after(store, session_id, tool_call_id),
+    )
+
+    assert json.loads(raw)["cancelled"] is False
+    assert gate.calls == ["release", "try_acquire"], (
+        "the slot must be given back before the wait and taken again after"
+    )
+    assert gate.held == 1, "net slot usage across the call must be unchanged"
+
+
+@pytest.mark.asyncio
+async def test_a_waiting_ask_does_not_consume_the_tenant_cap():
+    """The point of the change: waiters must not saturate the tenant.
+
+    With the slot released, a full cap's worth of pending questions leaves
+    room for other sessions to run.
+    """
+    session_id, tool_call_id = uuid4(), "call_2"
+    store = _IdentifiedStore()
+    gate = _RecordingGate(held=1, cap=1)
+
+    observed: list[int] = []
+
+    async def observe_then_answer() -> None:
+        await asyncio.sleep(0.05)
+        observed.append(gate.held)
+        await store.emit_event(
+            session_id,
+            EventType.ASK_USER_QUESTION_RESPONSE,
+            {"tool_call_id": tool_call_id, "responses": []},
+        )
+
+    await asyncio.gather(
+        _invoke(store, session_id, tool_call_id, gate),
+        observe_then_answer(),
+    )
+
+    assert observed == [0], (
+        "while the handler waits the tenant counter must be free, not held"
+    )
+
+
+@pytest.mark.asyncio
+async def test_slot_is_taken_back_on_the_cancelled_path():
+    """A stopped chat must not leak the slot the handler gave up."""
+    session_id, tool_call_id = uuid4(), "call_3"
+    store = _IdentifiedStore()
+    gate = _RecordingGate(held=1)
+
+    async def pause_after() -> None:
+        await asyncio.sleep(0.05)
+        store.status = "paused"
+
+    raw, _ = await asyncio.gather(
+        _invoke(store, session_id, tool_call_id, gate),
+        pause_after(),
+    )
+
+    assert json.loads(raw)["cancelled"] is True
+    assert gate.calls == ["release", "try_acquire"]
+    assert gate.held == 1
+
+
+@pytest.mark.asyncio
+async def test_answer_is_still_returned_when_the_slot_cannot_be_retaken(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A saturated cap on the way out must not lose the user's answer.
+
+    Under-counting the gate is acceptable; discarding an answer the human
+    already gave is not.
+    """
+    monkeypatch.setattr(
+        "surogates.runtime.turn_gate._REACQUIRE_TIMEOUT_SECONDS", 0.05,
+    )
+    monkeypatch.setattr(
+        "surogates.runtime.turn_gate._REACQUIRE_BACKOFF_SECONDS", 0.01,
+    )
+    session_id, tool_call_id = uuid4(), "call_4"
+    store = _IdentifiedStore()
+    gate = _RecordingGate(held=1)
+    gate.acquire_failures = 10_000  # never re-acquires
+
+    raw, _ = await asyncio.gather(
+        _invoke(store, session_id, tool_call_id, gate),
+        _answer_after(store, session_id, tool_call_id),
+    )
+
+    result = json.loads(raw)
+    assert result["cancelled"] is False
+    assert result["responses"][0]["answer"] == "A"
+
+
+@pytest.mark.asyncio
+async def test_no_gate_configured_still_answers():
+    """The gate is optional; deployments without one must be unaffected."""
+    session_id, tool_call_id = uuid4(), "call_5"
+    store = _IdentifiedStore()
+
+    raw, _ = await asyncio.gather(
+        _invoke(store, session_id, tool_call_id, None),
+        _answer_after(store, session_id, tool_call_id),
+    )
+
+    assert json.loads(raw)["cancelled"] is False
+
+
+@pytest.mark.asyncio
+async def test_release_failure_does_not_break_the_wait():
+    """A Redis blip on release must not cost the user their question."""
+    session_id, tool_call_id = uuid4(), "call_6"
+    store = _IdentifiedStore()
+
+    class _FlakyReleaseGate(_RecordingGate):
+        async def release(self, org_id: str, agent_id: str) -> None:
+            self.calls.append("release")
+            raise RuntimeError("redis blip")
+
+    gate = _FlakyReleaseGate(held=1)
+
+    raw, _ = await asyncio.gather(
+        _invoke(store, session_id, tool_call_id, gate),
+        _answer_after(store, session_id, tool_call_id),
+    )
+
+    assert json.loads(raw)["cancelled"] is False
+    assert "try_acquire" not in gate.calls, (
+        "a slot that was never released must not be re-acquired — that would "
+        "hand the tenant a slot it never gave up"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_session_identity_skips_the_gate_dance():
+    """Without org/agent there is no slot to release; the ask must still work."""
+    session_id, tool_call_id = uuid4(), "call_7"
+    store = FakeSessionStore()  # get_session returns no org_id/agent_id
+    gate = _RecordingGate(held=1)
+
+    raw, _ = await asyncio.gather(
+        _invoke(store, session_id, tool_call_id, gate),
+        _answer_after(store, session_id, tool_call_id),
+    )
+
+    assert json.loads(raw)["cancelled"] is False
+    assert gate.calls == []

--- a/tests/test_delegate_gate_release.py
+++ b/tests/test_delegate_gate_release.py
@@ -20,11 +20,10 @@ This module pins:
 
 from __future__ import annotations
 
-import asyncio
 import json
 from datetime import datetime, timezone
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
 
 import pytest
@@ -242,43 +241,6 @@ async def test_release_fires_even_when_no_gate(
     )
     # Single-goal path returns the child's text directly, not JSON.
     assert "Delegation failed" not in result
-
-
-async def test_reacquire_returns_true_when_slot_immediately_free() -> None:
-    gate_redis = _FakeRedisGate()
-    gate = TurnConcurrencyGate(gate_redis, default_max=10)
-    ok = await delegate_module._reacquire_gate_with_backoff(
-        gate, "org-1", "agent-A",
-    )
-    assert ok is True
-    assert gate_redis.values["surogates:turns:org-1:agent-A"] == 1
-
-
-async def test_reacquire_returns_false_after_deadline_at_cap(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """If the cap is saturated for the entire backoff window, the
-    helper gives up rather than blocking forever -- the parent's
-    return path is more important than perfect accounting."""
-    # Tight deadline + backoff so the test finishes promptly.
-    monkeypatch.setattr(
-        delegate_module, "_REACQUIRE_TIMEOUT_SECONDS", 0.05,
-    )
-    monkeypatch.setattr(
-        delegate_module, "_REACQUIRE_BACKOFF_SECONDS", 0.01,
-    )
-
-    gate_redis = _FakeRedisGate()
-    gate = TurnConcurrencyGate(gate_redis, default_max=2)
-    # Saturate by pre-loading 2 acquires.
-    gate_redis.values["surogates:turns:org-1:agent-A"] = 2
-
-    ok = await delegate_module._reacquire_gate_with_backoff(
-        gate, "org-1", "agent-A",
-    )
-    assert ok is False
-    # Counter unchanged -- helper aborted without acquiring.
-    assert gate_redis.values["surogates:turns:org-1:agent-A"] == 2
 
 
 async def test_release_fires_in_finally_when_gather_raises(


### PR DESCRIPTION
## The bug

`ask_user_question` parks the worker for up to 30 minutes waiting for an answer (`ASK_USER_QUESTION_MAX_WAIT_SECONDS = 30 * 60`). That wait is **idle** — `_wait_for_response` polls at 1 Hz and renews the lease, consuming no worker CPU — but it held a `TurnConcurrencyGate` slot for the whole duration.

The gate counts *active work*, and its cap is 10 per (org, agent). A handful of pending questions saturate the tenant and every unrelated session is requeued behind sleepers.

`delegate_task` already identified and fixed exactly this for its own blocking wait; the ask path simply never called the same primitive.

## The fix

Lift the release/re-acquire dance into `released_for_wait` in `surogates/runtime/turn_gate.py` — the inverse of the existing `TurnConcurrencyGate.acquire` context manager — and use it from **both** callers.

`delegate.py`'s private `_reacquire_gate_with_backoff` and its duplicated constants are **deleted** rather than left as a second implementation (−86 lines there). Its three behavioural tests passed untouched through the migration.

Both halves are best-effort and never raise into the body, with two deliberate asymmetries:

- **Failed release → no re-acquire.** Re-taking a slot we never gave up would hand the tenant one it does not own.
- **Failed re-acquire → the body's result still stands.** Under-counting a soft cap beats discarding an answer the user already gave.

Gate identity comes from the session row via `_resolve_gate_identity` and **fails closed** — without both org and agent there is no key we can safely account for, so the release is skipped entirely rather than guessing.

Verified not to be dead code: `surogates/harness/tool_exec.py:1498` injects `turn_gate` into every tool handler's kwargs.

## Tests

7 new in `tests/test_ask_user_question_gate.py` (3 RED first) + 6 for the new primitive in `tests/runtime/test_turn_gate.py`. The two delegate tests that poked the private helper moved to the helper's new home.

The clearest test asserts the tenant counter reads `0` while the handler waits — it read `1` before this change. The rest cover the paths that must **not** change: no gate configured, unresolvable session identity, a Redis blip on release, a saturated cap on the way out, and a body that raises.

## Verification

| | Result |
|---|---|
| Targeted (ask + gate + delegate + turn_gate) | 47 passed |
| Full unit suite | `28 failed / 4974 passed` |
| vs master baseline | **identical failure set** — 0 new, 0 fixed |
| Ruff | clean on all 6 files |

The 28 are pre-existing environment gaps (`reportlab`, browser storage, channel routes).

**Not run:** the integration suite — same caveat as #176. Note there is no test CI on PRs in this repo (`release.yml` fires on `v*` tags and only builds wheels), so nothing downstream will catch it either.