### PR TITLE
feat(todo): keep the agent's plan across a wake boundary

### DIFF
--- a/docs/superpowers/specs/2026-08-03-durable-todo-plan-design.md
+++ b/docs/superpowers/specs/2026-08-03-durable-todo-plan-design.md
@@ -1,0 +1,93 @@
+# Durable todo plan
+
+## Problem
+
+`TodoStore` instances live in a module-global dict keyed by session id
+(`surogates/tools/builtin/todo.py`). Nothing persists them and nothing evicts
+them. Three consequences:
+
+1. A cold store returns `{"todos": [], "total": 0}` while the conversation
+   history plainly shows a list — any new worker, pod, or wake starts blank.
+2. `merge=true` against a cold store falls through to replace
+   (`TodoStore.write` merges onto an empty `existing` map), silently dropping
+   every item written in an earlier wake.
+3. A long-running worker leaks one `TodoStore` per session it has ever
+   processed.
+
+The list itself is *not* lost — `tool_exec` emits `TOOL_CALL`/`TOOL_RESULT`
+with the full payload and the replay path restores both — so the model still
+sees its last list in history. This is a projection bug: the store disagrees
+with the transcript.
+
+## Design
+
+### Event
+
+`EventType.TODO_UPDATED = "todo.updated"`, payload `{"todos": [...]}`, emitted
+by the todo handler **on write only**. No migration: `events.type` is plain
+text with no CHECK constraint.
+
+Every todo response already returns the complete list, so this is a snapshot
+log, not a delta log. Recovery reads one row.
+
+### Retrieval
+
+`SessionStore.latest_todo_snapshot(session_id) -> list | None`
+
+```sql
+SELECT data FROM events
+ WHERE session_id = :sid AND type = 'todo.updated'
+ ORDER BY id DESC LIMIT 1
+```
+
+Served by `idx_events_session_type` over a handful of small rows. Contrast
+scanning `tool.result`, whose payloads carry file contents, web pages and
+terminal output.
+
+`None` (never written) is distinct from `[]` (explicitly emptied). The merge
+path needs that distinction.
+
+### No store cache
+
+The module-global dict is deleted rather than bounded. Once the snapshot is
+the source of truth, the cache buys nothing and costs a leak: the handler
+builds a `TodoStore` per call, applies the operation, and emits. A todo call
+is rare (a handful per session) and the query is one indexed row.
+
+This also removes `_get_store`, `format_for_injection` and `has_items`, none
+of which have a caller outside the module.
+
+### Tool classification
+
+`todo` moves out of `CONCURRENCY_SAFE_TOOLS` — and therefore out of
+`PARALLEL_TOOLS`, so it stops firing eagerly mid-stream — into a new
+`DURABLE_STATE_TOOLS`, unioned into `BATCH_PARALLEL_TOOLS` so it still fans
+out once the stream commits. It also leaves `SAGA_EXCLUDED_TOOLS`.
+
+This is the rule `PARALLEL_TOOLS`' own docstring already states:
+
+> Eager dispatch must be safe to cancel mid-flight, so side-effecting tools
+> that allocate durable state (delegation tools create child sessions in the
+> DB) are excluded even though they're safe to batch-dispatch concurrently
+> after the stream completes.
+
+A todo write now allocates durable state. Delegation tools are the existing
+precedent; `DURABLE_STATE_TOOLS` names the category for tools that qualify
+without being delegations.
+
+## Out of scope
+
+Post-compaction re-injection, the `projection_gap` marker, reviving
+`format_for_injection`, any pydantic schema port, any model-facing API change.
+
+## Tests
+
+- Two wakes, no shared process state: wake 2's `merge=true` keeps wake 1's
+  items.
+- A cold read after a wake that wrote returns the list, not `[]`.
+- `None` vs `[]`: a session that never wrote merges onto nothing; a session
+  that emptied its list stays empty.
+- The event fires on write, not on read.
+- Routing: `todo` absent from `PARALLEL_TOOLS`, present in
+  `BATCH_PARALLEL_TOOLS` — the regression that would silently restore
+  mid-stream writes.

--- a/docs/superpowers/specs/2026-08-03-durable-todo-plan-design.md
+++ b/docs/superpowers/specs/2026-08-03-durable-todo-plan-design.md
@@ -59,10 +59,26 @@ of which have a caller outside the module.
 
 ### Tool classification
 
