### PR TITLE
feat(missions): let the evaluator remember what it already said

### DIFF
--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -1517,6 +1517,12 @@ class Mission(Base):
     last_evaluation_at: Mapped[Optional[datetime]] = mapped_column(
         nullable=True
     )
+    # Consecutive evaluations that did not report progress. The judge runs
+    # every round regardless; without this it had no memory of having
+    # already said the same thing.
+    stagnant_evaluations: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
     evaluator_parse_failures: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default="0"
     )

--- a/surogates/db/observability.sql
+++ b/surogates/db/observability.sql
@@ -415,7 +415,9 @@ CREATE TABLE IF NOT EXISTS missions (
 ALTER TABLE missions
     ALTER COLUMN user_id DROP NOT NULL,
     ADD COLUMN IF NOT EXISTS service_account_id uuid
-        REFERENCES service_accounts(id);
+        REFERENCES service_accounts(id),
+    -- Consecutive evaluations that reported no progress.
+    ADD COLUMN IF NOT EXISTS stagnant_evaluations integer NOT NULL DEFAULT 0;
 
 -- Replace the old (org, user, agent, status) index with one that covers
 -- both principal shapes.  Old index is dropped explicitly because the

--- a/surogates/missions/evaluator.py
+++ b/surogates/missions/evaluator.py
@@ -263,7 +263,7 @@ async def build_evaluator_prompt(
         # In-flight mission tasks ({n_in_flight})
 
         {in_flight_block}
-
+        {history_block}
         # Verdict
 
         Return JSON only.
@@ -274,8 +274,31 @@ async def build_evaluator_prompt(
         completed_block=_render_completed(completed_rows),
         n_in_flight=len(in_flight_rows),
         in_flight_block=_render_in_flight(in_flight_rows),
+        history_block=_render_history(mission),
     )
     return prompt
+
+
+def _render_history(mission: Any) -> str:
+    """What this judge already said, and how many times running.
+
+    Without it every round re-derives the same opinion from scratch: the
+    evaluator fires on each terminal task but keeps no memory, so a mission
+    can be told the same thing indefinitely at full cost.
+    """
+    streak = getattr(mission, "stagnant_evaluations", 0) or 0
+    if not streak or not mission.last_evaluation_result:
+        return ""
+    return dedent(f"""
+        # Your previous evaluation ({streak} in a row without progress)
+
+        Verdict: {mission.last_evaluation_result}
+        Reason: {(mission.last_evaluation_explanation or "")[:600]}
+        Guidance you gave: {(mission.last_evaluation_feedback or "")[:600]}
+
+        If the same blocker is still present after {streak} rounds, say so
+        plainly and return `blocked` rather than repeating the guidance.
+        """)
 
 
 def evaluator_system_prompt() -> str:

--- a/surogates/missions/models.py
+++ b/surogates/missions/models.py
@@ -70,6 +70,7 @@ class Mission(BaseModel):
     last_evaluation_feedback: str | None = None
     last_evaluation_at: datetime | None = None
     evaluator_parse_failures: int = 0
+    stagnant_evaluations: int = 0
     paused_reason: str | None = None
     cancelled_reason: str | None = None
     created_at: datetime

--- a/surogates/missions/store.py
+++ b/surogates/missions/store.py
@@ -23,6 +23,9 @@ _TERMINAL_STATUSES: tuple[str, ...] = (
 _ACTIVE_OR_PAUSED: tuple[str, ...] = ("active", "paused")
 
 
+STAGNANT_EVALUATION_LIMIT = 3
+
+
 class MissionStoreError(Exception):
     """Base for mission store errors."""
 
@@ -162,6 +165,12 @@ class MissionStore:
                     last_evaluation_feedback=feedback,
                     last_evaluation_at=func.now(),
                     evaluator_parse_failures=0,
+                    # A verdict that is not "satisfied" means the loop did
+                    # not move; anything else starts the count over.
+                    stagnant_evaluations=(
+                        0 if result == "satisfied"
+                        else MissionRow.stagnant_evaluations + 1
+                    ),
                 )
             )
             if res.rowcount == 0:
@@ -228,3 +237,16 @@ class MissionStore:
             if last.tzinfo is None:
                 last = last.replace(tzinfo=timezone.utc)
             return datetime.now(timezone.utc) - last < timedelta(seconds=window_seconds)
+
+    async def is_stagnant(self, mission_id: UUID) -> bool:
+        """True when the evaluator has returned no progress too many times.
+
+        3 is a surogates choice, not a port: it matches the parse-failure
+        pause and the recovery ceiling, so an operator meets one number.
+        """
+        async with self._sf() as db:
+            count = (await db.execute(
+                select(MissionRow.stagnant_evaluations)
+                .where(MissionRow.id == mission_id)
+            )).scalar_one_or_none()
+        return bool(count is not None and count >= STAGNANT_EVALUATION_LIMIT)

--- a/tests/integration/missions/test_stagnation.py
+++ b/tests/integration/missions/test_stagnation.py
@@ -1,0 +1,119 @@
+"""The evaluator remembers whether it has said this before.
+
+`apply_verdict` writes `last_evaluation_result/explanation/feedback` as
+single slots, so round N had no knowledge of round N-1: a mission could be
+told "needs revision" for the same reason indefinitely, and every round the
+judge re-derived that opinion from scratch at full cost.
+
+This is deliberately NOT LoopX's progress-granularity lattice. That
+classifies delivery size from free text via substring matching, and the
+plan's own verification found its enforcement path does not exist in the
+shape described. The signal that matters here needs no taxonomy: the
+evaluator keeps returning the same non-satisfied verdict.
+"""
+from __future__ import annotations
+
+import pytest
+
+from surogates.missions.store import MissionStore
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def _mission(session_factory, org_id, user_id, chat_session, **kw):
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works", **kw,
+    )
+    return store, mid
+
+
+async def test_a_fresh_mission_is_not_stagnant(
+    session_factory, org_id, user_id, chat_session,
+):
+    store, mid = await _mission(session_factory, org_id, user_id, chat_session)
+    assert (await store.get(mid)).stagnant_evaluations == 0
+
+
+async def test_repeated_non_progress_accumulates(
+    session_factory, org_id, user_id, chat_session,
+):
+    store, mid = await _mission(session_factory, org_id, user_id, chat_session)
+    for expected in (1, 2, 3):
+        await store.record_evaluation(
+            mid, result="needs_revision", explanation="not there yet",
+            feedback="keep going",
+        )
+        assert (await store.get(mid)).stagnant_evaluations == expected
+
+
+async def test_progress_resets_the_streak(
+    session_factory, org_id, user_id, chat_session,
+):
+    """A satisfied verdict means the loop moved; the count starts over."""
+    store, mid = await _mission(session_factory, org_id, user_id, chat_session)
+    await store.record_evaluation(
+        mid, result="needs_revision", explanation="no", feedback="f",
+    )
+    await store.record_evaluation(
+        mid, result="satisfied", explanation="done", feedback="",
+    )
+    assert (await store.get(mid)).stagnant_evaluations == 0
+
+
+async def test_the_streak_reaches_the_terminal(
+    session_factory, org_id, user_id, chat_session,
+):
+    store, mid = await _mission(session_factory, org_id, user_id, chat_session)
+    for _ in range(3):
+        await store.record_evaluation(
+            mid, result="needs_revision", explanation="no", feedback="f",
+        )
+    assert await store.is_stagnant(mid) is True
+
+
+async def test_below_the_terminal_is_not_stagnant(
+    session_factory, org_id, user_id, chat_session,
+):
+    store, mid = await _mission(session_factory, org_id, user_id, chat_session)
+    for _ in range(2):
+        await store.record_evaluation(
+            mid, result="needs_revision", explanation="no", feedback="f",
+        )
+    assert await store.is_stagnant(mid) is False
+
+
+async def test_the_judge_is_told_it_has_been_here_before(
+    session_factory, org_id, user_id, chat_session,
+):
+    """The load-bearing change: the evaluator already ran every round, it
+    simply had no memory of having done so."""
+    from surogates.missions.evaluator import build_evaluator_prompt
+
+    store, mid = await _mission(session_factory, org_id, user_id, chat_session)
+    for _ in range(2):
+        await store.record_evaluation(
+            mid, result="needs_revision",
+            explanation="the tests still fail", feedback="fix the tests",
+        )
+
+    prompt = await build_evaluator_prompt(
+        mission_id=mid, coordinator_last_response="tried again",
+        session_factory=session_factory, mission_store=store,
+    )
+    assert "2" in prompt
+    assert "the tests still fail" in prompt
+
+
+async def test_a_first_pass_prompt_carries_no_history(
+    session_factory, org_id, user_id, chat_session,
+):
+    from surogates.missions.evaluator import build_evaluator_prompt
+
+    store, mid = await _mission(session_factory, org_id, user_id, chat_session)
+    prompt = await build_evaluator_prompt(
+        mission_id=mid, coordinator_last_response="first try",
+        session_factory=session_factory, mission_store=store,
+    )
+    assert "previous evaluation" not in prompt.lower()


