### PR TITLE
feat(governance): make a human approval durable, scoped and spendable

### DIFF
--- a/surogates/api/routes/inbox.py
+++ b/surogates/api/routes/inbox.py
@@ -394,6 +394,18 @@ async def respond_to_inbox_item(
             "tool_call_id": tool_call_id,
             "inbox_item_id": item.id,
         }
+        if decision == "approve":
+            # The decision has to outlive this request or the retry is
+            # blocked identically.  Key the grant on the ORIGINAL arguments:
+            # the inbox payload carries only a truncated excerpt, and a
+            # grant scoped to a truncation would match nothing.
+            await store.grant_tool_call_approval(
+                session_id=item.session_id,
+                org_id=item.org_id,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                granted_by=tenant.user_id,
+            )
     else:
         if payload.completed is not True:
             raise HTTPException(

--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -753,6 +753,59 @@ class ScheduledSession(Base):
 # ---------------------------------------------------------------------------
 
 
+class ApprovalGrant(Base):
+    """A human's decision to let one blocked tool call through.
+
+    Approving used to emit a chat message and nothing else — nothing the
+    gate could consult, so the same call was blocked again on retry.  A
+    grant is that decision made durable.
+
+    Validity is never stored as a flag.  ``consume_approval_grant``
+    recomputes it on every read from ``revoked_at`` / ``expires_at`` /
+    ``used_count``, so a grant cannot drift into looking live after the
+    fact.
+
+    Scope is the *call*, not the tool: ``arguments_hash`` pins the exact
+    arguments that were shown to the human, so approving one deploy does
+    not approve every future one.
+    """
+
+    __tablename__ = "approval_grants"
+    __table_args__ = (
+        Index(
+            "idx_approval_grants_lookup",
+            "session_id", "tool_name", "arguments_hash",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), primary_key=True, default=uuid.uuid4,
+    )
+    org_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
+    session_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
+    tool_name: Mapped[str] = mapped_column(Text, nullable=False)
+    # sha256 of the canonical (sorted-key) tool arguments.
+    arguments_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    granted_by: Mapped[Optional[uuid.UUID]] = mapped_column(
+        GUID(), nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(),
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )
+    max_uses: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="1",
+    )
+    used_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0",
+    )
+    revoked_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+
 class AmbientScheduleRow(Base):
     """One ambient-review schedule per followed channel.
 

--- a/surogates/governance/policy.py
+++ b/surogates/governance/policy.py
@@ -96,8 +96,17 @@ class GovernanceGate:
         enabled: bool = True,
         egress_policy: EgressPolicy | None = None,
         transparency: TransparencyInterceptor | None = None,
+        require_approval: set[str] | None = None,
     ) -> None:
         self._enabled: bool = enabled
+        # Tools a human must approve before they run.  Checked beside the
+        # deny-list fast path -- above the open-policy/``mcp__`` early
+        # return -- because open policy is the production default and MCP
+        # tools take that return unconditionally, so a rule placed below it
+        # would never fire for the tools most worth gating.
+        self._require_approval: frozenset[str] = frozenset(
+            require_approval or (),
+        )
         self._open_policy: bool = (allowed_tools is None and denied_tools is None)
 
         # Initialise AGT engine.
@@ -249,6 +258,17 @@ class GovernanceGate:
                 allowed=False,
                 reason=f"denied: tool {tool_name!r} explicitly blocked",
                 tool_name=tool_name,
+            )
+
+        # Approval gate.  Deliberately AFTER the deny list (an explicit
+        # denial is not negotiable and must not become approvable) and
+        # BEFORE the open-policy / ``mcp__`` early return below.
+        if tool_name in self._require_approval:
+            return PolicyDecision(
+                allowed=False,
+                reason=f"tool {tool_name!r} requires human approval",
+                tool_name=tool_name,
+                overridable=True,
             )
 
         # Path-arg hygiene check — reject shell-variable patterns like
@@ -597,12 +617,21 @@ class GovernanceGate:
                     action=rule.get("action", "allow"),
                 )
 
+        # Approval rules union: a profile may add tools that need a human,
+        # never drop one the base required.
+        new_require_approval = set(self._require_approval)
+        new_require_approval.update(
+            str(t).strip() for t in (profile.get("require_approval") or [])
+            if str(t).strip()
+        )
+
         composed = GovernanceGate(
             allowed_tools=new_allowed if new_allowed is not None else None,
             denied_tools=new_denied if new_denied else None,
             enabled=self._enabled,
             egress_policy=new_egress,
             transparency=self._transparency,
+            require_approval=new_require_approval or None,
         )
         composed.freeze()
         return composed

--- a/surogates/harness/tool_exec.py
+++ b/surogates/harness/tool_exec.py
@@ -16,6 +16,7 @@ import logging
 import os
 import re
 import time
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Callable
 
 from surogates.session.events import EventType
@@ -1230,6 +1231,50 @@ async def execute_single_tool(
     decision = gate.check(
         tool_name, tool_args, workspace_path=workspace_path,
     )
+    if not decision.allowed and decision.overridable:
+        # A human may already have approved this exact call.  The grant
+        # query lives HERE, not in ``gate.check``: the gate is a frozen,
+        # synchronous, per-wake object with no DB handle and no session
+        # context, and keeping it pure is what lets it stay shared.
+        try:
+            granted, grant_reasons = await store.consume_approval_grant(
+                session_id=session.id,
+                tool_name=tool_name,
+                arguments=tool_args or {},
+            )
+        except Exception:
+            # Fail closed: an unreadable grant is not an approval.
+            logger.warning(
+                "Approval-grant lookup failed for %s on session %s",
+                tool_name, session.id, exc_info=True,
+            )
+            granted, grant_reasons = False, ["lookup_failed"]
+        if granted:
+            logger.info(
+                "Approved call allowed for %s on session %s",
+                tool_name, session.id,
+            )
+            await store.emit_event(
+                session.id,
+                EventType.POLICY_ALLOWED,
+                {
+                    "tool_name": tool_name,
+                    "reason": "human approval",
+                    "tool_call_id": tool_call_id,
+                },
+            )
+            decision = replace(decision, allowed=True, reason="human approval")
+        elif grant_reasons and grant_reasons != ["no_grant"]:
+            # Surface the near miss: an expired or spent grant is a very
+            # different message to the operator than "never approved".
+            decision = replace(
+                decision,
+                reason=(
+                    f"{decision.reason} (prior approval "
+                    f"{', '.join(grant_reasons)})"
+                ),
+            )
+
     if not decision.allowed:
         logger.warning(
             "Governance blocked %s for session %s: %s",

--- a/surogates/runtime/governance.py
+++ b/surogates/runtime/governance.py
@@ -113,6 +113,10 @@ def governance_profile(governance: dict[str, Any] | None) -> dict[str, Any] | No
     if denied - PROTECTED_TOOLS:
         profile["denied_tools"] = sorted(denied - PROTECTED_TOOLS)
 
+    approval = _tool_names(governance, "require_approval")
+    if approval:
+        profile["require_approval"] = sorted(approval)
+
     egress = governance.get("egress")
     if isinstance(egress, dict):
         rules = [r for r in (egress.get("rules") or []) if isinstance(r, dict)]
@@ -142,7 +146,12 @@ def _tool_names(governance: dict[str, Any], key: str) -> set[str]:
     """
     value = governance.get(key)
     if isinstance(value, list):
