### PR TITLE
fix(orchestrator): honour the per-agent iteration cap

### DIFF
--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -80,6 +80,41 @@ ANONYMOUS_CHANNELS: frozenset[str] = frozenset({"website"})
 from surogates.channels.memory_boundary import MANAGED_CHANNELS as MANAGED_CREDENTIAL_CHANNELS  # noqa: E402
 
 
+# Platform ceiling on iterations per wake.  Agent-supplied configuration may
+# lower it, never raise it.
+_DEFAULT_MAX_ITERATIONS: int = 90
+
+
+def _resolve_iteration_budget(session: Any) -> IterationBudget:
+    """Build the wake's iteration budget, honouring the per-agent cap.
+
+    ``max_iterations`` is derived and written into the child's config by the
+    spawn paths (``harness/agent_resolver.py``, ``tools/builtin/coordinator.py``,
+    ``tools/builtin/delegate.py``, ``tasks/spawn.py``).  Children are separate
+    enqueued sessions, so the worker that wakes them is the only place that
+    value can take effect.
+
+    The config is agent-supplied, so it may only *lower* the platform ceiling.
+    Anything unusable -- absent, non-integer, zero, negative -- falls back to
+    the default rather than producing a budget that is exhausted on
+    construction, which would send the session straight to a final summary
+    having done no work.  ``bool`` is rejected explicitly: it is an ``int``
+    subclass in Python, and a config that says ``true`` would otherwise
+    silently cap the session at one iteration.
+    """
+    config = getattr(session, "config", None) or {}
+    raw = config.get("max_iterations")
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
+        if raw is not None:
+            logger.warning(
+                "Session %s: ignoring unusable max_iterations %r; "
+                "falling back to %d",
+                getattr(session, "id", "?"), raw, _DEFAULT_MAX_ITERATIONS,
+            )
+        return IterationBudget(max_total=_DEFAULT_MAX_ITERATIONS)
+    return IterationBudget(max_total=min(raw, _DEFAULT_MAX_ITERATIONS))
+
+
 def resolve_credential_principal(
     *,
     session: Any,
@@ -1521,7 +1556,7 @@ async def run_worker(settings: Settings) -> None:
         # the model, the worker reports what it picked.
         _warn_if_base_model_missing_from_metadata(model_id)
         await session_store.record_session_model(session.id, model_id)
-        budget = IterationBudget(max_total=90)
+        budget = _resolve_iteration_budget(session)
         summary_slot = llm_bundle.summary
         vision_slot = llm_bundle.vision
         advisor_slot = llm_bundle.advisor

--- a/tests/test_worker_iteration_budget.py
+++ b/tests/test_worker_iteration_budget.py
@@ -1,0 +1,77 @@
+"""The worker must honour the per-agent iteration cap the spawn path computed.
+
+Four separate producers derive a child's iteration allowance and write it into
+the session config -- ``harness/agent_resolver.py`` (clamped to 30),
+``tools/builtin/coordinator.py``, ``tools/builtin/delegate.py`` and
+``tasks/spawn.py``. Children are separate enqueued sessions, so the value has
+to survive to the worker that wakes them.
+
+It did not: ``grep -rn max_iterations surogates/orchestrator/`` returned
+nothing and every session got a flat ``IterationBudget(max_total=90)``. A
+cheap agent capped at 5 could burn 90 iterations; the carefully-derived cap
+was dead config.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from surogates.orchestrator.worker import (
+    _DEFAULT_MAX_ITERATIONS,
+    _resolve_iteration_budget,
+)
+
+
+def _session(config: dict | None) -> SimpleNamespace:
+    return SimpleNamespace(config=config)
+
+
+def test_config_cap_is_honoured():
+    budget = _resolve_iteration_budget(_session({"max_iterations": 5}))
+    assert budget.max_total == 5
+
+
+def test_absent_cap_falls_back_to_the_platform_default():
+    assert _resolve_iteration_budget(_session({})).max_total == (
+        _DEFAULT_MAX_ITERATIONS
+    )
+
+
+def test_missing_config_falls_back_to_the_platform_default():
+    assert _resolve_iteration_budget(_session(None)).max_total == (
+        _DEFAULT_MAX_ITERATIONS
+    )
+
+
+def test_cap_cannot_exceed_the_platform_ceiling():
+    """The config is agent-supplied; it may lower the ceiling, never raise it."""
+    budget = _resolve_iteration_budget(_session({"max_iterations": 10_000}))
+    assert budget.max_total == _DEFAULT_MAX_ITERATIONS
+
+
+@pytest.mark.parametrize("bad", [0, -1, "thirty", None, 3.5, [], {}])
+def test_unusable_values_fall_back_rather_than_stall_the_session(bad):
+    """A malformed cap must not produce a zero or negative budget.
+
+    ``IterationBudget(max_total=0)`` is exhausted on construction, so the
+    session would go straight to a final summary having done nothing.
+    """
+    budget = _resolve_iteration_budget(_session({"max_iterations": bad}))
+    assert budget.max_total == _DEFAULT_MAX_ITERATIONS
+
+
+def test_boolean_is_not_treated_as_an_integer():
+    """``True`` is an int in Python; a config that says ``true`` is malformed,
+    and a budget of 1 would silently cripple the session."""
+    budget = _resolve_iteration_budget(_session({"max_iterations": True}))
+    assert budget.max_total == _DEFAULT_MAX_ITERATIONS
+
+
+def test_the_returned_budget_is_usable():
+    budget = _resolve_iteration_budget(_session({"max_iterations": 2}))
+    assert budget.consume() is True
+    assert budget.consume() is True
+    assert budget.consume() is False
+    assert budget.exhausted is True


### PR DESCRIPTION
## The bug

Four producers derive a child agent's iteration allowance and write it into the session config:

| Producer | Line |
|---|---|
| `harness/agent_resolver.py` | `:174` — `min(agent_def.max_iterations, 30)` |
| `tools/builtin/coordinator.py` | `:344` |
| `tools/builtin/delegate.py` | `:417` |
| `tasks/spawn.py` | `:64` |

Children are separate **enqueued sessions**, so the worker that wakes them is the only place that value can take effect.

It never read it:

```
$ grep -rn max_iterations surogates/orchestrator/
(no output)
```

`orchestrator/worker.py:1524` built `IterationBudget(max_total=90)` unconditionally. An agent deliberately capped at 5 iterations could burn 90. The carefully-derived cap was dead config.

## The fix

`_resolve_iteration_budget(session)` reads `config["max_iterations"]` and clamps it to the platform ceiling. The config is agent-supplied, so it may **lower** the ceiling, never raise it.

The guards are not defensive padding — the naive one-liner has a live failure mode. `IterationBudget(max_total=0)` reports `exhausted` on construction, so `_run_loop`'s `while self._budget.remaining > 0` never enters and the session goes straight to `_request_final_summary` having done nothing. A `0`, a negative, or a JSON string would therefore *silently neuter* the session rather than cap it. All fall back to the default.

`bool` is rejected explicitly: it is an `int` subclass in Python, so a config that says `true` would otherwise cap the session at exactly one iteration.

## Tests

13 in `tests/test_worker_iteration_budget.py`, RED first: the cap is honoured, absent/missing config falls back, the ceiling cannot be raised, seven malformed values fall back rather than stall the session, `True` is not treated as `1`, and the returned budget actually consumes and exhausts.

## Verification

Full unit suite `28 failed / 4995 passed` — **identical failure set** to the master baseline (the 28 are pre-existing environment gaps). Ruff on `worker.py` unchanged at its one pre-existing `F401`.

**Not run:** the integration suite. Note this repo has no test CI on PRs.