-`todo` moves out of `CONCURRENCY_SAFE_TOOLS` — and therefore out of
-`PARALLEL_TOOLS`, so it stops firing eagerly mid-stream — into a new
-`DURABLE_STATE_TOOLS`, unioned into `BATCH_PARALLEL_TOOLS` so it still fans
-out once the stream commits. It also leaves `SAGA_EXCLUDED_TOOLS`.
+`todo` leaves `CONCURRENCY_SAFE_TOOLS`, and therefore `PARALLEL_TOOLS` and
+`BATCH_PARALLEL_TOOLS`. It runs sequentially.
+
+Two reasons, and the second only surfaced in review:
+
+1. A todo write allocates durable state, so it must not be dispatched
+   eagerly mid-stream — a discarded stream would leave the event behind.
+2. With the in-process cache gone, every call is an unlocked
+   read-modify-write on the event log. Two concurrent todo calls would
+   silently drop one update. The shared in-process store it replaced could
+   not lose one, so batch parallelism would have been a regression.
+
+The first reason alone would have allowed post-commit parallelism (the
+delegation-tool pattern). The second rules it out.
+
+It stays in `SAGA_EXCLUDED_TOOLS`. Saga compensation restores a sandbox
+checkpoint (`governance/saga/compensator.py`), and checkpoints are stashed
+only for file-mutating tools. A todo write mutates the event log, not the
+workspace, so a journaled step would carry no `checkpoint_hash` and its
+rollback could only raise `SagaStateError`.
 
 This is the rule `PARALLEL_TOOLS`' own docstring already states:
 
@@ -72,8 +88,8 @@ This is the rule `PARALLEL_TOOLS`' own docstring already states:
 > after the stream completes.
 
 A todo write now allocates durable state. Delegation tools are the existing
-precedent; `DURABLE_STATE_TOOLS` names the category for tools that qualify
-without being delegations.
+precedent for the mid-stream exclusion; `todo` goes further and stays
+sequential because it has no per-call isolation to fall back on.
 
 ## Out of scope
 

--- a/surogates/harness/tool_exec.py
+++ b/surogates/harness/tool_exec.py
@@ -299,15 +299,6 @@ CONCURRENCY_SAFE_TOOLS: frozenset[str] = frozenset({
     "web_crawl",
 })
 
-# Tools that allocate durable state and therefore must NOT be dispatched
-# eagerly mid-stream -- a discarded stream would leave the state behind.
-# Same rule as DELEGATION_TOOLS below, without the child session: ``todo``
-# appends a plan snapshot to the event log on every write.  Safe to batch
-# concurrently once the stream commits, so it joins BATCH_PARALLEL_TOOLS.
-DURABLE_STATE_TOOLS: frozenset[str] = frozenset({
-    "todo",
-})
-
 # Tools whose errors should abort all sibling concurrent executions.
 # A terminal error often signals an environment problem that makes
 # sibling tool results unreliable.
