### PR TITLE
feat(missions): set a mission's token budget from /mission

### DIFF
--- a/surogates/harness/loop_outcome_commands.py
+++ b/surogates/harness/loop_outcome_commands.py
@@ -117,6 +117,7 @@ class OutcomeCommandMixin:
             handle_mission_create,
             handle_mission_pause,
             handle_mission_resume,
+            handle_mission_budget,
             handle_mission_status,
             parse_mission_command,
         )
@@ -174,6 +175,7 @@ class OutcomeCommandMixin:
                             session_store=self._store,
                             session_factory=self._session_factory,
                             mission_store=mission_store,
+                            budget_tokens=command.budget_tokens,
                         )
                         message = result.message or result.error
                         if result.ok and result.mission_id is not None:
@@ -198,6 +200,12 @@ class OutcomeCommandMixin:
                                 preloaded.append("subagent-task-orchestrator")
                             cfg["preloaded_skills"] = preloaded
                             session.config = cfg
+                elif command.action == "budget":
+                    message = await handle_mission_budget(
+                        session_id=session.id,
+                        budget_tokens=command.budget_tokens,
+                        mission_store=mission_store,
+                    )
                 elif command.action == "status":
                     result = await handle_mission_status(
                         session_id=session.id, mission_store=mission_store,

--- a/surogates/missions/commands.py
+++ b/surogates/missions/commands.py
@@ -28,7 +28,9 @@ from surogates.session.events import EventType
 logger = logging.getLogger(__name__)
 
 
-MissionAction = Literal["create", "status", "pause", "resume", "cancel"]
+MissionAction = Literal[
+    "create", "status", "pause", "resume", "cancel", "budget",
+]
 
 
 class MissionCommandParseError(ValueError):
@@ -44,6 +46,10 @@ class MissionCommand:
     rubric: str | None = None
     reason: str | None = None
     cascade_to_workers: bool = False
+    # Token allowance. ``None`` means "not specified"; with action="budget"
+    # and clear_budget=True it means "take the ceiling off".
+    budget_tokens: int | None = None
+    clear_budget: bool = False
 
 
 @dataclass(slots=True)
@@ -62,11 +68,51 @@ class AutoResearchCommand(MissionCommand):
     baseline_test: float | None = None
 
 
-_CONTROL_VERBS = ("status", "pause", "resume", "cancel")
+_CONTROL_VERBS = ("status", "pause", "resume", "cancel", "budget")
 _RUBRIC_RE = re.compile(r"\bRubric\s*:", re.IGNORECASE)
 _AUTO_RESEARCH_KV_RE = re.compile(
     r"^(max_iterations|resume|repo|baseline|baseline_test)=(\S+)\s*"
 )
+
+
+
+# A ``Budget:`` directive line, anywhere in a create body. Anchored to a whole
+# line so prose like "reconcile the marketing Budget: Q3" is not a directive.
+_BUDGET_LINE_RE = re.compile(
+    r"^[ \t]*Budget[ \t]*:[ \t]*(?P<value>[^\n]*?)[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_TOKEN_COUNT_RE = re.compile(r"^(?P<num>\d+(?:\.\d+)?)(?P<suffix>[kKmM]?)$")
+_SUFFIX_SCALE = {"": 1, "k": 1_000, "m": 1_000_000}
+
+
+def parse_token_budget(raw: str) -> int:
+    """Parse a human token count: ``20000000``, ``20M``, ``500k``, ``1.5M``.
+
+    Raises :class:`MissionCommandParseError` on anything unusable rather than
+    falling back to "unbounded" — a mistyped ceiling that silently means no
+    ceiling is the failure mode this exists to prevent.
+    """
+    text = (raw or "").strip().replace("_", "")
+    m = _TOKEN_COUNT_RE.match(text)
+    if m is None:
+        raise MissionCommandParseError(
+            f"unusable budget {raw!r}. Use a token count like "
+            "'20M', '500k' or '20000000'."
+        )
+    value = int(float(m.group("num")) * _SUFFIX_SCALE[m.group("suffix").lower()])
+    if value <= 0:
+        raise MissionCommandParseError("budget must be greater than zero")
+    return value
+
+
+def _extract_budget(text: str) -> tuple[str, int | None]:
+    """Pull a ``Budget:`` directive out of *text*; return (remainder, tokens)."""
+    match = _BUDGET_LINE_RE.search(text)
+    if match is None:
+        return text, None
+    tokens = parse_token_budget(match.group("value"))
+    return text[:match.start()] + text[match.end():], tokens
 
 
 def parse_mission_command(raw: str) -> MissionCommand:
@@ -105,7 +151,22 @@ def parse_mission_command(raw: str) -> MissionCommand:
             return MissionCommand(action="pause", reason=rest or None)
         if verb == "resume":
             return MissionCommand(action="resume")
+        if verb == "budget":
+            if not rest:
+                raise MissionCommandParseError(
+                    "budget needs a value: '/mission budget 20M', or "
+                    "'/mission budget none' to remove the ceiling."
+                )
+            if rest.lower() in ("none", "off", "clear", "unlimited"):
+                return MissionCommand(
+                    action="budget", budget_tokens=None, clear_budget=True,
+                )
+            return MissionCommand(
+                action="budget", budget_tokens=parse_token_budget(rest),
+            )
         return MissionCommand(action="status")
+
+    text, budget_tokens = _extract_budget(text)
 
     match = _RUBRIC_RE.search(text)
     if match is None:
@@ -121,6 +182,7 @@ def parse_mission_command(raw: str) -> MissionCommand:
         raise MissionCommandParseError("Rubric: block is empty")
     return MissionCommand(
         action="create", description=description, rubric=rubric,
+        budget_tokens=budget_tokens,
     )
 
 
@@ -280,6 +342,7 @@ async def handle_mission_create(
     user_id: UUID | None = None,
     service_account_id: UUID | None = None,
     max_iterations: int = 20,
+    budget_tokens: int | None = None,
 ) -> MissionHandlerResult:
     """Create a new mission on the calling session.
 
@@ -341,6 +404,7 @@ async def handle_mission_create(
             description=description,
             rubric=rubric,
             max_iterations=max_iterations,
+            budget_tokens=budget_tokens,
         )
     except ActiveMissionConflictError as exc:
         return MissionHandlerResult(ok=False, error=str(exc))
@@ -649,3 +713,23 @@ async def _cascade_cancel_workers(
                 "Failed to publish interrupt for session %s during mission %s cascade",
                 sid, mission_id, exc_info=True,
             )
+
+
+async def handle_mission_budget(
+    *,
+    session_id: UUID,
+    budget_tokens: int | None,
+    mission_store: MissionStore,
+) -> str:
+    """Set or clear the active mission's token allowance."""
+    mission = await mission_store.get_active_for_session(session_id)
+    if mission is None:
+        return "No active mission on this session."
+    await mission_store.set_budget(mission.id, budget_tokens=budget_tokens)
+    if budget_tokens is None:
+        return "Mission budget cleared — the objective is now unbounded."
+    spent = await mission_store.tokens_spent(mission.id)
+    return (
+        f"Mission budget set to {budget_tokens:,} tokens "
+        f"({spent:,} already spent)."
+    )

--- a/surogates/missions/models.py
+++ b/surogates/missions/models.py
@@ -65,6 +65,8 @@ class Mission(BaseModel):
     status: MissionStatus
     iteration: int = 0
     max_iterations: int = 20
+    # Token allowance for the whole objective; None = unbounded.
+    budget_tokens: int | None = None
     last_evaluation_result: EvaluationResult | None = None
     last_evaluation_explanation: str | None = None
     last_evaluation_feedback: str | None = None

--- a/surogates/missions/store.py
+++ b/surogates/missions/store.py
@@ -244,6 +244,25 @@ class MissionStore:
                 last = last.replace(tzinfo=timezone.utc)
             return datetime.now(timezone.utc) - last < timedelta(seconds=window_seconds)
 
+    async def set_budget(
+        self, mission_id: UUID, *, budget_tokens: int | None,
+    ) -> None:
+        """Set or clear a mission's token allowance.
+
+        ``None`` removes the ceiling. Settable after creation because that is
+        when the need usually shows up — a mission already running turns out
+        to be burning more than expected.
+        """
+        async with self._sf() as db:
+            res = await db.execute(
+                update(MissionRow)
+                .where(MissionRow.id == mission_id)
+                .values(budget_tokens=budget_tokens, updated_at=func.now())
+            )
+            if res.rowcount == 0:
+                raise MissionNotFoundError(f"mission {mission_id} not found")
+            await db.commit()
+
     async def is_stagnant(self, mission_id: UUID) -> bool:
         """True when the evaluator has returned no progress too many times.
 

--- a/tests/integration/missions/test_token_budget.py
+++ b/tests/integration/missions/test_token_budget.py
@@ -218,3 +218,50 @@ async def test_a_mission_within_budget_still_evaluates(
         rate_limit_seconds=0,
     )
     assert decision.should is True
+
+
+async def test_the_budget_verb_sets_it_on_a_running_mission(
+    session_factory, org_id, user_id, chat_session,
+):
+    """The case that motivated this: a mission is already running and turns
+    out to be burning more than expected."""
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works",
+    )
+    assert (await store.get(mid)).budget_tokens is None
+
+    await store.set_budget(mid, budget_tokens=5_000_000)
+    assert (await store.get(mid)).budget_tokens == 5_000_000
+
+
+async def test_the_ceiling_can_be_taken_off_again(
+    session_factory, org_id, user_id, chat_session,
+):
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works",
+        budget_tokens=1000,
+    )
+    await store.set_budget(mid, budget_tokens=None)
+
+    assert (await store.get(mid)).budget_tokens is None
+    assert await store.budget_exhausted(mid) is False
+
+
+async def test_a_budget_set_at_creation_via_the_command_path(
+    session_factory, org_id, user_id, chat_session,
+):
+    """End to end: the parsed value reaches the row."""
+    from surogates.missions.commands import parse_mission_command
+
+    cmd = parse_mission_command("ship it\nBudget: 3M\nRubric: works")
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description=cmd.description, rubric=cmd.rubric,
+        budget_tokens=cmd.budget_tokens,
+    )
+    assert (await store.get(mid)).budget_tokens == 3_000_000

--- a/tests/test_mission_budget_command.py
+++ b/tests/test_mission_budget_command.py
@@ -1,0 +1,99 @@
+"""Setting a mission's token allowance without reaching for psql.
+
+`budget_tokens` shipped with no way to set it: a column the store accepted
+and nothing surfaced, so the only route was direct SQL. That is not a
+feature anyone can use.
+
+Two entry points, because a budget matters at both moments — you set one
+when you know the objective is large, and you set one when a running
+mission turns out to be burning more than you expected.
+"""
+from __future__ import annotations
+
+import pytest
+
+from surogates.missions.commands import (
+    MissionCommandParseError,
+    parse_mission_command,
+)
+
+
+# -- the value itself -------------------------------------------------------
+
+@pytest.mark.parametrize("text,expected", [
+    ("20000000", 20_000_000),
+    ("20M", 20_000_000),
+    ("20m", 20_000_000),
+    ("1.5M", 1_500_000),
+    ("500k", 500_000),
+    ("500K", 500_000),
+    ("2_000_000", 2_000_000),
+])
+def test_human_token_counts_are_accepted(text, expected):
+    """Nobody should have to type 20000000 correctly under pressure."""
+    cmd = parse_mission_command(f"ship it\nBudget: {text}\nRubric: works")
+    assert cmd.budget_tokens == expected
+
+
+@pytest.mark.parametrize("bad", ["lots", "-5", "0", "20MB", "", "M"])
+def test_an_unusable_budget_is_rejected_not_ignored(bad):
+    """Silently treating a typo as 'unbounded' is the fail-open this
+    codebase has been removing all week."""
+    with pytest.raises(MissionCommandParseError):
+        parse_mission_command(f"ship it\nBudget: {bad}\nRubric: works")
+
+
+# -- at creation ------------------------------------------------------------
+
+def test_no_budget_block_means_unbounded():
+    cmd = parse_mission_command("ship it\nRubric: works")
+    assert cmd.budget_tokens is None
+
+
+def test_the_budget_line_is_kept_out_of_the_description():
+    cmd = parse_mission_command("ship it\nBudget: 5M\nRubric: works")
+    assert cmd.description == "ship it"
+    assert "Budget" not in (cmd.description or "")
+
+
+def test_the_budget_line_is_kept_out_of_the_rubric():
+    """It may sit after the rubric too; either position must parse the same."""
+    cmd = parse_mission_command("ship it\nRubric: works\nBudget: 5M")
+    assert cmd.budget_tokens == 5_000_000
+    assert "Budget" not in (cmd.rubric or "")
+    assert cmd.rubric == "works"
+
+
+def test_a_description_mentioning_budget_prose_is_untouched():
+    """Only a line that IS a Budget: directive counts, not prose about one."""
+    cmd = parse_mission_command(
+        "reconcile the marketing Budget: Q3 overspend\nRubric: reconciled",
+    )
+    assert cmd.budget_tokens is None
+    assert "marketing Budget" in (cmd.description or "")
+
+
+# -- on a running mission ---------------------------------------------------
+
+def test_budget_is_a_control_verb():
+    cmd = parse_mission_command("budget 20M")
+    assert cmd.action == "budget"
+    assert cmd.budget_tokens == 20_000_000
+
+
+def test_the_budget_verb_rejects_a_bad_value():
+    with pytest.raises(MissionCommandParseError):
+        parse_mission_command("budget nonsense")
+
+
+def test_the_budget_verb_requires_a_value():
+    with pytest.raises(MissionCommandParseError):
+        parse_mission_command("budget")
+
+
+def test_budget_none_clears_the_ceiling():
+    """An operator must be able to take a ceiling off again."""
+    cmd = parse_mission_command("budget none")
+    assert cmd.action == "budget"
+    assert cmd.budget_tokens is None
+    assert cmd.clear_budget is True


### PR DESCRIPTION
Closes the reachability gap flagged on #190.

## The problem

`budget_tokens` landed with no way to set it. The store accepted the argument, nothing passed it, and no command or API surfaced it — so the only route was direct SQL against a live database. I called this out on #190 rather than inventing slash syntax unilaterally; that decision has now been made.

## Two entry points

**At creation** — a `Budget:` block parallel to `Rubric:`:

```
/mission Audit every test file for tests that pass for the wrong reason.

Budget: 20M
Rubric: every directory has a completed task and findings are recorded.
```

**On a running mission** — a control verb beside `status` / `pause` / `resume` / `cancel`:

```
/mission budget 20M     -> "Mission budget set to 20,000,000 tokens (4,479,815 already spent)."
/mission budget none    -> "Mission budget cleared — the objective is now unbounded."
```

The second is the one that actually matters in practice: you discover a mission is burning more than expected *while it runs*, not when you start it.

## Parsing decisions

- **Human counts.** `20M`, `500k`, `1.5M`, `2_000_000`, or a raw integer.
- **A bad value raises.** `Budget: lots` is a parse error, not a silent fallback to unbounded — a mistyped ceiling that means "no ceiling" is exactly the fail-open this series has been removing.
- **`Budget:` must be a whole line**, so `/mission reconcile the marketing Budget: Q3 overspend` stays prose. Pinned by a test.
- **Position-independent.** The directive is extracted before the description/rubric split, so it parses identically either side of the `Rubric:` block.
- `none` / `off` / `clear` / `unlimited` all remove the ceiling.

## Also fixes a gap #190 left

`Mission` — the domain model callers use — had **no `budget_tokens` field**. The ORM column existed and `budget_exhausted()` worked because it queries the column directly, but `store.get(mid).budget_tokens` raised `AttributeError`. #190's tests never read it off the model, so nothing caught it.

That is the third instance of one shape in this series: the column landed, the surface didn't (`require_approval` had no writer; `budget_tokens` had no command; the model had no field). Worth a standing check — when adding a column, confirm a writer, a reader, and the domain model all exist before calling it done.

## Tests

21 parser unit tests (value forms, rejection of bad values, prose safety, position independence, the control verb, clearing) + 3 integration tests against real PostgreSQL (set on a running mission, clear it again, end-to-end from the parsed command to the row).

## Verification

105 mission-related tests pass. Full unit suite `28 failed / 5093 passed` — **identical failure set** to master. Ruff on the touched files matches master exactly (15 pre-existing `F821`s from TYPE_CHECKING-only names).