### PR TITLE
fix(arbor): drop meta keys nothing implements

### DIFF
--- a/surogates/arbor/store.py
+++ b/surogates/arbor/store.py
@@ -28,8 +28,8 @@ META_KEYS: frozenset[str] = frozenset({
     "test_baseline_score", "test_trunk_score",
     "eval_cmd", "eval_cmd_test", "eval_timeout",
     "eval_retries", "eval_retry_base_delay", "eval_retry_max_delay",
-    "metric_direction", "dataset_info",
-    "protected_paths", "required_outputs",
+    "metric_direction",
+    "protected_paths",
     "max_cycles", "max_tree_depth", "max_parallel",
     "merge_threshold", "hitl_mode",
     # Convergence detector config (ConvergenceConfig.from_meta reads these).


### PR DESCRIPTION
## The bug

`required_outputs` and `dataset_info` sit in `META_KEYS` — the write-time allowlist that raises `MetaKeyError` on anything unknown (`arbor/store.py:139-140, 208-209`) — with **no reader anywhere** in either repo.

Run meta is consumed key by key (`arbor/prompts.py:67, 97`, `tools/builtin/arbor.py:123, 533, 610`), never rendered wholesale, so neither key can be picked up incidentally. Both are accepted from `idea_tree(set_meta)`, stored on the run, and silently ignored.

`required_outputs` in particular reads as a Research Contract term the merge gate enforces. It does not exist.

## The fix

Remove both from the allowlist, turning a silent false promise into an immediate `MetaKeyError` at the point of use.

`protected_paths`, the key sitting next to them on the same line, **is** genuinely read (`tools/builtin/arbor.py:733`) and stays. `dataset_info` was not in the original report — I found it while confirming `required_outputs`, and removing one while leaving an identically-inert neighbour would have been incoherent.

## Verification

92 arbor tests pass. Full unit suite `28 failed / 5007 passed`, **identical failure set** to master. Repo-wide grep confirms no remaining references to either key.