### PR TITLE
fix(missions): honour a budget set on an /auto-research run

### DIFF
--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -242,6 +242,10 @@ Controls (delegated to the same handlers as `/mission`):
 | `/auto-research pause` | Pause automatic continuation |
 | `/auto-research resume` | Resume a paused run |
 | `/auto-research cancel [--cascade]` | Cancel the run (and, with `--cascade`, its running executors) |
+| `/auto-research budget <count>` \| `budget none` | Set / remove the token allowance, as `/mission budget` |
+
+A `Budget:` line in the create body works here too, with the same token
+semantics as `/mission` — it caps the coordinator plus every executor session.
 
 Behavior notes:
 

--- a/surogates/harness/loop_outcome_commands.py
+++ b/surogates/harness/loop_outcome_commands.py
@@ -328,6 +328,7 @@ class OutcomeCommandMixin:
         from surogates.missions.commands import (
             MissionCommandParseError,
             MissionHandlerResult,
+            handle_mission_budget,
             handle_mission_cancel,
             handle_mission_pause,
             handle_mission_resume,
@@ -390,6 +391,12 @@ class OutcomeCommandMixin:
                                 row = await db.get(ORMSession, session.id)
                                 if row is not None:
                                     session.config = dict(row.config or {})
+                elif command.action == "budget":
+                    message = await handle_mission_budget(
+                        session_id=session.id,
+                        budget_tokens=command.budget_tokens,
+                        mission_store=mission_store,
+                    )
                 elif command.action == "status":
                     result = await handle_mission_status(
                         session_id=session.id, mission_store=mission_store,

--- a/surogates/missions/commands.py
+++ b/surogates/missions/commands.py
@@ -227,6 +227,10 @@ def parse_auto_research_command(raw: str) -> AutoResearchCommand:
     try:
         base = parse_mission_command(text)
     except MissionCommandParseError as exc:
+        if text.partition(" ")[0].lower() in _CONTROL_VERBS:
+            # 'budget 20MB' failed on its own value, not on the create shape —
+            # the reframe below would hide the only useful part of the message.
+            raise
         # parse_mission_command's message names /mission and omits the
         # research-specific repo= token. Reframe it for /auto-research so the
         # operator sees the actual required shape.
@@ -235,11 +239,13 @@ def parse_auto_research_command(raw: str) -> AutoResearchCommand:
             "/auto-research repo=/workspace/<repo> [max_iterations=N] "
             "[baseline=<dev>] [baseline_test=<test>] <objective>\n\n"
             "Rubric:\n<criteria>\n"
-            "(or a control verb: status | pause | resume | cancel [--cascade])"
+            "(or a control verb: status | pause | resume | cancel [--cascade]"
+            " | budget <20M|none>)"
         ) from exc
     return AutoResearchCommand(
         action=base.action, description=base.description, rubric=base.rubric,
         reason=base.reason, cascade_to_workers=base.cascade_to_workers,
+        budget_tokens=base.budget_tokens, clear_budget=base.clear_budget,
         max_iterations=_as_int("max_iterations"),
         resume_run=kv.get("resume"),
         repo=kv.get("repo"),
@@ -487,6 +493,7 @@ async def handle_research_mission_create(
         mission_store=mission_store,
         user_id=user_id, service_account_id=service_account_id,
         max_iterations=cmd.max_iterations or 20,
+        budget_tokens=cmd.budget_tokens,
     )
     if not base.ok:
         return base

--- a/tests/test_mission_budget_command.py
+++ b/tests/test_mission_budget_command.py
@@ -14,6 +14,7 @@ import pytest
 
 from surogates.missions.commands import (
     MissionCommandParseError,
+    parse_auto_research_command,
     parse_mission_command,
 )
 
@@ -97,3 +98,49 @@ def test_budget_none_clears_the_ceiling():
     assert cmd.action == "budget"
     assert cmd.budget_tokens is None
     assert cmd.clear_budget is True
+
+
+# -- on a research run ------------------------------------------------------
+
+def test_a_research_run_keeps_the_budget_its_parse_found():
+    """/auto-research delegates to the /mission parser and then rebuilds the
+    command; a field dropped in that rebuild is a ceiling the operator typed
+    and never got."""
+    cmd = parse_auto_research_command(
+        "repo=/workspace/r Improve F1\nBudget: 3M\n\nRubric:\n- improves",
+    )
+    assert cmd.budget_tokens == 3_000_000
+
+
+def test_a_bad_research_budget_says_so():
+    """/auto-research reframes parse errors into 'you need a repo and a
+    Rubric'; on a control verb that hides the only useful part."""
+    with pytest.raises(MissionCommandParseError, match="unusable budget"):
+        parse_auto_research_command("budget 20MB")
+
+
+async def test_a_research_budget_reaches_the_mission_row(monkeypatch):
+    """A research mission IS a mission, so its ceiling belongs on the same
+    column — which only happens if the research create path forwards it."""
+    from uuid import uuid4
+
+    from surogates.missions import commands
+
+    captured: dict = {}
+
+    async def spy(**kwargs):
+        captured.update(kwargs)
+        # Bail before the research sidecar so this stays DB-free.
+        return commands.MissionHandlerResult(ok=False, error="stop")
+
+    monkeypatch.setattr(commands, "handle_mission_create", spy)
+
+    await commands.handle_research_mission_create(
+        cmd=parse_auto_research_command(
+            "repo=/workspace/r Improve F1\nBudget: 3M\n\nRubric:\n- improves",
+        ),
+        session_id=uuid4(), org_id=uuid4(), agent_id="agent-a",
+        session_store=None, session_factory=None, mission_store=None,
+        user_id=uuid4(),
+    )
+    assert captured["budget_tokens"] == 3_000_000

--- a/tests/test_outcome_harness.py
+++ b/tests/test_outcome_harness.py
@@ -384,6 +384,37 @@ async def test_handle_mission_cancel_clears_in_memory_active_mission_id(
 
 
 @pytest.mark.asyncio
+async def test_handle_auto_research_budget_routes_to_the_mission_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: ``budget`` is a control verb the /auto-research parser
+    accepts, so a dispatcher without a branch for it drops the operator's
+    adjustment into the usage message and leaves the run unbounded."""
+    store = FakeStore()
+    harness = _make_harness(store, session_factory=MagicMock())
+    session = _session()
+    lease = _lease(session.id)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_budget(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "Mission budget set to 20,000,000 tokens (0 already spent)."
+
+    monkeypatch.setattr(
+        "surogates.missions.commands.handle_mission_budget", fake_budget,
+    )
+
+    await harness._handle_auto_research_command(
+        session, "/auto-research budget 20M", lease,
+    )
+
+    assert captured["budget_tokens"] == 20_000_000
+    response = [e for e in store.events if e[1] == EventType.LLM_RESPONSE][-1]
+    assert "20,000,000 tokens" in response[2]["message"]["content"]
+
+
+@pytest.mark.asyncio
 async def test_mission_has_pending_work_returns_false_without_session_factory(
 ) -> None:
     """No session_factory wired => fall back to allowing completion. The


### PR DESCRIPTION
A `Budget:` line on an `/auto-research` command was parsed and then silently discarded, so a research run was always unbounded even when the operator had set a ceiling. Three places, all unconnected plumbing rather than a design decision:

- `parse_auto_research_command` delegates to `parse_mission_command` — which parses `Budget:` correctly — but built its `AutoResearchCommand` without carrying `budget_tokens` / `clear_budget` across.
- `handle_research_mission_create` never passed `budget_tokens` to `handle_mission_create`, so even a carried value would have been dropped.
- `_handle_auto_research_command` had no branch for `action == "budget"`, so `/auto-research budget 20M` fell through to the usage message.

`/mission`'s behaviour is untouched; this only connects the research alias to the handlers `/mission` already uses.

One extra nicety: a control verb that fails on its own value (`budget 20MB`) now re-raises the specific parse error instead of being reframed into the generic "a research run needs a repo and a Rubric" message, which used to hide the only useful part.

## Tests

`tests/test_mission_budget_command.py` and `tests/test_outcome_harness.py` — 53 passing. The reviewer traced the value end to end (parse → `AutoResearchCommand.budget_tokens` → `handle_research_mission_create` → `handle_mission_create` → `mission_store.create` → `missions.budget_tokens` → `pause_if_budget_exhausted`) rather than only checking the diff.

Harness docs (`docs/commands/index.md`) updated in the same commit.

Found while syncing the ops docs against the harness docs (invergent-ai/surogate-docs#5), which currently documents the shipped-but-wrong behaviour; that page gets corrected once this lands.