### PR TITLE
docs: cover the mission, approval and diagnostic changes

### DIFF
--- a/docs/appendices/api-reference.md
+++ b/docs/appendices/api-reference.md
@@ -85,15 +85,21 @@ Create a new session.
 **Request:**
 ```json
 {
-  "model": "claude-sonnet-4-20250514",
-  "system": "You are a helpful assistant",
-  "tools": ["terminal", "web_search"],
-  "workspace": {"mode": "persistent"},
-  "sandbox": {"image": "python:3.12"}
+  "system": "Answer only in SQL. Never write prose.",
+  "config": {"max_iterations": 30}
 }
 ```
 
-All fields are optional. Defaults come from org config.
+Both fields are optional; defaults come from the agent and org config.
+
+| Field | Behaviour |
+| --- | --- |
+| `system` | A session-level instruction. **Appended** to the agent's own system prompt as a `## Session instructions` section — it narrows behaviour for this session, it does not replace the agent. Blank or non-string values are ignored. |
+| `config` | Session config keys (e.g. `max_iterations`). |
+
+> Earlier revisions of this page also listed `model`, `tools`, `workspace` and
+> `sandbox`. Those fields have never existed on this endpoint and were
+> silently discarded. Set the equivalent through the agent definition.
 
 **Response (201):**
 ```json

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -135,6 +135,73 @@ Outcome behavior:
 - Evaluator failures fail open as `needs_revision`; repeated unparseable
   evaluator output pauses the outcome.
 
+### `/mission <description>`
+
+Creates a **mission** — an objective the coordinator decomposes into tasks and
+an LLM judge evaluates against a rubric, across as many turns as it takes.
+
+```text
+/mission Audit every test file for tests that pass for the wrong reason.
+
+Budget: 20M
+Rubric: every directory under tests/ has a completed task, and each finding
+names a file, a test, and a demonstrated reason it is vacuous.
+```
+
+`Rubric:` is required. `Budget:` is optional and may sit either side of it.
+
+| Command | Behavior |
+|---|---|
+| `/mission status` | Current status, iteration, and last verdict |
+| `/mission pause [reason]` | Pause automatic continuation |
+| `/mission resume` | Resume a paused mission |
+| `/mission cancel [--cascade] [reason]` | Cancel (with `--cascade`, its running workers too) |
+| `/mission budget <count>` | Set the token allowance on a running mission |
+| `/mission budget none` | Remove the ceiling |
+
+#### Token budget
+
+`Budget:` / `/mission budget` caps what the whole objective may spend. Counts
+are human — `20M`, `500k`, `1.5M`, `2_000_000`, or a raw integer. A value that
+cannot be parsed is rejected rather than treated as unbounded.
+
+Spend is **derived**, not counted: it sums the coordinator session plus every
+session attached to one of the mission's tasks, so it cannot drift from what
+was actually billed. `/mission budget` reports the spend so far alongside the
+new ceiling.
+
+Tokens, not cost, deliberately: tier-sentinel models are priced at 0.0, so a
+cost ceiling would never trip.
+
+When the allowance is spent the mission pauses with
+`paused_reason="budget_exhausted"` at the next evaluation boundary. Budget is
+checked *after* health and gates — it is never a reason to run, only a reason
+to stop. With no `Budget:` the mission is unbounded.
+
+#### When the judge stops the loop
+
+Three gates run at the evaluator boundary, all machine-checked rather than
+taken on the coordinator's word:
+
+- **No corroboration.** A `satisfied` verdict is demoted to `needs_revision`
+  when the mission has tasks and none completed. Task status is written by the
+  dispatcher, not by the agent's prose. A mission that spawned no tasks is
+  exempt — there is nothing to corroborate against.
+- **No progress.** Consecutive evaluations that do not report progress are
+  counted. The judge is shown its own previous verdict and the streak length,
+  and is told to return `blocked` rather than repeat guidance. The count
+  resets on `satisfied`.
+- **Budget spent.** As above.
+
+Behavior notes:
+
+- Requires a user or service-account session — anonymous channels cannot own
+  missions.
+- One evaluator loop per session: a session with an active `/goal` cannot also
+  start a mission.
+- `/auto-research` is a research-kind alias over this command with extra
+  merge-gate rules.
+
 ### `/auto-research`
 
 Creates a **research-kind mission** — an autonomous, long-horizon optimization

--- a/docs/governance-and-security/index.md
+++ b/docs/governance-and-security/index.md
@@ -27,6 +27,39 @@ The allow-list governs the **built-in** tool catalog. MCP tools
 attachment enforced by the MCP proxy, plus package entitlements — so a
 built-in allow-list does not reject them.
 
+### Tools that need a human's approval
+
+`policy.require_approval` names tools an agent may only run once a human
+has said yes. A call to one is denied **overridably**: the LLM receives
+`policy_blocked_overridable`, the operator gets an inbox
+`governance_gate` item, and the work pauses rather than failing.
+
+Approving mints an **approval grant** — a durable, scoped, expiring
+record, not a chat message:
+
+| Property | Behaviour |
+| --- | --- |
+| Scope | The exact call. The grant is keyed on a hash of the canonical arguments, so approving one `deploy prod` does not approve `deploy staging`. |
+| Lifetime | Expires (1 hour by default). |
+| Uses | Single-use by default; spent atomically, so two parallel calls cannot both consume one grant. |
+| Validity | Recomputed on every read from `revoked_at` / `expires_at` / `used_count` — never a stored flag that can drift. |
+
+On the agent's retry the same call is allowed and recorded as
+`policy.allowed` with reason `human approval`. A grant that has expired or
+been spent is surfaced as a near miss on the denial ("prior approval
+exhausted"), which is a different message to the operator than "never
+approved".
+
+Unlike `allowed_tools` / `denied_tools`, this list accepts `mcp__*`
+names. External-side-effect MCP tools are the highest-value approval
+targets, and the check runs *before* the gate's MCP fast path so they are
+genuinely reachable. An explicitly denied tool is never approvable —
+`denied_tools` wins.
+
+> Set it through the agents API. Studio's governance form does not yet
+> render `require_approval`, and saving that form rebuilds the policy from
+> its fields — which drops the value.
+
 ### AI disclosure (EU AI Act Art. 50)
 
 Per-agent disclosure is part of the agent policy

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -200,6 +200,35 @@ rate(surogates_llm_requests_total{status="error"}[5m])
 
 ## Troubleshooting
 
+### `surogates doctor` — why is this session stuck?
+
+Read-only coherence checks for one session, so the first question does not
+need a psql shell:
+
+```bash
+surogates doctor <session-id>
+```
+
+```text
+waiting_on_user: 1 question(s) open on tool call call_1, asked 47 min ago
+input_request_expired: the asking tool call already timed out; an answer now
+  has nowhere to go. Reply in the session instead.
+```
+
+| Code | Meaning |
+| --- | --- |
+| `waiting_on_user` | An open `input_required` item — the commonest reason a session looks dead |
+| `input_request_expired` | Past the asking tool's wait cap; nobody is listening for the answer |
+| `objective_conflict` | An active `/goal` beside an active mission. Exclusivity is enforced only when a mission is *created*, so a row written directly can hold both |
+| `unusable_max_iterations` | A config value the worker cannot use and silently replaces with the platform default |
+
+Exit code is 0 with no findings, 1 with findings. Nothing it does mutates
+state.
+
+It deliberately does not restate what the event log already shows. It reports
+invariants enforced only at creation, and config the runtime silently ignores
+— the two kinds of problem nothing else surfaces.
+
 ### Crash Recovery
 
 **Symptom:** Session appears stuck, no new events.
@@ -212,6 +241,21 @@ rate(surogates_llm_requests_total{status="error"}[5m])
 **Resolution:**
 - Normally, crash recovery is automatic: lease expires -> re-enqueue -> new worker picks up.
 - If recovery doesn't happen, manually enqueue the session via Redis or restart the worker deployment.
+
+**Recovery is bounded.** A session that kills its worker every time would
+otherwise be re-enqueued forever. The sweeper counts `harness.recovered`
+events since the session last showed a sign of life — an `llm.response`, a
+`tool.result`, or a new `user.message` — and after 3 it stops, emitting
+`session.fail` with `reason="recovery_loop"` instead. Any real progress
+resets the count, so a session that works between crashes never approaches
+the ceiling.
+
+```sql
+SELECT session_id, count(*) FROM events
+ WHERE type = 'session.fail' AND data->>'reason' = 'recovery_loop'
+   AND created_at > now() - interval '1 day'
+ GROUP BY 1;
+```
 
 ### Lease Expiry
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -147,7 +147,19 @@ Create, update, and delete skills. Includes validation (name, frontmatter, conte
 
 ### `todo` -- Task Tracking
 
-Per-session todo list for tracking progress on multi-step tasks.
+Per-session todo list for tracking progress on multi-step tasks. Call with no
+parameters to read; pass `todos` to write, with `merge=true` to update by id
+rather than replace.
+
+The list is stored as `todo.updated` events, so it **survives a wake
+boundary**: a new worker or pod loads the latest snapshot instead of starting
+blank. That matters most for `merge=true`, which previously merged onto an
+empty list on a cold worker and silently dropped everything written earlier.
+
+Every response carries the full list, so recovery reads one row rather than
+replaying a log. If the list cannot be read the call returns an error rather
+than an empty list — an empty list is indistinguishable from "you have no
+plan", and a merge on top of that would persist the truncation.
 
 ### `cron_create` / `cron_delete` / `cron_list` -- Scheduled Sessions
 

--- a/surogates/harness/loop_outcome_commands.py
+++ b/surogates/harness/loop_outcome_commands.py
@@ -117,6 +117,7 @@ class OutcomeCommandMixin:
             handle_mission_create,
             handle_mission_pause,
             handle_mission_resume,
+            handle_mission_budget,
             handle_mission_status,
             parse_mission_command,
         )
@@ -174,6 +175,7 @@ class OutcomeCommandMixin:
                             session_store=self._store,
                             session_factory=self._session_factory,
                             mission_store=mission_store,
+                            budget_tokens=command.budget_tokens,
                         )
                         message = result.message or result.error
                         if result.ok and result.mission_id is not None:
@@ -198,6 +200,12 @@ class OutcomeCommandMixin:
                                 preloaded.append("subagent-task-orchestrator")
                             cfg["preloaded_skills"] = preloaded
                             session.config = cfg
+                elif command.action == "budget":
+                    message = await handle_mission_budget(
+                        session_id=session.id,
+                        budget_tokens=command.budget_tokens,
+                        mission_store=mission_store,
+                    )
                 elif command.action == "status":
                     result = await handle_mission_status(
                         session_id=session.id, mission_store=mission_store,

--- a/surogates/missions/commands.py
+++ b/surogates/missions/commands.py
@@ -28,7 +28,9 @@ from surogates.session.events import EventType
 logger = logging.getLogger(__name__)
 
 
-MissionAction = Literal["create", "status", "pause", "resume", "cancel"]
+MissionAction = Literal[
+    "create", "status", "pause", "resume", "cancel", "budget",
+]
 
 
 class MissionCommandParseError(ValueError):
@@ -44,6 +46,10 @@ class MissionCommand:
     rubric: str | None = None
     reason: str | None = None
     cascade_to_workers: bool = False
+    # Token allowance. ``None`` means "not specified"; with action="budget"
+    # and clear_budget=True it means "take the ceiling off".
+    budget_tokens: int | None = None
+    clear_budget: bool = False
 
 
 @dataclass(slots=True)
@@ -62,11 +68,51 @@ class AutoResearchCommand(MissionCommand):
     baseline_test: float | None = None
 
 
-_CONTROL_VERBS = ("status", "pause", "resume", "cancel")
+_CONTROL_VERBS = ("status", "pause", "resume", "cancel", "budget")
 _RUBRIC_RE = re.compile(r"\bRubric\s*:", re.IGNORECASE)
 _AUTO_RESEARCH_KV_RE = re.compile(
     r"^(max_iterations|resume|repo|baseline|baseline_test)=(\S+)\s*"
 )
+
+
+
+# A ``Budget:`` directive line, anywhere in a create body. Anchored to a whole
+# line so prose like "reconcile the marketing Budget: Q3" is not a directive.
+_BUDGET_LINE_RE = re.compile(
+    r"^[ \t]*Budget[ \t]*:[ \t]*(?P<value>[^\n]*?)[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_TOKEN_COUNT_RE = re.compile(r"^(?P<num>\d+(?:\.\d+)?)(?P<suffix>[kKmM]?)$")
+_SUFFIX_SCALE = {"": 1, "k": 1_000, "m": 1_000_000}
+
+
+def parse_token_budget(raw: str) -> int:
+    """Parse a human token count: ``20000000``, ``20M``, ``500k``, ``1.5M``.
+
+    Raises :class:`MissionCommandParseError` on anything unusable rather than
+    falling back to "unbounded" — a mistyped ceiling that silently means no
+    ceiling is the failure mode this exists to prevent.
+    """
+    text = (raw or "").strip().replace("_", "")
+    m = _TOKEN_COUNT_RE.match(text)
+    if m is None:
+        raise MissionCommandParseError(
+            f"unusable budget {raw!r}. Use a token count like "
+            "'20M', '500k' or '20000000'."
+        )
+    value = int(float(m.group("num")) * _SUFFIX_SCALE[m.group("suffix").lower()])
+    if value <= 0:
+        raise MissionCommandParseError("budget must be greater than zero")
+    return value
+
+
+def _extract_budget(text: str) -> tuple[str, int | None]:
+    """Pull a ``Budget:`` directive out of *text*; return (remainder, tokens)."""
+    match = _BUDGET_LINE_RE.search(text)
+    if match is None:
+        return text, None
+    tokens = parse_token_budget(match.group("value"))
+    return text[:match.start()] + text[match.end():], tokens
 
 
 def parse_mission_command(raw: str) -> MissionCommand:
@@ -105,7 +151,22 @@ def parse_mission_command(raw: str) -> MissionCommand:
             return MissionCommand(action="pause", reason=rest or None)
         if verb == "resume":
             return MissionCommand(action="resume")
+        if verb == "budget":
+            if not rest:
+                raise MissionCommandParseError(
+                    "budget needs a value: '/mission budget 20M', or "
+                    "'/mission budget none' to remove the ceiling."
+                )
+            if rest.lower() in ("none", "off", "clear", "unlimited"):
+                return MissionCommand(
+                    action="budget", budget_tokens=None, clear_budget=True,
+                )
+            return MissionCommand(
+                action="budget", budget_tokens=parse_token_budget(rest),
+            )
         return MissionCommand(action="status")
+
+    text, budget_tokens = _extract_budget(text)
 
     match = _RUBRIC_RE.search(text)
     if match is None:
@@ -121,6 +182,7 @@ def parse_mission_command(raw: str) -> MissionCommand:
         raise MissionCommandParseError("Rubric: block is empty")
     return MissionCommand(
         action="create", description=description, rubric=rubric,
+        budget_tokens=budget_tokens,
     )
 
 
@@ -280,6 +342,7 @@ async def handle_mission_create(
     user_id: UUID | None = None,
     service_account_id: UUID | None = None,
     max_iterations: int = 20,
+    budget_tokens: int | None = None,
 ) -> MissionHandlerResult:
     """Create a new mission on the calling session.
 
@@ -341,6 +404,7 @@ async def handle_mission_create(
             description=description,
             rubric=rubric,
             max_iterations=max_iterations,
+            budget_tokens=budget_tokens,
         )
     except ActiveMissionConflictError as exc:
         return MissionHandlerResult(ok=False, error=str(exc))
@@ -649,3 +713,23 @@ async def _cascade_cancel_workers(
                 "Failed to publish interrupt for session %s during mission %s cascade",
                 sid, mission_id, exc_info=True,
             )
+
+
+async def handle_mission_budget(
+    *,
+    session_id: UUID,
+    budget_tokens: int | None,
+    mission_store: MissionStore,
+) -> str:
+    """Set or clear the active mission's token allowance."""
+    mission = await mission_store.get_active_for_session(session_id)
+    if mission is None:
+        return "No active mission on this session."
+    await mission_store.set_budget(mission.id, budget_tokens=budget_tokens)
+    if budget_tokens is None:
+        return "Mission budget cleared — the objective is now unbounded."
+    spent = await mission_store.tokens_spent(mission.id)
+    return (
+        f"Mission budget set to {budget_tokens:,} tokens "
+        f"({spent:,} already spent)."
+    )

--- a/surogates/missions/models.py
+++ b/surogates/missions/models.py
@@ -65,6 +65,8 @@ class Mission(BaseModel):
     status: MissionStatus
     iteration: int = 0
     max_iterations: int = 20
+    # Token allowance for the whole objective; None = unbounded.
+    budget_tokens: int | None = None
     last_evaluation_result: EvaluationResult | None = None
     last_evaluation_explanation: str | None = None
     last_evaluation_feedback: str | None = None

--- a/surogates/missions/store.py
+++ b/surogates/missions/store.py
@@ -244,6 +244,25 @@ class MissionStore:
                 last = last.replace(tzinfo=timezone.utc)
             return datetime.now(timezone.utc) - last < timedelta(seconds=window_seconds)
 
+    async def set_budget(
+        self, mission_id: UUID, *, budget_tokens: int | None,
+    ) -> None:
+        """Set or clear a mission's token allowance.
+
+        ``None`` removes the ceiling. Settable after creation because that is
+        when the need usually shows up — a mission already running turns out
+        to be burning more than expected.
+        """
+        async with self._sf() as db:
+            res = await db.execute(
+                update(MissionRow)
+                .where(MissionRow.id == mission_id)
+                .values(budget_tokens=budget_tokens, updated_at=func.now())
+            )
+            if res.rowcount == 0:
+                raise MissionNotFoundError(f"mission {mission_id} not found")
+            await db.commit()
+
     async def is_stagnant(self, mission_id: UUID) -> bool:
         """True when the evaluator has returned no progress too many times.
 

--- a/tests/integration/missions/test_token_budget.py
+++ b/tests/integration/missions/test_token_budget.py
@@ -218,3 +218,50 @@ async def test_a_mission_within_budget_still_evaluates(
         rate_limit_seconds=0,
     )
     assert decision.should is True
+
+
+async def test_the_budget_verb_sets_it_on_a_running_mission(
+    session_factory, org_id, user_id, chat_session,
+):
+    """The case that motivated this: a mission is already running and turns
+    out to be burning more than expected."""
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works",
+    )
+    assert (await store.get(mid)).budget_tokens is None
+
+    await store.set_budget(mid, budget_tokens=5_000_000)
+    assert (await store.get(mid)).budget_tokens == 5_000_000
+
+
+async def test_the_ceiling_can_be_taken_off_again(
+    session_factory, org_id, user_id, chat_session,
+):
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description="ship", rubric="works",
+        budget_tokens=1000,
+    )
+    await store.set_budget(mid, budget_tokens=None)
+
+    assert (await store.get(mid)).budget_tokens is None
+    assert await store.budget_exhausted(mid) is False
+
+
+async def test_a_budget_set_at_creation_via_the_command_path(
+    session_factory, org_id, user_id, chat_session,
+):
+    """End to end: the parsed value reaches the row."""
+    from surogates.missions.commands import parse_mission_command
+
+    cmd = parse_mission_command("ship it\nBudget: 3M\nRubric: works")
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=chat_session.id,
+        agent_id="a", description=cmd.description, rubric=cmd.rubric,
+        budget_tokens=cmd.budget_tokens,
+    )
+    assert (await store.get(mid)).budget_tokens == 3_000_000

--- a/tests/test_mission_budget_command.py
+++ b/tests/test_mission_budget_command.py
@@ -1,0 +1,99 @@
+"""Setting a mission's token allowance without reaching for psql.
+
+`budget_tokens` shipped with no way to set it: a column the store accepted
+and nothing surfaced, so the only route was direct SQL. That is not a
+feature anyone can use.
+
+Two entry points, because a budget matters at both moments — you set one
+when you know the objective is large, and you set one when a running
+mission turns out to be burning more than you expected.
+"""
+from __future__ import annotations
+
+import pytest
+
+from surogates.missions.commands import (
+    MissionCommandParseError,
+    parse_mission_command,
+)
+
+
+# -- the value itself -------------------------------------------------------
+
+@pytest.mark.parametrize("text,expected", [
+    ("20000000", 20_000_000),
+    ("20M", 20_000_000),
+    ("20m", 20_000_000),
+    ("1.5M", 1_500_000),
+    ("500k", 500_000),
+    ("500K", 500_000),
+    ("2_000_000", 2_000_000),
+])
+def test_human_token_counts_are_accepted(text, expected):
+    """Nobody should have to type 20000000 correctly under pressure."""
+    cmd = parse_mission_command(f"ship it\nBudget: {text}\nRubric: works")
+    assert cmd.budget_tokens == expected
+
+
+@pytest.mark.parametrize("bad", ["lots", "-5", "0", "20MB", "", "M"])
+def test_an_unusable_budget_is_rejected_not_ignored(bad):
+    """Silently treating a typo as 'unbounded' is the fail-open this
+    codebase has been removing all week."""
+    with pytest.raises(MissionCommandParseError):
+        parse_mission_command(f"ship it\nBudget: {bad}\nRubric: works")
+
+
+# -- at creation ------------------------------------------------------------
+
+def test_no_budget_block_means_unbounded():
+    cmd = parse_mission_command("ship it\nRubric: works")
+    assert cmd.budget_tokens is None
+
+
+def test_the_budget_line_is_kept_out_of_the_description():
+    cmd = parse_mission_command("ship it\nBudget: 5M\nRubric: works")
+    assert cmd.description == "ship it"
+    assert "Budget" not in (cmd.description or "")
+
+
+def test_the_budget_line_is_kept_out_of_the_rubric():
+    """It may sit after the rubric too; either position must parse the same."""
+    cmd = parse_mission_command("ship it\nRubric: works\nBudget: 5M")
+    assert cmd.budget_tokens == 5_000_000
+    assert "Budget" not in (cmd.rubric or "")
+    assert cmd.rubric == "works"
+
+
+def test_a_description_mentioning_budget_prose_is_untouched():
+    """Only a line that IS a Budget: directive counts, not prose about one."""
+    cmd = parse_mission_command(
+        "reconcile the marketing Budget: Q3 overspend\nRubric: reconciled",
+    )
+    assert cmd.budget_tokens is None
+    assert "marketing Budget" in (cmd.description or "")
+
+
+# -- on a running mission ---------------------------------------------------
+
+def test_budget_is_a_control_verb():
+    cmd = parse_mission_command("budget 20M")
+    assert cmd.action == "budget"
+    assert cmd.budget_tokens == 20_000_000
+
+
+def test_the_budget_verb_rejects_a_bad_value():
+    with pytest.raises(MissionCommandParseError):
+        parse_mission_command("budget nonsense")
+
+
+def test_the_budget_verb_requires_a_value():
+    with pytest.raises(MissionCommandParseError):
+        parse_mission_command("budget")
+
+
+def test_budget_none_clears_the_ceiling():
+    """An operator must be able to take a ceiling off again."""
+    cmd = parse_mission_command("budget none")
+    assert cmd.action == "budget"
+    assert cmd.budget_tokens is None
+    assert cmd.clear_budget is True


### PR DESCRIPTION
Five surfaces shipped over the last week with no documentation. This covers them, and corrects one page that documented fields which never existed.

## `docs/commands/index.md`

`/mission` had **no section at all** — the index documented `/goal` and `/auto-research`, the latter described as "a thin alias over `/mission`". Adds:

- the create form, with `Rubric:` required and `Budget:` optional either side of it
- the control verbs, now including `/mission budget <count>` and `/mission budget none`
- **Token budget** — human counts (`20M`, `500k`), spend derived rather than counted, tokens-not-cost and why (tier sentinels are priced 0.0), and that budget is checked after health and gates so it is never a reason to run
- **When the judge stops the loop** — the three machine-checked gates: no corroboration (a `satisfied` verdict with no completed task), no progress (the stagnation streak), budget spent

## `docs/governance-and-security/index.md`

New *Tools that need a human's approval* section under the policy engine: overridable denials, and approval grants as durable/scoped/expiring records rather than chat messages — scoped to the exact call by argument hash, single-use and spent atomically, validity recomputed on every read.

Notes two things a reader would otherwise trip on: `require_approval` accepts `mcp__*` names where `allowed_tools`/`denied_tools` do not, and **Studio's governance form neither renders nor preserves the field**, so saving that form drops it.

## `docs/operations/index.md`

- `surogates doctor <session-id>` under Troubleshooting, with its four codes and sample output
- Crash recovery is now **bounded**: three `harness.recovered` events with no sign of life ends in `session.fail` / `reason="recovery_loop"`, plus the SQL to watch for it

## `docs/tools/index.md`

The `todo` entry now records that the list survives a wake boundary, that this matters most for `merge=true` (which previously merged onto an empty list on a cold worker and dropped everything), and why a failed read returns an error rather than an empty list.

## `docs/appendices/api-reference.md` — a correction

The create-session example documented `model`, `tools`, `workspace` and `sandbox`. **None have ever existed on `CreateSessionRequest`**, which carries only `system` and `config`; they were silently discarded. Replaced with the real shape.

`system` itself only began reaching the model in #181 — its behaviour (appended as a `## Session instructions` section, not substituted) is now described.

Docs only.