### PR TITLE
fix(missions): re-drive an objective whose coordinator went quiet

### DIFF
--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -1612,6 +1612,25 @@ class SessionStore:
         todos = row.get("todos")
         return todos if isinstance(todos, list) else None
 
+    async def count_synthetic_since(
+        self, session_id: UUID, *, synthetic: str, since: Any,
+    ) -> int:
+        """Count synthetic user messages of one kind emitted after *since*.
+
+        Used to bound automated nudges: the caller re-reads this each pass and
+        stops once the count reaches its ceiling, so a coordinator that keeps
+        going quiet is handed to a human rather than poked forever.
+        """
+        stmt = select(func.count()).select_from(EventRow).where(
+            EventRow.session_id == session_id,
+            EventRow.type == EventType.USER_MESSAGE.value,
+            EventRow.data["synthetic"].as_string() == synthetic,
+        )
+        if since is not None:
+            stmt = stmt.where(EventRow.created_at > since)
+        async with self._sf() as db:
+            return int((await db.execute(stmt)).scalar_one())
+
     async def count_recoveries_since_progress(self, session_id: UUID) -> int:
         """Count ``harness.recovered`` events since the session last progressed.
 

--- a/surogates/tasks/dispatcher.py
+++ b/surogates/tasks/dispatcher.py
@@ -406,6 +406,114 @@ async def _rollback_claim(
         )
 
 
+
+# How long a mission's coordinator may be idle before the tick re-drives it.
+# Generous on purpose: poking a coordinator mid-thought is worse than waiting,
+# and the sweep only exists to rescue objectives nothing else will touch.
+_MISSION_IDLE_SECONDS: int = 900
+
+# Nudges without an intervening evaluation before the mission is handed to a
+# human. Matches the orphan-recovery ceiling and the parse-failure pause, so an
+# operator meets one number rather than three.
+_MAX_MISSION_NUDGES: int = 3
+
+
+async def nudge_idle_missions(
+    *,
+    session_factory: async_sessionmaker,
+    session_store: Any,
+    redis: Any,
+    idle_seconds: int = _MISSION_IDLE_SECONDS,
+) -> int:
+    """Re-drive active missions whose coordinator has gone quiet.
+
+    ``should_evaluate`` only runs inside a coordinator turn, and a text-only
+    LLM response ends that turn without re-enqueueing anything. A mission
+    whose coordinator stops talking is therefore unreachable: no evaluation,
+    no budget check, no stagnation count — every other mission gate is
+    downstream of a loop nothing was driving.
+
+    Skips a mission whose coordinator currently holds a lease: a worker is on
+    it right now and interrupting mid-thought is worse than waiting.
+
+    Bounded. Nudges since the mission last progressed — its last evaluation,
+    or its creation if it has never been evaluated — are counted, and past
+    :data:`_MAX_MISSION_NUDGES` the mission is blocked for a human instead of
+    being poked forever. An evaluation resets the count, because that means
+    the loop moved.
+    """
+    from surogates.config import enqueue_session
+    from surogates.db.models import Mission as MissionRow
+    from surogates.missions.store import MissionStore
+    from surogates.session.events import EventType
+
+    # Compared by the database clock, which is the one that stamped
+    # ``updated_at`` — these columns are naive, so a Python-side aware
+    # datetime would not even encode.
+    async with session_factory() as db:
+        rows = (await db.execute(
+            select(MissionRow).where(
+                MissionRow.status == "active",
+                MissionRow.updated_at
+                < func.now() - text(f"make_interval(secs => {int(idle_seconds)})"),
+            ).limit(_MAX_ENQUEUES_PER_TICK)
+        )).scalars().all()
+        missions = [
+            (m.id, m.session_id, m.org_id, m.agent_id, m.description,
+             m.last_evaluation_at, m.created_at)
+            for m in rows
+        ]
+
+    store = MissionStore(session_factory)
+    woken = 0
+    for mid, sid, org_id, agent_id, description, last_eval, created in missions:
+        try:
+            if await session_store.has_live_lease(sid):
+                continue
+
+            since = last_eval or created
+            nudges = await session_store.count_synthetic_since(
+                sid, synthetic="mission_nudge", since=since,
+            )
+            if nudges >= _MAX_MISSION_NUDGES:
+                logger.warning(
+                    "mission %s nudged %d times with no evaluation; blocking",
+                    mid, nudges,
+                )
+                await store.set_status(
+                    mid, "blocked",
+                    paused_reason=(
+                        f"coordinator went quiet after {nudges} nudges "
+                        "without an evaluation"
+                    ),
+                )
+                continue
+
+            await session_store.emit_event(
+                sid, EventType.USER_MESSAGE,
+                {
+                    "content": (
+                        "[Mission still open]\n\n"
+                        f"Objective: {description}\n\n"
+                        "Your last turn ended without completing this mission "
+                        "and nothing has advanced it since. Continue the work: "
+                        "spawn the next task, or if the objective is genuinely "
+                        "finished say so and mark it complete."
+                    ),
+                    "synthetic": "mission_nudge",
+                    "mission_id": str(mid),
+                },
+            )
+            await enqueue_session(
+                redis, org_id=str(org_id), agent_id=agent_id, session_id=sid,
+            )
+            woken += 1
+        except Exception:
+            logger.exception("mission liveness nudge failed for %s", mid)
+
+    return woken
+
+
 async def tasks_tick(
     *,
     session_factory: async_sessionmaker,
@@ -416,7 +524,8 @@ async def tasks_tick(
 ) -> dict[str, int]:
     """Run one tick of the subagent task layer.
 
