### PR TITLE
fix(tasks): give the attempt back when worker_block pauses a task

### DIFF
--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -1374,9 +1374,10 @@ class Task(Base):
     )
     # One-sentence reason captured by the ``worker_block`` tool.
     blocked_reason: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    # Number of Sessions that have been claimed for this task (including
-    # in-flight). ``worker_block`` deliberately does not increment this —
-    # blocking is a pause, not a failure.
+    # Retry attempts consumed: incremented on claim, and given back by
+    # ``worker_block`` / ``_block_claim`` — blocking is a pause, not a
+    # failure. Not a count of Sessions spawned (a blocked attempt leaves
+    # its Session behind).
     attempt_count: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default="0"
     )

--- a/surogates/tasks/spawn.py
+++ b/surogates/tasks/spawn.py
@@ -193,11 +193,13 @@ async def _create_session_for_task(
     if task.context:
         user_msg = f"{task.goal}\n\n## Context\n{task.context}"
 
-    # On retry (attempt_count > 1 by the time we're spawning), inject a
-    # summary of prior attempts so the new worker can avoid repeating
-    # what already failed. Skip on the first attempt — there's no
-    # history to show and the section header would just be noise.
-    if task.attempt_count and task.attempt_count > 1:
+    # Inject a summary of prior attempts so the new worker can avoid
+    # repeating what already failed. ``current_session_id`` still points at
+    # the previous attempt at this point (the caller rewires it after the
+    # spawn) and is None only on a genuine first attempt — attempt_count
+    # can't be used here because worker_block hands its attempt back, which
+    # would hide the very attempt that asked the question.
+    if task.current_session_id is not None:
         from surogates.tasks.completion import (
             fetch_prior_attempt_summaries,
             render_prior_attempts_section,

--- a/surogates/tasks/tools.py
+++ b/surogates/tasks/tools.py
@@ -705,6 +705,11 @@ async def _worker_context_handler(arguments: dict[str, Any], **kwargs: Any) -> s
 async def _worker_block_handler(arguments: dict[str, Any], **kwargs: Any) -> str:
     """Pause the calling Session's task without consuming a retry attempt.
 
+    The claim already counted this attempt, so the block hands it back
+    (same as ``dispatcher._block_claim``) — here rather than in
+    ``unblock_task`` so a task blocked forever isn't sitting on an attempt
+    nobody will return.
+
     Gating: the per-session filter in
     ``surogates.orchestrator.worker._filter_effective_tools`` strips this
     tool from the schema when ``Session.task_id is None``, so the LLM
@@ -767,6 +772,7 @@ async def _worker_block_handler(arguments: dict[str, Any], **kwargs: Any) -> str
 
         task.status = "blocked"
         task.blocked_reason = reason_clean
+        task.attempt_count -= 1
         parent_session_id = task.parent_session_id
         await db.commit()
 

--- a/tests/integration/tasks/test_complete_and_show.py
+++ b/tests/integration/tasks/test_complete_and_show.py
@@ -374,7 +374,8 @@ async def test_retry_attempt_user_message_includes_prior_attempts(
     async with session_factory() as db:
         task = await db.get(Task, task_id)
         task.attempt_count = 2
-        task.current_session_id = None  # will be set by tick after spawn
+        # Still points at the prior attempt; the tick rewires it after spawn.
+        task.current_session_id = prior_session_id
         await db.commit()
         # Re-fetch a fresh row for the spawn.
         task = await db.get(Task, task_id)
@@ -411,7 +412,7 @@ async def test_retry_attempt_user_message_includes_prior_attempts(
 async def test_first_attempt_user_message_omits_prior_attempts_section(
     session_factory, session_store, org_id: uuid.UUID, parent_session,
 ):
-    """First attempt (attempt_count <= 1 at spawn time) has no Prior Attempts header."""
+    """A task with no prior Sessions has no Prior Attempts header."""
     from surogates.tasks.spawn import _create_session_for_task
 
     async with session_factory() as db:
@@ -439,6 +440,52 @@ async def test_first_attempt_user_message_omits_prior_attempts_section(
     events = await session_store.get_events(sess.id)
     user_msgs = [e for e in events if e.type == EventType.USER_MESSAGE.value]
     assert "## Prior attempts" not in user_msgs[0].data["content"]
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_resumed_after_block_still_sees_the_blocked_attempt(
+    session_factory, session_store, org_id: uuid.UUID, parent_session,
+):
+    """worker_block gives its attempt back, so the attempt spawned after
+    unblock_task is again attempt_count == 1 — it must still be shown the
+    session that did the work and asked the question."""
+    from surogates.tasks.spawn import _create_session_for_task
+
+    async with session_factory() as db:
+        t = Task(
+            org_id=org_id, parent_session_id=parent_session.id,
+            goal="ask me", status="ready",
+            attempt_count=1,  # blocked attempt handed its count back
+        )
+        db.add(t)
+        await db.flush()
+        blocked_session_id = uuid.uuid4()
+        db.add(ORMSession(
+            id=blocked_session_id, org_id=org_id, agent_id="orchestrator",
+            channel="task", status="stopped", task_id=t.id,
+        ))
+        await db.flush()
+        t.current_session_id = blocked_session_id
+        await db.commit()
+        task = await db.get(Task, t.id)
+
+    await _create_session_for_task(
+        task,
+        session_store=session_store,
+        session_factory=session_factory,
+        tenant=MagicMock(org_id=org_id),
+    )
+
+    async with session_factory() as db:
+        resumed = (await db.execute(
+            select(ORMSession)
+            .where(ORMSession.task_id == task.id)
+            .where(ORMSession.id != blocked_session_id)
+        )).scalar_one()
+
+    events = await session_store.get_events(resumed.id)
+    user_msgs = [e for e in events if e.type == EventType.USER_MESSAGE.value]
+    assert "## Prior attempts on this task" in user_msgs[0].data["content"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/tasks/test_unblock_cancel_block.py
+++ b/tests/integration/tasks/test_unblock_cancel_block.py
@@ -448,17 +448,21 @@ async def test_worker_block_refuses_when_attempt_was_reclaimed(
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_worker_block_does_not_increment_attempt_count(
+async def test_worker_block_returns_the_claimed_attempt(
     session_factory, org_id: uuid.UUID, parent_session, session_store,
 ):
-    """Blocking is a deliberate pause, NOT a failure — attempt_count stays."""
-    from surogates.tasks.tools import _worker_block_handler
+    """Blocking is a deliberate pause, NOT a failure — the claim's attempt is
+    handed back, so an unblocked task still has its full max_attempts."""
+    from surogates.tasks.tools import (
+        _unblock_task_handler,
+        _worker_block_handler,
+    )
 
     worker_session_id = uuid.uuid4()
     async with session_factory() as db:
         t = Task(
             org_id=org_id, parent_session_id=parent_session.id,
-            goal="g", status="running", attempt_count=1,
+            goal="g", status="running", attempt_count=1, max_attempts=3,
         )
         db.add(t)
         await db.flush()
@@ -483,4 +487,19 @@ async def test_worker_block_does_not_increment_attempt_count(
 
     async with session_factory() as db:
         t = await db.get(Task, tid)
-        assert t.attempt_count == 1  # unchanged
+        assert t.attempt_count == 0  # claim's +1 undone
+
+    await _unblock_task_handler(
+        {"task_id": str(tid)},
+        session_store=session_store, redis=redis,
+        tenant=MagicMock(org_id=org_id),
+        session_id=str(parent_session.id),
+        session_factory=session_factory,
+    )
+
+    # Back in the ready pool with every attempt still available.
+    async with session_factory() as db:
+        t = await db.get(Task, tid)
+        assert t.status == "ready"
+        assert t.attempt_count == 0
+        assert t.max_attempts == 3

--- a/tests/integration/test_arbor_tools.py
+++ b/tests/integration/test_arbor_tools.py
@@ -540,6 +540,7 @@ async def test_create_session_for_task_passes_bundle_to_resolver():
     task = SimpleNamespace(
         id=uuid.uuid4(), agent_def_name="arbor-executor", goal="g",
         context=None, attempt_count=0, parent_session_id=parent.id,
+        current_session_id=None,
     )
     store = SimpleNamespace(
         get_session=AsyncMock(return_value=parent), emit_event=AsyncMock(),


### PR DESCRIPTION
`worker_block` documents itself as pausing "without consuming a retry attempt", but the attempt was already counted when the dispatcher claimed it and nothing gave it back. A task that blocked for an answer and was later unblocked burned one of its `max_attempts` per block, and could fail short of its budget.

## The fix

Decrement at block time, mirroring `dispatcher._block_claim` — which already does exactly this, with the same rationale. Block time rather than unblock time so `worker_context` reports an honest `attempt_count` for however long the task sits blocked, and so a task that is never unblocked isn't holding an attempt nobody will return. `unblock_task` stays a pure status flip.

Note `_rollback_claim`'s deliberate *retention* of the attempt is untouched — that is a failed spawn, a different case.

## The interaction this exposed

Handing the attempt back breaks retry-detection in `_create_session_for_task`, which inferred "this is a retry" from `attempt_count > 1`. After a block the next attempt is `attempt_count == 1` again, so the worker resuming the task would **not** have been shown the attempt that asked the question — the one piece of context it most needs.

Keyed off `current_session_id` instead: at spawn time it still points at the previous attempt (the caller rewires it afterwards, dispatcher Phase C / `service.py:185`) and is `None` only on a genuine first attempt.

`_finalize_ended_sessions` cannot double-count the returned attempt: it only selects tasks in `running`, and the block commits before the interrupt that ends the worker session.

## Tests

- `test_worker_block_returns_the_claimed_attempt` — the decrement itself
- `test_resumed_after_block_still_sees_the_blocked_attempt` — the interaction above
- an existing fixture in `test_complete_and_show.py` was setting `current_session_id = None` with a comment claiming the tick sets it after spawn; corrected to the prior attempt, which is what actually holds at that point

Both new tests were confirmed to fail with their respective source change reverted and pass with it. `tests/integration/tasks/` + `test_arbor_tools.py`: 87 passing.