### PR TITLE
fix(inbox): retire questions nobody is waiting on, and make the panel tell the truth

### DIFF
--- a/docs/agent-inbox/index.md
+++ b/docs/agent-inbox/index.md
@@ -5,8 +5,11 @@ completed sessions. It turns selected session events into durable inbox rows so
 the web UI and shared React SDK can show items that need user attention without
 requiring the user to watch every session live.
 
-Inbox items are user-scoped. Service-account/API-channel sessions do not have a
-user inbox.
+Every item belongs to exactly one principal: the user who was acting when the
+event fired, or — for a service-account session such as an ops chat — that
+service account. The `/v1/inbox` API below serves the user inbox only;
+service-account items are read by the management plane (`surogate-ops`) from
+the database, scoped by the operator's ops-chat service account.
 
 ## When Inbox Items Are Created
 
@@ -19,7 +22,7 @@ Recognized event types:
 
 | Event type | Inbox kind | Meaning |
 |---|---|---|
-| `inbox.input_required` | `input_required` | The agent needs a text answer through the `clarify` flow. |
+| `inbox.input_required` | `input_required` | The agent needs an answer through the `ask_user_question` flow. |
 | `inbox.action_required` | `action_required` | The user must perform an external action, usually in the session or browser. |
 | `inbox.task_complete` | `task_complete` | A session completed and has a summary/outcome. |
 | `inbox.governance_gate` | `governance_gate` | A user-overridable governance decision needs approval or rejection. |
@@ -33,15 +36,28 @@ should fetch the row from the API.
 
 ### `input_required`
 
-Use this when the user can unblock the agent by answering a text question. The
-canonical path is the `clarify` tool.
+Use this when the user can unblock the agent by answering a question. The
+canonical path is the `ask_user_question` tool, which emits the event and then
+parks the turn waiting for the answer.
+
+**The item is only actionable while that tool is still waiting.** The wait is
+capped at `ASK_USER_QUESTION_MAX_WAIT_SECONDS` (30 minutes); past it the tool
+returns a timeout to the model and the turn moves on, so an answer submitted
+afterwards is recorded with nothing left to receive it. The sweeper expires
+these items on that schedule even when the session is still running, and both
+inbox UIs stop accepting an answer once the window has closed.
+
+An answer can arrive from any of four surfaces — the inbox form, the question
+widget in chat, a plain message typed in the web composer, or a channel reply
+(Telegram inline, Slack modal). The inbox row is the atomic claim, so exactly
+one of them wins.
 
 User actions:
 
 | Button | Effect |
 |---|---|
 | Open session | Navigates to the related session. |
-| Submit | Sends clarify answers to `/v1/sessions/{session_id}/clarify/{tool_call_id}/respond`, then refreshes the inbox item. |
+| Submit | Sends the answers to `/v1/sessions/{session_id}/ask_user_question/{tool_call_id}/respond`, then refreshes the inbox item. |
 | Delete | Hides the item by expiring it. It does not answer the agent. |
 
 ### `action_required`
@@ -51,7 +67,7 @@ MFA, approve OAuth, handle CAPTCHA, use a file picker, grant consent, or perform
 another browser/session action.
 
 The harness has a user-action judge for final assistant drafts. Text questions
-route to `clarify`; browser/session/manual action requests route to
+route to `ask_user_question`; browser/session/manual action requests route to
 `action_required`. The local fallback also classifies obvious login, browser,
 approval, and manual-action language as `action_required` if the structured
 judge fails.
@@ -82,6 +98,11 @@ User actions:
 Use this for informational updates from long-running sessions. The payload may
 include iteration count, elapsed seconds, last tool, and a progress summary.
 
+Off by default: check-ins are emitted only when the session's config carries
+`inbox_checkin_interval_seconds` (a positive integer), which a client sets in
+the `config` of the create-session request. Nothing in the platform's own UIs
+sets it.
+
 User actions:
 
 | Button | Effect |
@@ -111,11 +132,19 @@ User actions:
 | `pending` | The item still needs attention or has not been dismissed. |
 | `acknowledged` | The user acknowledged an informational item. |
 | `responded` | The user sent a response or completion signal back to the session. |
-| `expired` | The item is hidden from default inbox views. Deleting an item sets this status. |
+| `expired` | The item is hidden from default inbox views. Deleting an item sets this status, as does the sweeper. |
 
-`acknowledged`, `responded`, and `expired` are terminal states. Current default
-list queries hide `expired` items and include the other statuses unless a
-specific `status` filter is provided.
+`acknowledged`, `responded`, and `expired` are terminal states. A list query
+that names no status returns everything except `expired`, so an expired item is
+only ever returned to a request that asks for it by name.
+
+The sweeper (`jobs/inbox_expire.py`, every 300s) expires a `pending` item when
+either is true:
+
+- its session is terminal (`completed`, `failed`, `archived`) and its kind is
+  not acknowledge-only — an informational notification survives its session;
+- it is an `input_required` item older than the `ask_user_question` wait window
+  plus a grace margin, whatever the session is doing.
 
 ## API
 
@@ -134,7 +163,7 @@ Query parameters:
 
 | Parameter | Description |
 |---|---|
-| `status` | Optional exact status filter. Without it, expired items are hidden. |
+| `status` | Optional status filter; repeat it to accept several (`?status=responded&status=expired`). Without it, expired items are hidden. An unknown value is rejected with `422`. |
 | `kind` | Optional exact kind filter. |
 | `session_id` | Optional session UUID filter. |
 | `cursor` | Optional cursor returned by the previous page. |
@@ -246,7 +275,8 @@ but its status becomes `expired`, so it disappears from default list views.
 GET /v1/inbox/stream
 ```
 
-The stream uses Server-Sent Events. It first sends a `snapshot` event:
+The stream uses Server-Sent Events. It first sends a `snapshot` event listing
+the ids of `pending` items the user has not read:
 
 ```json
 { "unread_ids": [123, 124] }