-    Returns ``{"promoted": int, "finalized": int, "enqueued": int}`` for
+    Returns ``{"promoted": int, "finalized": int, "enqueued": int,
+    "nudged": int}`` for
     observability hooks (the orchestrator metrics pipeline consumes these
     in Task 10).
 
@@ -442,4 +551,15 @@ async def tasks_tick(
         tenant_for_task=tenant_for_task,
         file_bundle_cache=file_bundle_cache,
     )
-    return {"promoted": promoted, "finalized": finalized, "enqueued": enqueued}
+    # Re-drive objectives nothing else will touch. Runs last: the steps
+    # above may have produced the very progress that makes a mission look
+    # alive again.
+    nudged = await nudge_idle_missions(
+        session_factory=session_factory,
+        session_store=session_store,
+        redis=redis,
+    )
+    return {
+        "promoted": promoted, "finalized": finalized,
+        "enqueued": enqueued, "nudged": nudged,
+    }

--- a/tests/integration/missions/test_liveness_tick.py
+++ b/tests/integration/missions/test_liveness_tick.py
@@ -1,0 +1,193 @@
+"""An objective must not die because the agent stopped talking.
+
+`should_evaluate` only runs *inside* a coordinator turn. A text-only LLM
+response ends that turn, and nothing re-enqueues the session — so a mission
+whose coordinator goes quiet can never be re-examined. Both active missions
+on the dev box were stalled this way, one of them for 48 days.
+
+Every other mission gate is downstream of a loop this provides: budget checks
+at the evaluator boundary, stagnation counts evaluations, corroboration runs
+after the judge. None of them can fire if nothing wakes the coordinator.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import update
+
+from surogates.db.models import Mission as MissionRow
+from surogates.missions.store import MissionStore
+from surogates.tasks.dispatcher import nudge_idle_missions
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def _idle(session_factory, mission_id, *, minutes=120):
+    """Backdate the mission so it looks untouched."""
+    from datetime import timedelta
+
+    from sqlalchemy import func as safunc
+    async with session_factory() as db:
+        await db.execute(
+            update(MissionRow).where(MissionRow.id == mission_id)
+            .values(updated_at=safunc.now() - timedelta(minutes=minutes))
+        )
+        await db.commit()
+
+
+async def _mission(session_factory, session_store, org_id, user_id):
+    """Own coordinator session per test — the tick sweeps ALL active
+    missions, so a shared session lets one test's mission show up in
+    another's assertions."""
+    sess = await session_store.create_session(
+        org_id=org_id, user_id=user_id, agent_id="a", channel="web",
+    )
+    store = MissionStore(session_factory)
+    mid = await store.create(
+        org_id=org_id, user_id=user_id, session_id=sess.id,
+        agent_id="a", description="ship", rubric="works",
+    )
+    return store, mid, sess
+
+
+async def _nudges_for(session_store, session_id) -> int:
+    events = await session_store.get_events(session_id)
+    return sum(
+        1 for e in events
+        if (e.data or {}).get("synthetic") == "mission_nudge"
+    )
+
+
+async def test_an_idle_mission_wakes_its_coordinator(
+    session_factory, session_store, org_id, user_id,
+):
+    """The case that stalled for 48 days."""
+    store, mid, sess = await _mission(session_factory, session_store, org_id, user_id)
+    await _idle(session_factory, mid)
+    redis = AsyncMock()
+
+    woken = await nudge_idle_missions(
+        session_factory=session_factory, session_store=session_store,
+        redis=redis, idle_seconds=60,
+    )
+
+    assert woken >= 1
+    assert await _nudges_for(session_store, sess.id) == 1
+
+
+async def test_a_recently_active_mission_is_left_alone(
+    session_factory, session_store, org_id, user_id,
+):
+    """Poking a coordinator mid-thought is worse than waiting."""
+    store, mid, sess = await _mission(session_factory, session_store, org_id, user_id)
+    redis = AsyncMock()
+
+    await nudge_idle_missions(
+        session_factory=session_factory, session_store=session_store,
+        redis=redis, idle_seconds=3600,
+    )
+
+    assert await _nudges_for(session_store, sess.id) == 0
+
+
+async def test_a_live_coordinator_is_never_interrupted(
+    session_factory, session_store, org_id, user_id,
+):
+    """A held lease means a worker is on it right now."""
+    store, mid, sess = await _mission(session_factory, session_store, org_id, user_id)
+    await _idle(session_factory, mid)
+    await session_store.try_acquire_lease(sess.id, "worker-1")
+    redis = AsyncMock()
+
+    await nudge_idle_missions(
+        session_factory=session_factory, session_store=session_store,
+        redis=redis, idle_seconds=60,
+    )
+
+    assert await _nudges_for(session_store, sess.id) == 0
+
+
+async def test_terminal_missions_are_ignored(
+    session_factory, session_store, org_id, user_id,
+):
+    store, mid, sess = await _mission(session_factory, session_store, org_id, user_id)
+    await store.set_status(mid, "satisfied")
+    await _idle(session_factory, mid)
+    redis = AsyncMock()
+
+    await nudge_idle_missions(
+        session_factory=session_factory, session_store=session_store,
+        redis=redis, idle_seconds=60,
+    )
+    assert await _nudges_for(session_store, sess.id) == 0
+
+
+async def test_nudging_is_bounded(
+    session_factory, session_store, org_id, user_id,
+):
+    """A coordinator that keeps going quiet must not be poked forever.
+
+    Three nudges with no evaluation in between and the mission is blocked
+    for a human, not left spinning.
+    """
+    store, mid, sess = await _mission(session_factory, session_store, org_id, user_id)
+    redis = AsyncMock()
+
+    for _ in range(4):
+        await _idle(session_factory, mid)
+        await nudge_idle_missions(
+            session_factory=session_factory, session_store=session_store,
+            redis=redis, idle_seconds=60,
+        )
+
+    mission = await store.get(mid)
+    assert mission.status == "blocked"
+    assert await _nudges_for(session_store, sess.id) == 3
+
+
+async def test_progress_resets_the_nudge_budget(
+    session_factory, session_store, org_id, user_id,
+):
+    """An evaluation means the loop moved; the count starts over."""
+    store, mid, sess = await _mission(session_factory, session_store, org_id, user_id)
+    redis = AsyncMock()
+
+    for _ in range(2):
+        await _idle(session_factory, mid)
+        await nudge_idle_missions(
+            session_factory=session_factory, session_store=session_store,
+            redis=redis, idle_seconds=60,
+        )
+    await store.record_evaluation(
+        mid, result="needs_revision", explanation="keep going", feedback="f",
+    )
+    for _ in range(2):
+        await _idle(session_factory, mid)
+        await nudge_idle_missions(
+            session_factory=session_factory, session_store=session_store,
+            redis=redis, idle_seconds=60,
+        )
+
+    assert (await store.get(mid)).status == "active"
+    assert await _nudges_for(session_store, sess.id) == 4
+
+
+async def test_the_coordinator_is_told_why_it_woke(
+    session_factory, session_store, org_id, user_id,
+):
+    store, mid, sess = await _mission(session_factory, session_store, org_id, user_id)
+    await _idle(session_factory, mid)
+
+    await nudge_idle_missions(
+        session_factory=session_factory, session_store=session_store,
+        redis=AsyncMock(), idle_seconds=60,
+    )
+
+    events = await session_store.get_events(sess.id)
+    synthetic = [
+        e for e in events
+        if (e.data or {}).get("synthetic") == "mission_nudge"
+    ]
+    assert len(synthetic) == 1
+    assert "mission" in synthetic[0].data["content"].lower()


