### PR TITLE
fix(governance): stop accepting a policy_profile nothing enforces

### DIFF
--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -30,6 +30,7 @@ from surogates.runtime.governance import (
     BOARD_SELF_TOOLS,
     WORKER_SELF_TOOLS,
     build_governance_gate,
+    warn_if_profile_unenforced,
 )
 from surogates.harness.prompt_library import default_library as default_prompt_library
 from surogates.health import infrastructure_readiness, start_health_server
@@ -1557,6 +1558,11 @@ async def run_worker(settings: Settings) -> None:
         _warn_if_base_model_missing_from_metadata(model_id)
         await session_store.record_session_model(session.id, model_id)
         budget = _resolve_iteration_budget(session)
+        # A declared policy_profile is stamped by the spawn paths and shown in
+        # the UI, but no registry resolves a profile NAME to the shape the
+        # gate composes -- so it is inert. Say so rather than let a session
+        # look restricted when it is not.
+        warn_if_profile_unenforced(session.config, agent_id=session.agent_id)
         summary_slot = llm_bundle.summary
         vision_slot = llm_bundle.vision
         advisor_slot = llm_bundle.advisor

--- a/surogates/runtime/governance.py
+++ b/surogates/runtime/governance.py
@@ -170,6 +170,37 @@ def build_governance_gate(
     return _FLOOR_GATE.with_profile(profile)
 
 
+def warn_if_profile_unenforced(
+    session_config: dict[str, Any] | None, *, agent_id: str | None = None,
+) -> None:
+    """Log when a session declares a ``policy_profile`` nothing can enforce.
+
+    ``session.config["policy_profile"]`` is stamped by four spawn paths, shown
+    in the UI, and documented by the shipped ``build-sub-agent`` skill as
+    narrowing the tenant base policy.  No registry maps a profile *name* to
+    the ``allowed_tools`` / ``denied_tools`` / ``egress`` shape
+    :meth:`GovernanceGate.with_profile` needs, and the gate is built solely
+    from the agent's runtime-config governance blob — so the declaration is
+    inert.
+
+    Defining what each name permits is a security decision, not something to
+    infer.  Until that exists this at least makes the gap visible instead of
+    accepting a restriction and dropping it.
+    """
+    if not isinstance(session_config, dict):
+        return
+    declared = session_config.get("policy_profile")
+    if not isinstance(declared, str) or not declared.strip():
+        return
+    logger.warning(
+        "Session declares policy_profile %r (agent=%s) but named profiles are "
+        "not resolved: the session runs under the agent's governance policy "
+        "unchanged. Express the restriction as governance.allowed_tools / "
+        "denied_tools on the agent instead.",
+        declared, agent_id or "?",
+    )
+
+
 def disclosure_config(
     governance: dict[str, Any] | None,
 ) -> dict[str, Any] | None:

--- a/tests/test_policy_profile_not_enforced.py
+++ b/tests/test_policy_profile_not_enforced.py
@@ -1,0 +1,49 @@
+"""A declared ``policy_profile`` must not pass silently unenforced.
+
+Four writers stamp ``session.config["policy_profile"]``
+(``harness/agent_resolver.py``, ``tools/builtin/coordinator.py``,
+``tools/builtin/delegate.py``, ``tasks/spawn.py``), the API accepts it, the
+UI shows it, and the shipped ``build-sub-agent`` skill documents it as
+narrowing the tenant base policy ("intersects allowed, unions denied;
+profiles never widen") with ``policy_profile: read_only`` as its example.
+
+Nothing resolves the name. The only gate construction is
+``build_governance_gate(ctx.governance)`` from the per-agent runtime config;
+``session.config`` never reaches it, and no registry maps ``read_only`` (or
+any other name) to a profile. A sub-agent declared read-only runs with the
+parent's authority.
+
+Enforcing it means defining what each name permits — a security decision, not
+a bug fix. Until that exists, the platform must at least say so out loud
+instead of accepting the declaration and dropping it.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from surogates.runtime.governance import warn_if_profile_unenforced
+
+
+def test_declared_profile_is_reported(caplog):
+    with caplog.at_level(logging.WARNING, logger="surogates.runtime.governance"):
+        warn_if_profile_unenforced({"policy_profile": "read_only"}, agent_id="ag-1")
+    assert any("read_only" in r.getMessage() for r in caplog.records), (
+        "an operator must be told the declared restriction is not in force"
+    )
+
+
+def test_no_profile_is_silent(caplog):
+    with caplog.at_level(logging.WARNING, logger="surogates.runtime.governance"):
+        warn_if_profile_unenforced({}, agent_id="ag-1")
+        warn_if_profile_unenforced(None, agent_id="ag-1")
+        warn_if_profile_unenforced({"policy_profile": None}, agent_id="ag-1")
+        warn_if_profile_unenforced({"policy_profile": ""}, agent_id="ag-1")
+    assert caplog.records == []
+
+
+def test_a_malformed_config_does_not_raise(caplog):
+    """This runs on the wake path; it must never be the thing that fails."""
+    with caplog.at_level(logging.WARNING, logger="surogates.runtime.governance"):
+        warn_if_profile_unenforced({"policy_profile": 123}, agent_id="ag-1")
+        warn_if_profile_unenforced("not-a-dict", agent_id="ag-1")  # type: ignore[arg-type]


### PR DESCRIPTION
## The gap

`session.config["policy_profile"]` is stamped by four spawn paths — `harness/agent_resolver.py:178`, `tools/builtin/coordinator.py:350`, `tools/builtin/delegate.py:448`, `tasks/spawn.py` — surfaced in the API (`api/routes/agents.py:67`) and the UI.

It is also actively **taught**. The shipped `build-sub-agent` skill documents it as a real control:

> `agent-md-spec.md:51` — "An optional `policy_profile` narrows (intersects allowed, unions denied) on top of the base policy; profiles never widen."
> `:83` — `policy_profile: read_only`
> `:111` — "Named governance profile that narrows the tenant base policy for this child"

Nothing resolves the name. The only gate construction is `build_governance_gate(ctx.governance)` (`orchestrator/worker.py:2006`), built from the agent's runtime-config governance blob; `session.config` never reaches it. `governance_profile()` builds a profile from `allowed_tools`/`denied_tools`/`egress` — there is **no registry** mapping `read_only`, or any other name, to that shape.

A sub-agent declared read-only runs with the parent's authority. Nothing narrows, nothing logs, and the persisted config plus the docs both assert the restriction is in force.

`agent_resolver.py:159` still documents the field as "(consulted in Step 6)". There is no Step 6.

## What this PR does — and deliberately does not

It does **not** implement enforcement. Honouring the field means defining what each profile name permits, which is a security decision: too strict breaks working agents, too loose hands out false assurance. That is not something to infer from a docstring.

It makes the gap audible on the wake path (`warn_if_profile_unenforced`), so a session can no longer look restricted when it is not, and points the operator at the mechanism that *does* work — `governance.allowed_tools` / `denied_tools` on the agent.

The helper is total: non-dict config, non-string or blank profile, and malformed input all return without raising. It runs on the wake path and must never be the thing that fails.

## The decision this leaves open

- **Implement it** — add a named-profile registry and wire it through `GovernanceGate.with_profile`, which already exists and whose docstring calls profiles "per-session overlays". The composition semantics the skill documents are already implemented; only name resolution is missing. Requires specifying each profile.
- **Remove it** — strip the field from `AgentDef`, the agents API, the four writers, and the skill docs. A breaking change to a documented field.

I lean toward implementing, since `with_profile` is built for exactly this, but the semantics are a product decision.

## Tests

3 in `tests/test_policy_profile_not_enforced.py`, RED first: a declared profile is reported; no profile (absent / `None` / empty) is silent; malformed input does not raise.

## Verification

Full unit suite `28 failed / 5007 passed`, **identical failure set** to master. Zero new ruff findings.