### PR TITLE
feat(missions): give an objective a token allowance it can spend

### DIFF
--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -1502,6 +1502,12 @@ class Mission(Base):
     iteration: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default="0"
     )
+    # Token allowance for the whole objective. NULL = unbounded.  Tokens,
+    # not cost: PROD runs tier sentinels priced at 0.0, so a cost ceiling
+    # would never trip (a 1.48M-token session recorded 0 USD).
+    budget_tokens: Mapped[Optional[int]] = mapped_column(
+        Integer, nullable=True
+    )
     max_iterations: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default="20"
     )

--- a/surogates/db/observability.sql
+++ b/surogates/db/observability.sql
@@ -415,7 +415,9 @@ CREATE TABLE IF NOT EXISTS missions (
 ALTER TABLE missions
     ALTER COLUMN user_id DROP NOT NULL,
     ADD COLUMN IF NOT EXISTS service_account_id uuid
-        REFERENCES service_accounts(id);
+        REFERENCES service_accounts(id),
+    -- Token allowance for the objective; NULL = unbounded.
+    ADD COLUMN IF NOT EXISTS budget_tokens integer;
 
 -- Replace the old (org, user, agent, status) index with one that covers
 -- both principal shapes.  Old index is dropped explicitly because the

--- a/surogates/missions/evaluator.py
+++ b/surogates/missions/evaluator.py
@@ -115,7 +115,18 @@ async def should_evaluate(
     ):
         return EvaluationDecision(should=False, trigger="rate_limited")
 
+    # Budget is checked here, after the cheap rate-limit path and before
+    # any work — never a reason to RUN, only a reason to stop. Mirrors how
+    # Arbor enforces its cycle ceiling at the evaluator boundary rather
+    # than mid-turn.
+    if await mission_store.pause_if_budget_exhausted(mission_id):
+        return EvaluationDecision(should=False, trigger="budget_exhausted")
+
     mission = await mission_store.get(mission_id)
+    if mission.status != "active":
+        return EvaluationDecision(should=False, trigger="budget_exhausted"
+                                  if mission.paused_reason == "budget_exhausted"
+                                  else "not_active")
 
     # Use ``last_evaluation_at`` when present, else fall back to the
     # mission's ``created_at``. This prevents the first evaluator pass

--- a/surogates/missions/store.py
+++ b/surogates/missions/store.py
@@ -13,7 +13,11 @@ from uuid import UUID
 from sqlalchemy import case, func, select, update
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
-from surogates.db.models import Mission as MissionRow
+from surogates.db.models import (
+    Mission as MissionRow,
+    Session as ORMSession,
+    Task,
+)
 from surogates.missions.models import Mission, MissionStatus
 
 
@@ -56,6 +60,7 @@ class MissionStore:
         user_id: UUID | None = None,
         service_account_id: UUID | None = None,
         max_iterations: int = 20,
+        budget_tokens: int | None = None,
     ) -> UUID:
         """Insert a new mission with status='active'.
 
@@ -93,6 +98,7 @@ class MissionStore:
                 description=description,
                 rubric=rubric,
                 max_iterations=max_iterations,
+            budget_tokens=budget_tokens,
             )
             db.add(row)
             await db.commit()
@@ -228,3 +234,71 @@ class MissionStore:
             if last.tzinfo is None:
                 last = last.replace(tzinfo=timezone.utc)
             return datetime.now(timezone.utc) - last < timedelta(seconds=window_seconds)
+
+    async def tokens_spent(self, mission_id: UUID) -> int:
+        """Total tokens billed to *mission_id*.
+
+        DERIVED, never a counter: a SUM over the mission's own coordinator
+        session plus every session attached to one of its tasks.  A counter
+        incremented alongside the work can drift from what was actually
+        billed; this cannot.
+
+        The join goes ``sessions.task_id -> tasks.mission_id`` rather than
+        reading ``Task.current_session_id``, which only points at the
+        in-flight attempt and would miss every earlier one.
+        """
+        spend = func.coalesce(ORMSession.input_tokens, 0) + func.coalesce(
+            ORMSession.output_tokens, 0
+        )
+        async with self._sf() as db:
+            own = (await db.execute(
+                select(func.coalesce(func.sum(spend), 0))
+                .select_from(ORMSession)
+                .join(MissionRow, MissionRow.session_id == ORMSession.id)
+                .where(MissionRow.id == mission_id)
+            )).scalar_one()
+            workers = (await db.execute(
+                select(func.coalesce(func.sum(spend), 0))
+                .select_from(ORMSession)
+                .join(Task, Task.id == ORMSession.task_id)
+                .where(Task.mission_id == mission_id)
+            )).scalar_one()
+        return int(own or 0) + int(workers or 0)
+
+    async def budget_exhausted(self, mission_id: UUID) -> bool:
+        """True when the mission has a token allowance and has spent it."""
+        async with self._sf() as db:
+            budget = (await db.execute(
+                select(MissionRow.budget_tokens)
+                .where(MissionRow.id == mission_id)
+            )).scalar_one_or_none()
+        if not budget:
+            return False
+        return await self.tokens_spent(mission_id) >= budget
+
+    async def pause_if_budget_exhausted(self, mission_id: UUID) -> bool:
+        """Pause a mission that has spent its allowance. True if this call did it.
+
+        Reuses ``paused`` + ``paused_reason`` rather than adding a status:
+        a new one would have to land in the SDK's ``types.ts`` and its
+        rebuilt dist, which is a known release-breaker, and "paused with a
+        reason" is exactly what this is.
+        """
+        if not await self.budget_exhausted(mission_id):
+            return False
+        async with self._sf() as db:
+            updated = (await db.execute(
+                update(MissionRow)
+                .where(
+                    MissionRow.id == mission_id,
+                    MissionRow.status == "active",
+                )
+                .values(
+                    status="paused",
+                    paused_reason="budget_exhausted",
+                    updated_at=func.now(),
+                )
+                .returning(MissionRow.id)
+            )).scalar_one_or_none()
+            await db.commit()
+        return updated is not None

--- a/tests/integration/missions/test_token_budget.py
+++ b/tests/integration/missions/test_token_budget.py
@@ -1,0 +1,220 @@
+"""What has this mission cost, and has it spent its allowance?
+
+`missions` tracked iterations and nothing else. Token spend existed only
+per-session, compared to nothing, so "how much has this objective consumed"
+had no answer and no ceiling.
+
+Spend is DERIVED — a SUM over the mission's sessions — not a counter
+incremented alongside the work, so it cannot drift from what was actually
+billed. Tokens are the enforcement quantity deliberately: PROD runs tier
+sentinels priced at 0.0, which is how a 1.48M-token session recorded
+`estimated_cost_usd = 0`.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import update
+
+from surogates.db.models import Session as ORMSession, Task
+from surogates.missions.store import MissionStore
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def _spend(session_factory, session_id, *, inp, out):
+    async with session_factory() as db:
+        await db.execute(
+            update(ORMSession).where(ORMSession.id == session_id)
+            .values(input_tokens=inp, output_tokens=out)
+        )
+        await db.commit()
+
+
+async def test_a_fresh_mission_has_spent_nothing(
+    session_factory, org_id, user_id, chat_session,
+):
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works",
+    )
+    assert await store.tokens_spent(mid) == 0
+
+
+async def test_the_coordinator_session_counts(
+    session_factory, org_id, user_id, chat_session,
+):
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works",
+    )
+    await _spend(session_factory, chat_session.id, inp=100, out=50)
+    assert await store.tokens_spent(mid) == 150
+
+
+async def test_worker_sessions_under_the_mission_count(
+    session_factory, org_id, user_id, chat_session, session_store,
+):
+    """Spend joins through tasks: a worker session bills to its mission."""
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works",
+    )
+    async with session_factory() as db:
+        task = Task(
+            org_id=org_id, parent_session_id=chat_session.id,
+            goal="do it", status="ready", mission_id=mid,
+        )
+        db.add(task)
+        await db.commit()
+        task_id = task.id
+
+    worker = await session_store.create_session(
+        org_id=org_id, user_id=user_id, agent_id="a",
+        channel="web", task_id=task_id,
+    )
+    await _spend(session_factory, chat_session.id, inp=10, out=10)
+    await _spend(session_factory, worker.id, inp=200, out=100)
+
+    assert await store.tokens_spent(mid) == 320
+
+
+async def test_another_missions_spend_is_not_counted(
+    session_factory, org_id, user_id, chat_session, sa_chat_session,
+):
+    store = MissionStore(session_factory)
+    a = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works",
+    )
+    await _spend(session_factory, sa_chat_session.id, inp=999, out=999)
+    assert await store.tokens_spent(a) == 0
+
+
+async def test_no_budget_is_never_exhausted(
+    session_factory, org_id, user_id, chat_session,
+):
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works",
+    )
+    await _spend(session_factory, chat_session.id, inp=10**7, out=10**7)
+    assert await store.budget_exhausted(mid) is False
+
+
+async def test_under_budget_is_not_exhausted(
+    session_factory, org_id, user_id, chat_session,
+):
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works",
+        budget_tokens=1000,
+    )
+    await _spend(session_factory, chat_session.id, inp=100, out=100)
+    assert await store.budget_exhausted(mid) is False
+
+
+async def test_over_budget_is_exhausted(
+    session_factory, org_id, user_id, chat_session,
+):
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works", budget_tokens=150,
+    )
+    await _spend(session_factory, chat_session.id, inp=100, out=100)
+    assert await store.budget_exhausted(mid) is True
+
+
+async def test_exhaustion_pauses_rather_than_inventing_a_status(
+    session_factory, org_id, user_id, chat_session,
+):
+    """`paused` + `paused_reason` already exist and already render.
+
+    A new terminal status would have to land in the SDK's types.ts and its
+    rebuilt dist — a known release-breaker.
+    """
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works", budget_tokens=10,
+    )
+    await _spend(session_factory, chat_session.id, inp=100, out=100)
+
+    assert await store.pause_if_budget_exhausted(mid) is True
+    mission = await store.get(mid)
+    assert mission.status == "paused"
+    assert mission.paused_reason == "budget_exhausted"
+
+
+async def test_pausing_is_idempotent(
+    session_factory, org_id, user_id, chat_session,
+):
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works", budget_tokens=10,
+    )
+    await _spend(session_factory, chat_session.id, inp=100, out=100)
+    assert await store.pause_if_budget_exhausted(mid) is True
+    assert await store.pause_if_budget_exhausted(mid) is False
+
+
+async def test_an_unknown_mission_is_not_exhausted(session_factory):
+    assert await MissionStore(session_factory).budget_exhausted(uuid.uuid4()) is False
+
+
+async def test_an_exhausted_mission_stops_being_evaluated(
+    session_factory, org_id, user_id, chat_session,
+):
+    """Budget is checked at the evaluator boundary, mirroring how Arbor
+    enforces its cycle ceiling — and only after the cheap negative paths."""
+    from surogates.missions.evaluator import should_evaluate
+
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works", budget_tokens=10,
+    )
+    await _spend(session_factory, chat_session.id, inp=100, out=100)
+
+    decision = await should_evaluate(
+        mission_id=mid,
+        coordinator_last_response="done\n[[mission-complete]]",
+        session_factory=session_factory,
+        mission_store=store,
+        rate_limit_seconds=0,
+    )
+    assert decision.should is False
+    assert decision.trigger == "budget_exhausted"
+
+    assert (await store.get(mid)).status == "paused"
+
+
+async def test_a_mission_within_budget_still_evaluates(
+    session_factory, org_id, user_id, chat_session,
+):
+    from surogates.missions.evaluator import should_evaluate
+
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works",
+        budget_tokens=10**6,
+    )
+    await _spend(session_factory, chat_session.id, inp=10, out=10)
+
+    decision = await should_evaluate(
+        mission_id=mid,
+        coordinator_last_response="done\n[[mission-complete]]",
+        session_factory=session_factory,
+        mission_store=store,
+        rate_limit_seconds=0,
+    )
+    assert decision.should is True


