### PR TITLE
fix(harness): honour the session-level system instruction

### DIFF
--- a/surogates/harness/loop_context_replay.py
+++ b/surogates/harness/loop_context_replay.py
@@ -424,5 +424,15 @@ class ContextReplayMixin:
         ssh_section = render_ssh_targets_prompt(self._ssh_targets)
         if ssh_section:
             prompt = f"{prompt}\n\n{ssh_section}"
+        # Session-level instruction from ``POST /v1/sessions {"system": ...}``.
+        # Appended, never substituted: it narrows behaviour for one session,
+        # while the agent's own prompt carries the tool contract the harness
+        # depends on.  Ignored unless it is a non-blank string — ``config`` is
+        # caller-supplied JSON and a wrong type must not break the wake.
+        override = (session.config or {}).get("system")
+        if isinstance(override, str) and override.strip():
+            prompt = (
+                f"{prompt}\n\n## Session instructions\n\n{override.strip()}"
+            )
         self._system_prompt_cache.set(session.id, prompt)
         return prompt

--- a/tests/test_session_system_override.py
+++ b/tests/test_session_system_override.py
@@ -1,0 +1,97 @@
+"""``POST /v1/sessions {"system": ...}`` must actually reach the model.
+
+The field is declared on `CreateSessionRequest` (api/routes/sessions.py:85),
+persisted into `session.config["system"]` (:414-416), forwarded verbatim by
+surogate-ops, exposed on the SDK's `createSession`, listed in the public API
+reference, and asserted by a round-trip test.
+
+Nothing read it. `_build_system_prompt` calls `self._prompt.build()` and
+appends only the repos and ssh sections; `session.config` never enters. A
+caller got a 201, could read the value back off the session row, and every
+turn ran on the agent's default prompt with no error, warning or log line --
+which is exactly why debugging went to the model rather than to the dropped
+field.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from surogates.harness.loop import AgentHarness
+from surogates.harness.prompt_cache import SystemPromptCache
+
+
+def _harness(prompt_text: str = "BASE PROMPT") -> AgentHarness:
+    h = AgentHarness.__new__(AgentHarness)
+    h._prompt = SimpleNamespace(build=lambda: prompt_text)
+    h._system_prompt_cache = SystemPromptCache()
+    h._coding_repos = []
+    h._ssh_targets = []
+    return h
+
+
+def _session(config: dict | None) -> SimpleNamespace:
+    return SimpleNamespace(id=uuid4(), config=config)
+
+
+@pytest.mark.asyncio
+async def test_the_override_reaches_the_prompt():
+    h = _harness()
+    prompt = await h._build_system_prompt(
+        _session({"system": "Answer only in SQL. Never write prose."}),
+    )
+    assert "Answer only in SQL. Never write prose." in prompt
+
+
+@pytest.mark.asyncio
+async def test_the_agents_own_prompt_is_kept():
+    """Append, never replace.
+
+    Replacing would strip the tool contract and behavioural rules the harness
+    depends on -- the session-level field narrows behaviour, it does not
+    redefine the agent.
+    """
+    h = _harness("BASE PROMPT WITH TOOL RULES")
+    prompt = await h._build_system_prompt(_session({"system": "Be terse."}))
+    assert "BASE PROMPT WITH TOOL RULES" in prompt
+    assert prompt.index("BASE PROMPT WITH TOOL RULES") < prompt.index("Be terse.")
+
+
+@pytest.mark.asyncio
+async def test_no_override_leaves_the_prompt_untouched():
+    h = _harness()
+    assert await h._build_system_prompt(_session({})) == "BASE PROMPT"
+
+
+@pytest.mark.asyncio
+async def test_missing_config_is_safe():
+    h = _harness()
+    assert await h._build_system_prompt(_session(None)) == "BASE PROMPT"
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\n\t "])
+@pytest.mark.asyncio
+async def test_blank_overrides_are_ignored(blank):
+    """A whitespace-only value must not append an empty section."""
+    h = _harness()
+    assert await h._build_system_prompt(_session({"system": blank})) == "BASE PROMPT"
+
+
+@pytest.mark.asyncio
+async def test_non_string_override_is_ignored():
+    """config is caller-supplied JSON; a wrong type must not crash the wake."""
+    h = _harness()
+    assert await h._build_system_prompt(_session({"system": {"a": 1}})) == "BASE PROMPT"
+
+
+@pytest.mark.asyncio
+async def test_two_sessions_do_not_share_an_override():
+    """The cache is keyed by session id; prove the override rides along."""
+    h = _harness()
+    a = await h._build_system_prompt(_session({"system": "AAA"}))
+    b = await h._build_system_prompt(_session({"system": "BBB"}))
+    assert "AAA" in a and "BBB" not in a
+    assert "BBB" in b and "AAA" not in b


### PR DESCRIPTION
## The bug

`POST /v1/sessions {"system": ...}` is:

- declared on `CreateSessionRequest` (`api/routes/sessions.py:85`)
- persisted into `session.config["system"]` (`:414-416`)
- forwarded verbatim by ops (`surogate_ops/server/routes/sessions.py:181, 757-762`)
- exposed on the SDK's `createSession` (`sdk/agent-chat-react/src/types.ts:770-773`)
- listed in the public API reference (`docs/appendices/api-reference.md:89`)
- asserted by a round-trip test (`tests/integration/test_api.py:397`)

And read by **nothing**. `_build_system_prompt` calls `self._prompt.build()` and appends only the repos and ssh sections; `session.config` never enters. `git log -S'config.get("system"'` returns zero commits — a reader never existed.

A caller got a 201, could read the value back off the session row, and every turn ran on the agent's default prompt with no error, no warning, no log line. The persisted value made the session look correctly configured during debugging, so investigation went to the model rather than to the dropped field. The existing test asserts persistence only, which is exactly why CI never noticed.

## The fix

Append the override as a delimited `## Session instructions` section in `_build_system_prompt`.

**Append, not substitute.** Replacing would strip the tool contract and behavioural rules the harness depends on. The field narrows behaviour for one session; it does not redefine the agent.

Ignored unless it is a non-blank string — `config` is caller-supplied JSON and a wrong type must not break the wake.

No cache change needed: `SystemPromptCache` is already keyed by `session.id`, so a per-session override cannot leak across sessions (there is a test for that).

## Tests

9 in `tests/test_session_system_override.py`, 3 RED first: the override reaches the prompt; the agent's own prompt is kept and ordered first; absent/missing config is untouched; three blank forms are ignored; a non-string does not crash; and two sessions do not share an override.

## Verification

Full unit suite `28 failed / 5007 passed`, **identical failure set** to master. Zero new ruff findings.

**Not run:** the integration suite. This repo has no test CI on PRs.