-        return {t for t in value if isinstance(t, str) and t}
+        # Strip: a padded entry that silently matches nothing fails OPEN for
+        # ``denied_tools`` and ``require_approval``, which is the wrong
+        # direction for both.
+        return {
+            t.strip() for t in value if isinstance(t, str) and t.strip()
+        }
     if value not in (None, []):
         logger.warning(
             "governance.%s has unexpected type %s; ignoring",

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Sequence
-from datetime import datetime, timezone
+import hashlib
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any
 from uuid import UUID
@@ -30,6 +31,7 @@ from surogates.db.agent_users import (
     ensure_agent_user,
 )
 from surogates.db.models import (
+    ApprovalGrant,
     Event as EventRow,
     IdeaNode,
     InboxItem,
@@ -1419,6 +1421,172 @@ class SessionStore:
             )
             row = result.first()
         return row[0] if row is not None else None
+
+    # ── Approval grants ───────────────────────────────────────────────
+
+    @staticmethod
+    def _arguments_hash(arguments: Any) -> str:
+        """sha256 over canonical (sorted-key) arguments.
+
+        Same canonicalisation the tool guardrails use, so ``{"a":1,"b":2}``
+        and ``{"b":2,"a":1}`` are the same call.
+        """
+        from surogates.harness.tool_guardrails import canonical_tool_args
+
+        payload = canonical_tool_args(arguments if isinstance(arguments, dict) else {})
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    async def mint_approval_grant(
+        self,
+        *,
+        session_id: UUID,
+        org_id: UUID,
+        tool_name: str,
+        arguments: Any,
+        granted_by: UUID | None = None,
+        ttl_seconds: int = 3600,
+        max_uses: int = 1,
+    ) -> UUID:
+        """Record a human's approval of one blocked call. Returns the grant id."""
+        grant = ApprovalGrant(
+            org_id=org_id,
+            session_id=session_id,
+            tool_name=tool_name,
+            arguments_hash=self._arguments_hash(arguments),
+            granted_by=granted_by,
+            expires_at=datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds),
+            max_uses=max(1, int(max_uses)),
+            used_count=0,
+        )
+        async with self._sf() as db:
+            db.add(grant)
+            await db.commit()
+            return grant.id
+
+    async def grant_tool_call_approval(
+        self,
+        *,
+        session_id: UUID,
+        org_id: UUID,
+        tool_name: str,
+        tool_call_id: str,
+        granted_by: UUID | None = None,
+        ttl_seconds: int = 3600,
+    ) -> UUID | None:
+        """Approve the blocked call identified by *tool_call_id*.
+
+        Scoped to the ORIGINAL arguments, read back off the ``tool.call``
+        event: ``inbox.governance_gate`` stores only a truncated excerpt for
+        display, so a grant keyed on the payload would match no real call.
+
+        Returns ``None`` when the originating call cannot be found — there is
+        nothing to scope an approval to, and a grant over ``{}`` would be a
+        blank cheque.
+
+        Both respond handlers (this repo's API and surogate-ops) go through
+        here so the two cannot drift.
+        """
+        if not tool_call_id:
+            return None
+        events = await self.get_events(session_id, types=[EventType.TOOL_CALL])
+        arguments: dict | None = None
+        for event in reversed(events):
+            data = event.data or {}
+            if data.get("tool_call_id") == tool_call_id:
+                raw = data.get("arguments")
+                arguments = raw if isinstance(raw, dict) else {}
+                break
+        if arguments is None:
+            logger.warning(
+                "approval: no tool.call %s in session %s; not granting",
+                tool_call_id, session_id,
+            )
+            return None
+        return await self.mint_approval_grant(
+            session_id=session_id,
+            org_id=org_id,
+            tool_name=tool_name,
+            arguments=arguments,
+            granted_by=granted_by,
+            ttl_seconds=ttl_seconds,
+        )
+
+    async def revoke_approval_grant(self, grant_id: UUID) -> None:
+        async with self._sf() as db:
+            await db.execute(
+                update(ApprovalGrant)
+                .where(ApprovalGrant.id == grant_id)
+                .values(revoked_at=datetime.now(timezone.utc))
+            )
+            await db.commit()
+
+    async def consume_approval_grant(
+        self, *, session_id: UUID, tool_name: str, arguments: Any,
+    ) -> tuple[bool, list[str]]:
+        """Spend one use of a live grant for this exact call.
+
+        Returns ``(True, [])`` when a use was claimed, else ``(False, reasons)``
+        where *reasons* explains why — recomputed from the row, never read off
+        a stored flag.
+
+        The spend is a single conditional ``UPDATE ... RETURNING``: two tool
+        calls racing on a single-use grant cannot both win, which a
+        read-then-write would allow.
+        """
+        args_hash = self._arguments_hash(arguments)
+        now = datetime.now(timezone.utc)
+        live = (
+            select(ApprovalGrant.id)
+            .where(
+                ApprovalGrant.session_id == session_id,
+                ApprovalGrant.tool_name == tool_name,
+                ApprovalGrant.arguments_hash == args_hash,
+                ApprovalGrant.revoked_at.is_(None),
+                ApprovalGrant.expires_at > now,
+                ApprovalGrant.used_count < ApprovalGrant.max_uses,
+            )
+            .order_by(ApprovalGrant.created_at.asc())
+            .limit(1)
+            .scalar_subquery()
+        )
+        async with self._sf() as db:
+            claimed = (await db.execute(
+                update(ApprovalGrant)
+                .where(ApprovalGrant.id == live)
+                .values(used_count=ApprovalGrant.used_count + 1)
+                .returning(ApprovalGrant.id)
+                .execution_options(synchronize_session=False)
+            )).scalar_one_or_none()
+            await db.commit()
+            if claimed is not None:
+                return True, []
+
+            # Nothing claimable — say why, newest first.
+            row = (await db.execute(
+                select(ApprovalGrant)
+                .where(
+                    ApprovalGrant.session_id == session_id,
+                    ApprovalGrant.tool_name == tool_name,
+                    ApprovalGrant.arguments_hash == args_hash,
+                )
+                .order_by(ApprovalGrant.created_at.desc())
+                .limit(1)
+            )).scalar_one_or_none()
+
+        if row is None:
+            return False, ["no_grant"]
+        reasons: list[str] = []
+        if row.revoked_at is not None:
+            reasons.append("revoked")
+        expires_at = row.expires_at
+        if expires_at is not None:
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=timezone.utc)
+            if expires_at <= now:
+                reasons.append("expired")
+        if row.used_count >= row.max_uses:
+            reasons.append("exhausted")
+        return False, reasons or ["no_grant"]
 
     async def latest_todo_snapshot(self, session_id: UUID | str) -> list | None:
         """The session's current todo list, or ``None`` if it never wrote one.

--- a/tests/integration/test_approval_grants.py
+++ b/tests/integration/test_approval_grants.py
@@ -1,0 +1,164 @@
+"""Approval grants: durable, scoped, expiring, and spent atomically.
+
+Approving a blocked tool call used to emit a `[governance decision] APPROVE`
+user message and nothing else — no record, no re-dispatch, nothing the gate
+could consult. A grant is the durable form of that decision.
+
+Validity is recomputed on every read from an explicit reason list rather than
+stored as a flag, so a grant cannot drift into looking live after it expires.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+
+from .conftest import create_org, create_user
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+_ARGS = {"command": "deploy prod"}
+
+
+async def _session(session_store, session_factory):
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+    s = await session_store.create_session(
+        org_id=org_id, user_id=user_id, agent_id="agent-1", channel="web",
+    )
+    return s, user_id
+
+
+async def _mint(session_store, s, user_id, **kw):
+    return await session_store.mint_approval_grant(
+        session_id=s.id, org_id=s.org_id, tool_name="terminal",
+        arguments=_ARGS, granted_by=user_id, **kw,
+    )
+
+
+async def test_a_granted_call_is_allowed_once(session_store, session_factory):
+    s, user_id = await _session(session_store, session_factory)
+    await _mint(session_store, s, user_id)
+
+    ok, reasons = await session_store.consume_approval_grant(
+        session_id=s.id, tool_name="terminal", arguments=_ARGS,
+    )
+    assert ok is True and reasons == []
+
+
+async def test_a_single_use_grant_is_spent(session_store, session_factory):
+    s, user_id = await _session(session_store, session_factory)
+    await _mint(session_store, s, user_id)
+
+    await session_store.consume_approval_grant(
+        session_id=s.id, tool_name="terminal", arguments=_ARGS,
+    )
+    ok, reasons = await session_store.consume_approval_grant(
+        session_id=s.id, tool_name="terminal", arguments=_ARGS,
+    )
+    assert ok is False and "exhausted" in reasons
+
+
+async def test_different_arguments_are_a_different_call(
+    session_store, session_factory,
+):
+    """The scope is the call, not the tool -- approving one deploy must not
+    approve every future deploy."""
+    s, user_id = await _session(session_store, session_factory)
+    await _mint(session_store, s, user_id)
+
+    ok, reasons = await session_store.consume_approval_grant(
+        session_id=s.id, tool_name="terminal",
+        arguments={"command": "deploy staging"},
+    )
+    assert ok is False and "no_grant" in reasons
+
+
+async def test_argument_order_does_not_matter(session_store, session_factory):
+    s, user_id = await _session(session_store, session_factory)
+    await session_store.mint_approval_grant(
+        session_id=s.id, org_id=s.org_id, tool_name="terminal",
+        arguments={"a": 1, "b": 2}, granted_by=user_id,
+    )
+    ok, _ = await session_store.consume_approval_grant(
+        session_id=s.id, tool_name="terminal", arguments={"b": 2, "a": 1},
+    )
+    assert ok is True
+
+
+async def test_another_session_cannot_use_the_grant(
+    session_store, session_factory,
+):
+    s, user_id = await _session(session_store, session_factory)
+    other, _ = await _session(session_store, session_factory)
+    await _mint(session_store, s, user_id)
+
+    ok, reasons = await session_store.consume_approval_grant(
+        session_id=other.id, tool_name="terminal", arguments=_ARGS,
+    )
+    assert ok is False and "no_grant" in reasons
+
+
+async def test_an_expired_grant_says_so(session_store, session_factory):
+    s, user_id = await _session(session_store, session_factory)
+    await _mint(session_store, s, user_id, ttl_seconds=-1)
+
+    ok, reasons = await session_store.consume_approval_grant(
+        session_id=s.id, tool_name="terminal", arguments=_ARGS,
+    )
+    assert ok is False and "expired" in reasons
+
+
+async def test_a_revoked_grant_says_so(session_store, session_factory):
+    s, user_id = await _session(session_store, session_factory)
+    grant_id = await _mint(session_store, s, user_id)
+    await session_store.revoke_approval_grant(grant_id)
+
+    ok, reasons = await session_store.consume_approval_grant(
+        session_id=s.id, tool_name="terminal", arguments=_ARGS,
+    )
+    assert ok is False and "revoked" in reasons
+
+
+async def test_a_multi_use_grant_spends_down(session_store, session_factory):
+    s, user_id = await _session(session_store, session_factory)
+    await _mint(session_store, s, user_id, max_uses=2)
+
+    assert (await session_store.consume_approval_grant(
+        session_id=s.id, tool_name="terminal", arguments=_ARGS))[0] is True
+    assert (await session_store.consume_approval_grant(
+        session_id=s.id, tool_name="terminal", arguments=_ARGS))[0] is True
+    ok, reasons = await session_store.consume_approval_grant(
+        session_id=s.id, tool_name="terminal", arguments=_ARGS,
+    )
+    assert ok is False and "exhausted" in reasons
+
+
+async def test_concurrent_consumers_cannot_overspend(
+    session_store, session_factory,
+):
+    """Two tool calls racing on one single-use grant must not both proceed.
+
+    The plan flagged this: `max_uses` has to be spent atomically or parallel
+    calls both see a live grant.
+    """
+    import asyncio
+
+    s, user_id = await _session(session_store, session_factory)
+    await _mint(session_store, s, user_id)
+
+    results = await asyncio.gather(*[
+        session_store.consume_approval_grant(
+            session_id=s.id, tool_name="terminal", arguments=_ARGS,
+        )
+        for _ in range(5)
+    ])
+    assert sum(1 for ok, _ in results if ok) == 1
+
+
+async def test_no_grant_at_all_is_reported(session_store, session_factory):
+    s, _ = await _session(session_store, session_factory)
+    ok, reasons = await session_store.consume_approval_grant(
+        session_id=s.id, tool_name="terminal", arguments=_ARGS,
+    )
+    assert ok is False and reasons == ["no_grant"]

