### PR TITLE
fix(harness): keep worker self-tools under an AgentDef allowlist

### DIFF
--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -3596,7 +3596,25 @@ class AgentHarness(
                     )
                 tool_filter = set(self._tools.tool_names) - excluded
         elif explicit_allowed:
+            from surogates.runtime.governance import (
+                BOARD_SELF_TOOLS,
+                WORKER_SELF_TOOLS,
+            )
+
             tool_filter = set(config["allowed_tools"])
+            # Execution-context self-tools ride over an AgentDef allowlist:
+            # it scopes what a worker may DO, not how it reports doing it.
+            # ``worker._filter_effective_tools`` force-adds them to the
+            # prompt surface; without the same rule here the schemas
+            # disagree with the prompt and the worker is told to call
+            # ``worker_complete`` while holding no such tool.  Observed in
+            # the wild: a ``claude-coder`` task worker could not signal
+            # failure, so its refusal was filed as a successful result and
+            # the parent mission stalled with no failure signal.
+            if session.task_id is not None:
+                tool_filter |= WORKER_SELF_TOOLS
+            if config.get("context_group_id"):
+                tool_filter |= BOARD_SELF_TOOLS
         else:
             from surogates.tools.builtin.coordinator import WORKER_EXCLUDED_TOOLS
 

--- a/tests/test_worker_self_tools_allowlist.py
+++ b/tests/test_worker_self_tools_allowlist.py
@@ -1,0 +1,63 @@
+"""A task worker keeps its execution-context self-tools under an
+AgentDef ``tools`` allowlist.
+
+The allowlist scopes what a worker may DO; ``worker_complete`` /
+``worker_block`` / ``worker_context`` are how it reports doing it, and
+the board tools are how a coordination-group member shares notes.  When
+the schemas dropped them, a worker that could not proceed had no way to
+signal failure and its refusal was filed as a successful result.
+"""
+from __future__ import annotations
+
+from uuid import uuid4
+
+from surogates.runtime.governance import BOARD_SELF_TOOLS, WORKER_SELF_TOOLS
+from surogates.tools.registry import ToolRegistry, ToolSchema
+
+from tests.test_harness_resilience import _make_harness, _session_with_config
+
+_ALLOWED = {"run_coding_agent", "read_file", "list_files", "search_files"}
+_ALL = _ALLOWED | WORKER_SELF_TOOLS | BOARD_SELF_TOOLS | {"terminal", "write_file"}
+
+
+def _registry_with(names) -> ToolRegistry:
+    reg = ToolRegistry()
+    for name in names:
+        reg.register(
+            name, ToolSchema(name=name, description="t", parameters={}),
+            lambda _a, **_k: "{}",
+        )
+    return reg
+
+
+def _worker_session(**extra):
+    session = _session_with_config({"allowed_tools": sorted(_ALLOWED), **extra})
+    session.task_id = uuid4()
+    return session
+
+
+def test_task_worker_keeps_self_tools_under_allowlist():
+    harness = _make_harness(tool_registry=_registry_with(_ALL))
+    allowed = harness._tool_filter_for_session(_worker_session())
+    assert WORKER_SELF_TOOLS <= allowed      # can report completion / blockage
+    assert _ALLOWED <= allowed               # its own work tools survive
+    assert "terminal" not in allowed         # the allowlist still binds
+    assert "write_file" not in allowed
+
+
+def test_group_member_keeps_board_tools_under_allowlist():
+    harness = _make_harness(tool_registry=_registry_with(_ALL))
+    session = _worker_session(context_group_id=str(uuid4()))
+    allowed = harness._tool_filter_for_session(session)
+    assert BOARD_SELF_TOOLS <= allowed
+
+
+def test_solo_allowlisted_session_gets_no_self_tools():
+    """No task row and no group: the allowlist is taken verbatim."""
+    harness = _make_harness(tool_registry=_registry_with(_ALL))
+    allowed = harness._tool_filter_for_session(
+        _session_with_config({"allowed_tools": sorted(_ALLOWED)})
+    )
+    assert not (WORKER_SELF_TOOLS & allowed)
+    assert not (BOARD_SELF_TOOLS & allowed)
+    assert allowed == _ALLOWED


### PR DESCRIPTION
## Problem

A task worker spawned with an AgentDef `tools` allowlist lost its execution-context self-tools. `_tool_filter_for_session` took `config["allowed_tools"]` verbatim, dropping `worker_complete` / `worker_block` / `worker_context` and the coordination-board tools from the model-visible schemas.

`worker._filter_effective_tools` force-adds exactly those sets — but its result only feeds `PromptBuilder(available_tools=...)`. So the **prompt** told the worker to finish with `worker_complete` while the **schemas** carried no such tool. `runtime/governance.py` documents the two layers as agreeing; they did not.

## How it surfaced

DEV mission `6910dfdd` blocked. Its `claude-coder` workers had `run_coding_agent` stripped (the agent has `code_agents_enabled = false`), leaving them read-only. One said so plainly:

> "I can't complete this task: my tool surface in this session is read-only. I have `read_file`, `search_files`, and `list_files` only — no `write_file`, no `terminal`, no `run_coding_agent`, and no `worker_complete`/`worker_block`."

With no `worker_block`, the harness fell back to the final assistant message and filed the refusal as `outcome=success`. The mission saw two *done* tasks and an unchanged repo, went three rounds without progress, and hit the stagnation limit.

The missing write tool is a settings issue on that agent. The missing *failure signal* is this bug.

## Change

Force-add the self-tools in the `explicit_allowed` branch, gated the same way the worker gates them — `WORKER_SELF_TOOLS` when the session has a `task_id`, `BOARD_SELF_TOOLS` when it has a `context_group_id`. The allowlist still binds work tools.

## Tests

`tests/test_worker_self_tools_allowlist.py` — self-tools present for a task worker, board tools for a group member, allowlist taken verbatim for a solo session (work tools outside the list stay stripped in all three).

33 passed across the new file plus the adjacent tool-filter suites; 185 passed in the harness/worker/tool subset. The one failure in `test_browser_tool_storage.py` is pre-existing on `master` (stale installed package vs local tests) and unrelated.

## Known gap, not addressed here

The mirror direction is still divergent: a session *without* a task row keeps `worker_*` in its schemas via the no-allowlist branch, though the prompt strips them. Lower severity — the model is tempted to call a no-op rather than being unable to report — and a wider change. Flagging rather than folding in.