### PR TITLE
fix(ask): wake a session whose answer nobody was waiting for

### DIFF
--- a/surogates/api/routes/ask_user_question.py
+++ b/surogates/api/routes/ask_user_question.py
@@ -21,7 +21,11 @@ from surogates.api.session_guards import (
 )
 from surogates.db.models import InboxItem
 from surogates.session.events import EventType
-from surogates.session.interactive_input import asked_questions, derive_is_other
+from surogates.session.interactive_input import (
+    asked_questions,
+    derive_is_other,
+    wake_if_unattended,
+)
 from surogates.session.store import SessionNotFoundError, SessionStore
 from surogates.tenant.auth.middleware import get_current_tenant
 from surogates.tenant.context import TenantContext
@@ -179,4 +183,12 @@ async def respond_to_ask_user_question(
             await db.commit()
     except Exception:
         logger.exception("Failed to mark ask_user_question inbox item responded.")
+
+    # The asking tool is usually still parked and will see the event itself.
+    # If it is not — worker died, or the wait already timed out — the answer
+    # would sit in the log with nobody listening.
+    await wake_if_unattended(
+        store, redis=getattr(request.app.state, "redis", None),
+        session_id=session_id,
+    )
     return AskUserQuestionResponseReply(event_id=event_id)

--- a/surogates/session/interactive_input.py
+++ b/surogates/session/interactive_input.py
@@ -218,11 +218,18 @@ async def resolve_input_response(
         return None
 
     try:
-        return await store.emit_event(
+        event_id = await store.emit_event(
             session_id,
             EventType.ASK_USER_QUESTION_RESPONSE,
             {"tool_call_id": tc_id, "responses": responses},
         )
+        # Covers every channel caller from one place: the asking tool is
+        # usually still parked and sees this itself, but if it is gone the
+        # answer would sit here unread.
+        await wake_if_unattended(
+            store, redis=getattr(store, "_redis", None), session_id=session_id,
+        )
+        return event_id
     except Exception:
         # The claim committed but the response event did not: without a
         # revert the row reads "responded" while the tool keeps waiting
@@ -362,3 +369,44 @@ async def try_resolve_text_answer(
         tool_call_id=tool_call_id,
         responses=resolve_text_answer(pending.get("questions") or [], text),
     )
+
+
+async def wake_if_unattended(
+    store, *, redis, session_id, _enqueue=None,
+) -> None:
+    """Enqueue *session_id* when no worker is parked on it.
+
+    ``ask_user_question`` normally has a poller holding the session, and it
+    sees the answer within a second.  When that poller is gone — the worker
+    died, or the wait already timed out — the answer would otherwise sit in
+    the event log with nobody listening.
+
+    Conditional on the lease for a reason: enqueueing while a poller holds
+    the session rides the dispatcher's ``_rewake_pending`` path and runs an
+    extra turn on unchanged history once the current one ends.  An unknown
+    answer counts as attended, because a spurious turn is worse than an
+    answer the live poller picks up a moment later.
+
+    Never raises: the answer is already recorded, and failing the caller
+    would report a lost answer that was not lost.
+    """
+    if redis is None:
+        return
+    enqueue = _enqueue
+    if enqueue is None:
+        from surogates.config import enqueue_session as enqueue
+    try:
+        if await store.has_live_lease(session_id):
+            return
+        session = await store.get_session(session_id)
+        await enqueue(
+            redis,
+            org_id=str(session.org_id),
+            agent_id=session.agent_id,
+            session_id=session_id,
+        )
+    except Exception:
+        logger.warning(
+            "Could not wake session %s after an answer", session_id,
+            exc_info=True,
+        )

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -1789,6 +1789,16 @@ class SessionStore:
             rows = result.mappings().all()
         return [Event.model_validate(dict(r)) for r in rows]
 
+    async def has_live_lease(self, session_id: UUID) -> bool:
+        """True when a worker currently holds *session_id*."""
+        async with self._sf() as db:
+            return (await db.execute(
+                select(LeaseRow.session_id).where(
+                    LeaseRow.session_id == session_id,
+                    LeaseRow.expires_at > func.now(),
+                ).limit(1)
+            )).scalar_one_or_none() is not None
+
     async def release_stale_lease(self, session_id: UUID) -> bool:
         """Delete a session's lease row only if it has already expired.
 

--- a/tests/test_ask_answer_wakes_session.py
+++ b/tests/test_ask_answer_wakes_session.py
@@ -1,0 +1,92 @@
+"""An answer must reach a session nobody is parked on.
+
+`ask_user_question` parks a poller for up to 30 minutes. While that poller
+lives it sees the answer within a second and nothing else is needed. But the
+poller is not guaranteed to be there: the worker may have died, or the wait
+may already have timed out. In that case the answer landed in the event log
+with no one listening and the session sat idle holding it.
+
+Waking is conditional on there being no live lease. Enqueueing while a poller
+holds the session would ride the dispatcher's `_rewake_pending` path and run
+an extra turn on unchanged history once the current one finished.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from surogates.session.interactive_input import wake_if_unattended
+
+
+@pytest.mark.asyncio
+async def test_an_unattended_session_is_woken():
+    store = AsyncMock()
+    store.has_live_lease = AsyncMock(return_value=False)
+    store.get_session = AsyncMock(
+        return_value=type("S", (), {"org_id": uuid4(), "agent_id": "a"})(),
+    )
+    enqueue = AsyncMock()
+
+    await wake_if_unattended(
+        store, redis=object(), session_id=uuid4(), _enqueue=enqueue,
+    )
+
+    enqueue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_a_session_with_a_live_poller_is_left_alone():
+    """The parked poller will see the answer itself within a second."""
+    store = AsyncMock()
+    store.has_live_lease = AsyncMock(return_value=True)
+    enqueue = AsyncMock()
+
+    await wake_if_unattended(
+        store, redis=object(), session_id=uuid4(), _enqueue=enqueue,
+    )
+
+    enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_redis_is_a_noop():
+    store = AsyncMock()
+    store.has_live_lease = AsyncMock(return_value=False)
+    enqueue = AsyncMock()
+
+    await wake_if_unattended(
+        store, redis=None, session_id=uuid4(), _enqueue=enqueue,
+    )
+
+    enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_wake_failure_does_not_propagate():
+    """The answer is already recorded; failing the request would tell the
+    user their answer was lost when it was not."""
+    store = AsyncMock()
+    store.has_live_lease = AsyncMock(return_value=False)
+    store.get_session = AsyncMock(side_effect=RuntimeError("gone"))
+
+    await wake_if_unattended(
+        store, redis=object(), session_id=uuid4(), _enqueue=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_lease_check_failure_does_not_wake():
+    """Unknown attendance is treated as attended: a spurious extra turn is
+    worse than a slightly late answer, which the poller still picks up."""
+    store = AsyncMock()
+    store.has_live_lease = AsyncMock(side_effect=RuntimeError("db blip"))
+    enqueue = AsyncMock()
+
+    await wake_if_unattended(
+        store, redis=object(), session_id=uuid4(), _enqueue=enqueue,
+    )
+
+    enqueue.assert_not_awaited()


### PR DESCRIPTION
LoopX proposal P2, Ship 2. Ship 1 landed as #177. Plan: `docs/superpowers/plans/2026-08-03-loopx-adoption.md`.

## The gap

`ask_user_question` parks a poller for up to 30 minutes. While it lives, it sees the answer within a second and nothing else is needed.

It is not guaranteed to be there — the worker may have died, or the wait may already have timed out. The answer then sat in the event log with nobody listening, and the session stayed idle holding it.

## The fix

`wake_if_unattended` enqueues the session after an answer, **conditional on there being no live lease**.

That condition is the design, not a detail. Enqueueing underneath a live poller rides the dispatcher's `_rewake_pending` short-circuit and runs an extra turn on unchanged history once the current one finishes. A failed lease check counts as *attended*: a spurious turn is worse than an answer the live poller picks up a moment later, and the answer is durably recorded either way. The helper never raises — the caller failing would report a lost answer that was not lost.

Placement: both channel callers (`channels/inbound.py:935`, `platforms/telegram.py:926`) route through `resolve_input_response`, and `SessionStore` already carries redis, so the wake lives in that one function. Only the web widget route, which emits the event directly, calls it itself.

## Two thirds of this shipment was already done

The plan listed three parts. Checking each against the current tree:

- **"On timeout emit a real `TOOL_RESULT`"** — already true. The handler returns JSON and `tool_exec` turns that into a `TOOL_RESULT`.
- **"Fix `inbox_expire.py` to expire `input_required` past the wait cap regardless of session status"** — already true. `jobs/inbox_expire.py:67-71` has no session-status condition on that branch.

Only the wake remained.

## Tests

5, covering: an unattended session is woken; a session with a live poller is left alone; no redis is a no-op; a wake failure does not propagate; and a lease-check failure does not wake.

## Verification

Full unit suite `28 failed / 5044 passed` — **identical failure set** to master. Ruff clean on all changed files.