### PR TITLE
fix(tasks): stop re-claiming a task whose spawn can never succeed

### DIFF
--- a/surogates/tasks/dispatcher.py
+++ b/surogates/tasks/dispatcher.py
@@ -239,7 +239,9 @@ async def _enqueue_ready_tasks(
                 claimed.id,
             )
             failed_this_tick.add(claimed.id)
-            await _rollback_claim(session_factory, claimed.id)
+            await _retry_or_block(
+                session_factory, claimed, reason="tenant resolution failed",
+            )
             continue
 
         try:
@@ -265,24 +267,30 @@ async def _enqueue_ready_tasks(
             await _block_claim(session_factory, claimed.id, reason=str(exc))
             continue
         except ValueError as exc:
-            # Other config-level error (e.g. missing workspace fields on the
-            # parent session), which may be transient. Rolling back gives a
-            # human a chance to fix the config; the within-tick exclusion
-            # prevents hot-looping on this same row for the rest of THIS tick.
+            # Permanent config error, same class as UnknownAgentDefError above:
+            # the raise sites are shape checks on the PARENT session's config
+            # (missing storage_bucket / storage_key_prefix / workspace_path),
+            # which is a property of a row that never changes on its own.
+            # Rolling this back returned the task to 'ready' with its attempt
+            # given back, so the tick re-claimed it every 5s forever — the
+            # ceiling in _finalize_ended_attempts only inspects 'running'
+            # tasks and could never see it.
             logger.warning(
-                "tasks_tick: spawn failed for task %s: %s",
+                "tasks_tick: blocking task %s (spawn cannot succeed): %s",
                 claimed.id, exc,
             )
             failed_this_tick.add(claimed.id)
-            await _rollback_claim(session_factory, claimed.id)
+            await _block_claim(session_factory, claimed.id, reason=str(exc))
             continue
-        except Exception:
+        except Exception as exc:
             logger.exception(
-                "tasks_tick: unexpected error spawning task %s; rolling back",
+                "tasks_tick: unexpected error spawning task %s",
                 claimed.id,
             )
             failed_this_tick.add(claimed.id)
-            await _rollback_claim(session_factory, claimed.id)
+            await _retry_or_block(
+                session_factory, claimed, reason=f"spawn failed: {exc}",
+            )
             continue
 
         # Phase C: wire current_session_id onto the task.
@@ -347,11 +355,36 @@ async def _block_claim(
         )
 
 
+async def _retry_or_block(
+    session_factory: async_sessionmaker, claimed: Task, *, reason: str,
+) -> None:
+    """Return a failed claim to ``ready``, or block it once attempts are spent.
+
+    ``claimed.attempt_count`` already includes the attempt just consumed (the
+    claim increments it), so this is the only place a repeatedly-failing spawn
+    can be stopped: ``_finalize_ended_attempts``' ceiling only inspects tasks
+    in ``running`` joined to an ended Session, and a task returned to ``ready``
+    is never seen by it.
+    """
+    if claimed.attempt_count >= claimed.max_attempts:
+        logger.warning(
+            "tasks_tick: blocking task %s after %d/%d failed spawn attempts: %s",
+            claimed.id, claimed.attempt_count, claimed.max_attempts, reason,
+        )
+        await _block_claim(session_factory, claimed.id, reason=reason)
+        return
+    await _rollback_claim(session_factory, claimed.id)
+
+
 async def _rollback_claim(
     session_factory: async_sessionmaker, task_id: UUID,
 ) -> None:
-    """Best-effort: roll a failed claim back to ``ready`` and decrement
-    ``attempt_count`` so a config error doesn't burn a retry budget.
+    """Best-effort: roll a failed claim back to ``ready``.
+
+    The consumed attempt is deliberately **kept**.  Giving it back restored
+    the row to its exact pre-claim state, which made ``max_attempts``
+    unenforceable and let a task whose spawn could never succeed be
+    re-claimed on every tick, forever.
 
     Errors during the rollback itself are logged but not raised — the
     next finalize pass will recover by treating the running attempt as
@@ -362,10 +395,7 @@ async def _rollback_claim(
             await db.execute(
                 update(Task)
                 .where(Task.id == task_id)
-                .values(
-                    status="ready",
-                    attempt_count=Task.attempt_count - 1,
-                )
+                .values(status="ready")
             )
             await db.commit()
     except Exception:

--- a/tests/integration/tasks/test_spawn_failure_ceiling.py
+++ b/tests/integration/tasks/test_spawn_failure_ceiling.py
@@ -1,0 +1,260 @@
+"""A task whose spawn keeps failing must stop being re-claimed.
+
+``_enqueue_ready_tasks`` claims a ready task with
+``status='running', attempt_count + 1``, then spawns the child session.
+Every failure except ``UnknownAgentDefError`` called ``_rollback_claim``,
+which restored ``status='ready'`` **and decremented ``attempt_count`` back**
+-- byte-identical to the pre-claim row.
+
+That made the ceiling unreachable. ``attempt_count >= max_attempts`` is
+checked in ``_finalize_ended_attempts``, which only inspects tasks in
+``running`` joined to an ended Session; a rolled-back task is ``ready`` with
+no ``current_session_id``, so it is never finalised and never fails. The
+``failed_this_tick`` guard is explicitly per-tick. The tick runs every 5s.
+
+The trigger is permanent, not transient: ``create_child_session`` raises
+``ValueError`` when the parent's config lacks ``storage_bucket`` /
+``storage_key_prefix`` / ``workspace_path``, and that is a property of the
+parent row -- it never self-heals.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+
+from surogates.db.models import Session as ORMSession, Task
+from surogates.tasks.dispatcher import _enqueue_ready_tasks
+
+from tests.integration.conftest import create_org
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def org_id(session_factory) -> uuid.UUID:
+    return await create_org(session_factory)
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def broken_parent(session_factory, org_id: uuid.UUID) -> ORMSession:
+    """A parent missing ``storage_key_prefix``.
+
+    Not hypothetical: ``api/routes/website.py`` creates sessions with
+    ``storage_bucket`` and ``workspace_path`` only.
+    """
+    pid = uuid.uuid4()
+    async with session_factory() as db:
+        s = ORMSession(
+            id=pid, org_id=org_id, agent_id="orchestrator",
+            channel="website", status="active",
+            config={
+                "storage_bucket": "test-bucket",
+                "workspace_path": f"/workspace/test/{pid}",
+            },
+        )
+        db.add(s)
+        await db.commit()
+        await db.refresh(s)
+    return s
+
+
+def _tenant_for_task(task):
+    return MagicMock(org_id=task.org_id)
+
+
+async def _tick(session_factory, session_store) -> None:
+    redis = AsyncMock()
+    redis.zadd = AsyncMock()
+    await _enqueue_ready_tasks(
+        session_factory=session_factory,
+        redis=redis,
+        session_store=session_store,
+        tenant_for_task=_tenant_for_task,
+    )
+
+
+async def _add_ready_task(session_factory, org_id, parent, **kw) -> uuid.UUID:
+    async with session_factory() as db:
+        t = Task(
+            org_id=org_id, parent_session_id=parent.id,
+            goal="do the thing", status="ready", **kw,
+        )
+        db.add(t)
+        await db.commit()
+        return t.id
+
+
+async def test_a_permanently_broken_spawn_stops_being_retried(
+    session_factory, session_store, org_id, broken_parent,
+):
+    """The whole bug: ticks 1..N must not all re-claim the same dead row."""
+    tid = await _add_ready_task(
+        session_factory, org_id, broken_parent, max_attempts=3,
+    )
+
+    for _ in range(5):
+        await _tick(session_factory, session_store)
+
+    async with session_factory() as db:
+        task = await db.get(Task, tid)
+
+    assert task.status != "ready", (
+        "a task whose spawn can never succeed must leave the ready pool; "
+        "left 'ready' it is re-claimed every 5s forever"
+    )
+    assert task.status in {"blocked", "failed"}
+    assert task.current_session_id is None
+
+
+async def test_a_permanent_config_error_is_blocked_on_the_first_tick(
+    session_factory, session_store, org_id, broken_parent,
+):
+    """A missing workspace field is a property of the parent row.
+
+    It cannot self-heal, so retrying it even once is wasted work -- the
+    existing ``UnknownAgentDefError`` carve-out treats its own permanent
+    error exactly this way.
+    """
+    tid = await _add_ready_task(
+        session_factory, org_id, broken_parent, max_attempts=5,
+    )
+
+    await _tick(session_factory, session_store)
+
+    async with session_factory() as db:
+        task = await db.get(Task, tid)
+    assert task.status == "blocked", (
+        "a permanent config error must not wait for a retry ceiling"
+    )
+
+
+async def test_an_unclassified_failure_retries_but_is_bounded(
+    session_factory, session_store, org_id: uuid.UUID, monkeypatch,
+):
+    """An error we cannot classify is worth retrying -- but not forever.
+
+    This is the catch-all path, which had no bound at all.
+    """
+    pid = uuid.uuid4()
+    async with session_factory() as db:
+        parent = ORMSession(
+            id=pid, org_id=org_id, agent_id="orchestrator",
+            channel="web", status="active",
+            config={
+                "storage_bucket": "test-bucket",
+                "storage_key_prefix": "",
+                "workspace_path": f"/workspace/test/{pid}",
+                "supports_vision": False,
+            },
+        )
+        db.add(parent)
+        await db.commit()
+        await db.refresh(parent)
+
+    tid = await _add_ready_task(
+        session_factory, org_id, parent, max_attempts=2,
+    )
+
+    async def boom(*_a, **_kw):
+        raise RuntimeError("transient-looking but never recovers")
+
+    # The dispatcher imports this inside the function, so patch the source.
+    monkeypatch.setattr(
+        "surogates.tasks.spawn._create_session_for_task", boom,
+    )
+
+    # First tick: retried, still eligible.
+    await _tick(session_factory, session_store)
+    async with session_factory() as db:
+        assert (await db.get(Task, tid)).status == "ready"
+
+    # Ceiling reached on the second.
+    await _tick(session_factory, session_store)
+    async with session_factory() as db:
+        task = await db.get(Task, tid)
+    assert task.status != "ready", (
+        "an unclassified failure must still stop being re-claimed once the "
+        "task has burned max_attempts"
+    )
+
+
+async def test_the_block_reason_names_the_cause(
+    session_factory, session_store, org_id, broken_parent,
+):
+    """An operator must be able to see why without reading worker logs."""
+    tid = await _add_ready_task(
+        session_factory, org_id, broken_parent, max_attempts=1,
+    )
+
+    await _tick(session_factory, session_store)
+
+    async with session_factory() as db:
+        task = await db.get(Task, tid)
+    assert task.status == "blocked"
+    assert task.blocked_reason
+    assert "storage_key_prefix" in task.blocked_reason
+
+
+async def test_a_healthy_task_is_unaffected(
+    session_factory, session_store, org_id: uuid.UUID,
+):
+    """The ceiling must not touch a task that can actually spawn."""
+    pid = uuid.uuid4()
+    async with session_factory() as db:
+        parent = ORMSession(
+            id=pid, org_id=org_id, agent_id="orchestrator",
+            channel="web", status="active",
+            config={
+                "storage_bucket": "test-bucket",
+                "storage_key_prefix": "",
+                "workspace_path": f"/workspace/test/{pid}",
+                "supports_vision": False,
+            },
+        )
+        db.add(parent)
+        await db.commit()
+        await db.refresh(parent)
+
+    tid = await _add_ready_task(session_factory, org_id, parent)
+    await _tick(session_factory, session_store)
+
+    async with session_factory() as db:
+        task = await db.get(Task, tid)
+    assert task.status == "running"
+    assert task.current_session_id is not None
+
+
+async def test_one_dead_task_does_not_starve_its_healthy_neighbour(
+    session_factory, session_store, org_id, broken_parent,
+):
+    """The dead row must not consume the tick budget the good row needs."""
+    pid = uuid.uuid4()
+    async with session_factory() as db:
+        good_parent = ORMSession(
+            id=pid, org_id=org_id, agent_id="orchestrator",
+            channel="web", status="active",
+            config={
+                "storage_bucket": "test-bucket",
+                "storage_key_prefix": "",
+                "workspace_path": f"/workspace/test/{pid}",
+                "supports_vision": False,
+            },
+        )
+        db.add(good_parent)
+        await db.commit()
+        await db.refresh(good_parent)
+
+    dead = await _add_ready_task(
+        session_factory, org_id, broken_parent, max_attempts=1,
+    )
+    good = await _add_ready_task(session_factory, org_id, good_parent)
+
+    await _tick(session_factory, session_store)
+
+    async with session_factory() as db:
+        assert (await db.get(Task, dead)).status == "blocked"
+        assert (await db.get(Task, good)).status == "running"


### PR DESCRIPTION
## The bug

`_enqueue_ready_tasks` claims a ready task with `status='running', attempt_count + 1`, then spawns the child session. Every spawn failure except `UnknownAgentDefError` called `_rollback_claim`, which restored `status='ready'` **and gave the attempt back** — leaving the row byte-identical to its pre-claim state.

That made the ceiling unreachable. `attempt_count >= max_attempts` is only checked in `_finalize_ended_attempts`, whose query is `Task.status == "running"` joined to an ended Session (`tasks/dispatcher.py:99-104`). A rolled-back task is `ready` with no `current_session_id`, so it is never finalised and never fails. `failed_this_tick` is explicitly per-tick ("the exclusion is per-tick, not permanent"). The tick runs every 5s, forever.

**The trigger is permanent, not transient.** `create_child_session` raises `ValueError` when the parent's config lacks `storage_bucket` / `storage_key_prefix` / `workspace_path` (`session/provisioning.py:153-160`) — a property of the parent row that never self-heals. `api/routes/website.py:707-708` creates sessions with only two of the three.

The existing `_block_claim` carve-out comment names this exact failure ("instead of rolling it back to 'ready' and re-attempting every tick forever") but fixes only `UnknownAgentDefError`.

The RED test reproduced it verbatim — five identical warnings for one task id across five ticks.

## The fix

- **`ValueError` → `_block_claim`.** It is a permanent config error, the same class as `UnknownAgentDefError`. Blocked is a first-class "needs attention" state that self-heals via `unblock_task`.
- **Catch-all → `_retry_or_block`.** An error we cannot classify is still worth retrying, but `_rollback_claim` no longer gives the attempt back, so `max_attempts` finally bounds it.

## Tests

6 in `tests/integration/tasks/test_spawn_failure_ceiling.py`, RED first: a permanently broken spawn leaves the ready pool; a permanent config error blocks on the *first* tick; an unclassified failure retries once then stops at the ceiling; the block reason names `storage_key_prefix` so an operator need not read worker logs; a healthy task is unaffected; and one dead task does not starve its healthy neighbour.

## Verification

`tests/integration/tasks/` — 58 passed (including all pre-existing dispatcher/unblock tests). Full unit suite `28 failed / 5007 passed`, **identical failure set** to master. Ruff clean.