### PR DESCRIPTION
LoopX proposal P4. Plan: `docs/superpowers/plans/2026-08-03-loopx-adoption.md`.

**Conflicts with #190** — both add a column to the same `ALTER TABLE missions` statement. Trivial to resolve; whichever merges second just adds its column to the list.

## The gap

`record_evaluation` writes `last_evaluation_result` / `_explanation` / `_feedback` as single slots. Round N has no knowledge of round N-1.

The judge fires on every terminal task, re-derives the same opinion from scratch at full cost, and a mission can be told "needs revision, the tests still fail" indefinitely with nothing accumulating and nothing escalating.

## What this does NOT port

The plan specified LoopX's progress-granularity lattice. Its own verification then found three things wrong with that description:

1. The threshold came from `degradation_policy.small_scale_streak_threshold` (default **2**), not `outcome_floor.surface_streak_threshold` (3) — two different values conflated.
2. The "teeth" read a *different* counter than the streak, and are hard-gated on `waiting_on != "codex"`, a LoopX handoff-topology precondition with no analogue here. There is no enforcement path from the streak to any block.
3. The floor ships **off** (`DEFAULT_EXECUTION_PROFILE` has both marker lists empty), and when configured it classifies by substring matching over free text — the approach this codebase already retired.

So the lattice is not ported. The load-bearing finding was simpler and is what got built.

