### PR TITLE
fix(inbox): announce only what a person can act on, scoped to the agent they opened

### DIFF
--- a/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
+++ b/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
@@ -122,7 +122,9 @@ function kindIcon(kind: AgentChatInboxKind) {
   return CircleDotIcon;
 }
 
-type InboxView = "active" | "history";
+type InboxView = "active" | "updates" | "history";
+
+const VIEWS: InboxView[] = ["active", "updates", "history"];
 
 // History is asked for by name: a request that omits the status filter
 // gets everything except expired, which is exactly the half of history
@@ -130,8 +132,42 @@ type InboxView = "active" | "history";
 // that was dismissed.
 const STATUSES_BY_VIEW: Record<InboxView, AgentChatInboxStatus[]> = {
   active: ["pending"],
+  updates: ["pending"],
   history: ["acknowledged", "responded", "expired"],
 };
+
+// Active and Updates share a status and differ by kind: what is waiting
+// on the user, and what the agent finished while they were away. Mixed
+// together, one notice per completed session buried the questions that
+// actually needed an answer. History spans both, so it names no kind.
+const ANSWERABLE_KINDS: AgentChatInboxKind[] = [
+  "input_required",
+  "action_required",
+  "governance_gate",
+];
+const INFORMATIONAL_KINDS: AgentChatInboxKind[] = [
+  "task_complete",
+  "progress_checkin",
+];
+const KINDS_BY_VIEW: Record<InboxView, AgentChatInboxKind[] | undefined> = {
+  active: ANSWERABLE_KINDS,
+  updates: INFORMATIONAL_KINDS,
+  history: undefined,
+};
+
+const EMPTY_BY_VIEW: Record<InboxView, string> = {
+  active: "Nothing needs you right now",
+  updates: "No news from your agent",
+  history: "No history yet",
+};
+
+function belongsToView(item: AgentChatInboxItem, view: InboxView): boolean {
+  const kinds = KINDS_BY_VIEW[view];
+  return (
+    STATUSES_BY_VIEW[view].includes(item.status) &&
+    (kinds === undefined || kinds.includes(item.kind))
+  );
+}
 
 function sortItems(items: AgentChatInboxItem[]): AgentChatInboxItem[] {
   // Paging can overlap with a stream update; the first copy of a row
@@ -852,7 +888,7 @@ export function InboxPanel({
       if (current.some((item) => item.id === nextItem.id)) {
         return sortItems([nextItem, ...current]);
       }
-      return STATUSES_BY_VIEW[viewRef.current].includes(nextItem.status)
+      return belongsToView(nextItem, viewRef.current)
         ? sortItems([nextItem, ...current])
         : current;
     });
@@ -878,6 +914,7 @@ export function InboxPanel({
       try {
         const response = await inboxAdapter.listInbox({
           status: STATUSES_BY_VIEW[view],
+          kind: KINDS_BY_VIEW[view],
           cursor: cursor ?? undefined,
           limit,
         });
@@ -967,7 +1004,7 @@ export function InboxPanel({
           </div>
         )}
         <div className="flex gap-1 border-b border-line px-2 py-2">
-          {(["active", "history"] as const).map((value) => (
+          {VIEWS.map((value) => (
             <button
               key={value}
               type="button"
@@ -994,9 +1031,7 @@ export function InboxPanel({
           )}
           {items.length === 0 && !error && !loading && (
             <div className="px-4 py-8 text-sm text-muted-foreground">
-              {view === "active"
-                ? "Nothing needs you right now"
-                : "No history yet"}
+              {EMPTY_BY_VIEW[view]}
             </div>
           )}
           {items.map((item) => {

--- a/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
+++ b/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
@@ -953,10 +953,13 @@ export function InboxPanel({
         return;
       }
       if (typeof itemId !== "number") return;
-      // Only the Active view moves on its own — a nudge means something
-      // new is pending, which by definition is not history. Read from
-      // the ref so a tab click does not tear down the connection.
-      if (viewRef.current !== "active") return;
+      // A nudge means something new is pending, which by definition is
+      // not history — but Updates is a second pending view, and work
+      // finishing while the user watches that tab is exactly what it is
+      // for. applyItem files the item under the view it belongs to.
+      // Read from the ref so a tab click does not tear down the
+      // connection.
+      if (viewRef.current === "history") return;
       void inboxAdapter.getInboxItem({ itemId }).then(applyItem, () => undefined);
     });
     return () => stream.close();

--- a/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
+++ b/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
@@ -124,51 +124,51 @@ function kindIcon(kind: AgentChatInboxKind) {
 
 type InboxView = "active" | "updates" | "history";
 
-const VIEWS: InboxView[] = ["active", "updates", "history"];
-
-// History is asked for by name: a request that omits the status filter
-// gets everything except expired, which is exactly the half of history
-// worth keeping — a question the agent stopped waiting for, or an item
-// that was dismissed.
-const STATUSES_BY_VIEW: Record<InboxView, AgentChatInboxStatus[]> = {
-  active: ["pending"],
-  updates: ["pending"],
-  history: ["acknowledged", "responded", "expired"],
-};
-
-// Active and Updates share a status and differ by kind: what is waiting
+// One record per view: what it asks the server for, and what it says
+// when nothing comes back.
+//
+// Active and Updates share a status and differ by kind — what is waiting
 // on the user, and what the agent finished while they were away. Mixed
 // together, one notice per completed session buried the questions that
-// actually needed an answer. History spans both, so it names no kind.
+// actually needed an answer. History is asked for by name: a request
+// that omits the status filter gets everything except expired, which is
+// exactly the half of history worth keeping — a question the agent
+// stopped waiting for, or an item that was dismissed — and it spans both
+// kinds, so it names none.
 //
 // Studio carries the same split in its own inbox page — its pin predates
 // this one. Export these if a third surface ever needs them, and delete
 // that copy rather than letting a third appear.
-const ANSWERABLE_KINDS: AgentChatInboxKind[] = [
-  "input_required",
-  "action_required",
-  "governance_gate",
-];
-const INFORMATIONAL_KINDS: AgentChatInboxKind[] = [
-  "task_complete",
-  "progress_checkin",
-];
-const KINDS_BY_VIEW: Record<InboxView, AgentChatInboxKind[] | undefined> = {
-  active: ANSWERABLE_KINDS,
-  updates: INFORMATIONAL_KINDS,
-  history: undefined,
+const VIEWS: Record<
+  InboxView,
+  {
+    statuses: AgentChatInboxStatus[];
+    kinds?: AgentChatInboxKind[];
+    empty: string;
+  }
+> = {
+  active: {
+    statuses: ["pending"],
+    kinds: ["input_required", "action_required", "governance_gate"],
+    empty: "Nothing needs you right now",
+  },
+  updates: {
+    statuses: ["pending"],
+    kinds: ["task_complete", "progress_checkin"],
+    empty: "No news from your agent",
+  },
+  history: {
+    statuses: ["acknowledged", "responded", "expired"],
+    empty: "No history yet",
+  },
 };
 
-const EMPTY_BY_VIEW: Record<InboxView, string> = {
-  active: "Nothing needs you right now",
-  updates: "No news from your agent",
-  history: "No history yet",
-};
+const VIEW_NAMES = Object.keys(VIEWS) as InboxView[];
 
 function belongsToView(item: AgentChatInboxItem, view: InboxView): boolean {
-  const kinds = KINDS_BY_VIEW[view];
+  const kinds = VIEWS[view].kinds;
   return (
-    STATUSES_BY_VIEW[view].includes(item.status) &&
+    VIEWS[view].statuses.includes(item.status) &&
     (kinds === undefined || kinds.includes(item.kind))
   );
 }
@@ -917,8 +917,8 @@ export function InboxPanel({
       setLoading(true);
       try {
         const response = await inboxAdapter.listInbox({
-          status: STATUSES_BY_VIEW[view],
-          kind: KINDS_BY_VIEW[view],
+          status: VIEWS[view].statuses,
+          kind: VIEWS[view].kinds,
           cursor: cursor ?? undefined,
           limit,
         });
@@ -1011,7 +1011,7 @@ export function InboxPanel({
           </div>
         )}
         <div className="flex gap-1 border-b border-line px-2 py-2">
-          {VIEWS.map((value) => (
+          {VIEW_NAMES.map((value) => (
             <button
               key={value}
               type="button"
@@ -1038,7 +1038,7 @@ export function InboxPanel({
           )}
           {items.length === 0 && !error && !loading && (
             <div className="px-4 py-8 text-sm text-muted-foreground">
-              {EMPTY_BY_VIEW[view]}
+              {VIEWS[view].empty}
             </div>
           )}
           {items.map((item) => {

--- a/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
+++ b/sdk/agent-chat-react/src/components/inbox/inbox-panel.tsx
@@ -140,6 +140,10 @@ const STATUSES_BY_VIEW: Record<InboxView, AgentChatInboxStatus[]> = {
 // on the user, and what the agent finished while they were away. Mixed
 // together, one notice per completed session buried the questions that
 // actually needed an answer. History spans both, so it names no kind.
+//
+// Studio carries the same split in its own inbox page — its pin predates
+// this one. Export these if a third surface ever needs them, and delete
+// that copy rather than letting a third appear.
 const ANSWERABLE_KINDS: AgentChatInboxKind[] = [
   "input_required",
   "action_required",

--- a/sdk/agent-chat-react/src/types.ts
+++ b/sdk/agent-chat-react/src/types.ts
@@ -471,7 +471,11 @@ export interface AgentChatInboxListInput {
    * request that does not name them.
    */
   status?: AgentChatInboxStatus | AgentChatInboxStatus[];
-  kind?: AgentChatInboxKind;
+  /**
+   * Active and Updates are two lists over the same statuses, split by
+   * kind: what needs an answer, and what is only news.
+   */
+  kind?: AgentChatInboxKind | AgentChatInboxKind[];
   sessionId?: string;
   cursor?: string;
   limit?: number;

--- a/sdk/agent-chat-react/tests/inbox-adapter-stub.ts
+++ b/sdk/agent-chat-react/tests/inbox-adapter-stub.ts
@@ -9,6 +9,7 @@ import { NO_BROWSER_ADAPTER } from "../src/adapter-context";
 import type {
   AgentChatAdapter,
   AgentChatArtifactPayload,
+  AgentChatInboxItem,
   AgentChatSession,
   AgentChatSessionList,
   AgentChatWorkspaceFile,
@@ -69,3 +70,31 @@ export const NON_INBOX_ADAPTER: AgentChatAdapter = {
     throw new Error("not used by inbox tests");
   },
 };
+
+/**
+ * An inbox row with sensible defaults, stamped now so relative times
+ * render. Shared by the lifecycle and view suites, which both build
+ * dozens of these and would otherwise each carry the same factory.
+ */
+export function inboxItem(
+  input: Partial<AgentChatInboxItem> & { id: number },
+): AgentChatInboxItem {
+  const createdAt = new Date().toISOString();
+  return {
+    orgId: "org-1",
+    userId: "user-1",
+    sessionId: "session-1",
+    sourceEventId: input.id,
+    kind: "task_complete",
+    status: "pending",
+    title: `Item ${input.id}`,
+    body: "Body",
+    payload: {},
+    actionRef: null,
+    createdAt,
+    updatedAt: createdAt,
+    readAt: null,
+    respondedAt: null,
+    ...input,
+  };
+}

--- a/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
@@ -9,7 +9,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { NON_INBOX_ADAPTER } from "./inbox-adapter-stub";
+import { NON_INBOX_ADAPTER, inboxItem } from "./inbox-adapter-stub";
 import { InboxPanel } from "../src/components/inbox/inbox-panel";
 import type {
   AgentChatAdapter,
@@ -20,29 +20,6 @@ import type {
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
-
-function inboxItem(
-  input: Partial<AgentChatInboxItem> & { id: number },
-): AgentChatInboxItem {
-  const createdAt = new Date().toISOString();
-  return {
-    orgId: "org-1",
-    userId: "user-1",
-    sessionId: "session-1",
-    sourceEventId: input.id,
-    kind: "task_complete",
-    status: "pending",
-    title: `Item ${input.id}`,
-    body: "Body",
-    payload: {},
-    actionRef: null,
-    createdAt,
-    updatedAt: createdAt,
-    readAt: null,
-    respondedAt: null,
-    ...input,
-  };
-}
 
 interface Harness {
   adapter: AgentChatAdapter;

--- a/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel-lifecycle.test.tsx
@@ -175,9 +175,14 @@ describe("InboxPanel lifecycle", () => {
     const harness = createHarness(items);
     const view = await mount(harness.adapter);
 
-    items.push(inboxItem({ id: 2, title: "Arrived later" }));
+    items.push(
+      inboxItem({ id: 2, title: "Arrived later", kind: "input_required" }),
+    );
     await act(async () => {
-      harness.emit("item", JSON.stringify({ item_id: 2, kind: "task_complete" }));
+      harness.emit(
+        "item",
+        JSON.stringify({ item_id: 2, kind: "input_required" }),
+      );
       await Promise.resolve();
     });
 
@@ -257,9 +262,14 @@ describe("InboxPanel lifecycle", () => {
     });
     const view = await mount(harness.adapter);
 
-    items.push(inboxItem({ id: 2, title: "Arrived mid-load" }));
+    items.push(
+      inboxItem({ id: 2, title: "Arrived mid-load", kind: "input_required" }),
+    );
     await act(async () => {
-      harness.emit("item", JSON.stringify({ item_id: 2, kind: "task_complete" }));
+      harness.emit(
+        "item",
+        JSON.stringify({ item_id: 2, kind: "input_required" }),
+      );
       await Promise.resolve();
     });
     await act(async () => {

--- a/sdk/agent-chat-react/tests/inbox-panel-views.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel-views.test.tsx
@@ -8,7 +8,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it } from "vitest";
-import { NON_INBOX_ADAPTER } from "./inbox-adapter-stub";
+import { NON_INBOX_ADAPTER, inboxItem } from "./inbox-adapter-stub";
 import { InboxPanel } from "../src/components/inbox/inbox-panel";
 import type {
   AgentChatAdapter,
@@ -18,29 +18,6 @@ import type {
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
-
-function inboxItem(
-  input: Partial<AgentChatInboxItem> & { id: number },
-): AgentChatInboxItem {
-  const createdAt = new Date().toISOString();
-  return {
-    orgId: "org-1",
-    userId: "user-1",
-    sessionId: "session-1",
-    sourceEventId: input.id,
-    kind: "task_complete",
-    status: "pending",
-    title: `Item ${input.id}`,
-    body: "Body",
-    payload: {},
-    actionRef: null,
-    createdAt,
-    updatedAt: createdAt,
-    readAt: null,
-    respondedAt: null,
-    ...input,
-  };
-}
 
 interface Harness {
   adapter: AgentChatAdapter;

--- a/sdk/agent-chat-react/tests/inbox-panel-views.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel-views.test.tsx
@@ -181,6 +181,25 @@ describe("InboxPanel views", () => {
     expect(view.textContent).not.toContain("Which colour?");
   });
 
+  it("shows an update the stream announces while Updates is open", async () => {
+    // Updates is a second pending view, not history: work finishing
+    // while the user watches that tab is exactly what it is for.
+    const items = [inboxItem({ id: 1, kind: "task_complete", title: "First" })];
+    const harness = createHarness(items);
+    const view = await mount(harness.adapter);
+    await clickText("updates");
+
+    items.push(
+      inboxItem({ id: 2, kind: "task_complete", title: "Arrived later" }),
+    );
+    await act(async () => {
+      harness.emit("item", JSON.stringify({ item_id: 2, kind: "task_complete" }));
+      await Promise.resolve();
+    });
+
+    expect(view.textContent).toContain("Arrived later");
+  });
+
   it("does not let a nudge drop an update into Active", async () => {
     const items = [inboxItem({ id: 1, kind: "input_required", title: "Which colour?" })];
     const harness = createHarness(items);

--- a/sdk/agent-chat-react/tests/inbox-panel-views.test.tsx
+++ b/sdk/agent-chat-react/tests/inbox-panel-views.test.tsx
@@ -1,0 +1,197 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Active is what needs the user; Updates is what the agent finished
+// while they were away. Mixed together, one completed task per session
+// buried the two questions that actually needed an answer.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { NON_INBOX_ADAPTER } from "./inbox-adapter-stub";
+import { InboxPanel } from "../src/components/inbox/inbox-panel";
+import type {
+  AgentChatAdapter,
+  AgentChatInboxItem,
+  AgentChatInboxListInput,
+} from "../src/types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+function inboxItem(
+  input: Partial<AgentChatInboxItem> & { id: number },
+): AgentChatInboxItem {
+  const createdAt = new Date().toISOString();
+  return {
+    orgId: "org-1",
+    userId: "user-1",
+    sessionId: "session-1",
+    sourceEventId: input.id,
+    kind: "task_complete",
+    status: "pending",
+    title: `Item ${input.id}`,
+    body: "Body",
+    payload: {},
+    actionRef: null,
+    createdAt,
+    updatedAt: createdAt,
+    readAt: null,
+    respondedAt: null,
+    ...input,
+  };
+}
+
+interface Harness {
+  adapter: AgentChatAdapter;
+  listInputs: AgentChatInboxListInput[];
+  emit: (type: "item" | "snapshot", data: string) => void;
+}
+
+function createHarness(items: AgentChatInboxItem[]): Harness {
+  const listInputs: AgentChatInboxListInput[] = [];
+  let listeners = new Map<string, Array<(event: { data: string }) => void>>();
+
+  const adapter: AgentChatAdapter = {
+    ...NON_INBOX_ADAPTER,
+    async listInbox(input = {}) {
+      listInputs.push(input);
+      const statuses = [input.status ?? []].flat();
+      const kinds = [input.kind ?? []].flat();
+      return {
+        items: items.filter(
+          (item) =>
+            (!statuses.length || statuses.includes(item.status)) &&
+            (!kinds.length || kinds.includes(item.kind)),
+        ),
+        nextCursor: null,
+      };
+    },
+    async getInboxItem(input) {
+      const item = items.find((candidate) => candidate.id === input.itemId);
+      if (!item) throw new Error("missing item");
+      return item;
+    },
+    async markInboxItemRead(input) {
+      const item = items.find((candidate) => candidate.id === input.itemId);
+      if (!item) throw new Error("missing item");
+      item.readAt = item.readAt ?? new Date().toISOString();
+      return item;
+    },
+    async acknowledgeInboxItem(input) {
+      const item = items.find((candidate) => candidate.id === input.itemId);
+      if (!item) throw new Error("missing item");
+      item.status = "acknowledged";
+      return item;
+    },
+    async respondGovernanceInboxItem(input) {
+      const item = items.find((candidate) => candidate.id === input.itemId);
+      if (!item) throw new Error("missing item");
+      item.status = "responded";
+      return item;
+    },
+    openInboxStream() {
+      listeners = new Map();
+      return {
+        addEventListener(type, listener) {
+          listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+        },
+        close() {},
+        onerror: null,
+      };
+    },
+  };
+
+  return {
+    adapter,
+    listInputs,
+    emit: (type, data) => {
+      for (const listener of listeners.get(type) ?? []) listener({ data });
+    },
+  };
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function mount(adapter: AgentChatAdapter) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(<InboxPanel adapter={adapter} />);
+    await Promise.resolve();
+  });
+  return container;
+}
+
+function clickText(text: string) {
+  const button = [
+    ...(container?.querySelectorAll<HTMLButtonElement>("button") ?? []),
+  ].find((candidate) => candidate.textContent?.trim() === text);
+  return act(async () => {
+    button?.click();
+    await Promise.resolve();
+  });
+}
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+describe("InboxPanel views", () => {
+  it("asks for the answerable kinds in Active and the rest in Updates", async () => {
+    const harness = createHarness([]);
+    await mount(harness.adapter);
+
+    expect(harness.listInputs[0]).toMatchObject({
+      status: ["pending"],
+      kind: ["input_required", "action_required", "governance_gate"],
+    });
+
+    await clickText("updates");
+    expect(harness.listInputs[1]).toMatchObject({
+      status: ["pending"],
+      kind: ["task_complete", "progress_checkin"],
+    });
+
+    // History is about what is finished, whatever kind it was.
+    await clickText("history");
+    expect(harness.listInputs[2]).toMatchObject({
+      status: ["acknowledged", "responded", "expired"],
+    });
+    expect(harness.listInputs[2].kind).toBeUndefined();
+  });
+
+  it("keeps a finished task out of Active and shows it under Updates", async () => {
+    const harness = createHarness([
+      inboxItem({ id: 1, kind: "task_complete", title: "Wrote the file" }),
+      inboxItem({ id: 2, kind: "input_required", title: "Which colour?" }),
+    ]);
+    const view = await mount(harness.adapter);
+
+    expect(view.textContent).toContain("Which colour?");
+    expect(view.textContent).not.toContain("Wrote the file");
+
+    await clickText("updates");
+    expect(view.textContent).toContain("Wrote the file");
+    expect(view.textContent).not.toContain("Which colour?");
+  });
+
+  it("does not let a nudge drop an update into Active", async () => {
+    const items = [inboxItem({ id: 1, kind: "input_required", title: "Which colour?" })];
+    const harness = createHarness(items);
+    const view = await mount(harness.adapter);
+
+    items.push(inboxItem({ id: 2, kind: "task_complete", title: "Wrote the file" }));
+    await act(async () => {
+      harness.emit("item", JSON.stringify({ item_id: 2, kind: "task_complete" }));
+      await Promise.resolve();
+    });
+
+    expect(view.textContent).not.toContain("Wrote the file");
+  });
+});

--- a/surogates/api/routes/inbox.py
+++ b/surogates/api/routes/inbox.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
 
 from surogates.config import enqueue_session
+from surogates.runtime import AgentRuntimeContext, agent_runtime_context_dep
 from surogates.session.events import EventType
 from surogates.session.inbox_payload import ACKNOWLEDGE_ONLY_KINDS
 from surogates.tenant.auth.middleware import get_current_tenant
@@ -31,6 +32,14 @@ from surogates.tools.builtin.ask_user_question import (
 )
 
 router = APIRouter(prefix="/inbox")
+
+# The inbox belongs to one person AND one agent. A person talking to
+# several agents accumulates items from all of them on the same principal
+# — the SPA is served per agent, so showing it the others' work is a leak
+# of the same kind the session list already refuses to make. Resolved the
+# way every other agent-scoped route resolves it: host subdomain in
+# production, explicit agent_id otherwise.
+AgentRuntime = Annotated[AgentRuntimeContext, Depends(agent_runtime_context_dep)]
 
 # Repeat the parameter to ask for several at once. Declared as a literal
 # so an unknown value is rejected by the framework, rather than filtering
@@ -168,6 +177,7 @@ async def _wake_session_from_request(request: Request, session_id: UUID) -> None
 async def list_inbox(
     request: Request,
     tenant: Annotated[TenantContext, Depends(get_current_tenant)],
+    agent_runtime: AgentRuntime,
     status: list[InboxStatus] | None = Query(default=None),
     kind: str | None = Query(default=None),
     session_id: str | None = Query(default=None),
@@ -178,6 +188,7 @@ async def list_inbox(
     store = request.app.state.session_store
     items = await store.list_inbox(
         user_id=tenant.user_id,
+        agent_id=agent_runtime.agent_id,
         status=status or [],
         kind=kind,
         session_id=UUID(session_id) if session_id else None,
@@ -205,6 +216,7 @@ async def list_inbox(
 async def stream_inbox(
     request: Request,
     tenant: Annotated[TenantContext, Depends(get_current_tenant)],
+    agent_runtime: AgentRuntime,
 ):
     tenant = _require_user_tenant(tenant)
     redis = getattr(request.app.state, "redis", None)
@@ -226,7 +238,10 @@ async def stream_inbox(
             # badge jump the moment the stream connected.
             snapshot = await asyncio.shield(
                 store.list_inbox(
-                    user_id=tenant.user_id, status="pending", limit=200,
+                    user_id=tenant.user_id,
+                    agent_id=agent_runtime.agent_id,
+                    status="pending",
+                    limit=200,
                 )
             )
             unread_ids = [item.id for item in snapshot if item.read_at is None]
@@ -254,6 +269,16 @@ async def stream_inbox(
                     data = {"item_id": int(item_id), "kind": kind}
                 except (TypeError, ValueError):
                     continue
+                # The channel is keyed by principal, so every agent this
+                # person talks to publishes onto it. Nudging about someone
+                # else's agent would send the client after an item it is
+                # then refused.
+                if await store.get_inbox_item(
+                    item_id=data["item_id"],
+                    user_id=tenant.user_id,
+                    agent_id=agent_runtime.agent_id,
+                ) is None:
+                    continue
                 yield {"event": "item", "data": json.dumps(data, default=str)}
         except asyncio.CancelledError:
             return
@@ -272,10 +297,15 @@ async def get_inbox_item(
     item_id: int,
     request: Request,
     tenant: Annotated[TenantContext, Depends(get_current_tenant)],
+    agent_runtime: AgentRuntime,
 ):
     tenant = _require_user_tenant(tenant)
     store = request.app.state.session_store
-    item = await store.get_inbox_item(item_id=item_id, user_id=tenant.user_id)
+    item = await store.get_inbox_item(
+        item_id=item_id,
+        user_id=tenant.user_id,
+        agent_id=agent_runtime.agent_id,
+    )
     if item is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -289,16 +319,25 @@ async def mark_inbox_item_read(
     item_id: int,
     request: Request,
     tenant: Annotated[TenantContext, Depends(get_current_tenant)],
+    agent_runtime: AgentRuntime,
 ):
     tenant = _require_user_tenant(tenant)
     store = request.app.state.session_store
-    item = await store.get_inbox_item(item_id=item_id, user_id=tenant.user_id)
+    item = await store.get_inbox_item(
+        item_id=item_id,
+        user_id=tenant.user_id,
+        agent_id=agent_runtime.agent_id,
+    )
     if item is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Inbox item not found.",
         )
-    item = await store.mark_inbox_read(item_id=item_id, user_id=tenant.user_id)
+    item = await store.mark_inbox_read(
+        item_id=item_id,
+        user_id=tenant.user_id,
+        agent_id=agent_runtime.agent_id,
+    )
     return _serialize_item(item, await _agent_fields_for(request, item.session_id))
 
 
@@ -307,10 +346,15 @@ async def acknowledge_inbox_item(
     item_id: int,
     request: Request,
     tenant: Annotated[TenantContext, Depends(get_current_tenant)],
+    agent_runtime: AgentRuntime,
 ):
     tenant = _require_user_tenant(tenant)
     store = request.app.state.session_store
-    item = await store.get_inbox_item(item_id=item_id, user_id=tenant.user_id)
+    item = await store.get_inbox_item(
+        item_id=item_id,
+        user_id=tenant.user_id,
+        agent_id=agent_runtime.agent_id,
+    )
     if item is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -325,6 +369,7 @@ async def acknowledge_inbox_item(
         item = await store.set_inbox_status(
             item_id=item_id,
             user_id=tenant.user_id,
+            agent_id=agent_runtime.agent_id,
             new_status="acknowledged",
         )
     except ValueError as exc:
@@ -340,10 +385,15 @@ async def delete_inbox_item(
     item_id: int,
     request: Request,
     tenant: Annotated[TenantContext, Depends(get_current_tenant)],
+    agent_runtime: AgentRuntime,
 ):
     tenant = _require_user_tenant(tenant)
     store = request.app.state.session_store
-    item = await store.delete_inbox_item(item_id=item_id, user_id=tenant.user_id)
+    item = await store.delete_inbox_item(
+        item_id=item_id,
+        user_id=tenant.user_id,
+        agent_id=agent_runtime.agent_id,
+    )
     if item is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -358,10 +408,15 @@ async def respond_to_inbox_item(
     payload: InboxResponse,
     request: Request,
     tenant: Annotated[TenantContext, Depends(get_current_tenant)],
+    agent_runtime: AgentRuntime,
 ):
     tenant = _require_user_tenant(tenant)
     store = request.app.state.session_store
-    item = await store.get_inbox_item(item_id=item_id, user_id=tenant.user_id)
+    item = await store.get_inbox_item(
+        item_id=item_id,
+        user_id=tenant.user_id,
+        agent_id=agent_runtime.agent_id,
+    )
     if item is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -431,6 +486,7 @@ async def respond_to_inbox_item(
         item = await store.set_inbox_status(
             item_id=item_id,
             user_id=tenant.user_id,
+            agent_id=agent_runtime.agent_id,
             new_status="responded",
         )
     except ValueError as exc:

--- a/surogates/api/routes/inbox.py
+++ b/surogates/api/routes/inbox.py
@@ -41,10 +41,17 @@ router = APIRouter(prefix="/inbox")
 # production, explicit agent_id otherwise.
 AgentRuntime = Annotated[AgentRuntimeContext, Depends(agent_runtime_context_dep)]
 
-# Repeat the parameter to ask for several at once. Declared as a literal
+# Repeat the parameter to ask for several at once. Declared as literals
 # so an unknown value is rejected by the framework, rather than filtering
 # everything out and reading as an empty inbox.
 InboxStatus = Literal["pending", "acknowledged", "responded", "expired"]
+InboxKind = Literal[
+    "input_required",
+    "action_required",
+    "governance_gate",
+    "task_complete",
+    "progress_checkin",
+]
 
 
 class InboxResponse(BaseModel):
@@ -179,7 +186,7 @@ async def list_inbox(
     tenant: Annotated[TenantContext, Depends(get_current_tenant)],
     agent_runtime: AgentRuntime,
     status: list[InboxStatus] | None = Query(default=None),
-    kind: str | None = Query(default=None),
+    kind: list[InboxKind] | None = Query(default=None),
     session_id: str | None = Query(default=None),
     cursor: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
@@ -190,7 +197,7 @@ async def list_inbox(
         user_id=tenant.user_id,
         agent_id=agent_runtime.agent_id,
         status=status or [],
-        kind=kind,
+        kind=kind or [],
         session_id=UUID(session_id) if session_id else None,
         cursor=_decode_cursor(cursor),
         limit=limit,

--- a/surogates/channels/constants.py
+++ b/surogates/channels/constants.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 __all__ = [
     "ADAPTER_CHANNELS",
     "END_USER_CHANNELS",
+    "INBOX_NOTIFY_CHANNELS",
     "INTERACTIVE_PROMPT_CHANNELS",
     "multi_session_disabled",
 ]
@@ -54,3 +55,16 @@ INTERACTIVE_PROMPT_CHANNELS = frozenset({"slack", "telegram", "whatsapp"})
 END_USER_CHANNELS = frozenset(
     {"web", "website", "slack", "telegram", "teams", "whatsapp"}
 )
+
+#: Channels whose completed sessions raise a ``task_complete`` inbox item.
+#: Narrower than :data:`END_USER_CHANNELS` on purpose — this set is about
+#: where the notification can be RETIRED, not who is talking.  The item is
+#: cleared by opening its session's conversation (the chat surfaces delete
+#: it on open, and the store suppresses it outright for a live viewer), so
+#: a channel outside this set mints rows nothing can ever clear: ``api``,
+#: ``worker``/``task``/``delegation``, ``scheduled``, ``ambient`` and
+#: ``browser_setup`` have no conversation a person opens, and the adapter
+#: channels deliver the result in the conversation itself, where a second
+#: "Task complete" is noise.  Child sessions are excluded regardless of
+#: channel — see :func:`surogates.session.inbox_payload.raises_completion_inbox_item`.
+INBOX_NOTIFY_CHANNELS = frozenset({"web", "website"})

--- a/surogates/db/engine.py
+++ b/surogates/db/engine.py
@@ -109,6 +109,7 @@ def run_migrations(db_settings: DatabaseSettings) -> None:
 
     async def _create_all() -> None:
         from surogates.db.agent_users import BACKFILL_SQL
+        from surogates.db.inbox_backlog import RETIRE_UNREACHABLE_INBOX_SQL
 
         engine = async_engine_from_settings(db_settings)
         async with engine.begin() as conn:
@@ -118,6 +119,10 @@ def run_migrations(db_settings: DatabaseSettings) -> None:
             # Derive agent-user bindings from historical sessions once
             # the table exists; ON CONFLICT keeps re-runs free.
             await conn.exec_driver_sql(BACKFILL_SQL)
+            # Drain inbox notifications no surface can clear. Matches only
+            # rows the current emission rule would never write, so it
+            # settles to a no-op instead of fighting live data.
+            await conn.exec_driver_sql(RETIRE_UNREACHABLE_INBOX_SQL)
         await engine.dispose()
 
     asyncio.run(_create_all())

--- a/surogates/db/inbox_backlog.py
+++ b/surogates/db/inbox_backlog.py
@@ -1,0 +1,48 @@
+"""Retiring inbox notifications that no surface can clear.
+
+A ``task_complete`` item is cleared by opening its session's
+conversation, so one raised for a session with no conversation — a
+subagent, an API run, a messaging thread that already carried the answer
+— stays pending forever. The emission rule in
+:func:`surogates.session.inbox_payload.raises_completion_inbox_item` now
+refuses to create them, but the rows already in the table outlive that
+fix and keep every list unreadable.
+
+The predicate below is exactly the negation of that rule, which is what
+makes the statement safe to run on every migrate: once the backlog is
+drained there is nothing left for it to match, because nothing new of
+that shape is ever written.
+"""
+
+from __future__ import annotations
+
+from surogates.channels.constants import INBOX_NOTIFY_CHANNELS
+
+_NOTIFY_CHANNELS_SQL = ", ".join(
+    sorted(repr(channel) for channel in INBOX_NOTIFY_CHANNELS)
+)
+
+# ``expired`` rather than ``acknowledged``: nobody ever saw these, and
+# expired is the status the inbox already uses for "no longer actionable,
+# hidden from every view that does not ask for it by name" — the same one
+# the delete action writes.
+#
+# Scheduled runs are excluded to match the emission rule: they are
+# unwatched work by construction and their announcement is the only one
+# they get. ``progress_checkin`` is excluded because it is still raised
+# for any session that opts into it — retiring those would fight the
+# opt-in on every migrate instead of settling.
+RETIRE_UNREACHABLE_INBOX_SQL = f"""
+UPDATE inbox_items AS i
+SET status = 'expired',
+    updated_at = now()
+FROM sessions AS s
+WHERE s.id = i.session_id
+  AND i.status = 'pending'
+  AND i.kind = 'task_complete'
+  AND NOT (
+        s.channel = 'scheduled'
+     OR s.config ->> 'scheduled_session_id' IS NOT NULL
+     OR (s.parent_id IS NULL AND s.channel IN ({_NOTIFY_CHANNELS_SQL}))
+  )
+"""

--- a/surogates/db/inbox_backlog.py
+++ b/surogates/db/inbox_backlog.py
@@ -27,6 +27,9 @@ _NOTIFY_CHANNELS_SQL = ", ".join(
 # hidden from every view that does not ask for it by name" — the same one
 # the delete action writes.
 #
+# An empty scheduled_session_id is not a scheduled run — the Python
+# predicate reads it as falsy, and this has to agree with it.
+#
 # Scheduled runs are excluded to match the emission rule: they are
 # unwatched work by construction and their announcement is the only one
 # they get. ``progress_checkin`` is excluded because it is still raised
@@ -42,7 +45,7 @@ WHERE s.id = i.session_id
   AND i.kind = 'task_complete'
   AND NOT (
         s.channel = 'scheduled'
-     OR s.config ->> 'scheduled_session_id' IS NOT NULL
+     OR COALESCE(s.config ->> 'scheduled_session_id', '') <> ''
      OR (s.parent_id IS NULL AND s.channel IN ({_NOTIFY_CHANNELS_SQL}))
   )
 """

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -26,6 +26,7 @@ from surogates.harness.loop_messages import (
 )
 from surogates.harness.message_utils import extract_final_response
 from surogates.session.events import EventType
+from surogates.session.inbox_payload import raises_completion_inbox_item
 
 logger = logging.getLogger(__name__)
 
@@ -836,7 +837,12 @@ class ArtifactCompletionMixin:
                 )
 
         inbox_event_id: int | None = None
-        if loop_result_parent is None:
+        # A scheduled run keeps announcing itself whatever its channel: it
+        # is unwatched work by construction, and the branch above already
+        # took the web/api parents that receive the result inline instead.
+        if loop_result_parent is None and (
+            _is_scheduled_run(session) or raises_completion_inbox_item(session)
+        ):
             inbox_event_id = await self._store.emit_event(
                 session.id,
                 EventType.INBOX_TASK_COMPLETE,

--- a/surogates/session/inbox_payload.py
+++ b/surogates/session/inbox_payload.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 from surogates.channels.constants import INBOX_NOTIFY_CHANNELS
@@ -26,6 +27,32 @@ ACKNOWLEDGE_ONLY_KINDS = frozenset({"task_complete", "progress_checkin"})
 
 _TITLE_TRUNCATE = 120
 _BODY_TRUNCATE = 1000
+
+
+def apply_read_receipt(item) -> bool:
+    """Mark *item* read, retiring it if reading is all it needed.
+
+    Returns whether anything changed, so a caller can skip the write.
+
+    An informational item is finished the moment it has been read: there
+    is nothing else to do to a "task done" notice, and leaving it pending
+    kept it in the list until someone acknowledged each one by hand. A
+    kind that needs a real response stays pending — a question is not
+    answered by being looked at.
+
+    Lives here, next to the kinds it reads, because two processes write
+    this table: the harness store and the ops control plane. They used to
+    carry a copy each with a comment warning they must not drift.
+    """
+    if item.read_at is not None:
+        return False
+    now = datetime.now(timezone.utc)
+    item.read_at = now
+    if item.kind in ACKNOWLEDGE_ONLY_KINDS and item.status == "pending":
+        item.status = "acknowledged"
+        item.responded_at = now
+        item.updated_at = now
+    return True
 
 
 def raises_completion_inbox_item(session) -> bool:

--- a/surogates/session/inbox_payload.py
+++ b/surogates/session/inbox_payload.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from surogates.channels.constants import INBOX_NOTIFY_CHANNELS
 from surogates.session.events import EventType
 
 
@@ -25,6 +26,23 @@ ACKNOWLEDGE_ONLY_KINDS = frozenset({"task_complete", "progress_checkin"})
 
 _TITLE_TRUNCATE = 120
 _BODY_TRUNCATE = 1000
+
+
+def raises_completion_inbox_item(session) -> bool:
+    """Whether a completed session should announce itself in the inbox.
+
+    Two conditions, both about whether a person can ever act on the row:
+
+    * it is a root conversation — a delegated child's result reaches its
+      coordinator as ``WORKER_COMPLETE`` and is read in the parent
+      conversation, so a second copy in the inbox is unreachable noise;
+    * its channel is one the operator can open (:data:`INBOX_NOTIFY_CHANNELS`),
+      because opening the conversation is what clears the item.
+    """
+    return (
+        getattr(session, "parent_id", None) is None
+        and getattr(session, "channel", None) in INBOX_NOTIFY_CHANNELS
+    )
 
 
 def _truncate(value: str | None, *, limit: int) -> str:

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -1695,7 +1695,7 @@ class SessionStore:
         user_id: UUID,
         agent_id: str,
         status: str | Sequence[str] | None = None,
-        kind: str | None = None,
+        kind: str | Sequence[str] | None = None,
         session_id: UUID | None = None,
         cursor: tuple[datetime, int] | None = None,
         limit: int = 50,
@@ -1709,8 +1709,11 @@ class SessionStore:
             stmt = stmt.where(InboxItem.status.in_(statuses))
         else:
             stmt = stmt.where(InboxItem.status != "expired")
-        if kind:
-            stmt = stmt.where(InboxItem.kind == kind)
+        # Like the status filter: a view asks for a set of kinds — the
+        # ones that need a response, or the ones that are only news.
+        kinds = [kind] if isinstance(kind, str) else list(kind or ())
+        if kinds:
+            stmt = stmt.where(InboxItem.kind.in_(kinds))
         if session_id:
             stmt = stmt.where(InboxItem.session_id == session_id)
         if cursor:

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -1760,7 +1760,17 @@ class SessionStore:
                 )
             ).scalar_one()
             if row.read_at is None:
-                row.read_at = datetime.now(timezone.utc)
+                now = datetime.now(timezone.utc)
+                row.read_at = now
+                # An informational item is finished the moment it has been
+                # read: there is nothing else to do to a "task complete"
+                # notice, and leaving it pending kept it in the list until
+                # the operator acknowledged each one by hand. A kind that
+                # needs a real response stays pending — a question is not
+                # answered by being looked at.
+                if row.kind in ACKNOWLEDGE_ONLY_KINDS and row.status == "pending":
+                    row.status = "acknowledged"
+                    row.responded_at = now
                 await db.commit()
                 await db.refresh(row)
             return row

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -1671,10 +1671,29 @@ class SessionStore:
         async with self._sf() as db:
             return int((await db.execute(stmt)).scalar_one())
 
+    @staticmethod
+    def _inbox_scope(user_id: UUID, agent_id: str):
+        """The rows one person may see in one agent's inbox.
+
+        ``agent_id`` lives on the session, not the item, so it is applied
+        as a subquery rather than a join — every accessor here selects
+        whole ``InboxItem`` rows and stays that shape. Scoping is not
+        optional: a person talking to several agents has items from all
+        of them, and an unscoped read shows one agent's inbox the others'
+        work.
+        """
+        return (
+            InboxItem.user_id == user_id,
+            InboxItem.session_id.in_(
+                select(SessionRow.id).where(SessionRow.agent_id == agent_id)
+            ),
+        )
+
     async def list_inbox(
         self,
         *,
         user_id: UUID,
+        agent_id: str,
         status: str | Sequence[str] | None = None,
         kind: str | None = None,
         session_id: UUID | None = None,
@@ -1685,7 +1704,7 @@ class SessionStore:
         # responded and expired), so the filter takes a set as readily as
         # a single value. Without one, expired items stay hidden.
         statuses = [status] if isinstance(status, str) else list(status or ())
-        stmt = select(InboxItem).where(InboxItem.user_id == user_id)
+        stmt = select(InboxItem).where(*self._inbox_scope(user_id, agent_id))
         if statuses:
             stmt = stmt.where(InboxItem.status.in_(statuses))
         else:
@@ -1713,12 +1732,13 @@ class SessionStore:
         *,
         item_id: int,
         user_id: UUID,
+        agent_id: str,
     ) -> InboxItem | None:
         async with self._sf() as db:
             result = await db.execute(
                 select(InboxItem).where(
                     InboxItem.id == item_id,
-                    InboxItem.user_id == user_id,
+                    *self._inbox_scope(user_id, agent_id),
                 )
             )
             return result.scalar_one_or_none()
@@ -1728,13 +1748,14 @@ class SessionStore:
         *,
         item_id: int,
         user_id: UUID,
+        agent_id: str,
     ) -> InboxItem:
         async with self._sf() as db:
             row = (
                 await db.execute(
                     select(InboxItem).where(
                         InboxItem.id == item_id,
-                        InboxItem.user_id == user_id,
+                        *self._inbox_scope(user_id, agent_id),
                     )
                 )
             ).scalar_one()
@@ -1749,6 +1770,7 @@ class SessionStore:
         *,
         item_id: int,
         user_id: UUID,
+        agent_id: str,
         new_status: str,
     ) -> InboxItem:
         if new_status not in self._INBOX_TERMINAL:
@@ -1759,7 +1781,7 @@ class SessionStore:
                 await db.execute(
                     select(InboxItem).where(
                         InboxItem.id == item_id,
-                        InboxItem.user_id == user_id,
+                        *self._inbox_scope(user_id, agent_id),
                     )
                 )
             ).scalar_one()
@@ -1784,6 +1806,7 @@ class SessionStore:
         *,
         item_id: int,
         user_id: UUID,
+        agent_id: str,
     ) -> InboxItem | None:
         """Hide a user-owned inbox item from default inbox views.
 
@@ -1795,7 +1818,7 @@ class SessionStore:
                 await db.execute(
                     select(InboxItem).where(
                         InboxItem.id == item_id,
-                        InboxItem.user_id == user_id,
+                        *self._inbox_scope(user_id, agent_id),
                     )
                 )
             ).scalar_one_or_none()

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -53,6 +53,7 @@ from surogates.session.acting_principal import (
 from surogates.session.events import EventType
 from surogates.session.inbox_payload import (
     ACKNOWLEDGE_ONLY_KINDS,
+    apply_read_receipt,
     build_inbox_row,
 )
 from surogates.session.models import (
@@ -1682,7 +1683,7 @@ class SessionStore:
         of them, and an unscoped read shows one agent's inbox the others'
         work.
         """
-        return (
+        return and_(
             InboxItem.user_id == user_id,
             InboxItem.session_id.in_(
                 select(SessionRow.id).where(SessionRow.agent_id == agent_id)
@@ -1704,7 +1705,7 @@ class SessionStore:
         # responded and expired), so the filter takes a set as readily as
         # a single value. Without one, expired items stay hidden.
         statuses = [status] if isinstance(status, str) else list(status or ())
-        stmt = select(InboxItem).where(*self._inbox_scope(user_id, agent_id))
+        stmt = select(InboxItem).where(self._inbox_scope(user_id, agent_id))
         if statuses:
             stmt = stmt.where(InboxItem.status.in_(statuses))
         else:
@@ -1741,7 +1742,7 @@ class SessionStore:
             result = await db.execute(
                 select(InboxItem).where(
                     InboxItem.id == item_id,
-                    *self._inbox_scope(user_id, agent_id),
+                    self._inbox_scope(user_id, agent_id),
                 )
             )
             return result.scalar_one_or_none()
@@ -1758,22 +1759,11 @@ class SessionStore:
                 await db.execute(
                     select(InboxItem).where(
                         InboxItem.id == item_id,
-                        *self._inbox_scope(user_id, agent_id),
+                        self._inbox_scope(user_id, agent_id),
                     )
                 )
             ).scalar_one()
-            if row.read_at is None:
-                now = datetime.now(timezone.utc)
-                row.read_at = now
-                # An informational item is finished the moment it has been
-                # read: there is nothing else to do to a "task complete"
-                # notice, and leaving it pending kept it in the list until
-                # the operator acknowledged each one by hand. A kind that
-                # needs a real response stays pending — a question is not
-                # answered by being looked at.
-                if row.kind in ACKNOWLEDGE_ONLY_KINDS and row.status == "pending":
-                    row.status = "acknowledged"
-                    row.responded_at = now
+            if apply_read_receipt(row):
                 await db.commit()
                 await db.refresh(row)
             return row
@@ -1794,7 +1784,7 @@ class SessionStore:
                 await db.execute(
                     select(InboxItem).where(
                         InboxItem.id == item_id,
-                        *self._inbox_scope(user_id, agent_id),
+                        self._inbox_scope(user_id, agent_id),
                     )
                 )
             ).scalar_one()
@@ -1831,7 +1821,7 @@ class SessionStore:
                 await db.execute(
                     select(InboxItem).where(
                         InboxItem.id == item_id,
-                        *self._inbox_scope(user_id, agent_id),
+                        self._inbox_scope(user_id, agent_id),
                     )
                 )
             ).scalar_one_or_none()

--- a/tests/integration/inbox_e2e_helpers.py
+++ b/tests/integration/inbox_e2e_helpers.py
@@ -33,6 +33,55 @@ class StubTenant:
     user_id: UUID
 
 
+AGENT_ID = "test-agent"
+OTHER_AGENT_ID = "other-agent"
+
+
+class FakeRuntimeCache:
+    """Minimal stand-in for ``app.state.runtime_config_cache``.
+
+    Returns a valid runtime-config payload for the agents it knows and
+    raises ``LookupError`` for everything else, mirroring the real
+    cache's contract — which is what lets ``agent_runtime_context_dep``
+    resolve an agent without a live management plane.
+    """
+
+    def __init__(self, *agent_ids: str) -> None:
+        self._agent_ids = frozenset(agent_ids)
+
+    async def get(self, agent_id: str) -> dict:
+        if agent_id not in self._agent_ids:
+            raise LookupError(agent_id)
+        return {
+            "agent_id": agent_id,
+            "org_id": "00000000-0000-0000-0000-000000000000",
+            "project_id": "test-project",
+            "enabled": True,
+            "version": 1,
+            "storage_key_prefix": "",
+        }
+
+
+def inbox_path(
+    suffix: str = "",
+    *,
+    agent_id: str | None = AGENT_ID,
+    query: str = "",
+) -> str:
+    """A ``/v1/inbox`` URL that names the agent whose inbox it is.
+
+    Every real client names one: the SPA through its host subdomain in
+    production, through an ``agent_id`` the dev proxy injects otherwise.
+    ``agent_id=None`` builds the nameless URL the API rejects.
+    """
+    parts = [
+        part
+        for part in (query, f"agent_id={agent_id}" if agent_id else "")
+        if part
+    ]
+    return f"/v1/inbox{suffix}" + (f"?{'&'.join(parts)}" if parts else "")
+
+
 def build_inbox_test_app(session_factory, redis_client, pg_url, redis_url):
     os.environ["SUROGATES_DB_URL"] = pg_url
     os.environ["SUROGATES_REDIS_URL"] = redis_url
@@ -53,6 +102,9 @@ def build_inbox_test_app(session_factory, redis_client, pg_url, redis_url):
     application.state.credential_vault = CredentialVault(
         session_factory,
         Fernet.generate_key(),
+    )
+    application.state.runtime_config_cache = FakeRuntimeCache(
+        AGENT_ID, OTHER_AGENT_ID,
     )
     return application
 

--- a/tests/integration/test_inbox_api.py
+++ b/tests/integration/test_inbox_api.py
@@ -22,6 +22,12 @@ from surogates.tenant.auth.jwt import create_access_token
 from surogates.tenant.credentials import CredentialVault
 
 from .conftest import create_org, create_user, issue_service_account_token
+from .inbox_e2e_helpers import (
+    AGENT_ID,
+    OTHER_AGENT_ID,
+    FakeRuntimeCache,
+    inbox_path,
+)
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -48,6 +54,9 @@ async def app(session_factory, redis_client, pg_url, redis_url):
         session_factory,
         Fernet.generate_key(),
     )
+    application.state.runtime_config_cache = FakeRuntimeCache(
+        AGENT_ID, OTHER_AGENT_ID,
+    )
     return application
 
 
@@ -60,7 +69,12 @@ async def client(app):
         yield c
 
 
-async def _create_user_token_session(session_factory, session_store):
+async def _create_user_token_session(
+    session_factory,
+    session_store,
+    *,
+    agent_id: str = AGENT_ID,
+):
     org_id = await create_org(session_factory)
     user_id = uuid.uuid4()
     await create_user(session_factory, org_id, user_id=user_id)
@@ -72,7 +86,7 @@ async def _create_user_token_session(session_factory, session_store):
     session = await session_store.create_session(
         user_id=user_id,
         org_id=org_id,
-        agent_id="test-agent",
+        agent_id=agent_id,
     )
     return org_id, user_id, token, session
 
@@ -127,7 +141,7 @@ async def test_list_inbox_returns_only_callers_items(
     )
 
     response = await client.get(
-        "/v1/inbox",
+        inbox_path(),
         headers={"Authorization": f"Bearer {token}"},
     )
 
@@ -145,7 +159,7 @@ async def test_list_inbox_rejects_service_account(
     _, token = await _create_service_account_token(session_factory)
 
     response = await client.get(
-        "/v1/inbox",
+        inbox_path(),
         headers={"Authorization": f"Bearer {token}"},
     )
 
@@ -160,7 +174,7 @@ async def test_get_inbox_item(client, session_factory, session_store):
     item = await _emit_task_complete(session_store, session.id)
 
     response = await client.get(
-        f"/v1/inbox/{item.id}",
+        inbox_path(f"/{item.id}"),
         headers={"Authorization": f"Bearer {token}"},
     )
 
@@ -185,7 +199,7 @@ async def test_get_other_users_item_returns_404(
     item = await _emit_task_complete(session_store, session.id)
 
     response = await client.get(
-        f"/v1/inbox/{item.id}",
+        inbox_path(f"/{item.id}"),
         headers={"Authorization": f"Bearer {other_token}"},
     )
 
@@ -200,8 +214,8 @@ async def test_mark_read_is_idempotent(client, session_factory, session_store):
     item = await _emit_task_complete(session_store, session.id)
     headers = {"Authorization": f"Bearer {token}"}
 
-    first = await client.post(f"/v1/inbox/{item.id}/read", headers=headers)
-    second = await client.post(f"/v1/inbox/{item.id}/read", headers=headers)
+    first = await client.post(inbox_path(f"/{item.id}/read"), headers=headers)
+    second = await client.post(inbox_path(f"/{item.id}/read"), headers=headers)
 
     assert first.status_code == 200, first.text
     assert second.status_code == 200, second.text
@@ -221,7 +235,7 @@ async def test_ack_flips_status_to_acknowledged(
     item = await _emit_task_complete(session_store, session.id)
 
     response = await client.post(
-        f"/v1/inbox/{item.id}/ack",
+        inbox_path(f"/{item.id}/ack"),
         headers={"Authorization": f"Bearer {token}"},
     )
 
@@ -251,7 +265,7 @@ async def test_ack_rejects_non_ackable_kind(
     item = await _get_inbox_item_for_event(session_store, event_id)
 
     response = await client.post(
-        f"/v1/inbox/{item.id}/ack",
+        inbox_path(f"/{item.id}/ack"),
         headers={"Authorization": f"Bearer {token}"},
     )
 
@@ -270,15 +284,15 @@ async def test_delete_inbox_item_expires_and_hides_item(
     item = await _emit_task_complete(session_store, session.id)
     headers = {"Authorization": f"Bearer {token}"}
 
-    response = await client.delete(f"/v1/inbox/{item.id}", headers=headers)
+    response = await client.delete(inbox_path(f"/{item.id}"), headers=headers)
 
     assert response.status_code == 204, response.text
 
-    default_list = await client.get("/v1/inbox", headers=headers)
+    default_list = await client.get(inbox_path(), headers=headers)
     assert default_list.status_code == 200, default_list.text
     assert default_list.json()["items"] == []
 
-    expired_list = await client.get("/v1/inbox?status=expired", headers=headers)
+    expired_list = await client.get(inbox_path(query="status=expired"), headers=headers)
     assert expired_list.status_code == 200, expired_list.text
     assert [row["id"] for row in expired_list.json()["items"]] == [item.id]
     assert expired_list.json()["items"][0]["status"] == "expired"
@@ -307,12 +321,17 @@ async def test_list_accepts_several_statuses_at_once(
     acknowledged = await _emit_task_complete(session_store, session.id)
     hidden = await _emit_task_complete(session_store, session.id)
     await session_store.set_inbox_status(
-        item_id=acknowledged.id, user_id=user_id, new_status="acknowledged",
+        item_id=acknowledged.id,
+        user_id=user_id,
+        agent_id=AGENT_ID,
+        new_status="acknowledged",
     )
-    await session_store.delete_inbox_item(item_id=hidden.id, user_id=user_id)
+    await session_store.delete_inbox_item(
+        item_id=hidden.id, user_id=user_id, agent_id=AGENT_ID,
+    )
 
     response = await client.get(
-        "/v1/inbox?status=acknowledged&status=responded&status=expired",
+        inbox_path(query="status=acknowledged&status=responded&status=expired"),
         headers=headers,
     )
 
@@ -334,7 +353,7 @@ async def test_list_rejects_an_unknown_status(
     )
 
     response = await client.get(
-        "/v1/inbox?status=pending&status=nonsense",
+        inbox_path(query="status=pending&status=nonsense"),
         headers={"Authorization": f"Bearer {token}"},
     )
 
@@ -359,11 +378,112 @@ async def test_delete_other_users_item_returns_404(
     item = await _emit_task_complete(session_store, session.id)
 
     response = await client.delete(
-        f"/v1/inbox/{item.id}",
+        inbox_path(f"/{item.id}"),
         headers={"Authorization": f"Bearer {other_token}"},
     )
 
     assert response.status_code == 404
+
+
+def headers_for(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _item_on_another_agent(session_factory, session_store, org_id, user_id):
+    """One inbox item for the same person, raised by a different agent."""
+    other_session = await session_store.create_session(
+        user_id=user_id,
+        org_id=org_id,
+        agent_id=OTHER_AGENT_ID,
+    )
+    return await _emit_task_complete(session_store, other_session.id)
+
+
+async def test_list_excludes_items_raised_by_another_agent(
+    client,
+    session_factory,
+    session_store,
+):
+    """Each agent's inbox is its own.
+
+    One person talking to several agents has items from all of them; the
+    inbox they are looking at must show only the agent whose app they
+    opened, the same way the session list already does.
+    """
+    org_id, user_id, token, session = await _create_user_token_session(
+        session_factory,
+        session_store,
+    )
+    mine = await _emit_task_complete(session_store, session.id)
+    theirs = await _item_on_another_agent(
+        session_factory, session_store, org_id, user_id,
+    )
+
+    response = await client.get(
+        inbox_path(),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200, response.text
+    returned = {row["id"] for row in response.json()["items"]}
+    assert returned == {mine.id}
+    assert theirs.id not in returned
+
+
+@pytest.mark.parametrize(
+    ("method", "suffix", "body"),
+    [
+        ("get", "", None),
+        ("post", "/read", None),
+        ("post", "/ack", None),
+        ("delete", "", None),
+        ("post", "/respond", {"completed": True}),
+    ],
+    ids=["get", "read", "ack", "delete", "respond"],
+)
+async def test_item_of_another_agent_is_not_found(
+    client,
+    session_factory,
+    session_store,
+    method,
+    suffix,
+    body,
+):
+    org_id, user_id, token, _ = await _create_user_token_session(
+        session_factory,
+        session_store,
+    )
+    theirs = await _item_on_another_agent(
+        session_factory, session_store, org_id, user_id,
+    )
+
+    kwargs = {"headers": {"Authorization": f"Bearer {token}"}}
+    if body is not None:
+        kwargs["json"] = body
+    response = await getattr(client, method)(
+        inbox_path(f"/{theirs.id}{suffix}"), **kwargs,
+    )
+
+    assert response.status_code == 404, response.text
+
+
+async def test_inbox_requires_an_agent(
+    client,
+    session_factory,
+    session_store,
+):
+    """Without an agent there is no inbox to show — say so, don't guess."""
+    _, _, token, _ = await _create_user_token_session(
+        session_factory,
+        session_store,
+    )
+
+    response = await client.get(
+        inbox_path(agent_id=None),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 400, response.text
 
 
 async def test_respond_governance_records_decision_and_wakes_session(
@@ -401,7 +521,7 @@ async def test_respond_governance_records_decision_and_wakes_session(
     )
 
     response = await client.post(
-        f"/v1/inbox/{item.id}/respond",
+        inbox_path(f"/{item.id}/respond"),
         json={"decision": "approve"},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -464,7 +584,7 @@ async def test_respond_action_required_records_completion_and_wakes_session(
     )
 
     response = await client.post(
-        f"/v1/inbox/{item.id}/respond",
+        inbox_path(f"/{item.id}/respond"),
         json={"completed": True},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -504,7 +624,7 @@ async def test_respond_rejects_non_governance_kind(
     item = await _emit_task_complete(session_store, session.id)
 
     response = await client.post(
-        f"/v1/inbox/{item.id}/respond",
+        inbox_path(f"/{item.id}/respond"),
         json={"decision": "approve"},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -572,7 +692,7 @@ async def test_sse_stream_emits_snapshot_and_nudge_for_new_item(
     try:
         async with asyncio.timeout(5):
             response = await client.get(
-                "/v1/inbox/stream",
+                inbox_path("/stream"),
                 headers=headers,
             )
     finally:
@@ -605,6 +725,7 @@ async def test_sse_snapshot_counts_only_pending_unread(
     await store.set_inbox_status(
         item_id=already_handled.id,
         user_id=user_id,
+        agent_id=AGENT_ID,
         new_status="acknowledged",
     )
 
@@ -615,7 +736,7 @@ async def test_sse_snapshot_counts_only_pending_unread(
     )
 
     async with asyncio.timeout(5):
-        response = await client.get("/v1/inbox/stream", headers=headers)
+        response = await client.get(inbox_path("/stream"), headers=headers)
 
     assert response.status_code == 200, response.text
     snapshot = json.loads(
@@ -628,42 +749,56 @@ async def test_sse_snapshot_counts_only_pending_unread(
     assert snapshot["unread_ids"] == [still_pending.id]
 
 
-class _FakeRuntimeCache:
-    """Minimal stand-in for ``app.state.runtime_config_cache``.
+async def test_sse_snapshot_excludes_another_agents_items(
+    client,
+    app,
+    session_factory,
+    monkeypatch,
+):
+    """The stream seeds the unread badge, so it is scoped like the list.
 
-    Returns a valid runtime-config payload for ``agent_id`` and raises
-    ``LookupError`` for everything else, mirroring the real cache's
-    contract.
+    Items published to this person's channel by their OTHER agents land
+    on the same Redis channel — the snapshot must not count them, or the
+    badge shows a number the list cannot explain.
     """
+    store = app.state.session_store
+    org_id, user_id, token, session = await _create_user_token_session(
+        session_factory,
+        store,
+    )
+    mine = await _emit_task_complete(store, session.id)
+    theirs = await _item_on_another_agent(
+        session_factory, store, org_id, user_id,
+    )
 
-    def __init__(self, agent_id: str) -> None:
-        self._agent_id = agent_id
+    monkeypatch.setattr(
+        "surogates.api.routes.inbox.EventSourceResponse",
+        _finite_event_source("snapshot"),
+        raising=False,
+    )
 
-    async def get(self, agent_id: str) -> dict:
-        if agent_id != self._agent_id:
-            raise LookupError(agent_id)
-        return {
-            "agent_id": agent_id,
-            "org_id": "00000000-0000-0000-0000-000000000000",
-            "project_id": "test-project",
-            "enabled": True,
-            "version": 1,
-            "storage_key_prefix": "",
-        }
-
-
-async def test_auth_config_returns_current_agent_id(client, app):
-    # Seed the runtime-config cache so agent_runtime_context_dep can resolve
-    # "test-agent" without a live management-plane connection.
-    original = getattr(app.state, "runtime_config_cache", None)
-    app.state.runtime_config_cache = _FakeRuntimeCache("test-agent")
-    try:
-        response = await client.get("/v1/auth/config?agent_id=test-agent")
-    finally:
-        app.state.runtime_config_cache = original
+    async with asyncio.timeout(5):
+        response = await client.get(inbox_path("/stream"), headers=headers_for(token))
 
     assert response.status_code == 200, response.text
-    assert response.json()["agent_id"] == "test-agent"
+    snapshot = json.loads(
+        next(
+            line[len("data: "):]
+            for line in response.text.splitlines()
+            if line.startswith("data: ")
+        )
+    )
+    assert snapshot["unread_ids"] == [mine.id]
+    assert theirs.id not in snapshot["unread_ids"]
+
+
+async def test_auth_config_returns_current_agent_id(client):
+    # The app fixture seeds the runtime-config cache so
+    # agent_runtime_context_dep resolves without a live management plane.
+    response = await client.get(f"/v1/auth/config?agent_id={AGENT_ID}")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["agent_id"] == AGENT_ID
 
 
 async def test_ask_user_question_response_flips_inbox_to_responded(

--- a/tests/integration/test_inbox_api.py
+++ b/tests/integration/test_inbox_api.py
@@ -341,6 +341,68 @@ async def test_list_accepts_several_statuses_at_once(
     assert still_pending.id not in returned
 
 
+async def test_list_accepts_several_kinds_at_once(
+    client,
+    session_factory,
+    session_store,
+):
+    """Active and Updates are two lists, not one list filtered twice.
+
+    The kinds that need a response and the ones that are only news are
+    shown apart, so the request has to be able to name a set.
+    """
+    _, _, token, session = await _create_user_token_session(
+        session_factory,
+        session_store,
+    )
+    update = await _emit_task_complete(session_store, session.id)
+    question_event = await session_store.emit_event(
+        session.id,
+        EventType.INBOX_INPUT_REQUIRED,
+        {
+            "tool_call_id": "tc-kinds-1",
+            "questions": [{"prompt": "Which one?"}],
+            "context": "",
+        },
+    )
+    question = await _get_inbox_item_for_event(session_store, question_event)
+
+    answerable = await client.get(
+        inbox_path(query="kind=input_required&kind=governance_gate"),
+        headers=headers_for(token),
+    )
+    news = await client.get(
+        inbox_path(query="kind=task_complete&kind=progress_checkin"),
+        headers=headers_for(token),
+    )
+
+    assert answerable.status_code == 200, answerable.text
+    assert [row["id"] for row in answerable.json()["items"]] == [question.id]
+    assert news.status_code == 200, news.text
+    assert [row["id"] for row in news.json()["items"]] == [update.id]
+
+
+async def test_list_rejects_an_unknown_kind(
+    client,
+    session_factory,
+    session_store,
+):
+    """Same reason an unknown status is rejected: an empty list would
+    read as an empty inbox."""
+    _, _, token, _ = await _create_user_token_session(
+        session_factory,
+        session_store,
+    )
+
+    response = await client.get(
+        inbox_path(query="kind=nonsense"),
+        headers=headers_for(token),
+    )
+
+    assert response.status_code == 422, response.text
+    assert "nonsense" in response.text
+
+
 async def test_list_rejects_an_unknown_status(
     client,
     session_factory,

--- a/tests/integration/test_inbox_api.py
+++ b/tests/integration/test_inbox_api.py
@@ -4,28 +4,24 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import uuid
 from uuid import UUID
 
 import pytest
 import pytest_asyncio
-from cryptography.fernet import Fernet
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 from starlette.responses import StreamingResponse
 
 from surogates.db.models import Event, InboxItem
 from surogates.session.events import EventType
-from surogates.session.store import SessionStore
 from surogates.tenant.auth.jwt import create_access_token
-from surogates.tenant.credentials import CredentialVault
 
 from .conftest import create_org, create_user, issue_service_account_token
 from .inbox_e2e_helpers import (
     AGENT_ID,
     OTHER_AGENT_ID,
-    FakeRuntimeCache,
+    build_inbox_test_app,
     inbox_path,
 )
 
@@ -34,30 +30,7 @@ pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 @pytest_asyncio.fixture(loop_scope="session")
 async def app(session_factory, redis_client, pg_url, redis_url):
-    os.environ["SUROGATES_DB_URL"] = pg_url
-    os.environ["SUROGATES_REDIS_URL"] = redis_url
-
-    from surogates.api.app import create_app
-    from surogates.config import Settings
-    from surogates.storage.backend import create_backend
-
-    application = create_app()
-    application.state.session_factory = session_factory
-    application.state.redis = redis_client
-    application.state.session_store = SessionStore(
-        session_factory,
-        redis=redis_client,
-    )
-    application.state.settings = Settings()
-    application.state.storage = create_backend(application.state.settings)
-    application.state.credential_vault = CredentialVault(
-        session_factory,
-        Fernet.generate_key(),
-    )
-    application.state.runtime_config_cache = FakeRuntimeCache(
-        AGENT_ID, OTHER_AGENT_ID,
-    )
-    return application
+    return build_inbox_test_app(session_factory, redis_client, pg_url, redis_url)
 
 
 @pytest_asyncio.fixture(loop_scope="session")

--- a/tests/integration/test_inbox_api.py
+++ b/tests/integration/test_inbox_api.py
@@ -784,6 +784,60 @@ async def test_sse_snapshot_counts_only_pending_unread(
     assert snapshot["unread_ids"] == [still_pending.id]
 
 
+async def test_sse_drops_a_nudge_about_another_agents_item(
+    client,
+    app,
+    session_factory,
+    monkeypatch,
+):
+    """The nudge half of the stream is scoped like the snapshot half.
+
+    The Redis channel is keyed by principal, so every agent this person
+    talks to publishes onto the one this stream listens to. An unscoped
+    nudge sends the client after an item it is then refused.
+    """
+    store = app.state.session_store
+    org_id, user_id, token, session = await _create_user_token_session(
+        session_factory,
+        store,
+    )
+    theirs = await _item_on_another_agent(session_factory, store, org_id, user_id)
+    mine = await _emit_task_complete(store, session.id)
+
+    monkeypatch.setattr(
+        "surogates.api.routes.inbox.EventSourceResponse",
+        _finite_event_source("item"),
+        raising=False,
+    )
+
+    async def publish_both():
+        await asyncio.sleep(0.1)
+        # Straight onto the channel, the way the other agent's worker
+        # does: the foreign item first, so a stream that forwarded it
+        # would end the response before ever reaching ours.
+        for item_id in (theirs.id, mine.id):
+            await app.state.redis.publish(
+                f"surogates:inbox:{user_id}", f"{item_id}:task_complete",
+            )
+
+    publisher = asyncio.create_task(publish_both())
+    try:
+        async with asyncio.timeout(5):
+            response = await client.get(
+                inbox_path("/stream"), headers=headers_for(token),
+            )
+    finally:
+        await publisher
+
+    assert response.status_code == 200, response.text
+    nudged = [
+        json.loads(line[len("data: "):])["item_id"]
+        for line in response.text.splitlines()
+        if line.startswith("data: ") and "item_id" in line
+    ]
+    assert nudged == [mine.id]
+
+
 async def test_sse_snapshot_excludes_another_agents_items(
     client,
     app,

--- a/tests/integration/test_inbox_ask_user_question_e2e.py
+++ b/tests/integration/test_inbox_ask_user_question_e2e.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from surogates.db.models import Event
 from surogates.session.events import EventType
 
-from .inbox_e2e_helpers import create_user_token_session
+from .inbox_e2e_helpers import create_user_token_session, inbox_path
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -31,9 +31,11 @@ async def test_ask_user_question_through_inbox(
     )
 
     list_response = await inbox_client.get(
-        (
-            "/v1/inbox?kind=input_required"
-            f"&session_id={user_session.session.id}"
+        inbox_path(
+            query=(
+                "kind=input_required"
+                f"&session_id={user_session.session.id}"
+            )
         ),
         headers=user_session.auth_headers,
     )
@@ -58,7 +60,7 @@ async def test_ask_user_question_through_inbox(
     assert response.status_code == 201, response.text
 
     detail_response = await inbox_client.get(
-        f"/v1/inbox/{item['id']}",
+        inbox_path(f"/{item['id']}"),
         headers=user_session.auth_headers,
     )
     assert detail_response.status_code == 200, detail_response.text

--- a/tests/integration/test_inbox_backlog_retire.py
+++ b/tests/integration/test_inbox_backlog_retire.py
@@ -1,0 +1,159 @@
+"""Retiring the "task complete" rows nothing can ever clear.
+
+The emission rule now refuses to raise these for sessions with no
+conversation to open, but the ones already in the table outlive the fix:
+382 pending rows in the development database, the oldest five weeks old.
+The statement drains them and, because its predicate is exactly "a row
+the current rule would never create", stays a no-op afterwards.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select, text
+
+from surogates.db.inbox_backlog import RETIRE_UNREACHABLE_INBOX_SQL
+from surogates.db.models import InboxItem
+from surogates.session.events import EventType
+
+from .conftest import create_org, create_user
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def _session_on(
+    session_store,
+    session_factory,
+    *,
+    channel: str,
+    parent_id=None,
+    config: dict | None = None,
+):
+    org_id = await create_org(session_factory)
+    user_id = await create_user(session_factory, org_id)
+    return await session_store.create_session(
+        user_id=user_id,
+        org_id=org_id,
+        agent_id="test-agent",
+        channel=channel,
+        parent_id=parent_id,
+        config=config,
+    )
+
+
+async def _emit(session_store, session_id, event_type, data):
+    event_id = await session_store.emit_event(session_id, event_type, data)
+    async with session_store._sf() as db:
+        return (
+            await db.execute(
+                select(InboxItem).where(InboxItem.source_event_id == event_id)
+            )
+        ).scalar_one()
+
+
+async def _emit_task_complete(session_store, session_id):
+    return await _emit(
+        session_store,
+        session_id,
+        EventType.INBOX_TASK_COMPLETE,
+        {
+            "outcome": "success",
+            "summary": "All done.",
+            "duration_seconds": 1,
+            "session_title": "Task complete",
+        },
+    )
+
+
+async def _retire(session_store) -> None:
+    async with session_store._sf() as db:
+        await db.execute(text(RETIRE_UNREACHABLE_INBOX_SQL))
+        await db.commit()
+
+
+async def _status_of(session_store, item_id: int) -> str:
+    async with session_store._sf() as db:
+        return (await db.get(InboxItem, item_id)).status
+
+
+async def test_retires_items_no_surface_can_clear(session_store, session_factory):
+    parent = await _session_on(session_store, session_factory, channel="web")
+    subagent = await _session_on(
+        session_store, session_factory, channel="worker", parent_id=parent.id,
+    )
+    automation = await _session_on(session_store, session_factory, channel="api")
+    messaging = await _session_on(session_store, session_factory, channel="slack")
+
+    orphans = [
+        await _emit_task_complete(session_store, subagent.id),
+        await _emit_task_complete(session_store, automation.id),
+        await _emit_task_complete(session_store, messaging.id),
+    ]
+
+    await _retire(session_store)
+
+    for item in orphans:
+        assert await _status_of(session_store, item.id) == "expired"
+
+
+async def test_leaves_items_a_person_can_still_open(session_store, session_factory):
+    conversation = await _session_on(session_store, session_factory, channel="web")
+    scheduled = await _session_on(
+        session_store,
+        session_factory,
+        channel="scheduled",
+        config={"scheduled_session_id": "11111111-1111-1111-1111-111111111111"},
+    )
+
+    kept = [
+        await _emit_task_complete(session_store, conversation.id),
+        await _emit_task_complete(session_store, scheduled.id),
+    ]
+
+    await _retire(session_store)
+
+    for item in kept:
+        assert await _status_of(session_store, item.id) == "pending"
+
+
+async def test_touches_neither_answered_items_nor_questions(
+    session_store,
+    session_factory,
+):
+    automation = await _session_on(session_store, session_factory, channel="api")
+    question = await _emit(
+        session_store,
+        automation.id,
+        EventType.INBOX_INPUT_REQUIRED,
+        {
+            "tool_call_id": "tc-retire-1",
+            "questions": [{"prompt": "Which one?"}],
+            "context": "",
+        },
+    )
+    settled = await _emit_task_complete(session_store, automation.id)
+    await session_store.mark_inbox_read(
+        item_id=settled.id, user_id=automation.user_id, agent_id="test-agent",
+    )
+
+    await _retire(session_store)
+
+    # A question still needs its answer, whatever raised it, and a row
+    # already resolved is history — neither is this statement's business.
+    assert await _status_of(session_store, question.id) == "pending"
+    assert await _status_of(session_store, settled.id) == "acknowledged"
+
+
+async def test_second_run_changes_nothing(session_store, session_factory):
+    automation = await _session_on(session_store, session_factory, channel="api")
+    item = await _emit_task_complete(session_store, automation.id)
+
+    await _retire(session_store)
+    async with session_store._sf() as db:
+        first = (await db.get(InboxItem, item.id)).updated_at
+
+    await _retire(session_store)
+    async with session_store._sf() as db:
+        second = (await db.get(InboxItem, item.id)).updated_at
+
+    assert first == second

--- a/tests/integration/test_inbox_completion_e2e.py
+++ b/tests/integration/test_inbox_completion_e2e.py
@@ -8,7 +8,7 @@ from surogates.harness.budget import IterationBudget
 from surogates.harness.loop import AgentHarness
 from surogates.tools.registry import ToolRegistry
 
-from .inbox_e2e_helpers import StubTenant
+from .inbox_e2e_helpers import StubTenant, inbox_path
 from .inbox_e2e_helpers import create_user_token_session
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
@@ -54,7 +54,7 @@ async def test_completion_inbox_and_ack(
     )
 
     list_response = await inbox_client.get(
-        f"/v1/inbox?kind=task_complete&session_id={session.id}",
+        inbox_path(query=f"kind=task_complete&session_id={session.id}"),
         headers=user_session.auth_headers,
     )
     assert list_response.status_code == 200, list_response.text
@@ -68,7 +68,7 @@ async def test_completion_inbox_and_ack(
     assert item["payload"]["outcome"] == "success"
 
     response = await inbox_client.post(
-        f"/v1/inbox/{item['id']}/ack",
+        inbox_path(f"/{item['id']}/ack"),
         headers=user_session.auth_headers,
     )
 

--- a/tests/integration/test_inbox_expire.py
+++ b/tests/integration/test_inbox_expire.py
@@ -287,6 +287,7 @@ async def test_sweeper_does_not_touch_responded_items(
     await session_store.set_inbox_status(
         item_id=item.id,
         user_id=session.user_id,
+        agent_id="test-agent",
         new_status="responded",
     )
     async with session_store._sf() as db:

--- a/tests/integration/test_inbox_governance_e2e.py
+++ b/tests/integration/test_inbox_governance_e2e.py
@@ -14,7 +14,7 @@ from surogates.harness.tool_exec import execute_single_tool
 from surogates.session.events import EventType
 from surogates.tools.registry import ToolRegistry
 
-from .inbox_e2e_helpers import StubTenant
+from .inbox_e2e_helpers import StubTenant, inbox_path
 from .inbox_e2e_helpers import create_user_token_session
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
@@ -86,9 +86,11 @@ async def test_governance_approval_wakes_session(
     assert result_content["error"] == "policy_blocked_overridable"
 
     list_response = await inbox_client.get(
-        (
-            "/v1/inbox?kind=governance_gate"
-            f"&session_id={user_session.session.id}"
+        inbox_path(
+            query=(
+                "kind=governance_gate"
+                f"&session_id={user_session.session.id}"
+            )
         ),
         headers=user_session.auth_headers,
     )
@@ -101,7 +103,7 @@ async def test_governance_approval_wakes_session(
     assert item["payload"]["tool_call_id"] == "tc-e2e-gov"
 
     response = await inbox_client.post(
-        f"/v1/inbox/{item['id']}/respond",
+        inbox_path(f"/{item['id']}/respond"),
         json={"decision": "approve"},
         headers=user_session.auth_headers,
     )

--- a/tests/integration/test_inbox_store_helpers.py
+++ b/tests/integration/test_inbox_store_helpers.py
@@ -83,6 +83,82 @@ async def test_mark_inbox_read_sets_read_at_idempotently(
     assert again.read_at == first_read_at
 
 
+async def _emit_question(session_store, session_id):
+    event_id = await session_store.emit_event(
+        session_id,
+        EventType.INBOX_INPUT_REQUIRED,
+        {
+            "tool_call_id": "tc-read-1",
+            "questions": [{"prompt": "Which one?"}],
+            "context": "",
+        },
+    )
+    async with session_store._sf() as db:
+        return (
+            await db.execute(
+                select(InboxItem).where(InboxItem.source_event_id == event_id)
+            )
+        ).scalar_one()
+
+
+async def test_reading_an_update_retires_it(session_store, session_factory):
+    """An informational item is finished the moment it has been read.
+
+    There is nothing else to do to a "task complete" notice, so leaving
+    it pending kept it in the list forever and made the operator
+    acknowledge each one by hand — hundreds of them, in practice.
+    """
+    session = await _create_user_session(session_store, session_factory)
+    item = await _emit_task_complete(session_store, session.id)
+
+    updated = await session_store.mark_inbox_read(
+        item_id=item.id,
+        user_id=session.user_id,
+        agent_id="test-agent",
+    )
+
+    assert updated.read_at is not None
+    assert updated.status == "acknowledged"
+    assert updated.responded_at is not None
+
+
+async def test_reading_an_update_twice_is_idempotent(
+    session_store,
+    session_factory,
+):
+    session = await _create_user_session(session_store, session_factory)
+    item = await _emit_task_complete(session_store, session.id)
+
+    first = await session_store.mark_inbox_read(
+        item_id=item.id, user_id=session.user_id, agent_id="test-agent",
+    )
+    again = await session_store.mark_inbox_read(
+        item_id=item.id, user_id=session.user_id, agent_id="test-agent",
+    )
+
+    assert again.read_at == first.read_at
+    assert again.status == "acknowledged"
+
+
+async def test_reading_a_question_leaves_it_pending(
+    session_store,
+    session_factory,
+):
+    """A question is not answered by being looked at."""
+    session = await _create_user_session(session_store, session_factory)
+    item = await _emit_question(session_store, session.id)
+
+    updated = await session_store.mark_inbox_read(
+        item_id=item.id,
+        user_id=session.user_id,
+        agent_id="test-agent",
+    )
+
+    assert updated.read_at is not None
+    assert updated.status == "pending"
+    assert updated.responded_at is None
+
+
 async def test_set_inbox_status_rejects_terminal_transition(
     session_store,
     session_factory,

--- a/tests/integration/test_inbox_store_helpers.py
+++ b/tests/integration/test_inbox_store_helpers.py
@@ -52,7 +52,9 @@ async def test_list_inbox_returns_items_for_user_only(
     expected = await _emit_task_complete(session_store, session.id)
     await _emit_task_complete(session_store, other.id)
 
-    rows = await session_store.list_inbox(user_id=session.user_id, limit=50)
+    rows = await session_store.list_inbox(
+        user_id=session.user_id, agent_id="test-agent", limit=50,
+    )
 
     assert [row.id for row in rows] == [expected.id]
     assert rows[0].user_id == session.user_id
@@ -68,6 +70,7 @@ async def test_mark_inbox_read_sets_read_at_idempotently(
     updated = await session_store.mark_inbox_read(
         item_id=item.id,
         user_id=session.user_id,
+        agent_id="test-agent",
     )
     first_read_at = updated.read_at
     assert first_read_at is not None
@@ -75,6 +78,7 @@ async def test_mark_inbox_read_sets_read_at_idempotently(
     again = await session_store.mark_inbox_read(
         item_id=item.id,
         user_id=session.user_id,
+        agent_id="test-agent",
     )
     assert again.read_at == first_read_at
 
@@ -89,6 +93,7 @@ async def test_set_inbox_status_rejects_terminal_transition(
     updated = await session_store.set_inbox_status(
         item_id=item.id,
         user_id=session.user_id,
+        agent_id="test-agent",
         new_status="acknowledged",
     )
     assert updated.status == "acknowledged"
@@ -98,5 +103,6 @@ async def test_set_inbox_status_rejects_terminal_transition(
         await session_store.set_inbox_status(
             item_id=item.id,
             user_id=session.user_id,
+            agent_id="test-agent",
             new_status="responded",
         )

--- a/tests/test_inbox_completion_gate.py
+++ b/tests/test_inbox_completion_gate.py
@@ -1,0 +1,172 @@
+"""Which completed sessions raise a ``task_complete`` inbox item.
+
+The item exists to tell a person about work they did not watch, and the
+only thing that retires it is opening that session's conversation (the
+chat surfaces delete it on open; the store suppresses it outright while
+someone is watching). A session with no such conversation therefore mints
+an item nothing can ever clear — which is how one agent accumulated
+hundreds of unread "Task complete" rows from subagents and API runs.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from surogates.harness.loop_artifact_completion import ArtifactCompletionMixin
+from surogates.session.events import EventType
+from surogates.session.inbox_payload import raises_completion_inbox_item
+
+
+def _session(*, channel: str, parent_id=None, config=None, task_id=None):
+    now = datetime.now(timezone.utc)
+    return SimpleNamespace(
+        id=uuid4(),
+        user_id=uuid4(),
+        org_id=uuid4(),
+        agent_id="agent-a",
+        channel=channel,
+        status="active",
+        parent_id=parent_id,
+        title="A task",
+        config=config or {},
+        created_at=now,
+        updated_at=now,
+        task_id=task_id,
+    )
+
+
+class _RecordingStore:
+    """Just enough store for ``_complete_session`` to run end to end."""
+
+    def __init__(self):
+        self.events: list[tuple[EventType, dict]] = []
+        self.next_event_id = 100
+        self.statuses: list[str] = []
+        self.cursor_targets: list[int] = []
+
+    async def emit_event(self, session_id, event_type, data):
+        self.events.append((event_type, data))
+        self.next_event_id += 1
+        return self.next_event_id
+
+    async def get_events(self, session_id):
+        return []
+
+    async def update_session_status(self, session_id, status):
+        self.statuses.append(status)
+
+    async def advance_harness_cursor(self, session_id, target, lease_token):
+        self.cursor_targets.append(target)
+
+    async def get_session(self, session_id):
+        from surogates.session.store import SessionNotFoundError
+
+        raise SessionNotFoundError(str(session_id))
+
+
+def _harness(store):
+    host = type("_Harness", (ArtifactCompletionMixin,), {})()
+    host._store = store
+    host._sandbox_pool = None
+    host._memory_manager = None
+    host._turn_summarizer = None
+    host._worker_id = "worker-1"
+    host._redis = None
+    host._session_factory = None
+    host._tenant = SimpleNamespace(user_id=uuid4(), service_account_id=None)
+    return host
+
+
+async def _complete(session):
+    store = _RecordingStore()
+    await _harness(store)._complete_session(
+        session,
+        [{"role": "assistant", "content": "done"}],
+        SimpleNamespace(lease_token="lease-1"),
+        reason="stop",
+    )
+    return store
+
+
+def _kinds(store) -> list[EventType]:
+    return [event_type for event_type, _ in store.events]
+
+
+# --- the predicate ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("channel", ["web", "website"])
+def test_root_conversation_channels_notify(channel):
+    assert raises_completion_inbox_item(_session(channel=channel)) is True
+
+
+@pytest.mark.parametrize(
+    "channel", ["api", "slack", "telegram", "whatsapp", "ambient", "scheduled"]
+)
+def test_channels_without_an_inbox_surface_do_not_notify(channel):
+    # api/ambient/scheduled runs have no conversation a person opens; the
+    # messaging channels deliver the answer in the conversation itself.
+    assert raises_completion_inbox_item(_session(channel=channel)) is False
+
+
+@pytest.mark.parametrize("channel", ["worker", "task", "delegation", "web"])
+def test_child_sessions_never_notify(channel):
+    # A delegated child's result reaches its coordinator through
+    # WORKER_COMPLETE; the human reads it in the parent conversation.
+    assert (
+        raises_completion_inbox_item(_session(channel=channel, parent_id=uuid4()))
+        is False
+    )
+
+
+# --- the emission itself ---------------------------------------------------
+
+
+async def test_web_root_session_emits_the_inbox_item():
+    store = await _complete(_session(channel="web"))
+    assert EventType.INBOX_TASK_COMPLETE in _kinds(store)
+
+
+@pytest.mark.parametrize(
+    "session",
+    [
+        _session(channel="worker", parent_id=uuid4()),
+        _session(channel="task", parent_id=uuid4(), task_id=uuid4()),
+        _session(channel="delegation", parent_id=uuid4()),
+        _session(channel="api"),
+        _session(channel="slack"),
+    ],
+    ids=["worker", "task", "delegation", "api", "slack"],
+)
+async def test_sessions_without_an_inbox_surface_emit_no_item(session):
+    store = await _complete(session)
+    assert EventType.INBOX_TASK_COMPLETE not in _kinds(store)
+    # The session still completes and is still marked done — only the
+    # notification is dropped.
+    assert EventType.SESSION_COMPLETE in _kinds(store)
+    assert store.statuses == ["completed"]
+
+
+async def test_scheduled_run_with_a_channel_parent_still_announces():
+    # Scheduled runs are unwatched by construction: the gate must not
+    # swallow the one notification a loop run produces. (A web/api parent
+    # takes the inline loop.result path instead — covered in
+    # test_loop_result_inline_delivery.)
+    store = await _complete(
+        _session(
+            channel="scheduled",
+            parent_id=uuid4(),
+            config={"scheduled_session_id": str(uuid4())},
+        )
+    )
+    assert EventType.INBOX_TASK_COMPLETE in _kinds(store)
+
+
+async def test_cursor_advances_past_completion_without_an_inbox_item():
+    # The cursor used to ride on the inbox event id; with no item emitted
+    # it must fall back to the session-complete event or the worker
+    # replays the completion forever.
+    store = await _complete(_session(channel="api"))
+    assert store.cursor_targets == [store.next_event_id]

--- a/tests/test_inbox_read_receipt.py
+++ b/tests/test_inbox_read_receipt.py
@@ -1,0 +1,64 @@
+"""Reading an inbox item: what a receipt settles, and what it must not.
+
+Two processes write this table -- the harness store and the ops control
+plane -- so the rule lives in one function they both call rather than a
+copy each with a comment warning them not to drift.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from surogates.session.inbox_payload import apply_read_receipt
+
+
+def _item(*, kind: str, status: str = "pending", read_at=None) -> SimpleNamespace:
+    return SimpleNamespace(
+        kind=kind,
+        status=status,
+        read_at=read_at,
+        responded_at=None,
+        updated_at=None,
+    )
+
+
+@pytest.mark.parametrize("kind", ["task_complete", "progress_checkin"])
+def test_reading_an_update_retires_it(kind):
+    item = _item(kind=kind)
+
+    assert apply_read_receipt(item) is True
+    assert item.read_at is not None
+    assert item.status == "acknowledged"
+    assert item.responded_at is not None
+
+
+@pytest.mark.parametrize(
+    "kind", ["input_required", "action_required", "governance_gate"]
+)
+def test_reading_something_answerable_leaves_it_pending(kind):
+    # A question is not answered by being looked at.
+    item = _item(kind=kind)
+
+    assert apply_read_receipt(item) is True
+    assert item.read_at is not None
+    assert item.status == "pending"
+    assert item.responded_at is None
+
+
+def test_an_already_read_item_is_left_alone():
+    item = _item(kind="task_complete", status="expired", read_at="2026-08-04T00:00:00Z")
+
+    # Nothing to write, and no transition attempted out of a terminal
+    # status — which the store would reject.
+    assert apply_read_receipt(item) is False
+    assert item.status == "expired"
+
+
+def test_a_resolved_but_unread_item_only_gets_the_receipt():
+    """A row can be terminal without ever having been opened: the chat
+    surfaces retire informational items when the session is opened."""
+    item = _item(kind="task_complete", status="expired")
+
+    assert apply_read_receipt(item) is True
+    assert item.read_at is not None
+    assert item.status == "expired"

--- a/web/src/api/inbox.ts
+++ b/web/src/api/inbox.ts
@@ -65,7 +65,10 @@ function listUrl(input: AgentChatInboxListInput = {}): string {
   for (const status of [input.status ?? []].flat()) {
     params.append("status", status);
   }
-  if (input.kind) params.set("kind", input.kind);
+  // Repeated, like status: Active and Updates each ask for a set of kinds.
+  for (const kind of [input.kind ?? []].flat()) {
+    params.append("kind", kind);
+  }
   if (input.sessionId) params.set("session_id", input.sessionId);
   if (input.cursor) params.set("cursor", input.cursor);
   if (input.limit) params.set("limit", String(input.limit));


### PR DESCRIPTION
## What

The agent inbox raised notifications nobody could act on, showed one agent's items in another agent's app, and never let go of anything. Three fixes, plus a drain for the backlog the first one leaves behind.

### 1. Only announce completions a person can act on

A `task_complete` item is retired by opening its session's conversation — the chat surfaces delete it on open, and the store suppresses it outright for a live viewer. A session with no such conversation therefore minted rows nothing could ever clear.

Measured on the development database before the fix:

| origin of pending `task_complete` | rows | reachable? |
|---|---|---|
| `api` (service-account runs) | 283 | no principal a person logs in as |
| `slack` | 53 | the answer already went to Slack |
| `worker` / `task` / `delegation` (subagents) | 44 | not in any sidebar |
| `ambient` | 3 | background loop, no conversation |
| `web` | 3 | yes |

Three of 386 came from a session a person can open. Emission is now gated on `INBOX_NOTIFY_CHANNELS` (`web`/`website`) and on the session being a root conversation: a delegated child's result already reaches its coordinator as `WORKER_COMPLETE`. Scheduled runs keep announcing themselves whatever their channel — they are unwatched work by construction.

### 2. Scope the inbox to the agent it is served for

`/v1/inbox` filtered by principal alone. One user in the development database owns 93 items across 3 agents, and saw all of them in whichever agent's app they opened. Every route now takes `agent_runtime_context_dep` — the same resolver `list_sessions` already uses — and the store scopes each accessor through one shared predicate. The SSE stream is scoped on both halves: the snapshot that seeds the badge, and the per-item nudges, since its Redis channel is keyed by principal.

An inbox request naming no agent is now a 400 rather than a silently cross-agent read.

### 3. Active, Updates, History

Active holds what is waiting on the user; a new Updates tab holds what the agent finished while they were away. Reading an informational item now acknowledges it in the same write — there is nothing else to do to a "task done" notice — while questions and approvals stay pending.

### 4. Drain the backlog

The emission rule stops new ones; 386 pending rows already existed, the oldest five weeks old. `RETIRE_UNREACHABLE_INBOX_SQL` expires exactly the rows the current rule would never write, which is what lets it run on every migrate and settle to a no-op.

Applied to the development database: **383 retired, 3 left pending** — the web conversations a person can still open.

## Testing

- `tests/test_inbox_completion_gate.py` — new, 20 cases over the emission rule and the cursor fallback
- `tests/integration/test_inbox_api.py` — cross-agent list/get/read/ack/delete/respond all 404; both halves of the stream (snapshot and per-item nudge) exclude another agent's items; a nameless request 400s
- `tests/integration/test_inbox_store_helpers.py` — read-acknowledges, questions stay pending
- `tests/integration/test_inbox_backlog_retire.py` — new, what the drain takes and what it must not touch
- `sdk/agent-chat-react/tests/inbox-panel-views.test.tsx` — new, the three views and live nudges
- Full unit suite and inbox integration suite match the pre-change baseline; SDK suite 496 passed

Verified live against the development stack: on the agent that prompted this, Active went from 43 rows (2 questions buried under 41 notices) to 1.

## Merge order

Pairs with invergent-ai/surogate-ops#343, which is the Studio half of the same fix.

The two write the same table, so they belong in the same release, but neither blocks the other at build time: the ops PR imports only `ACKNOWLEDGE_ONLY_KINDS`, which its pinned `surogates` wheel already has. `apply_read_receipt`, added here, is deliberately *not* imported there — ops keeps a local copy until the wheel pin moves past this release.