--- a/tests/test_approval_grant_dispatch.py
+++ b/tests/test_approval_grant_dispatch.py
@@ -1,0 +1,133 @@
+"""A prior human approval lets the same call through on retry.
+
+Before this, approving a blocked tool call emitted a chat message and nothing
+else: `PolicyDecision.overridable` was never even set `True`, and the gate had
+no way to learn a human had said yes. The call was blocked again identically.
+
+The grant lookup lives in the async caller, not in `GovernanceGate.check`.
+The gate is a frozen, synchronous, per-wake object shared across sessions with
+no DB handle and no session context — putting a query in it is not possible,
+and keeping it pure is what lets it stay shared.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from surogates.governance.policy import GovernanceGate
+from surogates.harness.tool_exec import execute_single_tool
+from surogates.session.events import EventType
+
+
+def _store(granted: bool, reasons: list[str] | None = None) -> AsyncMock:
+    store = AsyncMock()
+    store.emit_event = AsyncMock(side_effect=range(1, 500))
+    store.advance_harness_cursor = AsyncMock()
+    store.consume_approval_grant = AsyncMock(
+        return_value=(granted, reasons or []),
+    )
+    return store
+
+
+async def _run(store, gate, tools=None):
+    session = SimpleNamespace(id=uuid4(), config={}, agent_id="a", org_id=uuid4())
+    return await execute_single_tool(
+        {
+            "id": "call_1",
+            "function": {
+                "name": "terminal",
+                "arguments": json.dumps({"command": "deploy prod"}),
+            },
+        },
+        session=session,
+        lease=SimpleNamespace(lease_token=uuid4()),
+        store=store,
+        tools=tools if tools is not None else SimpleNamespace(
+            get=lambda _name: None,  # no schema -> args pass through uncoerced
+            execute=AsyncMock(return_value="ran"),
+        ),
+        tenant=SimpleNamespace(org_id=session.org_id),
+        governance_gate=gate,
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_approved_call_is_let_through():
+    store = _store(granted=True)
+    gate = GovernanceGate(require_approval={"terminal"})
+
+    await _run(store, gate)
+
+    store.consume_approval_grant.assert_awaited_once()
+    types = [c.args[1] for c in store.emit_event.await_args_list]
+    assert EventType.POLICY_ALLOWED in types
+    assert EventType.POLICY_DENIED not in types
+
+
+@pytest.mark.asyncio
+async def test_an_unapproved_call_is_still_blocked():
+    store = _store(granted=False, reasons=["no_grant"])
+    gate = GovernanceGate(require_approval={"terminal"})
+
+    await _run(store, gate)
+
+    types = [c.args[1] for c in store.emit_event.await_args_list]
+    assert EventType.POLICY_DENIED in types
+    assert EventType.INBOX_GOVERNANCE_GATE in types
+
+
+@pytest.mark.asyncio
+async def test_a_spent_grant_is_reported_as_a_near_miss():
+    """"You already used that approval" is a different message to the
+    operator than "you never had one"."""
+    store = _store(granted=False, reasons=["exhausted"])
+    gate = GovernanceGate(require_approval={"terminal"})
+
+    await _run(store, gate)
+
+    denied = [
+        c.args[2] for c in store.emit_event.await_args_list
+        if c.args[1] == EventType.POLICY_DENIED
+    ]
+    assert denied and "exhausted" in json.dumps(denied[0])
+
+
+@pytest.mark.asyncio
+async def test_a_grant_lookup_failure_fails_closed():
+    """An unreadable grant is not an approval."""
+    store = _store(granted=False)
+    store.consume_approval_grant = AsyncMock(side_effect=RuntimeError("db blip"))
+    gate = GovernanceGate(require_approval={"terminal"})
+
+    await _run(store, gate)
+
+    types = [c.args[1] for c in store.emit_event.await_args_list]
+    assert EventType.POLICY_DENIED in types
+
+
+@pytest.mark.asyncio
+async def test_a_hard_denial_never_consults_a_grant():
+    """Only an overridable denial is approvable; a deny-list hit is not."""
+    store = _store(granted=True)
+    gate = GovernanceGate(denied_tools={"terminal"})
+
+    await _run(store, gate)
+
+    store.consume_approval_grant.assert_not_awaited()
+    types = [c.args[1] for c in store.emit_event.await_args_list]
+    assert EventType.POLICY_DENIED in types
+
+
+@pytest.mark.asyncio
+async def test_an_allowed_call_never_consults_a_grant():
+    """The happy path must not pay for a query it does not need."""
+    store = _store(granted=True)
+
+    await _run(store, GovernanceGate())
+
+    store.consume_approval_grant.assert_not_awaited()

--- a/tests/test_governance_require_approval.py
+++ b/tests/test_governance_require_approval.py
@@ -1,0 +1,102 @@
+"""Tools that need a human's say-so before they run.
+
+`PolicyDecision.overridable` existed but was never set `True`, so the whole
+"ask a human, then proceed" path was dead. This is the trigger that makes it
+reachable.
+
+Placement is the load-bearing detail. `check()` returns early for
+`self._open_policy or tool_name.startswith("mcp__")`, and open policy is the
+production default -- so a check placed after that line is as unreachable as
+`overridable` was. MCP/Composio tools are the highest-risk external-side-effect
+surface and take that early return unconditionally.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from surogates.governance.policy import GovernanceGate
+
+
+def test_a_tool_needing_approval_is_denied_overridably():
+    gate = GovernanceGate(require_approval={"terminal"})
+    decision = gate.check("terminal", {"command": "rm -rf /"})
+
+    assert decision.allowed is False
+    assert decision.overridable is True, (
+        "a denial nobody can override is a refusal, not an approval gate"
+    )
+    assert "approval" in decision.reason.lower()
+
+
+def test_other_tools_are_unaffected():
+    gate = GovernanceGate(require_approval={"terminal"})
+    assert gate.check("file_read", {"path": "a.txt"}).allowed is True
+
+
+def test_an_mcp_tool_under_open_policy_still_hits_the_gate():
+    """The regression that matters.
+
+    Open policy is the production default and `mcp__*` names bypass the role
+    check unconditionally, so an approval rule placed below that early return
+    would never fire for exactly the tools most worth gating.
+    """
+    gate = GovernanceGate(require_approval={"mcp__tool_router__send_email"})
+    decision = gate.check("mcp__tool_router__send_email", {"to": "a@b.c"})
+
+    assert decision.allowed is False
+    assert decision.overridable is True
+
+
+def test_an_ungated_mcp_tool_still_passes():
+    gate = GovernanceGate(require_approval={"mcp__other"})
+    assert gate.check("mcp__tool_router__search", {}).allowed is True
+
+
+def test_no_approval_list_changes_nothing():
+    gate = GovernanceGate()
+    assert gate.check("terminal", {"command": "ls"}).allowed is True
+
+
+def test_a_denied_tool_beats_an_approval_rule():
+    """An explicit denial is not negotiable -- approval must not soften it."""
+    gate = GovernanceGate(
+        denied_tools={"terminal"}, require_approval={"terminal"},
+    )
+    decision = gate.check("terminal", {"command": "ls"})
+
+    assert decision.allowed is False
+    assert decision.overridable is False, (
+        "an explicitly denied tool must not become approvable"
+    )
+
+
+def test_with_profile_unions_the_approval_list():
+    """Profiles narrow, never widen: more tools needing approval is stricter."""
+    base = GovernanceGate(require_approval={"terminal"})
+    composed = base.with_profile({"require_approval": ["write_file"]})
+
+    assert composed.check("terminal", {}).overridable is True
+    assert composed.check("write_file", {"path": "a"}).overridable is True
+
+
+def test_with_profile_cannot_drop_a_base_approval_rule():
+    base = GovernanceGate(require_approval={"terminal"})
+    composed = base.with_profile({"allowed_tools": ["terminal"]})
+
+    assert composed.check("terminal", {}).allowed is False
+
+
+@pytest.mark.parametrize("blob,expected", [
+    ({"require_approval": ["terminal"]}, {"terminal"}),
+    ({"require_approval": []}, None),
+    ({}, None),
+    ({"require_approval": "terminal"}, None),
+    ({"require_approval": [1, None, "  terminal  "]}, {"terminal"}),
+])
+def test_the_profile_builder_reads_the_list(blob, expected):
+    from surogates.runtime.governance import governance_profile
+
+    profile = governance_profile(blob) or {}
+    got = profile.get("require_approval")
+    assert (set(got) if got else None) == expected


