### PR TITLE
fix(ambient): back off a failed tick instead of spinning

### DIFF
--- a/surogates/ambient/store.py
+++ b/surogates/ambient/store.py
@@ -20,6 +20,11 @@ from surogates.db.models import AmbientScheduleRow
 
 __all__ = ["AmbientSchedule", "AmbientScheduleStore"]
 
+# Floor on how far a failed tick pushes its next run.  ``ensure`` creates rows
+# with ``cadence_seconds=0`` to mean "due now", so backing off by the cadence
+# alone would leave a failing row instantly due again.
+_MIN_FAILURE_BACKOFF_SECONDS: int = 300
+
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
@@ -160,6 +165,34 @@ class AmbientScheduleStore:
                 .values(
                     ambient_session_id=ambient_session_id,
                     next_run_at=now + timedelta(seconds=schedule.cadence_seconds),
+                    locked_by=None,
+                    locked_until=None,
+                    updated_at=now,
+                )
+            )
+            await db.commit()
+
+    async def mark_failed(self, schedule: AmbientSchedule) -> None:
+        """Advance a failed tick's clock and drop its lock.
+
+        Without this the row keeps ``next_run_at`` in the past while still
+        naming a worker that has already given up, so ``claim_due`` re-claims
+        it the moment the lease lapses -- forever, at lease frequency, with no
+        backoff.  A failed tick is treated as a skipped one: it waits a full
+        cadence like any other.
+
+        The floor matters because ``ensure`` creates rows with
+        ``cadence_seconds=0`` to mean "due now"; advancing by the cadence
+        alone would leave such a row instantly due again.
+        """
+        now = _utcnow()
+        backoff = max(schedule.cadence_seconds, _MIN_FAILURE_BACKOFF_SECONDS)
+        async with self._sf() as db:
+            await db.execute(
+                sa.update(AmbientScheduleRow)
+                .where(AmbientScheduleRow.id == schedule.id)
+                .values(
+                    next_run_at=now + timedelta(seconds=backoff),
                     locked_by=None,
                     locked_until=None,
                     updated_at=now,

--- a/surogates/ambient/ticker.py
+++ b/surogates/ambient/ticker.py
@@ -49,6 +49,18 @@ class AmbientTicker:
                     "ambient ticker failed to materialize channel %s",
                     getattr(row, "channel_id", "?"),
                 )
+                # materialize_ambient_tick advances next_run_at as its last
+                # step, so a failure leaves the row past-due and still
+                # holding a lock nobody owns.  Tell the store, or claim_due
+                # re-fires this row every time the lease lapses, forever.
+                try:
+                    await self._store.mark_failed(row)
+                except Exception:
+                    logger.exception(
+                        "ambient ticker failed to record the failed tick "
+                        "for channel %s; it will retry when the lease lapses",
+                        getattr(row, "channel_id", "?"),
+                    )
 
     async def run(self) -> None:
         while not self._stop.is_set():

--- a/tests/test_ambient_failure_backoff.py
+++ b/tests/test_ambient_failure_backoff.py
@@ -1,0 +1,239 @@
+"""A failed ambient tick must advance its clock, not spin.
+
+``materialize_ambient_tick`` calls ``mark_fired`` last, after
+``enqueue_session``. Anything that raises above it leaves ``next_run_at`` in
+the past and the row still ``locked_by`` a worker that has already given up.
+``claim_due`` only requires ``locked_until <= now``, so once the 120s lease
+lapses the row is claimed again -- and again, forever, at whatever rate the
+lease allows, with no backoff and no ceiling.
+
+The ticker already isolates a bad row so its neighbours still run; what it
+never did was tell the store the attempt failed.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from surogates.ambient.store import AmbientSchedule, AmbientScheduleStore
+from surogates.ambient.ticker import AmbientTicker
+from surogates.db.models import AmbientScheduleRow
+
+
+# ---------------------------------------------------------------------------
+# Ticker: a failed row must be reported to the store
+# ---------------------------------------------------------------------------
+
+
+class _RecordingStore:
+    def __init__(self, rows: list) -> None:
+        self._rows = rows
+        self.claims = 0
+        self.failed: list = []
+
+    async def claim_due(self, *, worker_id, limit, lease_seconds=120):
+        self.claims += 1
+        return self._rows if self.claims == 1 else []
+
+    async def mark_failed(self, schedule) -> None:
+        self.failed.append(schedule)
+
+
+def _row(channel: str = "C1") -> AmbientSchedule:
+    return AmbientSchedule(
+        id=uuid.uuid4(), org_id=uuid.uuid4(), agent_id="ag", platform="slack",
+        channel_id=channel, cadence_seconds=1800, status="active",
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_materialize_marks_the_schedule_failed():
+    rows = [_row("C1")]
+    store = _RecordingStore(rows)
+
+    async def boom(_row):
+        raise RuntimeError("materialize exploded")
+
+    ticker = AmbientTicker(
+        store, redis=None, materialize=boom, worker_id="w1",
+    )
+    await ticker.tick_once()
+
+    assert [s.channel_id for s in store.failed] == ["C1"], (
+        "a failed tick must advance its own clock, or it is re-claimed "
+        "as soon as the lease lapses, forever"
+    )
+
+
+@pytest.mark.asyncio
+async def test_successful_materialize_does_not_mark_failed():
+    store = _RecordingStore([_row("C1")])
+
+    async def ok(_row):
+        return None
+
+    ticker = AmbientTicker(store, redis=None, materialize=ok, worker_id="w1")
+    await ticker.tick_once()
+
+    assert store.failed == []
+
+
+@pytest.mark.asyncio
+async def test_one_failure_still_marks_only_that_row():
+    """Neighbours keep running and are not penalised for a sibling's failure."""
+    store = _RecordingStore([_row("C1"), _row("C2")])
+    seen: list[str] = []
+
+    async def first_fails(row):
+        seen.append(row.channel_id)
+        if row.channel_id == "C1":
+            raise RuntimeError("boom")
+
+    ticker = AmbientTicker(
+        store, redis=None, materialize=first_fails, worker_id="w1",
+    )
+    await ticker.tick_once()
+
+    assert seen == ["C1", "C2"]
+    assert [s.channel_id for s in store.failed] == ["C1"]
+
+
+@pytest.mark.asyncio
+async def test_a_failing_mark_failed_does_not_abort_the_pass():
+    """If the bookkeeping write itself fails, later rows must still run."""
+    store = _RecordingStore([_row("C1"), _row("C2")])
+
+    async def always_fails(_row):
+        raise RuntimeError("boom")
+
+    async def broken_mark_failed(_schedule):
+        raise RuntimeError("db blip")
+
+    store.mark_failed = broken_mark_failed  # type: ignore[assignment]
+
+    ticker = AmbientTicker(
+        store, redis=None, materialize=always_fails, worker_id="w1",
+    )
+    await ticker.tick_once()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Store: mark_failed advances the clock and drops the lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def store():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False}, poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(AmbientScheduleRow.__table__.create)
+    yield AmbientScheduleStore(async_sessionmaker(engine, expire_on_commit=False))
+    await engine.dispose()
+
+
+async def _make_due(store) -> None:
+    """``ensure`` schedules the first run one cadence out; pull it into the past."""
+    async with store._sf() as db:
+        await db.execute(
+            sa.update(AmbientScheduleRow).values(
+                next_run_at=dt.datetime.now(dt.timezone.utc)
+                - dt.timedelta(seconds=1),
+            )
+        )
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_pushes_the_row_out_of_the_due_set(store):
+    """The whole point: after a failure the row is no longer immediately due."""
+    sched = await store.ensure(
+        org_id=uuid.uuid4(), agent_id="ag", platform="slack", channel_id="C1",
+        source_session_id=None, cadence_seconds=1800, config={},
+    )
+    await _make_due(store)
+    claimed = await store.claim_due(worker_id="w1", limit=10)
+    assert len(claimed) == 1
+
+    await store.mark_failed(claimed[0])
+
+    # Simulate the lease lapsing -- this is what re-armed the hot loop.
+    async with store._sf() as db:
+        await db.execute(
+            sa.update(AmbientScheduleRow)
+            .where(AmbientScheduleRow.id == sched.id)
+            .values(locked_until=None)
+        )
+        await db.commit()
+
+    assert await store.claim_due(worker_id="w1", limit=10) == [], (
+        "an expired lease must not resurrect a row whose attempt just failed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_clears_the_lock(store):
+    """The worker that failed is gone; leaving its name on the row is a lie."""
+    await store.ensure(
+        org_id=uuid.uuid4(), agent_id="ag", platform="slack", channel_id="C1",
+        source_session_id=None, cadence_seconds=1800, config={},
+    )
+    await _make_due(store)
+    claimed = await store.claim_due(worker_id="w1", limit=10)
+    await store.mark_failed(claimed[0])
+
+    async with store._sf() as db:
+        row = (await db.execute(sa.select(AmbientScheduleRow))).scalars().one()
+        assert row.locked_by is None
+        assert row.locked_until is None
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_backs_off_at_least_one_cadence(store):
+    await store.ensure(
+        org_id=uuid.uuid4(), agent_id="ag", platform="slack", channel_id="C1",
+        source_session_id=None, cadence_seconds=1800, config={},
+    )
+    await _make_due(store)
+    claimed = await store.claim_due(worker_id="w1", limit=10)
+    before = dt.datetime.now(dt.timezone.utc)
+    await store.mark_failed(claimed[0])
+
+    async with store._sf() as db:
+        row = (await db.execute(sa.select(AmbientScheduleRow))).scalars().one()
+    nxt = row.next_run_at
+    if nxt.tzinfo is None:
+        nxt = nxt.replace(tzinfo=dt.timezone.utc)
+    assert (nxt - before).total_seconds() >= 1800
+
+
+@pytest.mark.asyncio
+async def test_a_zero_cadence_schedule_still_backs_off(store):
+    """cadence_seconds=0 is used by ensure() to mean "due now".
+
+    Advancing by the cadence alone would leave such a row instantly due
+    again -- the hot loop, reintroduced.
+    """
+    await store.ensure(
+        org_id=uuid.uuid4(), agent_id="ag", platform="slack", channel_id="C1",
+        source_session_id=None, cadence_seconds=0, config={},
+    )
+    await _make_due(store)
+    claimed = await store.claim_due(worker_id="w1", limit=10)
+    await store.mark_failed(claimed[0])
+
+    async with store._sf() as db:
+        await db.execute(
+            sa.update(AmbientScheduleRow).values(locked_until=None)
+        )
+        await db.commit()
+
+    assert await store.claim_due(worker_id="w1", limit=10) == []


### PR DESCRIPTION
## The bug

`materialize_ambient_tick` advances `next_run_at` as its **last** step, via `ambient_store.mark_fired` (`ambient/materialize.py`). Anything that raises above it — `create_session`, `recent_task_changes`, `emit_synthetic_user_message`, `enqueue_session` — leaves the row:

- past-due (`next_run_at` never moved), and
- still `locked_by` a worker that has already given up.

`claim_due` (`ambient/store.py:122`) filters on `status='active' AND next_run_at <= now AND (locked_until IS NULL OR locked_until <= now)`. So the moment the 120s lease lapses the row is claimed again — and again, forever, with no backoff and no ceiling.

The ticker caught the exception and logged it (`ambient/ticker.py:47`), which isolated the bad row so its neighbours still ran, but it never told the store the attempt had failed.

**Note on the retry rate:** this fires on the *lease lapse* (~120s), not the tick interval (30s). Same unbounded loop, slower than it looks.

## The fix

New `AmbientScheduleStore.mark_failed`: advance `next_run_at`, clear `locked_by`/`locked_until`. A failed tick is treated as a skipped one.

The ticker calls it from the `except` it already had, itself wrapped — a failed bookkeeping write must not abort the rest of the sweep.

**The backoff floor is load-bearing, not padding.** Backoff is `max(cadence_seconds, 300)`. `ensure` creates rows with `cadence_seconds=0` to mean "due now" (see `test_claim_due_returns_active_past_due`), so advancing by the cadence alone would leave exactly those rows instantly due again — reintroducing the bug for the rows most likely to hit it. `test_a_zero_cadence_schedule_still_backs_off` fails without the floor.

No schema change: both columns already exist.

## Tests

8 in `tests/test_ambient_failure_backoff.py`, 6 RED first.

*Ticker:* a failed materialize marks the schedule failed; a successful one does not; one failure marks only that row while neighbours still run; a failing `mark_failed` does not abort the pass.

*Store (SQLite-backed):* `mark_failed` pushes the row out of the due set **even after the lease is forced to lapse** — that is the exact sequence that re-armed the loop; it clears the lock; it backs off at least one cadence; and a zero-cadence row still backs off.

## Verification

Full unit suite `28 failed / 4995 passed` — **identical failure set** to the master baseline. Ruff clean on all three files.

**Not run:** the integration suite. Note this repo has no test CI on PRs.

## Related

A background audit turned up what looks like the same pattern in `surogates/tasks/dispatcher.py` (a permanent spawn failure appearing to retry without bound). Not addressed here — it is being verified separately and deserves its own PR.