### PR TITLE
feat(doctor): diagnose why one session is stuck

### DIFF
--- a/surogates/cli/main.py
+++ b/surogates/cli/main.py
@@ -7,6 +7,7 @@ image with a different subcommand:
     surogate worker           Start a harness worker (Redis queue consumer)
     surogate mcp-proxy        Start the MCP proxy service
     surogate migrate          Run database migrations
+    surogate doctor <id>      Diagnose why one session is stuck
 """
 
 from __future__ import annotations
@@ -153,6 +154,41 @@ def cmd_migrate(args: argparse.Namespace) -> None:
     run_migrations(settings.db)
 
 
+def cmd_doctor(args: argparse.Namespace) -> None:
+    """Report coherence problems for one session."""
+    from uuid import UUID
+
+    from surogates.config import load_settings
+
+    settings = load_settings()
+    _configure_logging("WARNING")  # findings go to stdout, not the log
+
+    async def _run() -> int:
+        from surogates.db.engine import (
+            async_engine_from_settings,
+            async_session_factory,
+        )
+        from surogates.session.doctor import diagnose_session
+        from surogates.session.store import SessionStore
+
+        engine = async_engine_from_settings(settings.db)
+        try:
+            findings = await diagnose_session(
+                SessionStore(async_session_factory(engine)),
+                UUID(args.session_id),
+            )
+        finally:
+            await engine.dispose()
+        if not findings:
+            print("no findings")
+            return 0
+        for f in findings:
+            print(f"{f.code}: {f.detail}")
+        return 1
+
+    sys.exit(asyncio.run(_run()))
+
+
 # -- parser ------------------------------------------------------------------
 
 
@@ -175,6 +211,12 @@ def build_parser() -> argparse.ArgumentParser:
     # surogate migrate
     sub.add_parser("migrate", help="Run database migrations")
 
+    # surogate doctor <session-id>
+    doctor_parser = sub.add_parser(
+        "doctor", help="Diagnose why one session is stuck",
+    )
+    doctor_parser.add_argument("session_id", help="Session UUID")
+
     # surogate channels [kind]
     channels_parser = sub.add_parser(
         "channels", help="Start the channel webhook service",
@@ -194,6 +236,7 @@ COMMANDS = {
     "worker": cmd_worker,
     "mcp-proxy": cmd_mcp_proxy,
     "migrate": cmd_migrate,
+    "doctor": cmd_doctor,
     "channels": cmd_channels,
 }
 

--- a/surogates/session/doctor.py
+++ b/surogates/session/doctor.py
@@ -1,0 +1,115 @@
+"""Read-only coherence checks for a single session.
+
+Answers the question the PROD debugging flow actually asks -- why is this
+session not doing anything -- without opening a psql shell. Every check is a
+read; nothing here mutates state.
+
+Two kinds of problem earn a place:
+
+* an invariant enforced only at *creation*, so a row written before the rule
+  existed (or written directly) can violate it with nothing to notice;
+* a config value the runtime silently ignores, so whoever set it has no way
+  to learn it did nothing.
+
+Restating what the event log already shows plainly does not earn a place.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from surogates.session.interactive_input import pending_input_for_session
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["Finding", "diagnose_session"]
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One coherence problem. ``code`` is stable; ``detail`` is for humans."""
+
+    code: str
+    detail: str
+
+
+def _outcome_is_active(outcome: Any) -> bool:
+    """A ``/goal`` counts as active exactly as the mission path counts it."""
+    return (
+        isinstance(outcome, dict)
+        and str(outcome.get("description") or "").strip() != ""
+        and str(outcome.get("status") or "active") == "active"
+    )
+
+
+def _age_seconds(value: Any) -> float | None:
+    """Seconds since *value*, tolerating the naive UTC Postgres hands back."""
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - value).total_seconds()
+
+
+async def diagnose_session(store: Any, session_id: UUID) -> list[Finding]:
+    """Return every coherence problem found for *session_id*."""
+    from surogates.tools.builtin.ask_user_question import (
+        ASK_USER_QUESTION_MAX_WAIT_SECONDS,
+    )
+
+    try:
+        session = await store.get_session(session_id)
+    except Exception:
+        return [Finding("session_not_found", f"no session {session_id}")]
+
+    findings: list[Finding] = []
+    config = getattr(session, "config", None) or {}
+
+    # Waiting on a human is the most common reason a session looks dead.
+    try:
+        pending = await pending_input_for_session(store, session_id=session_id)
+    except Exception:
+        logger.warning("doctor: pending-input lookup failed", exc_info=True)
+        pending = None
+    if pending:
+        age = _age_seconds(pending.get("created_at"))
+        asked = len(pending.get("questions") or [])
+        findings.append(Finding(
+            "waiting_on_user",
+            f"{asked} question(s) open on tool call "
+            f"{pending.get('tool_call_id') or '?'}"
+            + (f", asked {age / 60:.0f} min ago" if age is not None else ""),
+        ))
+        if age is not None and age > ASK_USER_QUESTION_MAX_WAIT_SECONDS:
+            findings.append(Finding(
+                "input_request_expired",
+                "the asking tool call already timed out; an answer now has "
+                "nowhere to go. Reply in the session instead.",
+            ))
+
+    # Exclusivity is enforced when a mission is created (missions/commands.py),
+    # never afterwards, so a legacy or hand-written row can hold both.
+    if _outcome_is_active(config.get("outcome")) and config.get("active_mission_id"):
+        findings.append(Finding(
+            "objective_conflict",
+            "an active /goal and an active mission are both set; only one "
+            "evaluator loop per session is supported.",
+        ))
+
+    # Mirrors the guard in orchestrator/worker.py:_resolve_iteration_budget --
+    # anything unusable there is silently replaced by the platform default.
+    raw = config.get("max_iterations")
+    if raw is not None and (
+        isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0
+    ):
+        findings.append(Finding(
+            "unusable_max_iterations",
+            f"config sets max_iterations={raw!r}, which the worker cannot "
+            "use; it falls back to the platform default.",
+        ))
+
+    return findings

--- a/tests/integration/test_session_doctor.py
+++ b/tests/integration/test_session_doctor.py
@@ -1,0 +1,75 @@
+"""`session doctor` against a real SessionStore and PostgreSQL.
+
+The unit tests drive a fake store and monkeypatch the pending-input lookup,
+so neither the real `get_session` nor the real inbox query runs there. This
+covers the wiring the CLI actually uses.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from surogates.session.doctor import diagnose_session
+from surogates.session.events import EventType
+
+from .conftest import create_org, create_user
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def _session(session_store, session_factory, **config):
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+    return await session_store.create_session(
+        org_id=org_id, user_id=user_id, agent_id="agent-1",
+        channel="web", config=config or {},
+    )
+
+
+async def _codes(session_store, session_id) -> list[str]:
+    return [f.code for f in await diagnose_session(session_store, session_id)]
+
+
+async def test_a_healthy_session_reports_nothing(session_store, session_factory):
+    session = await _session(session_store, session_factory)
+    assert await _codes(session_store, session.id) == []
+
+
+async def test_an_unknown_session_is_reported(session_store):
+    assert await _codes(session_store, uuid.uuid4()) == ["session_not_found"]
+
+
+async def test_an_open_question_is_found_through_the_real_inbox(
+    session_store, session_factory,
+):
+    """`inbox.input_required` auto-creates the row via `_INBOX_EVENTS`."""
+    session = await _session(session_store, session_factory)
+    await session_store.emit_event(
+        session.id,
+        EventType.INBOX_INPUT_REQUIRED,
+        {
+            "tool_call_id": "call_1",
+            "questions": [{"prompt": "which one?"}],
+            "context": "",
+        },
+    )
+
+    assert "waiting_on_user" in await _codes(session_store, session.id)
+
+
+async def test_two_objectives_at_once_is_reported(session_store, session_factory):
+    session = await _session(
+        session_store, session_factory,
+        outcome={"description": "ship it", "status": "active"},
+        active_mission_id=str(uuid.uuid4()),
+    )
+    assert "objective_conflict" in await _codes(session_store, session.id)
+
+
+async def test_an_unusable_iteration_cap_is_reported(
+    session_store, session_factory,
+):
+    session = await _session(session_store, session_factory, max_iterations=0)
+    assert "unusable_max_iterations" in await _codes(session_store, session.id)