### PR DESCRIPTION
LoopX proposal P3, second half. The dead-config half (the worker ignoring its derived `max_iterations`) landed as #178.

## The gap

`missions` had `iteration` and `max_iterations` and nothing about cost. `SessionCostTracker` measured per-session spend and compared it to nothing. So "how much has this objective consumed?" had no answer, and no ceiling.

## Spend is derived, not counted

`tokens_spent(mission_id)` SUMs the mission's coordinator session plus every session attached to one of its tasks.

No `increment_` counter — that is the same shape as `missions/store.py:increment_iteration`, which is precisely what LoopX avoids. A derived sum cannot drift from what was actually billed.

The join is `sessions.task_id -> tasks.mission_id`, **not** `Task.current_session_id`: that column points only at the in-flight attempt, so a task that retried would lose every earlier attempt's spend.

This generalises what arbor already does for research missions (`cycles_spent()` as a COUNT over records, ceiling in meta, enforced at the evaluator boundary) rather than importing anything from LoopX.

## Tokens, not cost

Deliberate, and the plan was firm about it: PROD runs tier sentinels (`surogate` / `surogate-pro`) priced at 0.0, which is how a 1.48M-token session recorded `estimated_cost_usd = 0`. A cost ceiling would never trip. Cost stays advisory.