@@ -258,7 +288,9 @@ Then it sends `item` events for new inbox rows:
 { "item_id": 125, "kind": "input_required" }
 ```
 
-Clients should fetch `/v1/inbox/{item_id}` after an `item` event.
+Clients should fetch `/v1/inbox/{item_id}` after an `item` event. An `item`
+event means "something changed", not "+1": derive any count from the list
+rather than incrementing on the nudge.
 
 ## Shared React SDK
 
@@ -285,6 +317,16 @@ Adapter methods used by the inbox UI:
 Every inbox detail view shows `Open session` and, when supported by the
 adapter, `Delete`. Kind-specific actions are rendered in the same row.
 
+`InboxPanel` splits the list in two: **Active** lists `pending` items, and
+**History** lists `acknowledged`, `responded` and `expired` ones. Only Active
+reacts to stream nudges — a nudge announces something new, which is by
+definition not history.
+
+Studio (`surogate-ops`) does not use `InboxPanel`; it has its own page against
+the same model, and keeps its own copies of the answer and expiry rules because
+its SDK pin predates them. Both copies name the condition for deleting
+themselves.
+
 ## Operational Notes
 
 - Inbox rows are per-user and per-org; API lookups always include the current
@@ -292,6 +334,7 @@ adapter, `Delete`. Kind-specific actions are rendered in the same row.
 - The inbox is a workflow view, not the source of truth. The source event log
   remains authoritative.
 - Redis streaming is best-effort. Clients should tolerate missed nudges by
-  refreshing the list.
+  refreshing the list, and should reconnect: a stream that stays open for hours
+  outlives token refreshes, suspended laptops and dropped idle connections.
 - Deleting an item does not answer the agent. For blocking work, use `Submit`,
   `I completed this`, or `Approve` / `Reject` as appropriate.

--- a/docs/agent-inbox/index.md
+++ b/docs/agent-inbox/index.md
@@ -43,9 +43,14 @@ parks the turn waiting for the answer.
 **The item is only actionable while that tool is still waiting.** The wait is
 capped at `ASK_USER_QUESTION_MAX_WAIT_SECONDS` (30 minutes); past it the tool
 returns a timeout to the model and the turn moves on, so an answer submitted
-afterwards is recorded with nothing left to receive it. The sweeper expires
-these items on that schedule even when the session is still running, and both
-inbox UIs stop accepting an answer once the window has closed.
+afterwards is recorded with nothing left to receive it.
+
+The tool retires its own row the moment it gives up — on timeout, and when the
+session is paused or completed under it. Serialized items carry `expires_at`
+so clients never mirror the wait constant: a UI stops accepting an answer at
+that instant, and anything without a deadline serializes `expires_at: null`.
+The sweeper is the backstop for a row whose worker died before it could clean
+up (see Statuses).
 
 An answer can arrive from any of four surfaces — the inbox form, the question
 widget in chat, a plain message typed in the web composer, or a channel reply
@@ -138,13 +143,15 @@ User actions:
 that names no status returns everything except `expired`, so an expired item is
 only ever returned to a request that asks for it by name.
 
-The sweeper (`jobs/inbox_expire.py`, every 300s) expires a `pending` item when
-either is true:
+A question is normally retired by the tool that asked it. The sweeper
+(`jobs/inbox_expire.py`, every 300s) covers what that cannot, expiring a
+`pending` item when either is true:
 
 - its session is terminal (`completed`, `failed`, `archived`) and its kind is
   not acknowledge-only — an informational notification survives its session;
 - it is an `input_required` item older than the `ask_user_question` wait window
-  plus a grace margin, whatever the session is doing.
+  plus a grace margin, whatever the session is doing — the row is orphaned,
+  because a worker that reached its own timeout would already have cleared it.
 
 ## API
 
@@ -198,6 +205,7 @@ Response:
         "completion_endpoint": "/v1/inbox/{item_id}/respond"
       },
       "created_at": "2026-05-11T12:00:00+00:00",
+      "expires_at": null,
       "updated_at": "2026-05-11T12:00:00+00:00",
       "read_at": null,
       "responded_at": null

--- a/sdk/agent-chat-react/src/components/inbox/inbox-expiry.ts
+++ b/sdk/agent-chat-react/src/components/inbox/inbox-expiry.ts
@@ -3,22 +3,25 @@
 //
 // How long a question stays answerable.
 //
-// Studio carries the same rule in features/work/inbox-expiry.ts for its
-// own inbox but cannot import this one: its SDK pin predates the module.
-// If a third surface needs it, export it from the package index and
-// delete that copy rather than making a third.
+// The deadline itself is the server's: it is the only place that knows
+// how long the tool call parks waiting, and it sends it as `expiresAt`.
+// What is left here is presentation — turning that instant into a
+// countdown and a yes/no.
+//
+// Studio carries the same two helpers in features/work/inbox-expiry.ts
+// for its own inbox but cannot import these: its SDK pin predates the
+// module. If a third surface needs them, export them from the package
+// index and delete that copy rather than making a third.
 
 import { useEffect, useState } from "react";
 
-// The ask_user_question tool parks the turn for this long waiting for an
-// answer (mirrors ASK_USER_QUESTION_MAX_WAIT_SECONDS on the server); the
-// wait starts when the inbox item is created.
-export const ANSWER_WINDOW_MS = 30 * 60 * 1000;
-
 const TICK_MS = 30_000;
 
-export function formatExpiresIn(createdAtIso: string, nowMs: number): string {
-  const remainingMs = Date.parse(createdAtIso) + ANSWER_WINDOW_MS - nowMs;
+export function formatExpiresIn(
+  expiresAtIso: string,
+  nowMs: number,
+): string {
+  const remainingMs = Date.parse(expiresAtIso) - nowMs;
   if (remainingMs <= 0) return "Expired";
   if (remainingMs < 60_000) return "Expires in under a minute";
   const minutes = Math.round(remainingMs / 60_000);
@@ -30,10 +33,13 @@ export function formatExpiresIn(createdAtIso: string, nowMs: number): string {
  *
  * The window can close while the user is looking at the question, so
  * whether it is still answerable cannot be read once at render: the
- * sweeper expires the item shortly after, and an answer submitted in
- * between is recorded with no tool call left to receive it.
+ * tool gives up shortly after, and an answer submitted in between is
+ * recorded with nothing left to receive it.
+ *
+ * An item with no deadline — anything that is not a question — never
+ * expires.
  */
-export function useAnswerWindow(createdAtIso: string): {
+export function useAnswerWindow(expiresAtIso: string | null | undefined): {
   expired: boolean;
   label: string;
 } {
@@ -42,8 +48,11 @@ export function useAnswerWindow(createdAtIso: string): {
     const id = setInterval(() => setNow(Date.now()), TICK_MS);
     return () => clearInterval(id);
   }, []);
+  if (!expiresAtIso) {
+    return { expired: false, label: "" };
+  }
   return {
-    expired: Date.parse(createdAtIso) + ANSWER_WINDOW_MS <= now,
-    label: formatExpiresIn(createdAtIso, now),
+    expired: Date.parse(expiresAtIso) <= now,
+    label: formatExpiresIn(expiresAtIso, now),
   };
 }

--- a/sdk/agent-chat-react/src/components/inbox/inbox-expiry.ts
+++ b/sdk/agent-chat-react/src/components/inbox/inbox-expiry.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// How long a question stays answerable.
+//
+// Studio carries the same rule in features/work/inbox-expiry.ts for its
+// own inbox but cannot import this one: its SDK pin predates the module.
+// If a third surface needs it, export it from the package index and
+// delete that copy rather than making a third.
+
+import { useEffect, useState } from "react";
+
+// The ask_user_question tool parks the turn for this long waiting for an
+// answer (mirrors ASK_USER_QUESTION_MAX_WAIT_SECONDS on the server); the
+// wait starts when the inbox item is created.
+export const ANSWER_WINDOW_MS = 30 * 60 * 1000;
+
+const TICK_MS = 30_000;
+
+export function formatExpiresIn(createdAtIso: string, nowMs: number): string {
+  const remainingMs = Date.parse(createdAtIso) + ANSWER_WINDOW_MS - nowMs;
+  if (remainingMs <= 0) return "Expired";
+  if (remainingMs < 60_000) return "Expires in under a minute";
+  const minutes = Math.round(remainingMs / 60_000);
+  return `Expires in ~${minutes} minute${minutes === 1 ? "" : "s"}`;
+}
+
+/**
+ * How much of the answer window is left, recomputed as it drains.
+ *
+ * The window can close while the user is looking at the question, so
+ * whether it is still answerable cannot be read once at render: the
+ * sweeper expires the item shortly after, and an answer submitted in
+ * between is recorded with no tool call left to receive it.
+ */
+export function useAnswerWindow(createdAtIso: string): {
+  expired: boolean;
+  label: string;
+} {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+  return {
+    expired: Date.parse(createdAtIso) + ANSWER_WINDOW_MS <= now,
+    label: formatExpiresIn(createdAtIso, now),
+  };
+}

--- a/sdk/agent-chat-react/src/components/inbox/inbox-expiry.ts
+++ b/sdk/agent-chat-react/src/components/inbox/inbox-expiry.ts
@@ -17,10 +17,7 @@ import { useEffect, useState } from "react";
 
 const TICK_MS = 30_000;
 
-export function formatExpiresIn(
-  expiresAtIso: string,
-  nowMs: number,
-): string {
+function formatExpiresIn(expiresAtIso: string, nowMs: number): string {
   const remainingMs = Date.parse(expiresAtIso) - nowMs;
   if (remainingMs <= 0) return "Expired";
   if (remainingMs < 60_000) return "Expires in under a minute";

--- a/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
+++ b/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
@@ -830,12 +830,30 @@ export function InboxPanel({
     [items, selectedItemId],
   );
 
-  const applyItem = useCallback((nextItem: AgentChatInboxItem) => {
-    // An insert, not just a replacement: the stream announces items the
-    // list has never seen, and dropping those left the inbox frozen at
-    // whatever was there when the page loaded.
-    setItems((current) => sortItems([nextItem, ...current]));
-  }, []);
+  const applyItem = useCallback(
+    (nextItem: AgentChatInboxItem) => {
+      setItems((current) => {
+        // A row already on screen updates in place, whatever its new
+        // status: the user just acted on it and the result — Acknowledged,
+        // Responded — is the confirmation. It leaves the view on the next
+        // load, the way a read mail stays put until you come back to the
+        // folder.
+        //
+        // A row that is not on screen is an insert, which is how the
+        // stream announces something new; mapping over the existing rows
+        // dropped those entirely and froze the list at whatever it held
+        // when the page opened. Only insert what belongs here, so a nudge
+        // about a fresh pending item cannot land in History.
+        if (current.some((item) => item.id === nextItem.id)) {
+          return sortItems([nextItem, ...current]);
+        }
+        return STATUSES_BY_VIEW[view].includes(nextItem.status)
+          ? sortItems([nextItem, ...current])
+          : current;
+      });
+    },
+    [view],
+  );
 
   const selectItem = useCallback(
     async (itemId: number) => {

--- a/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
+++ b/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
@@ -381,7 +381,7 @@ function InputRequiredDetail({
   const questions = useMemo(() => parseInboxQuestions(item), [item]);
   const [drafts, setDrafts] = useState<Record<string, AnswerDraft>>({});
   const { error, busy: submitting, run } = useAction();
-  const { expired, label: expiryLabel } = useAnswerWindow(item.createdAt);
+  const { expired, label: expiryLabel } = useAnswerWindow(item.expiresAt);
   const pending = item.status === "pending" && !expired;
   const disabled = !pending || submitting;
 
@@ -899,6 +899,17 @@ export function InboxPanel({
     void load(null);
   }, [load]);
 
+  // Read through a ref so the subscription below does not depend on the
+  // view: tearing down and reopening the connection on a tab click is
+  // work for something that is a pure client-side re-render.
+  const onNudgeRef = useRef<(itemId: number) => void>(() => undefined);
+  onNudgeRef.current = (itemId: number) => {
+    // Only the Active view moves on its own — a nudge means something
+    // new is pending, which by definition is not history.
+    if (view !== "active") return;
+    void inboxAdapter.getInboxItem({ itemId }).then(applyItem, () => undefined);
+  };
+
   useEffect(() => {
     const stream = inboxAdapter.openInboxStream();
     stream.addEventListener("item", (event) => {
@@ -911,13 +922,10 @@ export function InboxPanel({
         return;
       }
       if (typeof itemId !== "number") return;
-      // Only the Active view moves on its own — a nudge means something
-      // new is pending, which by definition is not history.
-      if (view !== "active") return;
-      void inboxAdapter.getInboxItem({ itemId }).then(applyItem, () => undefined);
+      onNudgeRef.current(itemId);
     });
     return () => stream.close();
-  }, [applyItem, inboxAdapter, view]);
+  }, [inboxAdapter]);
 
   function updateSelectedItem(item: AgentChatInboxItem) {
     applyItem(item);

--- a/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
+++ b/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
@@ -29,6 +29,7 @@ import {
   buildInboxResponse,
   parseInboxQuestions,
 } from "./inbox-answers";
+import { useAnswerWindow } from "./inbox-expiry";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { cn } from "../../lib/utils";
@@ -39,6 +40,7 @@ import type {
   AgentChatInboxItem,
   AgentChatInboxKind,
   AgentChatInboxList,
+  AgentChatInboxStatus,
 } from "../../types";
 
 type OnSessionSelect = (sessionId: string, item?: AgentChatInboxItem) => void;
@@ -120,8 +122,25 @@ function kindIcon(kind: AgentChatInboxKind) {
   return CircleDotIcon;
 }
 
+type InboxView = "active" | "history";
+
+// History is asked for by name: a request that omits the status filter
+// gets everything except expired, which is exactly the half of history
+// worth keeping — a question the agent stopped waiting for, or an item
+// that was dismissed.
+const STATUSES_BY_VIEW: Record<InboxView, AgentChatInboxStatus[]> = {
+  active: ["pending"],
+  history: ["acknowledged", "responded", "expired"],
+};
+
 function sortItems(items: AgentChatInboxItem[]): AgentChatInboxItem[] {
-  return [...items].sort((a, b) => {
+  // Paging can overlap with a stream update; the first copy of a row
+  // wins (callers put the fresher one first) and it is listed once.
+  const byId = new Map<number, AgentChatInboxItem>();
+  for (const item of items) {
+    if (!byId.has(item.id)) byId.set(item.id, item);
+  }
+  return [...byId.values()].sort((a, b) => {
     if (a.createdAt !== b.createdAt) return a.createdAt > b.createdAt ? -1 : 1;
     return b.id - a.id;
   });
@@ -139,6 +158,67 @@ function InboxBody({ body, muted }: { body: string; muted?: boolean }) {
 
 const FIELD_CLASS =
   "h-9 w-full border border-line bg-background px-2 text-sm text-foreground outline-none focus:border-primary disabled:opacity-50";
+
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
+/**
+ * Runs a detail-pane action, reporting failure where the user is looking.
+ *
+ * Every action here reaches the network, and an unhandled rejection put
+ * the button back the way it was with nothing said — indistinguishable
+ * from a submit that worked.
+ */
+function useAction(): {
+  error: string | null;
+  busy: boolean;
+  run: (fallback: string, action: () => Promise<void>) => Promise<void>;
+} {
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const run = useCallback(
+    async (fallback: string, action: () => Promise<void>) => {
+      setBusy(true);
+      setError(null);
+      try {
+        await action();
+      } catch (err) {
+        setError(errorMessage(err, fallback));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [],
+  );
+
+  return { error, busy, run };
+}
+
+function ActionError({ message }: { message: string | null }) {
+  if (!message) return null;
+  return (
+    <p role="alert" className="text-sm text-destructive">
+      {message}
+    </p>
+  );
+}
+
+function ExpiryNote({ label, expired }: { label: string; expired: boolean }) {
+  return (
+    <p
+      className={cn(
+        "text-xs",
+        expired ? "text-muted-foreground" : "text-foreground",
+      )}
+    >
+      {expired
+        ? "The agent stopped waiting for this answer and moved on, so it can no longer be submitted."
+        : `${label}. Deleting it will not answer the agent; it only clears it from your inbox.`}
+    </p>
+  );
+}
 
 // <option> values are choice INDEXES, never labels: an agent-supplied
 // label could otherwise collide with whatever sentinel marks the
@@ -243,44 +323,42 @@ function InboxDetailActions({
   onSessionSelect?: OnSessionSelect;
   children?: ReactNode;
 }) {
-  const [deleting, setDeleting] = useState(false);
+  const { error, busy: deleting, run } = useAction();
 
   async function deleteItem() {
     if (!adapter.deleteInboxItem) return;
-    setDeleting(true);
-    try {
-      await onDeleted(item.id);
-    } finally {
-      setDeleting(false);
-    }
+    await run("Failed to delete", () => onDeleted(item.id));
   }
 
   return (
-    <div className="flex flex-wrap gap-2">
-      <Button
-        type="button"
-        size="sm"
-        onClick={() => onSessionSelect?.(item.sessionId, item)}
-        aria-label="Open session"
-      >
-        <ExternalLinkIcon className="size-3.5" />
-        Open session
-      </Button>
-      {children}
-      {adapter.deleteInboxItem && (
+    <div className="space-y-2">
+      <ActionError message={error} />
+      <div className="flex flex-wrap gap-2">
         <Button
           type="button"
           size="sm"
-          variant="ghost"
-          onClick={() => void deleteItem()}
-          disabled={deleting}
-          aria-label="Delete inbox item"
-          title="Delete inbox item"
+          onClick={() => onSessionSelect?.(item.sessionId, item)}
+          aria-label="Open session"
         >
-          <Trash2Icon className="size-3.5" />
-          {deleting ? "Deleting" : "Delete"}
+          <ExternalLinkIcon className="size-3.5" />
+          Open session
         </Button>
-      )}
+        {children}
+        {adapter.deleteInboxItem && (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={() => void deleteItem()}
+            disabled={deleting}
+            aria-label="Delete inbox item"
+            title="Delete inbox item"
+          >
+            <Trash2Icon className="size-3.5" />
+            {deleting ? "Deleting" : "Delete"}
+          </Button>
+        )}
+      </div>
     </div>
   );
 }
@@ -302,8 +380,10 @@ function InputRequiredDetail({
   // choice object while the user is only editing an answer.
   const questions = useMemo(() => parseInboxQuestions(item), [item]);
   const [drafts, setDrafts] = useState<Record<string, AnswerDraft>>({});
-  const [submitting, setSubmitting] = useState(false);
-  const disabled = item.status !== "pending" || submitting;
+  const { error, busy: submitting, run } = useAction();
+  const { expired, label: expiryLabel } = useAnswerWindow(item.createdAt);
+  const pending = item.status === "pending" && !expired;
+  const disabled = !pending || submitting;
 
   const editDraft = (prompt: string, patch: Partial<AnswerDraft>) =>
     setDrafts((current) => ({
@@ -311,9 +391,11 @@ function InputRequiredDetail({
       [prompt]: { ...current[prompt], ...patch },
     }));
 
-  const canSubmit = questions.every(
-    (question) => answerText(question, drafts[question.prompt]),
-  );
+  // An empty batch satisfies every(), and the server rejects a
+  // submission with no answers in it.
+  const canSubmit =
+    questions.length > 0 &&
+    questions.every((question) => answerText(question, drafts[question.prompt]));
 
   async function submit() {
     const toolCallId =
@@ -321,8 +403,7 @@ function InputRequiredDetail({
         ? item.payload.tool_call_id
         : "";
     if (!toolCallId || !canSubmit) return;
-    setSubmitting(true);
-    try {
+    await run("Failed to submit your answer", async () => {
       const responses: AgentChatAskUserQuestionAnswer[] = questions.map(
         (question) => buildInboxResponse(question, drafts[question.prompt]),
       );
@@ -332,9 +413,7 @@ function InputRequiredDetail({
         responses,
       });
       onUpdated(await adapter.getInboxItem({ itemId: item.id }));
-    } finally {
-      setSubmitting(false);
-    }
+    });
   }
 
   return (
@@ -363,6 +442,10 @@ function InputRequiredDetail({
           />
         </label>
       ))}
+      {item.status === "pending" && (
+        <ExpiryNote label={expiryLabel} expired={expired} />
+      )}
+      <ActionError message={error} />
       <InboxDetailActions
         item={item}
         adapter={adapter}
@@ -396,8 +479,11 @@ function AckDetail({
   onDeleted: (itemId: number) => Promise<void>;
   onSessionSelect?: OnSessionSelect;
 }) {
+  const { error, busy, run } = useAction();
   async function acknowledge() {
-    onUpdated(await adapter.acknowledgeInboxItem({ itemId: item.id }));
+    await run("Failed to acknowledge", async () => {
+      onUpdated(await adapter.acknowledgeInboxItem({ itemId: item.id }));
+    });
   }
   const outcome = typeof item.payload.outcome === "string" ? item.payload.outcome : "";
   const duration =
@@ -418,6 +504,7 @@ function AckDetail({
           Duration: {Math.round(duration / 60)} min ({duration} s)
         </p>
       )}
+      <ActionError message={error} />
       <InboxDetailActions
         item={item}
         adapter={adapter}
@@ -429,10 +516,11 @@ function AckDetail({
             type="button"
             size="sm"
             onClick={() => void acknowledge()}
+            disabled={busy}
             aria-label="Acknowledge inbox item"
           >
             <CheckIcon className="size-3.5" />
-            Acknowledge
+            {busy ? "Saving" : "Acknowledge"}
           </Button>
         )}
       </InboxDetailActions>
@@ -453,10 +541,13 @@ function GovernanceDetail({
   onDeleted: (itemId: number) => Promise<void>;
   onSessionSelect?: OnSessionSelect;
 }) {
+  const { error, busy, run } = useAction();
   async function decide(decision: "approve" | "reject") {
-    onUpdated(
-      await adapter.respondGovernanceInboxItem({ itemId: item.id, decision }),
-    );
+    await run(`Failed to ${decision}`, async () => {
+      onUpdated(
+        await adapter.respondGovernanceInboxItem({ itemId: item.id, decision }),
+      );
+    });
   }
   const toolName =
     typeof item.payload.tool_name === "string" ? item.payload.tool_name : "tool";
@@ -466,7 +557,7 @@ function GovernanceDetail({
       : "";
   const reason =
     typeof item.payload.deny_reason === "string" ? item.payload.deny_reason : "";
-  const disabled = item.status !== "pending";
+  const disabled = item.status !== "pending" || busy;
   return (
     <div className="space-y-4">
       <div>
@@ -480,6 +571,7 @@ function GovernanceDetail({
           {args}
         </pre>
       )}
+      <ActionError message={error} />
       <InboxDetailActions
         item={item}
         adapter={adapter}
@@ -521,7 +613,7 @@ function ActionRequiredDetail({
   onDeleted: (itemId: number) => Promise<void>;
   onSessionSelect?: OnSessionSelect;
 }) {
-  const [submitting, setSubmitting] = useState(false);
+  const { error, busy: submitting, run } = useAction();
   const actionType =
     typeof item.payload.action_type === "string"
       ? item.payload.action_type
@@ -532,13 +624,11 @@ function ActionRequiredDetail({
     item.status !== "pending" || submitting || !adapter.respondActionRequiredInboxItem;
 
   async function complete() {
-    if (!adapter.respondActionRequiredInboxItem) return;
-    setSubmitting(true);
-    try {
-      onUpdated(await adapter.respondActionRequiredInboxItem({ itemId: item.id }));
-    } finally {
-      setSubmitting(false);
-    }
+    const respond = adapter.respondActionRequiredInboxItem;
+    if (!respond) return;
+    await run("Failed to mark the action complete", async () => {
+      onUpdated(await respond({ itemId: item.id }));
+    });
   }
 
   return (
@@ -550,6 +640,7 @@ function ActionRequiredDetail({
         </p>
       )}
       {actionType && <Badge variant="secondary">{actionType}</Badge>}
+      <ActionError message={error} />
       <InboxDetailActions
         item={item}
         adapter={adapter}
@@ -584,8 +675,11 @@ function ProgressDetail({
   onDeleted: (itemId: number) => Promise<void>;
   onSessionSelect?: OnSessionSelect;
 }) {
+  const { error, busy, run } = useAction();
   async function acknowledge() {
-    onUpdated(await adapter.acknowledgeInboxItem({ itemId: item.id }));
+    await run("Failed to acknowledge", async () => {
+      onUpdated(await adapter.acknowledgeInboxItem({ itemId: item.id }));
+    });
   }
   const rows: Array<[string, unknown]> = [];
   for (const row of [
@@ -610,6 +704,7 @@ function ProgressDetail({
           ))}
         </dl>
       )}
+      <ActionError message={error} />
       <InboxDetailActions
         item={item}
         adapter={adapter}
@@ -621,10 +716,11 @@ function ProgressDetail({
             type="button"
             size="sm"
             onClick={() => void acknowledge()}
+            disabled={busy}
             aria-label="Acknowledge inbox item"
           >
             <CheckIcon className="size-3.5" />
-            Acknowledge
+            {busy ? "Saving" : "Acknowledge"}
           </Button>
         )}
       </InboxDetailActions>
@@ -724,6 +820,7 @@ export function InboxPanel({
   const [items, setItems] = useState<AgentChatInboxItem[]>([]);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [internalSelectedId, setInternalSelectedId] = useState<number | null>(null);
+  const [view, setView] = useState<InboxView>("active");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const requestId = useRef(0);
@@ -734,11 +831,10 @@ export function InboxPanel({
   );
 
   const applyItem = useCallback((nextItem: AgentChatInboxItem) => {
-    setItems((current) =>
-      sortItems(
-        current.map((item) => (item.id === nextItem.id ? nextItem : item)),
-      ),
-    );
+    // An insert, not just a replacement: the stream announces items the
+    // list has never seen, and dropping those left the inbox frozen at
+    // whatever was there when the page loaded.
+    setItems((current) => sortItems([nextItem, ...current]));
   }, []);
 
   const selectItem = useCallback(
@@ -758,9 +854,9 @@ export function InboxPanel({
     async (cursor?: string | null) => {
       const id = ++requestId.current;
       setLoading(true);
-      setError(null);
       try {
         const response = await inboxAdapter.listInbox({
+          status: STATUSES_BY_VIEW[view],
           cursor: cursor ?? undefined,
           limit,
         });
@@ -769,15 +865,16 @@ export function InboxPanel({
           sortItems(cursor ? [...current, ...response.items] : response.items),
         );
         setNextCursor(response.nextCursor);
+        setError(null);
       } catch (err) {
         if (id === requestId.current) {
-          setError(err instanceof Error ? err.message : "Failed to load inbox");
+          setError(errorMessage(err, "Failed to load inbox"));
         }
       } finally {
         if (id === requestId.current) setLoading(false);
       }
     },
-    [inboxAdapter, limit],
+    [inboxAdapter, limit, view],
   );
 
   useEffect(() => {
@@ -787,16 +884,41 @@ export function InboxPanel({
   useEffect(() => {
     const stream = inboxAdapter.openInboxStream();
     stream.addEventListener("item", (event) => {
-      const payload = JSON.parse(event.data) as { item_id?: unknown };
-      if (typeof payload.item_id !== "number") return;
-      void inboxAdapter.getInboxItem({ itemId: payload.item_id }).then(applyItem);
+      // A stream frame is not a trusted shape: a malformed one must not
+      // throw out of the listener and take the subscription with it.
+      let itemId: unknown;
+      try {
+        itemId = (JSON.parse(event.data) as { item_id?: unknown }).item_id;
+      } catch {
+        return;
+      }
+      if (typeof itemId !== "number") return;
+      // Only the Active view moves on its own — a nudge means something
+      // new is pending, which by definition is not history.
+      if (view !== "active") return;
+      void inboxAdapter.getInboxItem({ itemId }).then(applyItem, () => undefined);
     });
     return () => stream.close();
-  }, [applyItem, inboxAdapter]);
+  }, [applyItem, inboxAdapter, view]);
 
   function updateSelectedItem(item: AgentChatInboxItem) {
     applyItem(item);
   }
+
+  const selectView = useCallback(
+    (next: InboxView) => {
+      if (next === view) return;
+      // The two views share no items, so keeping the old ones on screen
+      // while the new page loads would show the wrong list.
+      setView(next);
+      setItems([]);
+      setNextCursor(null);
+      setError(null);
+      if (selectedId === undefined) setInternalSelectedId(null);
+      onSelectedIdChange?.(null);
+    },
+    [onSelectedIdChange, selectedId, view],
+  );
 
   const deleteItem = useCallback(
     async (itemId: number) => {
@@ -820,13 +942,37 @@ export function InboxPanel({
             <h1 className="font-semibold">{title}</h1>
           </div>
         )}
+        <div className="flex gap-1 border-b border-line px-2 py-2">
+          {(["active", "history"] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => selectView(value)}
+              className={cn(
+                "px-2 py-1 text-xs capitalize transition-colors",
+                view === value
+                  ? "bg-line font-medium text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {value}
+            </button>
+          ))}
+        </div>
         <div className="min-h-0 flex-1 overflow-y-auto">
-          {error && (
-            <div className="px-4 py-3 text-sm text-destructive">{error}</div>
+          {error && items.length === 0 && (
+            <div className="space-y-2 px-4 py-3">
+              <p className="text-sm text-destructive">{error}</p>
+              <Button type="button" size="sm" onClick={() => void load(null)}>
+                Try again
+              </Button>
+            </div>
           )}
-          {!error && items.length === 0 && !loading && (
+          {items.length === 0 && !error && !loading && (
             <div className="px-4 py-8 text-sm text-muted-foreground">
-              No inbox items
+              {view === "active"
+                ? "Nothing needs you right now"
+                : "No history yet"}
             </div>
           )}
           {items.map((item) => {

--- a/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
+++ b/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
@@ -830,30 +830,33 @@ export function InboxPanel({
     [items, selectedItemId],
   );
 
-  const applyItem = useCallback(
-    (nextItem: AgentChatInboxItem) => {
-      setItems((current) => {
-        // A row already on screen updates in place, whatever its new
-        // status: the user just acted on it and the result — Acknowledged,
-        // Responded — is the confirmation. It leaves the view on the next
-        // load, the way a read mail stays put until you come back to the
-        // folder.
-        //
-        // A row that is not on screen is an insert, which is how the
-        // stream announces something new; mapping over the existing rows
-        // dropped those entirely and froze the list at whatever it held
-        // when the page opened. Only insert what belongs here, so a nudge
-        // about a fresh pending item cannot land in History.
-        if (current.some((item) => item.id === nextItem.id)) {
-          return sortItems([nextItem, ...current]);
-        }
-        return STATUSES_BY_VIEW[view].includes(nextItem.status)
-          ? sortItems([nextItem, ...current])
-          : current;
-      });
-    },
-    [view],
-  );
+  // Read through a ref, never closed over: an action started before a
+  // tab switch resolves after it, and a callback holding the old view
+  // would file the result under the list the user has since left.
+  const viewRef = useRef(view);
+  viewRef.current = view;
+
+  const applyItem = useCallback((nextItem: AgentChatInboxItem) => {
+    setItems((current) => {
+      // A row already on screen updates in place, whatever its new
+      // status: the user just acted on it and the result — Acknowledged,
+      // Responded — is the confirmation. It leaves the view on the next
+      // load, the way a read mail stays put until you come back to the
+      // folder.
+      //
+      // A row that is not on screen is an insert, which is how the
+      // stream announces something new; mapping over the existing rows
+      // dropped those entirely and froze the list at whatever it held
+      // when the page opened. Only insert what belongs here, so a nudge
+      // about a fresh pending item cannot land in History.
+      if (current.some((item) => item.id === nextItem.id)) {
+        return sortItems([nextItem, ...current]);
+      }
+      return STATUSES_BY_VIEW[viewRef.current].includes(nextItem.status)
+        ? sortItems([nextItem, ...current])
+        : current;
+    });
+  }, []);
 
   const selectItem = useCallback(
     async (itemId: number) => {
@@ -879,9 +882,11 @@ export function InboxPanel({
           limit,
         });
         if (id !== requestId.current) return;
-        setItems((current) =>
-          sortItems(cursor ? [...current, ...response.items] : response.items),
-        );
+        // Merged, never replaced. A first page is only ever loaded into
+        // an empty list — mount, a view switch, a retry — so the only
+        // thing merging preserves is an item a nudge inserted while this
+        // request was in flight, which a replace would silently drop.
+        setItems((current) => sortItems([...response.items, ...current]));
         setNextCursor(response.nextCursor);
         setError(null);
       } catch (err) {
@@ -899,17 +904,6 @@ export function InboxPanel({
     void load(null);
   }, [load]);
 
-  // Read through a ref so the subscription below does not depend on the
-  // view: tearing down and reopening the connection on a tab click is
-  // work for something that is a pure client-side re-render.
-  const onNudgeRef = useRef<(itemId: number) => void>(() => undefined);
-  onNudgeRef.current = (itemId: number) => {
-    // Only the Active view moves on its own — a nudge means something
-    // new is pending, which by definition is not history.
-    if (view !== "active") return;
-    void inboxAdapter.getInboxItem({ itemId }).then(applyItem, () => undefined);
-  };
-
   useEffect(() => {
     const stream = inboxAdapter.openInboxStream();
     stream.addEventListener("item", (event) => {
@@ -922,10 +916,14 @@ export function InboxPanel({
         return;
       }
       if (typeof itemId !== "number") return;
-      onNudgeRef.current(itemId);
+      // Only the Active view moves on its own — a nudge means something
+      // new is pending, which by definition is not history. Read from
+      // the ref so a tab click does not tear down the connection.
+      if (viewRef.current !== "active") return;
+      void inboxAdapter.getInboxItem({ itemId }).then(applyItem, () => undefined);
     });
     return () => stream.close();
-  }, [inboxAdapter]);
+  }, [applyItem, inboxAdapter]);
 
   function updateSelectedItem(item: AgentChatInboxItem) {
     applyItem(item);
@@ -1050,6 +1048,10 @@ export function InboxPanel({
       </aside>
       {selectedItem ? (
         <InboxDetail
+          // Remount per item: two items of the same kind render the same
+          // component, so without this the previous one's failure message
+          // and half-typed answers carry over to the next.
+          key={selectedItem.id}
           item={selectedItem}
           adapter={inboxAdapter}
           onUpdated={updateSelectedItem}

--- a/sdk/agent-chat-react/src/components/inbox/use-inbox-unread-count.ts
+++ b/sdk/agent-chat-react/src/components/inbox/use-inbox-unread-count.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026, Invergent SA, developed by Flavius Burca
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { AgentChatAdapter, AgentChatInboxEventStream } from "../../types";
 
 export interface InboxUnreadCountState {
@@ -10,64 +10,70 @@ export interface InboxUnreadCountState {
   error: string | null;
 }
 
+/**
+ * How many pending inbox items the user has not opened.
+ *
+ * Re-derived from the list on every signal rather than adjusted in
+ * place: the stream carries "something changed", not a delta, so
+ * counting its nudges only ever pushed the badge up — it never came back
+ * down when the user read, answered or dismissed an item.
+ */
 export function useInboxUnreadCount(
   adapter: AgentChatAdapter,
 ): InboxUnreadCountState {
   const [unreadCount, setUnreadCount] = useState(0);
   const [hasLoaded, setHasLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const requestId = useRef(0);
+
+  const listInbox = adapter.listInbox;
+  const openInboxStream = adapter.openInboxStream;
+
+  const refetch = useCallback(async () => {
+    if (!listInbox) return;
+    const id = ++requestId.current;
+    try {
+      const response = await listInbox({ status: "pending", limit: 200 });
+      if (id !== requestId.current) return;
+      setUnreadCount(response.items.filter((item) => !item.readAt).length);
+      setError(null);
+    } catch (err) {
+      if (id !== requestId.current) return;
+      // Keep the last known count: a transient failure is not "zero".
+      setError(err instanceof Error ? err.message : "Failed to load inbox");
+    } finally {
+      if (id === requestId.current) setHasLoaded(true);
+    }
+  }, [listInbox]);
 
   useEffect(() => {
-    let cancelled = false;
-    let stream: AgentChatInboxEventStream | null = null;
-
-    if (!adapter.listInbox || !adapter.openInboxStream) {
+    if (!listInbox || !openInboxStream) {
       setError("Inbox is not supported by this adapter.");
       setHasLoaded(true);
-      return () => {
-        cancelled = true;
-      };
+      return;
     }
 
-    adapter
-      .listInbox({ status: "pending", limit: 200 })
-      .then((response) => {
-        if (cancelled) return;
-        setUnreadCount(response.items.filter((item) => !item.readAt).length);
-        setHasLoaded(true);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        setError(err instanceof Error ? err.message : "Failed to load inbox");
-        setHasLoaded(true);
-      });
-
+    void refetch();
+    let stream: AgentChatInboxEventStream | null = null;
     try {
-      stream = adapter.openInboxStream();
-      stream.addEventListener("snapshot", (event) => {
-        if (cancelled) return;
-        const payload = JSON.parse(event.data) as { unread_ids?: unknown };
-        const ids = Array.isArray(payload.unread_ids) ? payload.unread_ids : [];
-        setUnreadCount(ids.length);
-        setHasLoaded(true);
-      });
-      stream.addEventListener("item", () => {
-        if (cancelled) return;
-        setUnreadCount((count) => count + 1);
-        setHasLoaded(true);
-      });
-      stream.onerror = () => {
-        if (!cancelled) setError("Inbox stream disconnected.");
-      };
+      stream = openInboxStream();
+      const onChange = () => void refetch();
+      stream.addEventListener("snapshot", onChange);
+      stream.addEventListener("item", onChange);
+      stream.onerror = () => setError("Inbox stream disconnected.");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to open inbox stream");
+      setError(
+        err instanceof Error ? err.message : "Failed to open inbox stream",
+      );
     }
 
     return () => {
-      cancelled = true;
+      // Abandons any refetch still in flight, so a late response cannot
+      // set state after unmount.
+      requestId.current += 1;
       stream?.close();
     };
-  }, [adapter]);
+  }, [listInbox, openInboxStream, refetch]);
 
   return { unreadCount, hasLoaded, error };
 }

--- a/sdk/agent-chat-react/src/types.ts
+++ b/sdk/agent-chat-react/src/types.ts
@@ -446,6 +446,12 @@ export interface AgentChatInboxItem {
   payload: Record<string, unknown>;
   actionRef: Record<string, unknown> | null;
   createdAt: string;
+  /**
+   * When the item stops being actionable, for the kinds that have a
+   * deadline — today only a question, which is answerable while its tool
+   * call is parked waiting. Null when nothing expires.
+   */
+  expiresAt?: string | null;
   updatedAt: string;
   readAt: string | null;
   respondedAt: string | null;

--- a/sdk/agent-chat-react/src/types.ts
+++ b/sdk/agent-chat-react/src/types.ts
@@ -459,7 +459,12 @@ export interface AgentChatInboxList {
 }
 
 export interface AgentChatInboxListInput {
-  status?: AgentChatInboxStatus;
+  /**
+   * A history view needs several statuses at once (acknowledged,
+   * responded and expired), and expired items are invisible to any
+   * request that does not name them.
+   */
+  status?: AgentChatInboxStatus | AgentChatInboxStatus[];
   kind?: AgentChatInboxKind;
   sessionId?: string;
   cursor?: string;

--- a/sdk/agent-chat-react/tests/inbox-adapter-stub.ts
+++ b/sdk/agent-chat-react/tests/inbox-adapter-stub.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// The parts of an adapter the inbox never touches. `AgentChatAdapter`
+// requires them all, and each inbox test file was declaring its own
+// identical set just to satisfy the type.
+
+import { NO_BROWSER_ADAPTER } from "../src/adapter-context";
+import type {
+  AgentChatAdapter,
+  AgentChatArtifactPayload,
+  AgentChatSession,
+  AgentChatSessionList,
+  AgentChatWorkspaceFile,
+  AgentChatWorkspaceTree,
+  AgentChatWorkspaceUpload,
+} from "../src/types";
+
+export function session(
+  input: Partial<AgentChatSession> & { id: string },
+): AgentChatSession {
+  return {
+    status: "completed",
+    title: "Session",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...input,
+  };
+}
+
+export const NON_INBOX_ADAPTER: AgentChatAdapter = {
+  ...NO_BROWSER_ADAPTER,
+  async listSessions(): Promise<AgentChatSessionList> {
+    return { sessions: [], total: 0 };
+  },
+  async createSession() {
+    return session({ id: "created" });
+  },
+  async getSession(input) {
+    return session({ id: input.sessionId });
+  },
+  async sendMessage() {
+    return { eventId: 1, status: "accepted" };
+  },
+  async pauseSession() {},
+  async retrySession(input) {
+    return session({ id: input.sessionId });
+  },
+  async getArtifact(): Promise<AgentChatArtifactPayload> {
+    throw new Error("not used by inbox tests");
+  },
+  async submitAskUserQuestionResponse() {
+    return { eventId: 1 };
+  },
+  async getWorkspaceTree(): Promise<AgentChatWorkspaceTree> {
+    return { root: "workspace", entries: [], truncated: false };
+  },
+  async getWorkspaceFile(): Promise<AgentChatWorkspaceFile> {
+    throw new Error("not used by inbox tests");
+  },
+  async uploadWorkspaceFile(): Promise<AgentChatWorkspaceUpload> {
+    return { path: "uploaded.txt", size: 4 };
+  },
+  async deleteWorkspaceFile() {},
+  getWorkspaceDownloadUrl(input) {
+    return `/api/v1/sessions/${input.sessionId}/workspace/download?path=${encodeURIComponent(input.path)}`;
+  },
+  openEventStream() {
+    throw new Error("not used by inbox tests");
+  },
+};

--- a/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
@@ -204,6 +204,76 @@ describe("InboxPanel lifecycle", () => {
     expect(view.textContent).not.toContain("Brand new");
   });
 
+  it("files an action that lands after a tab switch under the new view", async () => {
+    const items = [
+      inboxItem({ id: 1, title: "Still pending" }),
+      inboxItem({ id: 2, title: "Old news", status: "responded" }),
+    ];
+    let releaseRead: (() => void) | null = null;
+    const harness = createHarness(items, {
+      async markInboxItemRead(input) {
+        await new Promise<void>((resolve) => {
+          releaseRead = resolve;
+        });
+        const item = items.find((candidate) => candidate.id === input.itemId);
+        if (!item) throw new Error("missing item");
+        item.readAt = new Date().toISOString();
+        return item;
+      },
+    });
+    const view = await mount(harness.adapter);
+
+    // Open a pending item, then switch tabs while its read receipt is
+    // still in flight.
+    await click('button[aria-label="Open inbox item Still pending"]');
+    await clickText("history");
+    expect(view.textContent).toContain("Old news");
+
+    await act(async () => {
+      releaseRead?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // A callback holding the view it started in would file this pending
+    // item under History.
+    expect(view.textContent).not.toContain("Still pending");
+  });
+
+  it("keeps an item the stream announced while the first page was loading", async () => {
+    const items = [inboxItem({ id: 1, title: "From the list" })];
+    let releaseList: (() => void) | null = null;
+    let listCalls = 0;
+    const harness = createHarness(items, {
+      async listInbox() {
+        listCalls += 1;
+        if (listCalls === 1) {
+          await new Promise<void>((resolve) => {
+            releaseList = resolve;
+          });
+        }
+        return { items: [items[0]!], nextCursor: null };
+      },
+    });
+    const view = await mount(harness.adapter);
+
+    items.push(inboxItem({ id: 2, title: "Arrived mid-load" }));
+    await act(async () => {
+      harness.emit("item", JSON.stringify({ item_id: 2, kind: "task_complete" }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      releaseList?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The list snapshot predates the nudge, so replacing rather than
+    // merging would drop the item the agent just raised.
+    expect(view.textContent).toContain("Arrived mid-load");
+    expect(view.textContent).toContain("From the list");
+  });
+
   it("ignores a malformed stream frame instead of throwing", async () => {
     const harness = createHarness([inboxItem({ id: 1, title: "First" })]);
     const view = await mount(harness.adapter);

--- a/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
@@ -10,7 +10,6 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { NO_BROWSER_ADAPTER } from "../src/adapter-context";
-import { ANSWER_WINDOW_MS } from "../src/components/inbox/inbox-expiry";
 import { InboxPanel } from "../src/components/inbox/inbox-panel";
 import type {
   AgentChatAdapter,
@@ -298,7 +297,7 @@ describe("InboxPanel lifecycle", () => {
       title: "Which color?",
       payload: { tool_call_id: "tc-1", questions: [{ prompt: "Which color?" }] },
     });
-    stale.createdAt = new Date(Date.now() - ANSWER_WINDOW_MS - 1000).toISOString();
+    stale.expiresAt = new Date(Date.now() - 1000).toISOString();
     const submitted: unknown[] = [];
     const harness = createHarness([stale], {
       async submitAskUserQuestionResponse(input) {

--- a/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
@@ -57,10 +57,14 @@ function createHarness(
   overrides: Partial<AgentChatAdapter> = {},
 ): Harness {
   const listInputs: AgentChatInboxListInput[] = [];
-  const listeners = new Map<
-    string,
-    Array<(event: AgentChatInboxStreamEvent) => void>
-  >();
+  // Listeners belong to one stream instance, and a closed stream
+  // delivers nothing — otherwise a reopened subscription would look like
+  // it still carries the handlers of the one it replaced.
+  interface Subscription {
+    listeners: Map<string, Array<(event: AgentChatInboxStreamEvent) => void>>;
+    closed: boolean;
+  }
+  let live: Subscription | null = null;
   let closes = 0;
 
   const adapter: AgentChatAdapter = {
@@ -135,11 +139,17 @@ function createHarness(
       return item;
     },
     openInboxStream() {
+      const subscription: Subscription = { listeners: new Map(), closed: false };
+      live = subscription;
       return {
         addEventListener(type, listener) {
-          listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+          subscription.listeners.set(type, [
+            ...(subscription.listeners.get(type) ?? []),
+            listener,
+          ]);
         },
         close() {
+          subscription.closed = true;
           closes += 1;
         },
         onerror: null,
@@ -152,7 +162,8 @@ function createHarness(
     adapter,
     listInputs,
     emit: (type, data) => {
-      for (const listener of listeners.get(type) ?? []) listener({ data });
+      if (!live || live.closed) return;
+      for (const listener of live.listeners.get(type) ?? []) listener({ data });
     },
     closed: () => closes,
   };
@@ -213,6 +224,23 @@ describe("InboxPanel lifecycle", () => {
     // brand new one was dropped and the inbox looked empty all day.
     expect(view.textContent).toContain("Arrived later");
     expect(view.textContent).toContain("First");
+  });
+
+  it("does not let a nudge drop a pending item into History", async () => {
+    const items = [inboxItem({ id: 1, title: "Old news", status: "responded" })];
+    const harness = createHarness(items);
+    const view = await mount(harness.adapter);
+    await clickText("history");
+    expect(view.textContent).toContain("Old news");
+
+    items.push(inboxItem({ id: 2, title: "Brand new" }));
+    await act(async () => {
+      harness.emit("item", JSON.stringify({ item_id: 2, kind: "task_complete" }));
+      await Promise.resolve();
+    });
+
+    // Something the agent just raised is the opposite of history.
+    expect(view.textContent).not.toContain("Brand new");
   });
 
   it("ignores a malformed stream frame instead of throwing", async () => {

--- a/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
@@ -9,7 +9,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { NO_BROWSER_ADAPTER } from "../src/adapter-context";
+import { NON_INBOX_ADAPTER } from "./inbox-adapter-stub";
 import { InboxPanel } from "../src/components/inbox/inbox-panel";
 import type {
   AgentChatAdapter,
@@ -67,45 +67,7 @@ function createHarness(
   let closes = 0;
 
   const adapter: AgentChatAdapter = {
-    ...NO_BROWSER_ADAPTER,
-    async listSessions() {
-      return { sessions: [], total: 0 };
-    },
-    async createSession() {
-      throw new Error("not used");
-    },
-    async getSession() {
-      throw new Error("not used");
-    },
-    async sendMessage() {
-      return { eventId: 1, status: "accepted" as const };
-    },
-    async pauseSession() {},
-    async retrySession() {
-      throw new Error("not used");
-    },
-    async getArtifact() {
-      throw new Error("not used");
-    },
-    async submitAskUserQuestionResponse() {
-      return { eventId: 1 };
-    },
-    openEventStream() {
-      throw new Error("not used");
-    },
-    async getWorkspaceTree() {
-      return { root: "workspace", entries: [], truncated: false };
-    },
-    async getWorkspaceFile() {
-      throw new Error("not used");
-    },
-    async uploadWorkspaceFile() {
-      return { path: "uploaded.txt", size: 4 };
-    },
-    async deleteWorkspaceFile() {},
-    getWorkspaceDownloadUrl(input) {
-      return `/api/v1/sessions/${input.sessionId}/workspace/download?path=${encodeURIComponent(input.path)}`;
-    },
+    ...NON_INBOX_ADAPTER,
     async listInbox(input = {}) {
       listInputs.push(input);
       const wanted = [input.status ?? []].flat();

--- a/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
@@ -1,0 +1,318 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// What the inbox owes the user beyond rendering a list: that a new item
+// shows up without a reload, that history is reachable, that a failed
+// action says so, and that a question the agent stopped waiting for
+// cannot be answered into the void.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NO_BROWSER_ADAPTER } from "../src/adapter-context";
+import { ANSWER_WINDOW_MS } from "../src/components/inbox/inbox-expiry";
+import { InboxPanel } from "../src/components/inbox/inbox-panel";
+import type {
+  AgentChatAdapter,
+  AgentChatInboxItem,
+  AgentChatInboxListInput,
+  AgentChatInboxStreamEvent,
+} from "../src/types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+function inboxItem(
+  input: Partial<AgentChatInboxItem> & { id: number },
+): AgentChatInboxItem {
+  const createdAt = new Date().toISOString();
+  return {
+    orgId: "org-1",
+    userId: "user-1",
+    sessionId: "session-1",
+    sourceEventId: input.id,
+    kind: "task_complete",
+    status: "pending",
+    title: `Item ${input.id}`,
+    body: "Body",
+    payload: {},
+    actionRef: null,
+    createdAt,
+    updatedAt: createdAt,
+    readAt: null,
+    respondedAt: null,
+    ...input,
+  };
+}
+
+interface Harness {
+  adapter: AgentChatAdapter;
+  listInputs: AgentChatInboxListInput[];
+  emit: (type: "item" | "snapshot", data: string) => void;
+  closed: () => number;
+}
+
+function createHarness(
+  items: AgentChatInboxItem[],
+  overrides: Partial<AgentChatAdapter> = {},
+): Harness {
+  const listInputs: AgentChatInboxListInput[] = [];
+  const listeners = new Map<
+    string,
+    Array<(event: AgentChatInboxStreamEvent) => void>
+  >();
+  let closes = 0;
+
+  const adapter: AgentChatAdapter = {
+    ...NO_BROWSER_ADAPTER,
+    async listSessions() {
+      return { sessions: [], total: 0 };
+    },
+    async createSession() {
+      throw new Error("not used");
+    },
+    async getSession() {
+      throw new Error("not used");
+    },
+    async sendMessage() {
+      return { eventId: 1, status: "accepted" as const };
+    },
+    async pauseSession() {},
+    async retrySession() {
+      throw new Error("not used");
+    },
+    async getArtifact() {
+      throw new Error("not used");
+    },
+    async submitAskUserQuestionResponse() {
+      return { eventId: 1 };
+    },
+    openEventStream() {
+      throw new Error("not used");
+    },
+    async getWorkspaceTree() {
+      return { root: "workspace", entries: [], truncated: false };
+    },
+    async getWorkspaceFile() {
+      throw new Error("not used");
+    },
+    async uploadWorkspaceFile() {
+      return { path: "uploaded.txt", size: 4 };
+    },
+    async deleteWorkspaceFile() {},
+    getWorkspaceDownloadUrl(input) {
+      return `/api/v1/sessions/${input.sessionId}/workspace/download?path=${encodeURIComponent(input.path)}`;
+    },
+    async listInbox(input = {}) {
+      listInputs.push(input);
+      const wanted = [input.status ?? []].flat();
+      const visible = wanted.length
+        ? items.filter((item) => wanted.includes(item.status))
+        : items;
+      return { items: [...visible], nextCursor: null };
+    },
+    async getInboxItem(input) {
+      const item = items.find((candidate) => candidate.id === input.itemId);
+      if (!item) throw new Error("missing item");
+      return item;
+    },
+    async markInboxItemRead(input) {
+      const item = items.find((candidate) => candidate.id === input.itemId);
+      if (!item) throw new Error("missing item");
+      item.readAt = item.readAt ?? new Date().toISOString();
+      return item;
+    },
+    async acknowledgeInboxItem(input) {
+      const item = items.find((candidate) => candidate.id === input.itemId);
+      if (!item) throw new Error("missing item");
+      item.status = "acknowledged";
+      return item;
+    },
+    async respondGovernanceInboxItem(input) {
+      const item = items.find((candidate) => candidate.id === input.itemId);
+      if (!item) throw new Error("missing item");
+      item.status = "responded";
+      return item;
+    },
+    openInboxStream() {
+      return {
+        addEventListener(type, listener) {
+          listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+        },
+        close() {
+          closes += 1;
+        },
+        onerror: null,
+      };
+    },
+    ...overrides,
+  };
+
+  return {
+    adapter,
+    listInputs,
+    emit: (type, data) => {
+      for (const listener of listeners.get(type) ?? []) listener({ data });
+    },
+    closed: () => closes,
+  };
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function mount(adapter: AgentChatAdapter) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(<InboxPanel adapter={adapter} />);
+    await Promise.resolve();
+  });
+  return container;
+}
+
+function click(selector: string) {
+  return act(async () => {
+    container?.querySelector<HTMLButtonElement>(selector)?.click();
+    await Promise.resolve();
+  });
+}
+
+function clickText(text: string) {
+  const button = [
+    ...(container?.querySelectorAll<HTMLButtonElement>("button") ?? []),
+  ].find((candidate) => candidate.textContent?.trim() === text);
+  return act(async () => {
+    button?.click();
+    await Promise.resolve();
+  });
+}
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+  vi.useRealTimers();
+});
+
+describe("InboxPanel lifecycle", () => {
+  it("shows an item the stream announces after the list loaded", async () => {
+    const items = [inboxItem({ id: 1, title: "First" })];
+    const harness = createHarness(items);
+    const view = await mount(harness.adapter);
+
+    items.push(inboxItem({ id: 2, title: "Arrived later" }));
+    await act(async () => {
+      harness.emit("item", JSON.stringify({ item_id: 2, kind: "task_complete" }));
+      await Promise.resolve();
+    });
+
+    // Before, applyItem only replaced rows the list already had, so a
+    // brand new one was dropped and the inbox looked empty all day.
+    expect(view.textContent).toContain("Arrived later");
+    expect(view.textContent).toContain("First");
+  });
+
+  it("ignores a malformed stream frame instead of throwing", async () => {
+    const harness = createHarness([inboxItem({ id: 1, title: "First" })]);
+    const view = await mount(harness.adapter);
+
+    await act(async () => {
+      harness.emit("item", "not json");
+      await Promise.resolve();
+    });
+
+    expect(view.textContent).toContain("First");
+  });
+
+  it("asks for pending in Active and the resolved statuses in History", async () => {
+    const harness = createHarness([
+      inboxItem({ id: 1, title: "Live" }),
+      inboxItem({ id: 2, title: "Gone", status: "expired" }),
+    ]);
+    const view = await mount(harness.adapter);
+
+    expect(harness.listInputs[0]?.status).toEqual(["pending"]);
+    expect(view.textContent).toContain("Live");
+    expect(view.textContent).not.toContain("Gone");
+
+    await clickText("history");
+
+    expect(harness.listInputs[1]?.status).toEqual([
+      "acknowledged",
+      "responded",
+      "expired",
+    ]);
+    expect(view.textContent).toContain("Gone");
+    expect(view.textContent).not.toContain("Live");
+  });
+
+  it("reports a failed acknowledgement instead of silently reverting", async () => {
+    const harness = createHarness([inboxItem({ id: 1, title: "Done" })], {
+      async acknowledgeInboxItem() {
+        throw new Error("server said no");
+      },
+    });
+    const view = await mount(harness.adapter);
+
+    await click('button[aria-label="Open inbox item Done"]');
+    await click('button[aria-label="Acknowledge inbox item"]');
+
+    expect(view.textContent).toContain("server said no");
+  });
+
+  it("refuses to submit a question past its answer window", async () => {
+    const stale = inboxItem({
+      id: 1,
+      kind: "input_required",
+      title: "Which color?",
+      payload: { tool_call_id: "tc-1", questions: [{ prompt: "Which color?" }] },
+    });
+    stale.createdAt = new Date(Date.now() - ANSWER_WINDOW_MS - 1000).toISOString();
+    const submitted: unknown[] = [];
+    const harness = createHarness([stale], {
+      async submitAskUserQuestionResponse(input) {
+        submitted.push(input);
+        return { eventId: 1 };
+      },
+    });
+    const view = await mount(harness.adapter);
+
+    await click('button[aria-label="Open inbox item Which color?"]');
+    const input = container?.querySelector<HTMLInputElement>("input");
+    await act(async () => {
+      if (input) {
+        input.value = "blue";
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+      await Promise.resolve();
+    });
+    await click('button[aria-label="Submit inbox response"]');
+
+    expect(submitted).toEqual([]);
+    expect(view.textContent).toContain("stopped waiting");
+  });
+
+  it("keeps Submit disabled when the payload carries no questions", async () => {
+    const harness = createHarness([
+      inboxItem({
+        id: 1,
+        kind: "input_required",
+        title: "Empty ask",
+        payload: { tool_call_id: "tc-1", questions: [] },
+      }),
+    ]);
+    await mount(harness.adapter);
+
+    await click('button[aria-label="Open inbox item Empty ask"]');
+    const submit = container?.querySelector<HTMLButtonElement>(
+      'button[aria-label="Submit inbox response"]',
+    );
+
+    // every() is vacuously true on an empty batch, and the server
+    // rejects a submission with no answers in it.
+    expect(submit?.disabled).toBe(true);
+  });
+});

--- a/sdk/agent-chat-react/tests/inbox-panel.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel.test.tsx
@@ -30,10 +30,7 @@ function session(input: Partial<AgentChatSession> & { id: string }): AgentChatSe
 
 function inboxItem(input: Partial<AgentChatInboxItem> & { id: number }): AgentChatInboxItem {
   const { id, ...rest } = input;
-  // Created just now: a question older than the tool's answer window is
-  // no longer submittable, so a fixed date would render every
-  // input_required fixture as already expired.
-  const createdAt = new Date().toISOString();
+  const createdAt = "2026-01-01T00:00:00Z";
   return {
     id,
     orgId: "org-1",

--- a/sdk/agent-chat-react/tests/inbox-panel.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel.test.tsx
@@ -30,6 +30,10 @@ function session(input: Partial<AgentChatSession> & { id: string }): AgentChatSe
 
 function inboxItem(input: Partial<AgentChatInboxItem> & { id: number }): AgentChatInboxItem {
   const { id, ...rest } = input;
+  // Created just now: a question older than the tool's answer window is
+  // no longer submittable, so a fixed date would render every
+  // input_required fixture as already expired.
+  const createdAt = new Date().toISOString();
   return {
     id,
     orgId: "org-1",
@@ -42,8 +46,8 @@ function inboxItem(input: Partial<AgentChatInboxItem> & { id: number }): AgentCh
     body: "All done.",
     payload: { outcome: "success", duration_seconds: 90 },
     actionRef: null,
-    createdAt: "2026-01-01T00:00:00Z",
-    updatedAt: "2026-01-01T00:00:00Z",
+    createdAt,
+    updatedAt: createdAt,
     readAt: null,
     respondedAt: null,
     ...rest,
@@ -476,7 +480,7 @@ describe("InboxPanel", () => {
 
     expect(deleted).toEqual([5]);
     expect(container.textContent).not.toContain("Need account");
-    expect(container.textContent).toContain("No inbox items");
+    expect(container.textContent).toContain("Nothing needs you right now");
     expect(container.textContent).toContain("Select an item");
   });
 
@@ -636,7 +640,7 @@ describe("InboxPanel", () => {
 
     expect(deleted).toEqual([4]);
     expect(container.textContent).not.toContain("Old notification");
-    expect(container.textContent).toContain("No inbox items");
+    expect(container.textContent).toContain("Nothing needs you right now");
     expect(container.textContent).toContain("Select an item");
   });
 });

--- a/sdk/agent-chat-react/tests/inbox-panel.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel.test.tsx
@@ -1,32 +1,16 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it } from "vitest";
-import { NO_BROWSER_ADAPTER } from "../src/adapter-context";
+import { NON_INBOX_ADAPTER } from "./inbox-adapter-stub";
 import { InboxPanel } from "../src/components/inbox/inbox-panel";
 import type {
   AgentChatAdapter,
-  AgentChatArtifactPayload,
   AgentChatInboxItem,
   AgentChatInboxList,
-  AgentChatSession,
-  AgentChatSessionList,
-  AgentChatWorkspaceFile,
-  AgentChatWorkspaceTree,
-  AgentChatWorkspaceUpload,
 } from "../src/types";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
-
-function session(input: Partial<AgentChatSession> & { id: string }): AgentChatSession {
-  return {
-    status: "completed",
-    title: "Session",
-    createdAt: "2026-01-01T00:00:00Z",
-    updatedAt: "2026-01-01T00:00:00Z",
-    ...input,
-  };
-}
 
 function inboxItem(input: Partial<AgentChatInboxItem> & { id: number }): AgentChatInboxItem {
   const { id, ...rest } = input;
@@ -53,45 +37,7 @@ function inboxItem(input: Partial<AgentChatInboxItem> & { id: number }): AgentCh
 
 function createAdapter(items: AgentChatInboxItem[]): AgentChatAdapter {
   return {
-    ...NO_BROWSER_ADAPTER,
-    async listSessions(): Promise<AgentChatSessionList> {
-      return { sessions: [], total: 0 };
-    },
-    async createSession() {
-      return session({ id: "created" });
-    },
-    async getSession(input) {
-      return session({ id: input.sessionId });
-    },
-    async sendMessage() {
-      return { eventId: 1, status: "accepted" };
-    },
-    async pauseSession() {},
-    async retrySession(input) {
-      return session({ id: input.sessionId });
-    },
-    async getArtifact(): Promise<AgentChatArtifactPayload> {
-      throw new Error("not used by inbox tests");
-    },
-    async submitAskUserQuestionResponse() {
-      return { eventId: 1 };
-    },
-    async getWorkspaceTree(): Promise<AgentChatWorkspaceTree> {
-      return { root: "workspace", entries: [], truncated: false };
-    },
-    async getWorkspaceFile(): Promise<AgentChatWorkspaceFile> {
-      throw new Error("not used by inbox tests");
-    },
-    async uploadWorkspaceFile(): Promise<AgentChatWorkspaceUpload> {
-      return { path: "uploaded.txt", size: 4 };
-    },
-    async deleteWorkspaceFile() {},
-    getWorkspaceDownloadUrl(input) {
-      return `/api/v1/sessions/${input.sessionId}/workspace/download?path=${encodeURIComponent(input.path)}`;
-    },
-    openEventStream() {
-      throw new Error("not used by inbox tests");
-    },
+    ...NON_INBOX_ADAPTER,
     async listInbox(): Promise<AgentChatInboxList> {
       return { items, nextCursor: null };
     },

--- a/sdk/agent-chat-react/tests/inbox-unread-count.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-unread-count.test.tsx
@@ -1,0 +1,184 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// The unread badge. The stream says "something changed", never how much,
+// so the count has to come back from the list every time — counting
+// nudges only ever pushed the number up.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { NO_BROWSER_ADAPTER } from "../src/adapter-context";
+import { useInboxUnreadCount } from "../src/components/inbox/use-inbox-unread-count";
+import type {
+  AgentChatAdapter,
+  AgentChatInboxItem,
+  AgentChatInboxListInput,
+  AgentChatInboxStreamEvent,
+} from "../src/types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+function inboxItem(id: number, readAt: string | null): AgentChatInboxItem {
+  return {
+    id,
+    orgId: "org-1",
+    userId: "user-1",
+    sessionId: "session-1",
+    sourceEventId: id,
+    kind: "task_complete",
+    status: "pending",
+    title: `Item ${id}`,
+    body: null,
+    payload: {},
+    actionRef: null,
+    createdAt: "2026-08-01T00:00:00Z",
+    updatedAt: "2026-08-01T00:00:00Z",
+    readAt,
+    respondedAt: null,
+  };
+}
+
+function createHarness(pages: AgentChatInboxItem[][]) {
+  const listInputs: AgentChatInboxListInput[] = [];
+  const listeners = new Map<
+    string,
+    Array<(event: AgentChatInboxStreamEvent) => void>
+  >();
+  let closes = 0;
+  let failure: Error | null = null;
+
+  const adapter = {
+    ...NO_BROWSER_ADAPTER,
+    async listInbox(input: AgentChatInboxListInput = {}) {
+      listInputs.push(input);
+      if (failure) throw failure;
+      const items = pages.length > 1 ? pages.shift() : pages[0];
+      return { items: items ?? [], nextCursor: null };
+    },
+    openInboxStream() {
+      return {
+        addEventListener(
+          type: string,
+          listener: (event: AgentChatInboxStreamEvent) => void,
+        ) {
+          listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+        },
+        close() {
+          closes += 1;
+        },
+        onerror: null,
+      };
+    },
+  } as unknown as AgentChatAdapter;
+
+  return {
+    adapter,
+    listInputs,
+    emit: (type: "item" | "snapshot", data: string) => {
+      for (const listener of listeners.get(type) ?? []) listener({ data });
+    },
+    failWith: (error: Error | null) => {
+      failure = error;
+    },
+    closed: () => closes,
+  };
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function Probe({ adapter }: { adapter: AgentChatAdapter }) {
+  const { unreadCount } = useInboxUnreadCount(adapter);
+  return <span data-testid="count">{unreadCount}</span>;
+}
+
+async function mount(adapter: AgentChatAdapter) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(<Probe adapter={adapter} />);
+    await Promise.resolve();
+  });
+  return () => container?.textContent;
+}
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+describe("useInboxUnreadCount", () => {
+  it("counts pending items the user has not opened", async () => {
+    const harness = createHarness([
+      [inboxItem(1, null), inboxItem(2, "2026-08-01T01:00:00Z")],
+    ]);
+    const count = await mount(harness.adapter);
+
+    expect(count()).toBe("1");
+    expect(harness.listInputs[0]?.status).toBe("pending");
+  });
+
+  it("goes back down when a nudge follows the user reading an item", async () => {
+    const harness = createHarness([
+      [inboxItem(1, null), inboxItem(2, null)],
+      [inboxItem(1, "2026-08-01T01:00:00Z"), inboxItem(2, null)],
+    ]);
+    const count = await mount(harness.adapter);
+    expect(count()).toBe("2");
+
+    await act(async () => {
+      harness.emit("item", JSON.stringify({ item_id: 1, kind: "task_complete" }));
+      await Promise.resolve();
+    });
+
+    // Incrementing on the nudge would say 3 here, and would keep saying
+    // 3 no matter what the user did next.
+    expect(count()).toBe("1");
+  });
+
+  it("re-derives on the snapshot rather than trusting its length", async () => {
+    const harness = createHarness([
+      [inboxItem(1, null)],
+      [inboxItem(1, null), inboxItem(2, null), inboxItem(3, null)],
+    ]);
+    const count = await mount(harness.adapter);
+    expect(count()).toBe("1");
+
+    await act(async () => {
+      harness.emit("snapshot", JSON.stringify({ unread_ids: [1, 2, 3, 4, 5] }));
+      await Promise.resolve();
+    });
+
+    expect(count()).toBe("3");
+  });
+
+  it("keeps the last count when a refetch fails", async () => {
+    const harness = createHarness([[inboxItem(1, null), inboxItem(2, null)]]);
+    const count = await mount(harness.adapter);
+    expect(count()).toBe("2");
+
+    harness.failWith(new Error("offline"));
+    await act(async () => {
+      harness.emit("item", JSON.stringify({ item_id: 9, kind: "task_complete" }));
+      await Promise.resolve();
+    });
+
+    // A failed request is not evidence of an empty inbox.
+    expect(count()).toBe("2");
+  });
+
+  it("closes the stream on unmount", async () => {
+    const harness = createHarness([[]]);
+    await mount(harness.adapter);
+
+    act(() => root?.unmount());
+    root = null;
+
+    expect(harness.closed()).toBe(1);
+  });
+});

--- a/surogates/api/routes/inbox.py
+++ b/surogates/api/routes/inbox.py
@@ -29,6 +29,24 @@ from surogates.tenant.context import TenantContext
 
 router = APIRouter(prefix="/inbox")
 
+_STATUSES = frozenset({"pending", "acknowledged", "responded", "expired"})
+
+
+def _validated_statuses(requested: list[str] | None) -> list[str]:
+    """The requested statuses, rejecting anything that cannot exist.
+
+    An unknown value would otherwise filter everything out and read as an
+    empty inbox rather than as the typo it is.
+    """
+    values = [value for value in (requested or []) if value]
+    unknown = sorted(set(values) - _STATUSES)
+    if unknown:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown inbox status: {', '.join(unknown)}",
+        )
+    return values
+
 
 class InboxResponse(BaseModel):
     decision: str | None = Field(default=None, pattern="^(approve|reject)$")
@@ -142,17 +160,18 @@ async def _wake_session_from_request(request: Request, session_id: UUID) -> None
 async def list_inbox(
     request: Request,
     tenant: Annotated[TenantContext, Depends(get_current_tenant)],
-    status: str | None = Query(default=None),
+    status: list[str] | None = Query(default=None),
     kind: str | None = Query(default=None),
     session_id: str | None = Query(default=None),
     cursor: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
 ):
+    statuses = _validated_statuses(status)
     tenant = _require_user_tenant(tenant)
     store = request.app.state.session_store
     items = await store.list_inbox(
         user_id=tenant.user_id,
-        status=status,
+        status=statuses,
         kind=kind,
         session_id=UUID(session_id) if session_id else None,
         cursor=_decode_cursor(cursor),

--- a/surogates/api/routes/inbox.py
+++ b/surogates/api/routes/inbox.py
@@ -107,7 +107,8 @@ def _serialize_item(item, agent_fields: dict | None = None) -> dict:
     return {
         "id": item.id,
         "org_id": str(item.org_id),
-        "user_id": str(item.user_id),
+        # Null for service-account-owned items; str() would emit "None".
+        "user_id": str(item.user_id) if item.user_id is not None else None,
         "session_id": str(item.session_id),
         "source_event_id": item.source_event_id,
         "kind": item.kind,
@@ -193,14 +194,16 @@ async def stream_inbox(
         pubsub = redis.pubsub()
         try:
             await pubsub.subscribe(channel)
+            # Pending only, matching what the badge counts from the list
+            # endpoint: an unread item the user already acknowledged or
+            # responded to is history, and counting it here made the
+            # badge jump the moment the stream connected.
             snapshot = await asyncio.shield(
-                store.list_inbox(user_id=tenant.user_id, limit=200)
+                store.list_inbox(
+                    user_id=tenant.user_id, status="pending", limit=200,
+                )
             )
-            unread_ids = [
-                item.id
-                for item in snapshot
-                if item.read_at is None and item.status != "expired"
-            ]
+            unread_ids = [item.id for item in snapshot if item.read_at is None]
             yield {
                 "event": "snapshot",
                 "data": json.dumps({"unread_ids": unread_ids}, default=str),

--- a/surogates/api/routes/inbox.py
+++ b/surogates/api/routes/inbox.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-from datetime import datetime
-from typing import Annotated
+from datetime import datetime, timedelta
+from typing import Annotated, Literal
 from uuid import UUID
 
 from fastapi import (
@@ -26,26 +26,16 @@ from surogates.session.events import EventType
 from surogates.session.inbox_payload import ACKNOWLEDGE_ONLY_KINDS
 from surogates.tenant.auth.middleware import get_current_tenant
 from surogates.tenant.context import TenantContext
+from surogates.tools.builtin.ask_user_question import (
+    ASK_USER_QUESTION_MAX_WAIT_SECONDS,
+)
 
 router = APIRouter(prefix="/inbox")
 
-_STATUSES = frozenset({"pending", "acknowledged", "responded", "expired"})
-
-
-def _validated_statuses(requested: list[str] | None) -> list[str]:
-    """The requested statuses, rejecting anything that cannot exist.
-
-    An unknown value would otherwise filter everything out and read as an
-    empty inbox rather than as the typo it is.
-    """
-    values = [value for value in (requested or []) if value]
-    unknown = sorted(set(values) - _STATUSES)
-    if unknown:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Unknown inbox status: {', '.join(unknown)}",
-        )
-    return values
+# Repeat the parameter to ask for several at once. Declared as a literal
+# so an unknown value is rejected by the framework, rather than filtering
+# everything out and reading as an empty inbox.
+InboxStatus = Literal["pending", "acknowledged", "responded", "expired"]
 
 
 class InboxResponse(BaseModel):
@@ -120,6 +110,23 @@ async def _agent_fields_for(request: Request, session_id: UUID) -> dict:
     return fields.get(session_id, {})
 
 
+def _expires_at(item) -> str | None:
+    """When a question stops being answerable, or None if it does not.
+
+    Only a question has a deadline: it is answerable while the tool call
+    that asked it is parked waiting, and that wait is capped. Computed
+    here so the one place that knows the cap is the one that owns it —
+    every client used to mirror the constant, and a mirror is only
+    correct until someone changes the original.
+    """
+    if item.kind != "input_required":
+        return None
+    deadline = item.created_at + timedelta(
+        seconds=ASK_USER_QUESTION_MAX_WAIT_SECONDS
+    )
+    return deadline.isoformat()
+
+
 def _serialize_item(item, agent_fields: dict | None = None) -> dict:
     fields = agent_fields or {}
     return {
@@ -136,6 +143,7 @@ def _serialize_item(item, agent_fields: dict | None = None) -> dict:
         "payload": item.payload,
         "action_ref": item.action_ref,
         "created_at": item.created_at.isoformat(),
+        "expires_at": _expires_at(item),
         "updated_at": item.updated_at.isoformat(),
         "read_at": item.read_at.isoformat() if item.read_at else None,
         "responded_at": item.responded_at.isoformat()
@@ -160,18 +168,17 @@ async def _wake_session_from_request(request: Request, session_id: UUID) -> None
 async def list_inbox(
     request: Request,
     tenant: Annotated[TenantContext, Depends(get_current_tenant)],
-    status: list[str] | None = Query(default=None),
+    status: list[InboxStatus] | None = Query(default=None),
     kind: str | None = Query(default=None),
     session_id: str | None = Query(default=None),
     cursor: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
 ):
-    statuses = _validated_statuses(status)
     tenant = _require_user_tenant(tenant)
     store = request.app.state.session_store
     items = await store.list_inbox(
         user_id=tenant.user_id,
-        status=statuses,
+        status=status or [],
         kind=kind,
         session_id=UUID(session_id) if session_id else None,
         cursor=_decode_cursor(cursor),

--- a/surogates/db/inbox_principal.sql
+++ b/surogates/db/inbox_principal.sql
@@ -21,3 +21,13 @@ END $$;
 -- status, ordered by created_at), mirroring idx_inbox_user_status_created.
 CREATE INDEX IF NOT EXISTS idx_inbox_sa_status_created
     ON inbox_items (service_account_id, status, created_at);
+
+-- The expiry sweeper's working set. Every other index here is led by a
+-- principal, so its "pending items, by kind and age" pass had to read the
+-- whole table every 300s — on a table that only ever grows, since inbox rows
+-- are kept as history. Partial on status because pending is the small,
+-- shrinking minority of rows, which also keeps the write cost near zero:
+-- an entry is added when an item is created and removed when it is resolved.
+CREATE INDEX IF NOT EXISTS idx_inbox_pending_kind_created
+    ON inbox_items (kind, created_at)
+    WHERE status = 'pending';

--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -496,6 +496,16 @@ class InboxItem(Base):
         ),
         Index("idx_inbox_org_created", "org_id", "created_at"),
         Index("idx_inbox_session", "session_id"),
+        # The expiry sweeper's working set — pending items by kind and
+        # age. Partial because pending is the small minority of a table
+        # that only grows; see inbox_principal.sql, which retrofits it
+        # onto databases that already exist.
+        Index(
+            "idx_inbox_pending_kind_created",
+            "kind",
+            "created_at",
+            postgresql_where=text("status = 'pending'"),
+        ),
         CheckConstraint(
             "(user_id IS NOT NULL)::int + (service_account_id IS NOT NULL)::int = 1",
             name="ck_inbox_items_one_principal",

--- a/surogates/jobs/inbox_expire.py
+++ b/surogates/jobs/inbox_expire.py
@@ -1,10 +1,14 @@
 """Background job for expiring stale inbox items.
 
 Pending inbox items are actionable only while something is still waiting to
-consume the user's response. Two things end that wait: the owning session
-going terminal, and — for a question — the blocked tool call giving up. Past
-either point the item stays in the history but must stop presenting itself as
-actionable, or the user submits an answer no one reads.
+consume the user's response. Past that point the item stays in the history but
+must stop presenting itself as actionable, or the user submits an answer no one
+reads.
+
+A question is normally retired by the tool that asked it, at the moment it
+gives up (see :func:`surogates.session.interactive_input.expire_input_request`).
+This sweeper covers what that cannot: sessions that went terminal, and rows
+orphaned by a worker that died before it could clean up after itself.
 """
 
 from __future__ import annotations
@@ -55,11 +59,12 @@ async def expire_inbox_items(session_store) -> int:
                         # expiring on a terminal session.
                         InboxItem.kind.notin_(ACKNOWLEDGE_ONLY_KINDS),
                     ),
-                    # A question outlives its tool call on a session that
-                    # is still running: the tool returned a timeout to the
-                    # LLM and the turn moved on, but nothing else clears
-                    # the row. Compared against the database clock, which
-                    # is the one that stamped created_at.
+                    # The backstop for a question whose tool never got to
+                    # retire its own row — a worker killed mid-wait leaves
+                    # one behind, and on a session that is still running
+                    # nothing else would ever clear it. Compared against
+                    # the database clock, which is the one that stamped
+                    # created_at.
                     and_(
                         InboxItem.kind == "input_required",
                         InboxItem.created_at < func.now() - answer_window,

--- a/surogates/jobs/inbox_expire.py
+++ b/surogates/jobs/inbox_expire.py
@@ -1,40 +1,70 @@
 """Background job for expiring stale inbox items.
 
-Pending inbox items are actionable only while their owning session can still
-consume a user response. Once the session is terminal, the item stays in the
-history but should no longer appear as actionable.
+Pending inbox items are actionable only while something is still waiting to
+consume the user's response. Two things end that wait: the owning session
+going terminal, and — for a question — the blocked tool call giving up. Past
+either point the item stays in the history but must stop presenting itself as
+actionable, or the user submits an answer no one reads.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import timedelta
 
-from sqlalchemy import func, select, update
+from sqlalchemy import and_, func, or_, select, update
 
 from surogates.db.models import InboxItem, Session
 from surogates.session.inbox_payload import ACKNOWLEDGE_ONLY_KINDS
+from surogates.tools.builtin.ask_user_question import (
+    ASK_USER_QUESTION_MAX_WAIT_SECONDS,
+)
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_SWEEP_INTERVAL_SECONDS = 300.0
 _TERMINAL_SESSION_STATUSES = frozenset({"completed", "failed", "archived"})
 
+# Added to the tool's own wait before a question is considered dead. The row
+# is stamped by the database while the tool counts down on the worker's
+# monotonic clock, so the two disagree by whatever skew exists between them.
+# Erring long only leaves a dead question listed a minute longer; erring short
+# would expire one a live tool could still consume.
+_ANSWER_WINDOW_GRACE_SECONDS = 60
+
 
 async def expire_inbox_items(session_store) -> int:
-    """Expire pending inbox items whose sessions are terminal."""
+    """Expire pending inbox items that can no longer be acted on."""
     terminal_sessions = select(Session.id).where(
         Session.status.in_(_TERMINAL_SESSION_STATUSES)
+    )
+    answer_window = timedelta(
+        seconds=ASK_USER_QUESTION_MAX_WAIT_SECONDS + _ANSWER_WINDOW_GRACE_SECONDS
     )
     async with session_store._sf() as db:
         result = await db.execute(
             update(InboxItem)
             .where(
                 InboxItem.status == "pending",
-                InboxItem.session_id.in_(terminal_sessions),
-                # Acknowledge-only kinds are informational; they persist until
-                # read/acknowledged rather than expiring on a terminal session.
-                InboxItem.kind.notin_(ACKNOWLEDGE_ONLY_KINDS),
+                or_(
+                    and_(
+                        InboxItem.session_id.in_(terminal_sessions),
+                        # Acknowledge-only kinds are informational; they
+                        # persist until read/acknowledged rather than
+                        # expiring on a terminal session.
+                        InboxItem.kind.notin_(ACKNOWLEDGE_ONLY_KINDS),
+                    ),
+                    # A question outlives its tool call on a session that
+                    # is still running: the tool returned a timeout to the
+                    # LLM and the turn moved on, but nothing else clears
+                    # the row. Compared against the database clock, which
+                    # is the one that stamped created_at.
+                    and_(
+                        InboxItem.kind == "input_required",
+                        InboxItem.created_at < func.now() - answer_window,
+                    ),
+                ),
             )
             .values(
                 status="expired",
@@ -46,7 +76,7 @@ async def expire_inbox_items(session_store) -> int:
         await db.commit()
 
     if ids:
-        logger.info("Expired %d inbox item(s) for terminal sessions", len(ids))
+        logger.info("Expired %d inbox item(s)", len(ids))
     return len(ids)
 
 

--- a/surogates/session/interactive_input.py
+++ b/surogates/session/interactive_input.py
@@ -258,6 +258,40 @@ async def resolve_input_response(
         raise
 
 
+async def expire_input_request(
+    store,
+    *,
+    session_id,
+    tool_call_id: str,
+) -> bool:
+    """Retire the pending row for a question nobody is waiting on.
+
+    Called when the blocked tool gives up — a timeout, or a session that
+    was paused or completed under it. Until then the row is the only
+    thing standing between a user and an answer that would be recorded
+    with no consumer, and the tool is the one that knows the exact
+    moment: the sweeper's periodic pass is a backstop for the case where
+    the worker died without reaching this call, not the primary path.
+    """
+    tc_id = valid_tool_call_id(tool_call_id)
+    if tc_id is None:
+        return False
+
+    async with store._sf() as db:
+        result = await db.execute(
+            update(InboxItem)
+            .where(
+                InboxItem.session_id == session_id,
+                InboxItem.kind == "input_required",
+                InboxItem.action_ref["tool_call_id"].as_string() == tc_id,
+                InboxItem.status == "pending",
+            )
+            .values(status="expired", updated_at=func.now()),
+        )
+        await db.commit()
+    return bool(getattr(result, "rowcount", 0))
+
+
 async def response_event_exists(
     store,
     *,

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
@@ -1423,17 +1424,21 @@ class SessionStore:
         self,
         *,
         user_id: UUID,
-        status: str | None = None,
+        status: str | Sequence[str] | None = None,
         kind: str | None = None,
         session_id: UUID | None = None,
         cursor: tuple[datetime, int] | None = None,
         limit: int = 50,
     ) -> list[InboxItem]:
-        stmt = select(InboxItem).where(InboxItem.user_id == user_id)
-        if status:
-            stmt = stmt.where(InboxItem.status == status)
+        # A history view wants several statuses at once (acknowledged,
+        # responded and expired), so the filter takes a set as readily as
+        # a single value. Without one, expired items stay hidden.
+        statuses = [status] if isinstance(status, str) else list(status or ())
+        if statuses:
+            stmt = select(InboxItem).where(InboxItem.status.in_(statuses))
         else:
-            stmt = stmt.where(InboxItem.status != "expired")
+            stmt = select(InboxItem).where(InboxItem.status != "expired")
+        stmt = stmt.where(InboxItem.user_id == user_id)
         if kind:
             stmt = stmt.where(InboxItem.kind == kind)
         if session_id:

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -1434,11 +1434,11 @@ class SessionStore:
         # responded and expired), so the filter takes a set as readily as
         # a single value. Without one, expired items stay hidden.
         statuses = [status] if isinstance(status, str) else list(status or ())
+        stmt = select(InboxItem).where(InboxItem.user_id == user_id)
         if statuses:
-            stmt = select(InboxItem).where(InboxItem.status.in_(statuses))
+            stmt = stmt.where(InboxItem.status.in_(statuses))
         else:
-            stmt = select(InboxItem).where(InboxItem.status != "expired")
-        stmt = stmt.where(InboxItem.user_id == user_id)
+            stmt = stmt.where(InboxItem.status != "expired")
         if kind:
             stmt = stmt.where(InboxItem.kind == kind)
         if session_id:

--- a/surogates/tools/builtin/ask_user_question.py
+++ b/surogates/tools/builtin/ask_user_question.py
@@ -31,6 +31,7 @@ from typing import Any
 from uuid import UUID
 
 from surogates.session.events import EventType
+from surogates.session.interactive_input import expire_input_request
 from surogates.tools.registry import ToolRegistry, ToolSchema
 
 logger = logging.getLogger(__name__)
@@ -363,6 +364,20 @@ async def _ask_user_question_handler(arguments: dict[str, Any], **kwargs: Any) -
     )
 
     if outcome.get("cancelled"):
+        # Nothing is waiting on the answer any more, so the inbox item
+        # stops offering to take one. Best-effort: the sweeper catches a
+        # row left behind by a worker that died before getting here.
+        try:
+            await expire_input_request(
+                session_store,
+                session_id=session_id,
+                tool_call_id=str(tool_call_id),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to expire the inbox item for ask_user_question %s",
+                tool_call_id, exc_info=True,
+            )
         return json.dumps(
             {
                 "cancelled": True,

--- a/tests/integration/test_inbox_api.py
+++ b/tests/integration/test_inbox_api.py
@@ -512,6 +512,31 @@ async def test_respond_rejects_non_governance_kind(
     assert response.status_code == 409
 
 
+def _finite_event_source(stop_on: str):
+    """Turn the route's endless SSE generator into one that stops.
+
+    The test client drains a response fully before handing it back, and
+    an inbox stream is designed never to end.
+    """
+
+    def factory(generator):
+        async def limited_stream():
+            async for event in generator:
+                if "event" not in event:
+                    continue
+                yield f"event: {event['event']}\n"
+                yield f"data: {event['data']}\n\n"
+                if event["event"] == stop_on:
+                    break
+
+        return StreamingResponse(
+            limited_stream(),
+            media_type="text/event-stream",
+        )
+
+    return factory
+
+
 async def test_sse_stream_emits_snapshot_and_nudge_for_new_item(
     client,
     app,
@@ -524,24 +549,9 @@ async def test_sse_stream_emits_snapshot_and_nudge_for_new_item(
     )
     headers = {"Authorization": f"Bearer {token}"}
 
-    def finite_event_source(generator):
-        async def limited_stream():
-            async for event in generator:
-                if "event" not in event:
-                    continue
-                yield f"event: {event['event']}\n"
-                yield f"data: {event['data']}\n\n"
-                if event["event"] == "item":
-                    break
-
-        return StreamingResponse(
-            limited_stream(),
-            media_type="text/event-stream",
-        )
-
     monkeypatch.setattr(
         "surogates.api.routes.inbox.EventSourceResponse",
-        finite_event_source,
+        _finite_event_source("item"),
         raising=False,
     )
 
@@ -598,24 +608,9 @@ async def test_sse_snapshot_counts_only_pending_unread(
         new_status="acknowledged",
     )
 
-    def finite_event_source(generator):
-        async def limited_stream():
-            async for event in generator:
-                if "event" not in event:
-                    continue
-                yield f"event: {event['event']}\n"
-                yield f"data: {event['data']}\n\n"
-                if event["event"] == "snapshot":
-                    break
-
-        return StreamingResponse(
-            limited_stream(),
-            media_type="text/event-stream",
-        )
-
     monkeypatch.setattr(
         "surogates.api.routes.inbox.EventSourceResponse",
-        finite_event_source,
+        _finite_event_source("snapshot"),
         raising=False,
     )
 

--- a/tests/integration/test_inbox_api.py
+++ b/tests/integration/test_inbox_api.py
@@ -339,7 +339,7 @@ async def test_list_rejects_an_unknown_status(
     )
 
     assert response.status_code == 422, response.text
-    assert "nonsense" in response.json()["detail"]
+    assert "nonsense" in response.text
 
 
 async def test_delete_other_users_item_returns_404(

--- a/tests/integration/test_inbox_api.py
+++ b/tests/integration/test_inbox_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import uuid
 from uuid import UUID
@@ -519,6 +520,65 @@ async def test_sse_stream_emits_snapshot_and_nudge_for_new_item(
     assert "event: snapshot" in response.text
     assert "event: item" in response.text
     assert "task_complete" in response.text
+
+
+async def test_sse_snapshot_counts_only_pending_unread(
+    client,
+    app,
+    session_factory,
+    monkeypatch,
+):
+    """The badge derives from pending items, so the snapshot it seeds must
+    agree — counting unread items the user already dealt with made the
+    number jump the moment the stream connected."""
+    store = app.state.session_store
+    _, user_id, token, session = await _create_user_token_session(
+        session_factory,
+        store,
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+
+    still_pending = await _emit_task_complete(store, session.id)
+    already_handled = await _emit_task_complete(store, session.id)
+    await store.set_inbox_status(
+        item_id=already_handled.id,
+        user_id=user_id,
+        new_status="acknowledged",
+    )
+
+    def finite_event_source(generator):
+        async def limited_stream():
+            async for event in generator:
+                if "event" not in event:
+                    continue
+                yield f"event: {event['event']}\n"
+                yield f"data: {event['data']}\n\n"
+                if event["event"] == "snapshot":
+                    break
+
+        return StreamingResponse(
+            limited_stream(),
+            media_type="text/event-stream",
+        )
+
+    monkeypatch.setattr(
+        "surogates.api.routes.inbox.EventSourceResponse",
+        finite_event_source,
+        raising=False,
+    )
+
+    async with asyncio.timeout(5):
+        response = await client.get("/v1/inbox/stream", headers=headers)
+
+    assert response.status_code == 200, response.text
+    snapshot = json.loads(
+        next(
+            line[len("data: "):]
+            for line in response.text.splitlines()
+            if line.startswith("data: ")
+        )
+    )
+    assert snapshot["unread_ids"] == [still_pending.id]
 
 
 class _FakeRuntimeCache:

--- a/tests/integration/test_inbox_api.py
+++ b/tests/integration/test_inbox_api.py
@@ -290,6 +290,58 @@ async def test_delete_inbox_item_expires_and_hides_item(
     assert row.responded_at is not None
 
 
+async def test_list_accepts_several_statuses_at_once(
+    client,
+    session_factory,
+    session_store,
+):
+    """A history view asks for everything the user is done with, which
+    spans three statuses — and expired items are invisible to any request
+    that does not name them."""
+    _, user_id, token, session = await _create_user_token_session(
+        session_factory,
+        session_store,
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+    still_pending = await _emit_task_complete(session_store, session.id)
+    acknowledged = await _emit_task_complete(session_store, session.id)
+    hidden = await _emit_task_complete(session_store, session.id)
+    await session_store.set_inbox_status(
+        item_id=acknowledged.id, user_id=user_id, new_status="acknowledged",
+    )
+    await session_store.delete_inbox_item(item_id=hidden.id, user_id=user_id)
+
+    response = await client.get(
+        "/v1/inbox?status=acknowledged&status=responded&status=expired",
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    returned = {row["id"] for row in response.json()["items"]}
+    assert returned == {acknowledged.id, hidden.id}
+    assert still_pending.id not in returned
+
+
+async def test_list_rejects_an_unknown_status(
+    client,
+    session_factory,
+    session_store,
+):
+    """Silently returning nothing would read as an empty inbox."""
+    _, _, token, _ = await _create_user_token_session(
+        session_factory,
+        session_store,
+    )
+
+    response = await client.get(
+        "/v1/inbox?status=pending&status=nonsense",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 422, response.text
+    assert "nonsense" in response.json()["detail"]
+
+
 async def test_delete_other_users_item_returns_404(
     client,
     session_factory,

--- a/tests/integration/test_inbox_expire.py
+++ b/tests/integration/test_inbox_expire.py
@@ -82,6 +82,43 @@ async def _backdate_inbox_items(session_store, session_id, *, seconds: float):
         await db.commit()
 
 
+async def test_tool_retires_its_own_row_when_it_gives_up(
+    session_factory,
+    session_store,
+):
+    """The tool knows the exact moment it stops waiting; leaving that to
+    the periodic sweep would leave the question offering to take an
+    answer for up to another sweep interval."""
+    from surogates.session.interactive_input import expire_input_request
+
+    session = await _create_user_session(session_factory, session_store)
+    await session_store.emit_event(
+        session.id,
+        EventType.INBOX_INPUT_REQUIRED,
+        {
+            "tool_call_id": "tc-gave-up",
+            "questions": [{"prompt": "Continue?"}],
+            "context": "",
+        },
+    )
+
+    retired = await expire_input_request(
+        session_store, session_id=session.id, tool_call_id="tc-gave-up",
+    )
+    item = await _get_inbox_item_for_session(session_store, session.id)
+
+    assert retired is True
+    assert item.status == "expired"
+    # The row was already claimed by an answer, so there is nothing to
+    # retire and the caller learns it lost the race.
+    assert (
+        await expire_input_request(
+            session_store, session_id=session.id, tool_call_id="tc-gave-up",
+        )
+        is False
+    )
+
+
 async def test_sweeper_expires_questions_past_the_answer_window(
     session_factory,
     session_store,

--- a/tests/integration/test_inbox_expire.py
+++ b/tests/integration/test_inbox_expire.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from sqlalchemy import select, update
 
 from surogates.db.models import InboxItem, Session
-from surogates.jobs.inbox_expire import expire_inbox_items
+from surogates.jobs.inbox_expire import (
+    _ANSWER_WINDOW_GRACE_SECONDS,
+    expire_inbox_items,
+)
 from surogates.session.events import EventType
+from surogates.tools.builtin.ask_user_question import (
+    ASK_USER_QUESTION_MAX_WAIT_SECONDS,
+)
 
 from .conftest import create_org, create_user
 
@@ -60,6 +68,103 @@ async def test_sweeper_expires_pending_items_for_terminal_sessions(
 
     assert expired_count >= 1
     assert item.status == "expired"
+
+
+async def _backdate_inbox_items(session_store, session_id, *, seconds: float):
+    async with session_store._sf() as db:
+        await db.execute(
+            update(InboxItem)
+            .where(InboxItem.session_id == session_id)
+            .values(
+                created_at=datetime.now(timezone.utc) - timedelta(seconds=seconds)
+            )
+        )
+        await db.commit()
+
+
+async def test_sweeper_expires_questions_past_the_answer_window(
+    session_factory,
+    session_store,
+):
+    """The blocked tool gives up after its wait window even though the
+    session keeps running, so nothing is left to consume an answer."""
+    session = await _create_user_session(session_factory, session_store)
+    await session_store.emit_event(
+        session.id,
+        EventType.INBOX_INPUT_REQUIRED,
+        {
+            "tool_call_id": "tc-timed-out",
+            "questions": [{"prompt": "Continue?"}],
+            "context": "",
+        },
+    )
+    await _backdate_inbox_items(
+        session_store,
+        session.id,
+        seconds=ASK_USER_QUESTION_MAX_WAIT_SECONDS
+        + _ANSWER_WINDOW_GRACE_SECONDS
+        + 60,
+    )
+
+    expired_count = await expire_inbox_items(session_store)
+    item = await _get_inbox_item_for_session(session_store, session.id)
+
+    assert expired_count == 1
+    assert item.status == "expired"
+
+
+async def test_sweeper_keeps_questions_inside_the_answer_window(
+    session_factory,
+    session_store,
+):
+    """Skew between the worker's clock and the database's must not expire
+    a question the tool is still parked on."""
+    session = await _create_user_session(session_factory, session_store)
+    await session_store.emit_event(
+        session.id,
+        EventType.INBOX_INPUT_REQUIRED,
+        {
+            "tool_call_id": "tc-still-waiting",
+            "questions": [{"prompt": "Continue?"}],
+            "context": "",
+        },
+    )
+    await _backdate_inbox_items(
+        session_store,
+        session.id,
+        seconds=ASK_USER_QUESTION_MAX_WAIT_SECONDS - 60,
+    )
+
+    expired_count = await expire_inbox_items(session_store)
+    item = await _get_inbox_item_for_session(session_store, session.id)
+
+    assert expired_count == 0
+    assert item.status == "pending"
+
+
+async def test_answer_window_does_not_expire_other_kinds(
+    session_factory,
+    session_store,
+):
+    """Only a question has a deadline: an action or a gate stays actionable
+    for as long as its session can still wake and consume the response."""
+    session = await _create_user_session(session_factory, session_store)
+    await session_store.emit_event(
+        session.id,
+        EventType.INBOX_ACTION_REQUIRED,
+        {"instructions": "Sign in", "action_type": "browser"},
+    )
+    await _backdate_inbox_items(
+        session_store,
+        session.id,
+        seconds=ASK_USER_QUESTION_MAX_WAIT_SECONDS * 10,
+    )
+
+    expired_count = await expire_inbox_items(session_store)
+    item = await _get_inbox_item_for_session(session_store, session.id)
+
+    assert expired_count == 0
+    assert item.status == "pending"
 
 
 async def test_sweeper_does_not_touch_active_sessions(

--- a/tests/test_inbox_serialize.py
+++ b/tests/test_inbox_serialize.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Invergent SA, developed by Flavius Burca
 # SPDX-License-Identifier: AGPL-3.0-only
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -24,6 +24,28 @@ def test_serialize_item_includes_agent_fields():
     out = _serialize_item(_item(sid), {"agent_id": "agent-x", "agent_slug": "agent-x-slug"})
     assert out["agent_id"] == "agent-x"
     assert out["agent_slug"] == "agent-x-slug"
+
+
+def test_serialize_item_dates_a_question_by_the_tools_wait():
+    """The answer window is the server's rule; clients read it rather
+    than each mirroring the constant."""
+    from surogates.tools.builtin.ask_user_question import (
+        ASK_USER_QUESTION_MAX_WAIT_SECONDS,
+    )
+
+    item = _item(uuid.uuid4())
+    item.kind = "input_required"
+
+    expires_at = _serialize_item(item)["expires_at"]
+
+    assert expires_at == (
+        item.created_at + timedelta(seconds=ASK_USER_QUESTION_MAX_WAIT_SECONDS)
+    ).isoformat()
+
+
+def test_serialize_item_leaves_kinds_without_a_deadline_open():
+    """Only a question stops being actionable on a clock."""
+    assert _serialize_item(_item(uuid.uuid4()))["expires_at"] is None
 
 
 def test_serialize_item_keeps_a_missing_user_id_null():

--- a/tests/test_inbox_serialize.py
+++ b/tests/test_inbox_serialize.py
@@ -26,6 +26,13 @@ def test_serialize_item_includes_agent_fields():
     assert out["agent_slug"] == "agent-x-slug"
 
 
+def test_serialize_item_keeps_a_missing_user_id_null():
+    """Service-account-owned rows carry no user; str() would emit "None"."""
+    item = _item(uuid.uuid4())
+    item.user_id = None
+    assert _serialize_item(item)["user_id"] is None
+
+
 def test_serialize_item_defaults_agent_fields_to_none():
     out = _serialize_item(_item(uuid.uuid4()))
     assert out["agent_id"] is None

--- a/web/src/api/inbox.ts
+++ b/web/src/api/inbox.ts
@@ -24,6 +24,7 @@ interface InboxItemResponse {
   payload: Record<string, unknown>;
   action_ref: Record<string, unknown> | null;
   created_at: string;
+  expires_at?: string | null;
   updated_at: string;
   read_at: string | null;
   responded_at: string | null;
@@ -50,6 +51,7 @@ function toInboxItem(item: InboxItemResponse): AgentChatInboxItem {
     payload: item.payload,
     actionRef: item.action_ref,
     createdAt: item.created_at,
+    expiresAt: item.expires_at ?? null,
     updatedAt: item.updated_at,
     readAt: item.read_at,
     respondedAt: item.responded_at,

--- a/web/src/api/inbox.ts
+++ b/web/src/api/inbox.ts
@@ -60,7 +60,9 @@ function toInboxItem(item: InboxItemResponse): AgentChatInboxItem {
 
 function listUrl(input: AgentChatInboxListInput = {}): string {
   const params = new URLSearchParams();
-  if (input.status) params.set("status", input.status);
+  for (const status of [input.status ?? []].flat()) {
+    params.append("status", status);
+  }
   if (input.kind) params.set("kind", input.kind);
   if (input.sessionId) params.set("session_id", input.sessionId);
   if (input.cursor) params.set("cursor", input.cursor);


### PR DESCRIPTION
Fixes a set of defects found by mapping the inbox end to end — the write path, both read paths, and the four surfaces that can answer a question.

## The backend

**A question outlived the tool that asked it.** `ask_user_question` parks the turn for 30 minutes, then returns a timeout and the turn moves on — but nothing cleared its inbox row. The sweeper only expired rows whose *session* had gone terminal, so on a still-running session the question stayed listed as actionable forever, and answering it recorded a response event with nothing left to consume it.

The tool now retires its own row at the moment it gives up (timeout, or a session paused or completed under it). The sweeper keeps a window-based rule as the backstop for a row orphaned by a worker that died before it could clean up.

**The 30-minute rule lived in four places** — the tool, the sweeper, the SDK and Studio — agreeing only by inspection. Items now serialize `expires_at`, computed once on the server, and the clients read it. Neither frontend knows the rule any more.

**The unread badge counted two different things.** The stream snapshot listed unread items of *any* non-expired status while the list endpoint the badge derives from counts pending only, so the number jumped on connect. Both count pending unread now.

**History was unreachable.** The status filter matched one exact value, so a request that omitted it could never return expired items. It now accepts a set (`?status=responded&status=expired`), declared as a `Literal` so the framework rejects an unknown value rather than returning nothing and reading as an empty inbox.

**The sweeper scanned the whole table every 300s.** Every index on `inbox_items` is led by a principal, and the table only grows — inbox rows are kept as history. Added the partial index its pass actually needs: `(kind, created_at) WHERE status = 'pending'`.

Also: a null `user_id` no longer serializes as the string `"None"` for service-account-owned rows.

## The panel (`sdk/agent-chat-react`)

- **New items never appeared.** The stream handler mapped over the rows it already had, so anything it announced was dropped: a list opened in the morning stayed as it was all day, and only a reload showed anything new.
- **Failures were silent.** Every action in the detail pane reached the network inside a `try/finally` with no `catch` — a failed submit, acknowledge, approve or delete put the button back and said nothing, which is what success looks like.
- **An empty batch was submittable.** `every()` is vacuously true on no questions, so the panel would submit a payload the server rejects.
- **A dead question still took answers.** The panel now says the agent moved on and stops accepting one.
- **Answered, dismissed and expired items shared one list with the live ones**, and expired ones were invisible entirely. Active and History are now separate queries.
- The unread hook counted stream nudges, which only move a number up. It never came back down when an item was read or answered; it is now re-derived from the list on every signal, and a failed refetch keeps the last known count instead of reading as an empty inbox.

## Verification

- `pytest tests/` and `tests/integration -k inbox`: the failures that remain are byte-identical to `master` (23 unit, 4 integration, all pre-existing and unrelated).
- SDK: 490 tests pass, typecheck clean; web typechecks.
- New coverage: the tool retiring its own row, the sweeper's window rule and its skew margin, multi-status listing, the snapshot's pending-only count, `expires_at` for a question and its absence for everything else, live insertion, error surfacing, the empty-batch guard, the expired-question refusal, view-scoped inserts, and the unread count going *down*.

## Notes for the reviewer

- The SDK changes reach the web app immediately (it aliases source) and Studio only once the npm pin moves; Studio has the equivalent fix in `surogate-ops`.
- Studio keeps its own copies of the answer and expiry helpers because its pin lags. Both copies name the condition for deleting themselves.
- `progress_checkin` turns out to be reachable only through an undocumented session-config key (`inbox_checkin_interval_seconds`) that nothing in our own UIs sets. Documented rather than changed.

---

Studio half: invergent-ai/surogate-ops#335. Merge order does not matter — the two are independent, though Studio's expiry UI only reads `expires_at` once this one is deployed.