@@ -366,9 +357,7 @@ DELEGATION_TOOLS: frozenset[str] = frozenset({
 # All tools that ``should_parallelize`` may dispatch concurrently after
 # the stream completes.  Superset of :data:`PARALLEL_TOOLS` plus
 # delegation tools.  Used only for batched (post-stream) dispatch.
-BATCH_PARALLEL_TOOLS: frozenset[str] = (
-    PARALLEL_TOOLS | DELEGATION_TOOLS | DURABLE_STATE_TOOLS
-)
+BATCH_PARALLEL_TOOLS: frozenset[str] = PARALLEL_TOOLS | DELEGATION_TOOLS
 
 MAX_TOOL_WORKERS: int = 8
 
@@ -383,6 +372,12 @@ SAGA_EXCLUDED_TOOLS: frozenset[str] = frozenset({
     "session_search",
     "skill_view",
     "skills_list",
+    # Saga compensation restores a sandbox checkpoint (see
+    # governance/saga/compensator.py), and checkpoints are stashed only for
+    # file-mutating tools.  ``todo`` mutates the event log, not the
+    # workspace, so a journaled step would carry no checkpoint_hash and its
+    # rollback could only raise.
+    "todo",
     "web_crawl",
     "web_extract",
     "web_search",

--- a/surogates/harness/tool_exec.py
+++ b/surogates/harness/tool_exec.py
@@ -297,6 +297,14 @@ CONCURRENCY_SAFE_TOOLS: frozenset[str] = frozenset({
     "web_search",
     "web_extract",
     "web_crawl",
+})
+
+# Tools that allocate durable state and therefore must NOT be dispatched
+# eagerly mid-stream -- a discarded stream would leave the state behind.
+# Same rule as DELEGATION_TOOLS below, without the child session: ``todo``
+# appends a plan snapshot to the event log on every write.  Safe to batch
+# concurrently once the stream commits, so it joins BATCH_PARALLEL_TOOLS.
+DURABLE_STATE_TOOLS: frozenset[str] = frozenset({
     "todo",
 })
 
@@ -358,7 +366,9 @@ DELEGATION_TOOLS: frozenset[str] = frozenset({
 # All tools that ``should_parallelize`` may dispatch concurrently after
 # the stream completes.  Superset of :data:`PARALLEL_TOOLS` plus
 # delegation tools.  Used only for batched (post-stream) dispatch.
-BATCH_PARALLEL_TOOLS: frozenset[str] = PARALLEL_TOOLS | DELEGATION_TOOLS
+BATCH_PARALLEL_TOOLS: frozenset[str] = (
+    PARALLEL_TOOLS | DELEGATION_TOOLS | DURABLE_STATE_TOOLS
+)
 
 MAX_TOOL_WORKERS: int = 8
 
@@ -373,7 +383,6 @@ SAGA_EXCLUDED_TOOLS: frozenset[str] = frozenset({
     "session_search",
     "skill_view",
     "skills_list",
-    "todo",
     "web_crawl",
     "web_extract",
     "web_search",

--- a/surogates/session/events.py
+++ b/surogates/session/events.py
@@ -113,6 +113,10 @@ class EventType(str, Enum):
     # triggers the dispatcher's retry path when the session re-wakes.
     HARNESS_RECOVERED = "harness.recovered"
 
+    # Agent plan snapshot (todo tool). Full list on every write, so
+    # recovery reads the latest row rather than folding a delta log.
+    TODO_UPDATED = "todo.updated"
+
     # Sub-agent delegation (delegate_task tool)
     DELEGATION_START = "delegation.start"
     DELEGATION_COMPLETE = "delegation.complete"

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -1419,6 +1419,30 @@ class SessionStore:
             row = result.first()
         return row[0] if row is not None else None
 
+    async def latest_todo_snapshot(self, session_id: UUID | str) -> list | None:
+        """The session's current todo list, or ``None`` if it never wrote one.
+
+        Every todo response carries the full list, so the newest
+        ``todo.updated`` row *is* the current state -- no fold required.
+        ``None`` (never written) is distinct from ``[]`` (emptied): the merge
+        path needs to tell those apart.
+        """
+        stmt = (
+            select(EventRow.data)
+            .where(
+                EventRow.session_id == session_id,
+                EventRow.type == EventType.TODO_UPDATED.value,
+            )
+            .order_by(EventRow.id.desc())
+            .limit(1)
+        )
+        async with self._sf() as db:
+            row = (await db.execute(stmt)).scalar_one_or_none()
+        if not isinstance(row, dict):
+            return None
+        todos = row.get("todos")
+        return todos if isinstance(todos, list) else None
+
     async def count_recoveries_since_progress(self, session_id: UUID) -> int:
         """Count ``harness.recovered`` events since the session last progressed.
 

--- a/surogates/tools/builtin/todo.py
+++ b/surogates/tools/builtin/todo.py
@@ -1,8 +1,12 @@
-"""Builtin todo tool -- in-memory task management per session.
+"""Builtin todo tool -- event-sourced task management per session.
 
 Registers the ``todo`` tool with the tool registry.  Provides a
-per-session in-memory task list for decomposing complex tasks,
-tracking progress, and maintaining focus across long conversations.
+per-session task list for decomposing complex tasks, tracking progress,
+and maintaining focus across long conversations.
+
+The list is stored as ``todo.updated`` events, so it survives a wake
+boundary: a new worker loads the latest snapshot rather than starting
+blank.  Every response carries the full list, so recovery reads one row.
 
 Design:
 - Single ``todo`` tool: provide ``todos`` param to write, omit to read
@@ -15,8 +19,9 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
+from surogates.session.events import EventType
 from surogates.tools.registry import ToolRegistry, ToolSchema
 
 logger = logging.getLogger(__name__)
@@ -26,7 +31,7 @@ VALID_STATUSES = {"pending", "in_progress", "completed", "cancelled"}
 
 
 class TodoStore:
-    """In-memory todo list. One instance per session.
+    """Todo list. Built per call from the latest snapshot.
 
     Items are ordered -- list position is priority. Each item has:
       - id: unique string identifier (agent-chosen)
@@ -84,43 +89,6 @@ class TodoStore:
         """Return a copy of the current list."""
         return [item.copy() for item in self._items]
 
-    def has_items(self) -> bool:
-        """Check if there are any items in the list."""
-        return bool(self._items)
-
-    def format_for_injection(self) -> Optional[str]:
-        """Render the todo list for post-compression injection.
-
-        Returns a human-readable string to append to the compressed
-        message history, or None if the list is empty.
-        """
-        if not self._items:
-            return None
-
-        # Status markers for compact display
-        markers = {
-            "completed": "[x]",
-            "in_progress": "[>]",
-            "pending": "[ ]",
-            "cancelled": "[~]",
-        }
-
-        # Only inject pending/in_progress items — completed/cancelled ones
-        # cause the model to re-do finished work after compression.
-        active_items = [
-            item for item in self._items
-            if item["status"] in ("pending", "in_progress")
-        ]
-        if not active_items:
-            return None
-
-        lines = ["[Your active task list was preserved across context compression]"]
-        for item in active_items:
-            marker = markers.get(item["status"], "[?]")
-            lines.append(f"- {marker} {item['id']}. {item['content']} ({item['status']})")
-
-        return "\n".join(lines)
-
     @staticmethod
     def _validate(item: Dict[str, Any]) -> Dict[str, str]:
         """Validate and normalize a todo item.
@@ -141,21 +109,6 @@ class TodoStore:
             status = "pending"
 
         return {"id": item_id, "content": content, "status": status}
-
-
-# Per-session TodoStore instances, keyed by session_id string.
-_session_stores: dict[str, TodoStore] = {}
-
-
-def _get_store(session_id: Any) -> TodoStore:
-    """Get or create a TodoStore for the given session.
-
-    Thread-safe because each session runs in a single async task.
-    """
-    key = str(session_id) if session_id else "default"
-    if key not in _session_stores:
-        _session_stores[key] = TodoStore()
-    return _session_stores[key]
 
 
 def register(registry: ToolRegistry) -> None:
@@ -229,16 +182,43 @@ async def _todo_handler(
     """Handle todo tool calls.
 
     Reads or writes depending on whether ``todos`` is provided.
-    Uses a per-session TodoStore keyed by ``session_id`` from kwargs.
+
+    The list lives in the event log, not in this process: it is loaded from
+    the newest ``todo.updated`` snapshot on every call and a write appends a
+    new one.  That is what keeps a merge correct across a wake boundary --
+    the previous design kept the store in a module-global that a new worker
+    started blank, so ``merge=true`` merged onto nothing and dropped the plan.
     """
     session_id = kwargs.get("session_id")
-    store = _get_store(session_id)
+    session_store = kwargs.get("session_store")
 
     todos = arguments.get("todos")
     merge = arguments.get("merge", False)
 
+    store = TodoStore()
+    if session_store is not None and session_id:
+        try:
+            snapshot = await session_store.latest_todo_snapshot(session_id)
+        except Exception:
+            # Degrade to a blank list rather than failing the turn: a read
+            # blip must not cost the model its tool call.
+            logger.warning(
+                "todo: could not load the plan for session %s",
+                session_id, exc_info=True,
+            )
+            snapshot = None
+        if snapshot:
+            store.write(snapshot, merge=False)
+
     if todos is not None:
         items = store.write(todos, merge)
+        if session_store is not None and session_id:
+            # Deliberately not swallowed: if the plan cannot be persisted the
+            # model must see the failure, or it proceeds against a list that
+            # will be gone on the next wake.
+            await session_store.emit_event(
+                session_id, EventType.TODO_UPDATED, {"todos": items},
+            )
     else:
         items = store.read()
 

--- a/surogates/tools/builtin/todo.py
+++ b/surogates/tools/builtin/todo.py
@@ -200,13 +200,21 @@ async def _todo_handler(
         try:
             snapshot = await session_store.latest_todo_snapshot(session_id)
         except Exception:
-            # Degrade to a blank list rather than failing the turn: a read
-            # blip must not cost the model its tool call.
+            # Fail the call rather than answer from a blank store.  An empty
+            # list is indistinguishable from "you have no plan", so degrading
+            # would invite the model to re-plan over a list that still
+            # exists -- and a merge on top of it would then persist the
+            # truncated result, which is the exact bug this tool now avoids.
             logger.warning(
                 "todo: could not load the plan for session %s",
                 session_id, exc_info=True,
             )
-            snapshot = None
+            return json.dumps({
+                "error": (
+                    "Could not read the current task list. Nothing was "
+                    "changed. Retry the call."
+                ),
+            }, ensure_ascii=False)
         if snapshot:
             store.write(snapshot, merge=False)
 

--- a/tests/integration/test_todo_snapshot.py
+++ b/tests/integration/test_todo_snapshot.py
@@ -1,0 +1,94 @@
+"""``latest_todo_snapshot`` against real PostgreSQL.
+
+The unit tests drive the handler with a fake store, so the actual SQL is
+never executed there. The handler receives ``session_id`` as a **string**
+(``tool_exec`` passes ``session_id=str(session.id)``) while ``events.session_id``
+is a UUID column -- if that comparison does not coerce, the query silently
+returns nothing and the plan is lost in production while every unit test
+passes.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from surogates.session.events import EventType
+
+from .conftest import create_org, create_user
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def _session(session_store, session_factory):
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+    return await session_store.create_session(
+        org_id=org_id, user_id=user_id, agent_id="agent-1", channel="web",
+    )
+
+
+async def test_a_string_session_id_finds_the_snapshot(
+    session_store, session_factory,
+):
+    """The handler passes a str; the column is a UUID."""
+    session = await _session(session_store, session_factory)
+    await session_store.emit_event(
+        session.id, EventType.TODO_UPDATED,
+        {"todos": [{"id": "1", "content": "a", "status": "pending"}]},
+    )
+
+    got = await session_store.latest_todo_snapshot(str(session.id))
+    assert got == [{"id": "1", "content": "a", "status": "pending"}]
+
+
+async def test_the_newest_snapshot_wins(session_store, session_factory):
+    session = await _session(session_store, session_factory)
+    for n in ("1", "2", "3"):
+        await session_store.emit_event(
+            session.id, EventType.TODO_UPDATED,
+            {"todos": [{"id": n, "content": n, "status": "pending"}]},
+        )
+
+    got = await session_store.latest_todo_snapshot(session.id)
+    assert [t["id"] for t in got] == ["3"]
+
+
+async def test_never_written_is_none_not_empty(session_store, session_factory):
+    """``None`` and ``[]`` must stay distinct -- merge depends on it."""
+    session = await _session(session_store, session_factory)
+    assert await session_store.latest_todo_snapshot(session.id) is None
+
+
+async def test_an_emptied_list_is_empty_not_none(session_store, session_factory):
+    session = await _session(session_store, session_factory)
+    await session_store.emit_event(
+        session.id, EventType.TODO_UPDATED, {"todos": []},
+    )
+    assert await session_store.latest_todo_snapshot(session.id) == []
+
+
+async def test_other_event_types_are_ignored(session_store, session_factory):
+    session = await _session(session_store, session_factory)
+    await session_store.emit_event(
+        session.id, EventType.TOOL_RESULT,
+        {"name": "todo", "content": '{"todos": [{"id": "x"}]}'},
+    )
+    assert await session_store.latest_todo_snapshot(session.id) is None
+
+
+async def test_snapshots_are_scoped_to_one_session(
+    session_store, session_factory,
+):
+    a = await _session(session_store, session_factory)
+    b = await _session(session_store, session_factory)
+    await session_store.emit_event(
+        a.id, EventType.TODO_UPDATED,
+        {"todos": [{"id": "1", "content": "a", "status": "pending"}]},
+    )
+    assert await session_store.latest_todo_snapshot(b.id) is None
+
+
+async def test_unknown_session_is_none(session_store):
+    assert await session_store.latest_todo_snapshot(uuid.uuid4()) is None

--- a/tests/test_streaming_executor.py
+++ b/tests/test_streaming_executor.py
@@ -148,14 +148,19 @@ class TestConcurrencyClassification:
         safe_tools = [
             "read_file", "search_files", "list_files",
             "session_search", "skills_list", "skill_view",
-            "web_search", "web_extract", "web_crawl", "todo",
+            "web_search", "web_extract", "web_crawl",
         ]
         for name in safe_tools:
             assert is_parallelizable(name), f"{name} should be concurrency-safe"
 
     def test_write_tools_are_not_parallelizable(self) -> None:
+        # ``todo`` sits here with ``delegate_task``: both allocate durable
+        # state mid-stream (a plan snapshot event, a child session), so a
+        # discarded stream must not have already committed them. Both are
+        # promoted to parallel once the stream commits -- see
+        # BATCH_PARALLEL_TOOLS.
         non_parallel_tools = [
-            "write_file", "patch",
+            "write_file", "patch", "todo",
             "memory", "skill_manage", "delegate_task", "ask_user_question",
         ]
         for name in non_parallel_tools:

--- a/tests/test_todo_durable.py
+++ b/tests/test_todo_durable.py
@@ -1,0 +1,179 @@
+"""The todo list must survive a wake boundary.
+
+`TodoStore` lived in a module-global dict that nothing persisted and nothing
+evicted, so a new worker/pod/wake started blank: a read returned
+`{"todos": [], "total": 0}` while the transcript plainly showed a list, and
+`merge=true` fell through to replace (merging onto an empty map), silently
+dropping everything written earlier.
+
+The list is recovered from the last `todo.updated` event — every todo response
+is already a complete snapshot, so recovery reads one row.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from surogates.session.events import EventType
+from surogates.tools.builtin.todo import _todo_handler
+
+
+class _Store:
+    """Records emitted events and serves the latest todo snapshot from them."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[Any, str, dict]] = []
+
+    async def emit_event(self, session_id, type_, data) -> int:
+        self.events.append((session_id, getattr(type_, "value", type_), data))
+        return len(self.events)
+
+    async def latest_todo_snapshot(self, session_id) -> list | None:
+        for sid, type_, data in reversed(self.events):
+            if sid == session_id and type_ == EventType.TODO_UPDATED.value:
+                return data["todos"]
+        return None
+
+
+async def _call(store, sid, **args) -> dict:
+    return json.loads(
+        await _todo_handler(args, session_id=str(sid), session_store=store)
+    )
+
+
+def _new_wake() -> None:
+    """Simulate a fresh worker: drop any in-process todo state.
+
+    Without this the module-global store carries the list between calls and
+    the wake-boundary tests pass for the wrong reason. A no-op once the
+    global is gone, which is the point.
+    """
+    import surogates.tools.builtin.todo as todo_mod
+
+    getattr(todo_mod, "_session_stores", {}).clear()
+
+
+@pytest.mark.asyncio
+async def test_merge_across_a_wake_boundary_keeps_earlier_items():
+    """The bug: wake 2 merged onto nothing and dropped wake 1's plan."""
+    store, sid = _Store(), uuid4()
+
+    await _call(store, sid, todos=[
+        {"id": "1", "content": "first", "status": "completed"},
+        {"id": "2", "content": "second", "status": "pending"},
+    ])
+
+    _new_wake()  # Wake 2 — no shared process state, only the event log.
+    out = await _call(store, sid, todos=[
+        {"id": "3", "content": "third", "status": "pending"},
+    ], merge=True)
+
+    assert [t["id"] for t in out["todos"]] == ["1", "2", "3"]
+    assert out["summary"]["total"] == 3
+
+
+@pytest.mark.asyncio
+async def test_a_cold_read_returns_the_list():
+    store, sid = _Store(), uuid4()
+    await _call(store, sid, todos=[{"id": "1", "content": "a", "status": "pending"}])
+
+    _new_wake()
+    out = await _call(store, sid)  # read
+    assert [t["id"] for t in out["todos"]] == ["1"]
+
+
+@pytest.mark.asyncio
+async def test_a_session_that_never_wrote_reads_empty():
+    out = await _call(_Store(), uuid4())
+    assert out["todos"] == []
+    assert out["summary"]["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_an_explicitly_emptied_list_stays_empty():
+    """`[]` (emptied) must not be confused with `None` (never written)."""
+    store, sid = _Store(), uuid4()
+    await _call(store, sid, todos=[{"id": "1", "content": "a", "status": "pending"}])
+    await _call(store, sid, todos=[])
+
+    _new_wake()
+    assert await _call(store, sid) == {
+        "todos": [],
+        "summary": {"total": 0, "pending": 0, "in_progress": 0,
+                    "completed": 0, "cancelled": 0},
+    }
+
+
+@pytest.mark.asyncio
+async def test_replace_still_replaces():
+    store, sid = _Store(), uuid4()
+    await _call(store, sid, todos=[{"id": "1", "content": "a", "status": "pending"}])
+    _new_wake()
+    out = await _call(store, sid, todos=[{"id": "9", "content": "z", "status": "pending"}])
+    assert [t["id"] for t in out["todos"]] == ["9"]
+
+
+@pytest.mark.asyncio
+async def test_the_event_fires_on_write_only():
+    store, sid = _Store(), uuid4()
+    await _call(store, sid, todos=[{"id": "1", "content": "a", "status": "pending"}])
+    await _call(store, sid)  # read
+    await _call(store, sid)  # read
+
+    todo_events = [e for e in store.events if e[1] == EventType.TODO_UPDATED.value]
+    assert len(todo_events) == 1
+    assert todo_events[0][2]["todos"][0]["id"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_two_sessions_do_not_share_a_list():
+    store, a, b = _Store(), uuid4(), uuid4()
+    await _call(store, a, todos=[{"id": "a1", "content": "a", "status": "pending"}])
+
+    _new_wake()
+    assert await _call(store, b) == {
+        "todos": [],
+        "summary": {"total": 0, "pending": 0, "in_progress": 0,
+                    "completed": 0, "cancelled": 0},
+    }
+
+
+@pytest.mark.asyncio
+async def test_no_store_still_answers():
+    """Tool kwargs are best-effort; a missing store must not break the wake."""
+    out = json.loads(
+        await _todo_handler(
+            {"todos": [{"id": "1", "content": "a", "status": "pending"}]},
+            session_id=str(uuid4()),
+        )
+    )
+    assert [t["id"] for t in out["todos"]] == ["1"]
+
+
+@pytest.mark.asyncio
+async def test_a_snapshot_read_failure_does_not_break_the_call():
+    """A DB blip must degrade to a blank list, not raise into the tool loop."""
+    class _Broken(_Store):
+        async def latest_todo_snapshot(self, session_id):
+            raise RuntimeError("db blip")
+
+    out = await _call(_Broken(), uuid4())
+    assert out["todos"] == []
+
+
+def test_todo_is_not_dispatched_mid_stream():
+    """A todo write allocates durable state, so a discarded stream must not
+    have already committed it -- the rule PARALLEL_TOOLS' docstring states."""
+    from surogates.harness.tool_exec import (
+        BATCH_PARALLEL_TOOLS,
+        PARALLEL_TOOLS,
+        SAGA_EXCLUDED_TOOLS,
+    )
+
+    assert "todo" not in PARALLEL_TOOLS
+    assert "todo" in BATCH_PARALLEL_TOOLS  # still parallel once committed
+    assert "todo" not in SAGA_EXCLUDED_TOOLS

--- a/tests/test_todo_durable.py
+++ b/tests/test_todo_durable.py
@@ -154,15 +154,37 @@ async def test_no_store_still_answers():
     assert [t["id"] for t in out["todos"]] == ["1"]
 
 
-@pytest.mark.asyncio
-async def test_a_snapshot_read_failure_does_not_break_the_call():
-    """A DB blip must degrade to a blank list, not raise into the tool loop."""
-    class _Broken(_Store):
-        async def latest_todo_snapshot(self, session_id):
-            raise RuntimeError("db blip")
+class _Broken(_Store):
+    async def latest_todo_snapshot(self, session_id):
+        raise RuntimeError("db blip")
 
+
+@pytest.mark.asyncio
+async def test_a_failed_load_never_persists_a_truncated_list():
+    """The bug this whole change exists to fix, re-entered by the back door.
+
+    If the snapshot cannot be read the store is empty. A `merge=true` write
+    would then merge onto nothing and emit THAT as the new snapshot --
+    destroying the real plan permanently, which is strictly worse than the
+    in-memory version it replaced.
+    """
+    store = _Broken()
+    out = await _call(store, uuid4(), todos=[
+        {"id": "9", "content": "new", "status": "pending"},
+    ], merge=True)
+
+    assert "error" in out, "a write must not proceed on a plan it could not read"
+    assert not [e for e in store.events if e[1] == EventType.TODO_UPDATED.value], (
+        "nothing may be persisted when the prior list is unknown"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_failed_load_does_not_report_an_empty_plan():
+    """Returning [] invites the model to re-plan over a list that still exists."""
     out = await _call(_Broken(), uuid4())
-    assert out["todos"] == []
+    assert "error" in out
+    assert out.get("todos") != []
 
 
 def test_todo_is_not_dispatched_mid_stream():
@@ -175,5 +197,12 @@ def test_todo_is_not_dispatched_mid_stream():
     )
 
     assert "todo" not in PARALLEL_TOOLS
-    assert "todo" in BATCH_PARALLEL_TOOLS  # still parallel once committed
-    assert "todo" not in SAGA_EXCLUDED_TOOLS
+    # Nor after the stream commits: every call is an unlocked
+    # read-modify-write on the event log, so two concurrent todo calls would
+    # silently drop one update. The old shared in-process store could not
+    # lose one; running sequentially is what keeps that true.
+    assert "todo" not in BATCH_PARALLEL_TOOLS
+    # Saga compensation restores a sandbox checkpoint, and todo never gets
+    # one -- journaling it would create a step that can only fail to roll
+    # back.
+    assert "todo" in SAGA_EXCLUDED_TOOLS


### PR DESCRIPTION
First of the LoopX proposals (P1). Design committed in the range at `docs/superpowers/specs/2026-08-03-durable-todo-plan-design.md`.

## The bug

`TodoStore` lived in a module-global dict keyed by session id, never persisted and never evicted. Three consequences:

1. A cold store returned `{"todos": [], "total": 0}` while the transcript plainly showed a list — any new worker, pod or wake started blank.
2. `merge=true` against a cold store merged onto an empty map and **silently dropped** everything written in an earlier wake.
3. A long-running worker leaked one `TodoStore` per session it had ever processed.

The list itself was never lost — `tool_exec` emits the full payload and the replay path restores it — so the model still saw its last list in history. This was a projection bug: the store disagreed with the transcript.

## The fix

Store the list as `todo.updated` events. Every todo response already carries the full list, so this is a snapshot log and recovery reads one row: `ORDER BY id DESC LIMIT 1` over `idx_events_session_type`, rather than scanning `tool.result` payloads that carry file contents and web pages. No migration — `events.type` is plain text with no CHECK.

With the event as the source of truth the in-process cache buys nothing, so it is **deleted rather than bounded** — which is also how the leak goes away. `_get_store`, `format_for_injection` and `has_items` go with it; none had a caller outside the module (`study/hermes-agent/` has its own copy and zero `from surogates` imports). `todo.py` ends up **20 lines shorter than before the feature**.

`todo` leaves `CONCURRENCY_SAFE_TOOLS`, so it runs sequentially. Two reasons:

- A write allocates durable state, so it must not be dispatched eagerly mid-stream where a discarded stream would leave the event behind — the rule `PARALLEL_TOOLS`' docstring already states for delegation tools.
- Every call is now an unlocked read-modify-write, so two concurrent todo calls would drop one update. The shared in-process store could not lose one; batch parallelism would have been a regression.

## Review found two defects in the first commit

Both fixed in `5c2f85fe`, and both worth a look:

**A failed read could destroy the plan.** A snapshot read failure left the store empty; a `merge=true` write then merged onto nothing and emitted the truncated result as the new snapshot — the original bug, re-entered through the failure path and now *persisted*. A failed load returns an error and writes nothing. Returning `[]` was also wrong: indistinguishable from "you have no plan", inviting the model to re-plan over a list that still exists.

**The saga removal was wrong.** The first commit dropped `todo` from `SAGA_EXCLUDED_TOOLS`. But saga compensation restores a sandbox checkpoint (`governance/saga/compensator.py`), and checkpoints are stashed only for file-mutating tools — a journaled todo step would carry no `checkpoint_hash` and its rollback could only raise `SagaStateError`. The durable-state argument justifies the mid-stream exclusion, not saga journaling.

## Tests

11 unit (`tests/test_todo_durable.py`) + 7 integration against real PostgreSQL (`tests/integration/test_todo_snapshot.py`).

The integration tests exist because the unit tests drive a **fake** store, so the actual SQL had never run — notably a `str` session_id (which is what `tool_exec` passes) against a UUID column, plus `None` vs `[]`, newest-wins and session scoping.

Two test-quality notes: the unit tests needed a `_new_wake()` helper that drops in-process state, because without it the module-global carried the list between calls and the wake-boundary tests passed for the wrong reason (8 green initially; the honest count was 4 red). And `tests/test_streaming_executor.py::test_read_only_tools_are_safe` asserted `todo` was concurrency-safe — that moved to `test_write_tools_are_not_parallelizable` beside `delegate_task`, which is now the correct category.

## Verification

Full unit suite `28 failed / 5018 passed` — **identical failure set** to master (the 28 are pre-existing environment gaps). Ruff clean on all changed files.

## Out of scope

Post-compaction re-injection, the `projection_gap` marker, reviving `format_for_injection`, any pydantic schema port, any model-facing API change.