### PR TITLE
feat(missions): the judge does not declare success on its own word

### DIFF
--- a/surogates/harness/loop_mission_evaluator.py
+++ b/surogates/harness/loop_mission_evaluator.py
@@ -171,6 +171,17 @@ async def _maybe_run_mission_evaluator(
             report_task_done=report_done,
             budget_exhausted=research_cycles >= research_max_cycles,
         )
+    else:
+        # Same principle for standard missions: the judge does not mint the
+        # terminal verdict on its own word. Task status is machine-written
+        # by the dispatcher and the completion classifier, so it is evidence
+        # the coordinator cannot author.
+        from surogates.missions.verdict_policy import adjust_mission_verdict
+
+        done, total = await _mission_task_counts(session_factory, active.id)
+        verdict = adjust_mission_verdict(
+            verdict, completed_tasks=done, total_tasks=total,
+        )
 
     await apply_verdict(
         mission_id=active.id,
@@ -331,3 +342,19 @@ def _build_mission_judge(
             raise MissionJudgeParseError(str(exc)) from exc
 
     return judge
+
+
+async def _mission_task_counts(session_factory, mission_id) -> tuple[int, int]:
+    """(completed, total) tasks for *mission_id*."""
+    from sqlalchemy import func, select
+
+    from surogates.db.models import Task
+
+    async with session_factory() as db:
+        row = (await db.execute(
+            select(
+                func.count(),
+                func.count().filter(Task.status == "done"),
+            ).where(Task.mission_id == mission_id)
+        )).one()
+    return int(row[1] or 0), int(row[0] or 0)

--- a/surogates/missions/verdict_policy.py
+++ b/surogates/missions/verdict_policy.py
@@ -1,0 +1,65 @@
+"""Deterministic gates on the mission judge's verdict.
+
+`arbor/evaluator_policy.py` already establishes the principle for research
+missions: the LLM does not mint the terminal verdict. ``satisfied`` is demoted
+unless a machine-written score improved and the report task is done.
+
+Standard missions had no equivalent — the judge's word was final, so a
+coordinator that talked its way to "done" was done.
+
+The corroborating signal is deliberately machine-written. Task status is set
+by the dispatcher and the completion classifier, never by the coordinator's
+prose. A ``tool.result`` event would not do: it proves *some* tool ran, and
+the coordinator chooses the tool and its arguments, so
+``bash -c 'echo tests passed'` produces one.
+
+Nothing here executes anything. Per-criterion validator commands — declared
+at mission creation with trusted argv and exit-code-only semantics, the way
+arbor's ``eval_cmd_test`` works — are a separate and much larger design
+(sandbox access, timeouts, argument trust) and are deliberately not this.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["adjust_mission_verdict"]
+
+_DEMOTION_FEEDBACK = (
+    "A mission is not satisfied while none of its tasks completed. Either "
+    "finish the outstanding work, or — if the objective genuinely needs no "
+    "further tasks — say so explicitly and explain what evidence supports "
+    "that."
+)
+
+
+def adjust_mission_verdict(
+    verdict: dict[str, Any],
+    *,
+    completed_tasks: int,
+    total_tasks: int | None = None,
+) -> dict[str, Any]:
+    """Demote a ``satisfied`` verdict that nothing corroborates.
+
+    *completed_tasks* counts mission tasks in a done state; *total_tasks*
+    counts every mission task. When a mission spawned no tasks at all there
+    is nothing to corroborate against, so the gate stands aside rather than
+    deadlocking a mission that was never meant to decompose.
+
+    Verdicts other than ``satisfied`` pass through: they already claim less
+    than the evidence would need to support.
+    """
+    if not isinstance(verdict, dict) or verdict.get("result") != "satisfied":
+        return verdict
+    if completed_tasks > 0:
+        return verdict
+    if not total_tasks:
+        return verdict
+    return {
+        "result": "needs_revision",
+        "explanation": (
+            "satisfied rejected: no mission task completed, so nothing "
+            "corroborates the claim"
+        ),
+        "feedback": _DEMOTION_FEEDBACK,
+    }

--- a/tests/test_mission_verdict_corroboration.py
+++ b/tests/test_mission_verdict_corroboration.py
@@ -1,0 +1,71 @@
+"""A judge cannot declare a mission satisfied with nothing to show for it.
+
+`adjust_research_verdict` already implements "the LLM does not mint the
+terminal verdict" for research missions: `satisfied` is demoted unless a
+machine-written score improved and the report task is done. Standard missions
+had no such gate — the judge's word was final.
+
+The corroborating signal here is deliberately machine-written: task status is
+set by the dispatcher and the completion classifier, never by the coordinator's
+own prose. A `tool.result` event would NOT do — it proves some tool ran, and
+the coordinator chooses the tool and its arguments.
+
+Nothing here executes anything. Declared validator commands are a separate,
+larger design (sandbox access, timeouts, argv trust) and are not this.
+"""
+from __future__ import annotations
+
+import pytest
+
+from surogates.missions.verdict_policy import adjust_mission_verdict
+
+
+def _v(result: str) -> dict:
+    return {"result": result, "explanation": "e", "feedback": "f"}
+
+
+def test_satisfied_with_completed_work_stands():
+    out = adjust_mission_verdict(_v("satisfied"), completed_tasks=2)
+    assert out["result"] == "satisfied"
+
+
+def test_satisfied_with_nothing_done_is_demoted():
+    out = adjust_mission_verdict(
+        _v("satisfied"), completed_tasks=0, total_tasks=2,
+    )
+    assert out["result"] == "needs_revision"
+    assert "corroborat" in out["explanation"].lower()
+
+
+def test_the_demotion_explains_itself_to_the_agent():
+    out = adjust_mission_verdict(
+        _v("satisfied"), completed_tasks=0, total_tasks=2,
+    )
+    assert out["feedback"] != "f", "must replace the judge's own feedback"
+
+
+@pytest.mark.parametrize("result", ["needs_revision", "blocked", "failed"])
+def test_non_terminal_verdicts_pass_through(result):
+    """Only `satisfied` claims completion; the rest are already conservative."""
+    out = adjust_mission_verdict(_v(result), completed_tasks=0, total_tasks=3)
+    assert out["result"] == result
+
+
+def test_a_taskless_mission_can_still_be_satisfied():
+    """Not every mission decomposes into tasks. When none were ever created
+    there is nothing to corroborate against and the gate must not deadlock."""
+    out = adjust_mission_verdict(
+        _v("satisfied"), completed_tasks=0, total_tasks=0,
+    )
+    assert out["result"] == "satisfied"
+
+
+def test_a_mission_with_tasks_none_done_is_demoted():
+    out = adjust_mission_verdict(
+        _v("satisfied"), completed_tasks=0, total_tasks=3,
+    )
+    assert out["result"] == "needs_revision"
+
+
+def test_a_malformed_verdict_is_left_alone():
+    assert adjust_mission_verdict({}, completed_tasks=0) == {}


### PR DESCRIPTION
LoopX proposal P9, built as the plan's own "cheapest version": a generic verdict gate, not a new ledger.

## The gap

`adjust_research_verdict` already implements *the LLM does not mint the terminal verdict* for research missions — `satisfied` is demoted unless a machine-written `test_trunk_score` improved and the report task is done.

Standard missions had no equivalent. The judge's word was final, so a coordinator that talked its way to "done" was done.

## The gate

`adjust_mission_verdict` runs at the same hook (`loop_mission_evaluator.py`, right after the judge and before `apply_verdict`), dispatched on mission kind. A `satisfied` verdict is demoted to `needs_revision` when the mission has tasks and none completed.

**The corroborating signal is chosen deliberately.** Task status is written by the dispatcher and the completion classifier — never by the coordinator's prose. The plan was explicit that a `tool.result` event will not serve: it proves *some* tool ran, and the coordinator picks the tool and its arguments, so `bash -c 'echo tests passed'` produces a real one.

**Escape hatch:** a mission that spawned no tasks at all has nothing to corroborate against, so the gate stands aside rather than deadlocking an objective never meant to decompose. Only "has tasks, none done" is demoted. Verdicts other than `satisfied` pass through — they already claim less than the evidence would need to support.

## Two parts of P9 deliberately not built

**Per-criterion structured rubric.** Its stated value was killing re-litigation churn. #191 already addresses that by giving the judge its previous verdict, reason and streak length. A criteria table on top would be speculative until someone shows the churn persists — and the plan's own verification warned the proposed "latch settled criteria" design is anti-LoopX and has no invalidation driver ("tests pass" latches in round 3, round 5 changes the code, judge is told it's settled).

**Declared validator commands.** The genuinely valuable remaining piece, and genuinely large: executing declared argv from the evaluator path needs sandbox access, timeouts and an argument-trust model. That is its own design, not a rider on this one. Arbor's `eval_cmd_test` is the shape to copy when it happens.

## Tests

9 unit. Two of them initially passed for the wrong reason — they omitted `total_tasks`, so they never distinguished "nothing done" from "no tasks exist", and one asserted a truthy `feedback` that the *unchanged* verdict already satisfied. Both now pin the real behaviour.

## Verification

71 mission integration tests pass. Full unit suite `28 failed / 5048 passed` — **identical failure set** to master. Ruff clean.