--- a/tests/test_session_doctor.py
+++ b/tests/test_session_doctor.py
@@ -1,0 +1,143 @@
+"""`session doctor` -- read-only coherence checks for one session.
+
+Answers the question the PROD debugging flow actually asks: why is this
+session not doing anything? Every check is a read; nothing here can change
+state.
+
+Scope is deliberately narrow. Invariants that are enforced only at creation
+(so a legacy row can violate them undetected) and config values the runtime
+silently ignores are worth reporting; restating what the event log already
+shows plainly is not.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from surogates.session.doctor import diagnose_session
+
+
+class _Store:
+    def __init__(self, session: Any, pending: dict | None = None) -> None:
+        self._session = session
+        self._pending = pending
+
+    async def get_session(self, session_id):
+        if self._session is None:
+            raise LookupError("nope")
+        return self._session
+
+
+def _session(**config) -> SimpleNamespace:
+    return SimpleNamespace(id=uuid4(), status="active", config=config)
+
+
+async def _codes(store, monkeypatch, pending=None) -> list[str]:
+    async def fake_pending(_store, *, session_id, tool_call_id=None):
+        return pending
+
+    monkeypatch.setattr(
+        "surogates.session.doctor.pending_input_for_session", fake_pending,
+    )
+    return [f.code for f in await diagnose_session(store, uuid4())]
+
+
+@pytest.mark.asyncio
+async def test_a_healthy_session_reports_nothing(monkeypatch):
+    assert await _codes(_Store(_session()), monkeypatch) == []
+
+
+@pytest.mark.asyncio
+async def test_missing_session_is_reported(monkeypatch):
+    assert "session_not_found" in await _codes(_Store(None), monkeypatch)
+
+
+@pytest.mark.asyncio
+async def test_an_open_question_explains_the_silence(monkeypatch):
+    """The most common 'stuck' session is one waiting on a human."""
+    pending = {
+        "tool_call_id": "call_1",
+        "questions": [{"prompt": "which one?"}],
+        "created_at": datetime.now(timezone.utc) - timedelta(minutes=2),
+    }
+    codes = await _codes(_Store(_session()), monkeypatch, pending=pending)
+    assert "waiting_on_user" in codes
+    assert "input_request_expired" not in codes
+
+
+@pytest.mark.asyncio
+async def test_an_expired_question_is_called_out(monkeypatch):
+    """Past the tool's own wait cap nobody is listening for the answer."""
+    pending = {
+        "tool_call_id": "call_1",
+        "questions": [],
+        "created_at": datetime.now(timezone.utc) - timedelta(hours=3),
+    }
+    codes = await _codes(_Store(_session()), monkeypatch, pending=pending)
+    assert "input_request_expired" in codes
+
+
+@pytest.mark.asyncio
+async def test_naive_timestamps_do_not_crash_the_check(monkeypatch):
+    """Postgres hands back naive UTC; comparing it to an aware now() raises."""
+    pending = {
+        "tool_call_id": "call_1",
+        "questions": [],
+        "created_at": datetime.utcnow() - timedelta(hours=3),
+    }
+    codes = await _codes(_Store(_session()), monkeypatch, pending=pending)
+    assert "input_request_expired" in codes
+
+
+@pytest.mark.asyncio
+async def test_two_objectives_at_once_is_reported(monkeypatch):
+    """Exclusivity is enforced only when a mission is created, so a row that
+    predates the rule -- or was written directly -- can hold both."""
+    session = _session(
+        outcome={"description": "ship it", "status": "active"},
+        active_mission_id=str(uuid4()),
+    )
+    assert "objective_conflict" in await _codes(_Store(session), monkeypatch)
+
+
+@pytest.mark.asyncio
+async def test_a_paused_goal_beside_a_mission_is_fine(monkeypatch):
+    """Only an *active* outcome conflicts -- the rule the creation path uses."""
+    session = _session(
+        outcome={"description": "ship it", "status": "paused"},
+        active_mission_id=str(uuid4()),
+    )
+    assert "objective_conflict" not in await _codes(_Store(session), monkeypatch)
+
+
+@pytest.mark.parametrize("bad", [0, -1, "thirty", 3.5, True, [], {}])
+@pytest.mark.asyncio
+async def test_an_unusable_iteration_cap_is_reported(monkeypatch, bad):
+    """The worker silently falls back to the platform default, so an operator
+    who set this has no way to know it did nothing."""
+    codes = await _codes(_Store(_session(max_iterations=bad)), monkeypatch)
+    assert "unusable_max_iterations" in codes
+
+
+@pytest.mark.parametrize("good", [1, 30, 90])
+@pytest.mark.asyncio
+async def test_a_usable_iteration_cap_is_silent(monkeypatch, good):
+    codes = await _codes(_Store(_session(max_iterations=good)), monkeypatch)
+    assert "unusable_max_iterations" not in codes
+
+
+@pytest.mark.asyncio
+async def test_findings_carry_a_readable_detail(monkeypatch):
+    async def fake_pending(_store, *, session_id, tool_call_id=None):
+        return None
+
+    monkeypatch.setattr(
+        "surogates.session.doctor.pending_input_for_session", fake_pending,
+    )
+    findings = await diagnose_session(_Store(_session(max_iterations=0)), uuid4())
+    assert findings and all(f.detail.strip() for f in findings)