## No new status

The plan called for a `budget_exhausted` status — and separately warned it would have to land in `sdk/agent-chat-react/src/types.ts` plus its rebuilt dist, a known release-breaker.

`paused` + `paused_reason="budget_exhausted"` already exist, already render, and are exactly what this is. Zero SDK impact.

## Enforcement point

At the evaluator boundary in `should_evaluate`, mirroring arbor: after the cheap rate-limit path, before any work, and never a reason to *run* — only a reason to stop.

## Migration

`budget_tokens` is NULL by default, so every existing mission is unbounded and nothing changes until someone sets one. `create_all` does not add columns to existing tables, so it also needs the guarded `ADD COLUMN IF NOT EXISTS` in `db/observability.sql`.

## Tests

12 against real PostgreSQL: fresh mission spends nothing; coordinator spend counts; worker spend joins through tasks; another mission's spend is excluded; no budget is never exhausted; under/over budget; exhaustion pauses with the reason; pausing is idempotent; unknown mission; and both evaluator-boundary cases.

## Verification

All 74 mission integration tests pass. Full unit suite `28 failed / 5039 passed` — **identical failure set** to master. Ruff clean.

## Scope

`harness/outcomes.py`'s `/goal` layer has the same shape and is **not** covered here — it is a separate objective layer with its own config-backed state, and folding it in would double the blast radius of a first budget implementation.