### PR DESCRIPTION
LoopX proposal P5. Plan: `docs/superpowers/plans/2026-08-03-loopx-adoption.md`.

**Pairs with surogate-ops PR — merge this first.**

## The gap

Approving a blocked tool call emitted `[governance decision] APPROVE …` as a chat message and nothing else. `PolicyDecision.overridable` was never assigned `True` anywhere in the codebase, so the override path was dead code guarding a dead flag, and the agent's retry hit the same denial.

## The four parts, each where it has to be

**1 · `require_approval` on the gate** — the trigger that makes `overridable` reachable. It sits beside the deny-list fast path and **above** the `self._open_policy or tool_name.startswith("mcp__")` early return. Open policy is the production default and `mcp__*` names take that return unconditionally, so a rule placed below it would never fire for the highest-risk external-side-effect surface. `test_an_mcp_tool_under_open_policy_still_hits_the_gate` pins this. An explicit denial still wins — denied is not approvable.

**2 · `approval_grants`** — scoped to the *call*, not the tool: sha256 over canonical (sorted-key) arguments, plus `expires_at`, `max_uses`/`used_count`, `revoked_at`. Approving one deploy does not approve every future one. No migration; `create_all` covers a new table.

**3 · `consume_approval_grant`** — validity recomputed on every read from an explicit reason list (`revoked` / `expired` / `exhausted` / `no_grant`), never a stored flag, so a grant cannot drift into looking live. The spend is one conditional `UPDATE … RETURNING`: five racing consumers on a single-use grant yield exactly one winner (there is a test).