### PR DESCRIPTION
LoopX proposal P6, step 1. Plan: `docs/superpowers/plans/2026-08-03-loopx-adoption.md`.

## What it does

```
$ surogate doctor 8b1f0c2e-...
waiting_on_user: 1 question(s) open on tool call call_1, asked 47 min ago
input_request_expired: the asking tool call already timed out; an answer now
  has nowhere to go. Reply in the session instead.
```

Read-only checks for one session. Nothing here mutates state.

| code | why it earns a place |
|---|---|
| `waiting_on_user` | the commonest reason a session looks dead |
| `input_request_expired` | past `ASK_USER_QUESTION_MAX_WAIT_SECONDS` nobody is listening for the answer |
| `objective_conflict` | an active `/goal` beside an active mission — exclusivity is enforced only when a mission is *created* (`missions/commands.py:324-332`), so a legacy or hand-written row violates it undetected |
| `unusable_max_iterations` | a value the worker silently replaces with the platform default (#178), so whoever set it cannot tell it did nothing |

The admission rule: report invariants enforced only at creation, and config the runtime silently ignores. Don't restate what the event log already shows.

## Scope, and why it differs from the plan

The plan frames step 1 as a `sessions.config` lint whose centrepiece is an `unknown_session_config_key` warning. Its own analysis says that check "catches almost nothing alone" without a known-key registry — and puts that registry at 45-55 keys spread across harness, missions, board, channels, tasks, ambient and the API, plus surogate-ops. That is a hand-maintained list that rots the first time someone adds a key.

These four checks need no registry and answer the question the CLAUDE.md PROD-debugging flow actually opens with. Typed `sessions.config` validation stays step 2 — the plan is explicit that inverting the order is the risky way round, since rejecting writes on a 50-key untyped surface with live PROD rows is where the regression risk lives.

Also skipped: the API route. Add it when something other than a shell needs this.

## Tests

18 unit (`tests/test_session_doctor.py`) + 5 integration against real PostgreSQL (`tests/integration/test_session_doctor.py`).

The integration tests exist for a specific reason: the unit tests fake the store *and* monkeypatch `pending_input_for_session`, so neither the real `get_session` nor the real inbox query would ever run — the same gap that hid the SQL in #185 until integration tests were added there. The integration test drives the genuine path, including `inbox.input_required` auto-creating its row via `_INBOX_EVENTS`.

One unit test covers naive-UTC timestamps specifically: Postgres returns them, and comparing a naive datetime to an aware `now()` raises.

## Verification

Full unit suite `28 failed / 5039 passed` — **identical failure set** to master (the 28 are pre-existing environment gaps). Ruff clean. CLI parser smoke-checked.