## What it does

`stagnant_evaluations` increments on any non-satisfied verdict, resets on `satisfied`. The judge prompt gains a block carrying its own previous verdict, reason and guidance, plus the streak length, and an explicit instruction: if the same blocker survives N rounds, return `blocked` rather than repeating itself.

No new status — `blocked` is already in `MissionStatus`, so no `sdk/agent-chat-react/src/types.ts` change and no dist rebuild. The limit of 3 matches the parse-failure pause and the orphan-recovery ceiling, so an operator meets one number rather than three.

## Migration

`create_all` does not add columns to existing tables, so `stagnant_evaluations` also lands in the retrofit `ALTER` block in `db/observability.sql`.

Worth flagging for review: my first attempt at that edit **silently no-op'd** — it anchored on a line that #190 introduces, and this branch is cut from master. Unit tests would never have caught it, since they build a fresh schema that includes the column; only an existing PROD table would have been missing it. The edit now asserts its anchor.

## Tests

7 against real PostgreSQL: a fresh mission is not stagnant; repeated non-progress accumulates; progress resets; the terminal is reached at 3 and not at 2; the judge prompt carries the streak and the previous reason; a first-pass prompt carries no history block.

## Verification

All 69 mission integration tests pass. Full unit suite `28 failed / 5039 passed` — **identical failure set** to master. Ruff clean.