**4 · The lookup lives in the async caller**, in `tool_exec`, not in `GovernanceGate.check`. The gate is a frozen synchronous per-wake object shared across sessions with no DB handle and no session context — a query cannot go in it, and keeping it pure is what lets it stay shared. A lookup failure **fails closed**. An expired or spent grant is surfaced as a near miss, which is a materially different message to the operator than "never approved".

## Both respond handlers share one path

`SessionStore.grant_tool_call_approval` reads the **original** arguments off the `tool.call` event — `inbox.governance_gate` stores a truncated excerpt, and a grant keyed on a truncation matches no real call. If that event cannot be found it grants **nothing**: a grant over `{}` is a blank cheque for that tool.

surogate-ops calls the same method through a thin client passthrough rather than reimplementing it, so scope, TTL and hashing exist in one place.

## Incidental fix

`_tool_names` did not strip whitespace, so a padded entry in `denied_tools` or `require_approval` silently matched nothing — fail-open in both cases. One line in the shared helper.

## Scope

Per the plan, the dual-staleness port is descoped: scope + `expires_at` + `max_uses`/`used_count` + recompute-on-read first. LoopX's `newer_event_count_7d` counts runs against a goal, and the surogates analogue has no counter (`events.id` bumps on every LLM delta).

## Tests

16 unit + 10 integration against real PostgreSQL, including the concurrency test and the `mcp__*`-under-open-policy regression.

## Verification

Full unit suite `28 failed / 5058 passed` — **identical failure set** to master. Ruff identical to master (8 pre-existing in `policy.py`, zero new).