### PR DESCRIPTION
Found by inspecting a real stalled dev session. **Both** active missions on that box were dead — one 16 minutes in, the other for 48 days.

## The gap

`should_evaluate` only runs *inside a coordinator turn*. A text-only LLM response ends that turn, and nothing re-enqueues the session. So a mission whose coordinator stops talking can never be re-examined: no evaluation, no budget check, no stagnation count, no watchdog. No ticker touches `missions` at all — I checked `platform_ticker` and `orchestrator/dispatcher`.

Observed:

```
3b0a91a6  iter=0  tasks=0                               never evaluated  idle 16m
6db265b2  iter=1  tasks: 3 failed, 3 cancelled, 2 todo  needs_revision   idle 48 days
```

The second is the sharper one: it *was* evaluated, the judge said `needs_revision`, two tasks are still in `todo`, and then everything stopped. Nothing had looked at it since 17 June.

**This makes every other mission gate in this series unreachable.** Budget (#190) checks at the evaluator boundary. Stagnation (#191) counts evaluations. Corroboration (#192) runs after the judge. All three are correct, and all three are downstream of a loop nothing was driving.

The turn loop itself is not at fault — a text-only response genuinely is the end of a turn. What was missing is a loop above it.

## The fix

`nudge_idle_missions` sweeps active missions in `tasks_tick` — already running every 5s, already aware of `mission_id`, so no new machinery.

For each: skip if the coordinator holds a live lease (a worker is on it *now*; interrupting mid-thought is worse than waiting), otherwise emit a synthetic user message naming the objective and enqueue the coordinator.

**Bounded**, same shape as the orphan-recovery ceiling in #176: nudges since the mission last progressed — its last evaluation, or creation if never evaluated — are counted, and past 3 the mission goes `blocked` with a reason instead of being poked forever. An evaluation resets the count, because that means the loop moved. 3 matches the recovery ceiling and the parse-failure pause, so an operator meets one number rather than three.

Idle threshold defaults to 15 minutes and is a parameter, not a constant chosen for anyone's workload.

## Verified against the real failure

```
nudge_idle_missions(...)  ->  missions re-driven: 2
```

Both stalled dev missions are picked up. (That dry run used a real store, so each coordinator now carries one queued nudge message; only the Redis enqueue was mocked, so neither actually woke.)

## Two mistakes worth recording

**Timezone.** I reached for a Python-side cutoff. These columns are `timestamp without time zone`, so an aware datetime will not even encode. Moved SQL-side using the same `make_interval` pattern `find_orphaned_sessions` uses — the database clock is the one that stamped `updated_at`.

**Test pollution.** My tests shared one coordinator session, and since the tick sweeps *all* active missions, earlier tests' missions appeared in later assertions — every test passing alone, three failing together. Each test now owns its session and asserts per-mission rather than on global counters.

## Tests

7 against real PostgreSQL: an idle mission wakes its coordinator; a recently-active one is left alone; a live coordinator is never interrupted; terminal missions are ignored; nudging is bounded at 3 then blocks; an evaluation resets the budget; the coordinator is told why it woke.

## Verification

146 mission + task integration tests pass. Full unit suite `28 failed / 5072 passed` — **identical failure set** to master. Ruff clean.