### PR TITLE
feat(channels): tell an operator's own chat apart from an API client

### DIFF
--- a/surogates/api/routes/prompts.py
+++ b/surogates/api/routes/prompts.py
@@ -23,6 +23,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
 
+from surogates.channels.constants import API_CHANNEL
 from surogates.config import enqueue_session
 from surogates.runtime import (
     AgentRuntimeContext,
@@ -40,7 +41,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-API_CHANNEL = "api"
 # Upper bound on a single batch request.  Larger batches should page.
 MAX_BATCH_SIZE = 100
 # Upper bound on a single prompt body.  ~200k characters is ~50k tokens —

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -36,6 +36,10 @@ from surogates.api.session_guards import (
     require_session_visible,
     require_user_writable_session,
 )
+from surogates.channels.constants import (
+    API_CHANNEL,
+    SERVICE_ACCOUNT_CHANNELS,
+)
 from surogates.coding_agents.command import is_code_command
 from surogates.config import INTERRUPT_CHANNEL_PREFIX, enqueue_session
 from surogates.api.routes._commerce_turn import (
@@ -74,8 +78,6 @@ def _get_injection_detector():
 
 router = APIRouter()
 
-API_CHANNEL = "api"
-
 
 # ---------------------------------------------------------------------------
 # Request / response schemas
@@ -85,6 +87,23 @@ API_CHANNEL = "api"
 class CreateSessionRequest(BaseModel):
     system: str | None = None
     config: dict = Field(default_factory=dict)
+    #: Which kind of service-account client is creating this session.
+    #: Honoured only on the service-account route, and only for a value
+    #: in :data:`SERVICE_ACCOUNT_CHANNELS` — the web route ignores it
+    #: outright, so a logged-in end-user cannot label their own session
+    #: as an operator's.  Absent means :data:`API_CHANNEL`, which keeps
+    #: every existing third-party client working unchanged.
+    channel: str | None = None
+
+    @field_validator("channel")
+    @classmethod
+    def _validate_channel(cls, v: str | None) -> str | None:
+        if v is not None and v not in SERVICE_ACCOUNT_CHANNELS:
+            allowed = ", ".join(sorted(SERVICE_ACCOUNT_CHANNELS))
+            raise ValueError(
+                f"channel must be one of: {allowed} (got {v!r})"
+            )
+        return v
 
 
 _ALLOWED_IMAGE_MIMES = {"image/png", "image/jpeg", "image/gif", "image/webp"}
@@ -501,7 +520,14 @@ async def create_api_session(
     agent_runtime: AgentRuntimeContext = Depends(agent_runtime_context_dep),
     _rate: None = Depends(rate_limit_dep),
 ) -> Session:
-    """Create a new API-channel session for a service-account client."""
+    """Create a new session for a service-account client.
+
+    Lands on :data:`API_CHANNEL` unless the caller declares another
+    service-account channel — the control plane declares
+    :data:`STUDIO_CHANNEL` so an operator's own Work conversation is
+    distinguishable from a third-party integration.  Both authenticate
+    identically; only the label differs.
+    """
     service_account_id = _require_service_account_api_route(
         request,
         tenant,
@@ -517,7 +543,7 @@ async def create_api_session(
         request,
         tenant,
         agent_runtime.agent_id,
-        channel=API_CHANNEL,
+        channel=body.channel or API_CHANNEL,
         user_id=None,
         service_account_id=service_account_id,
     )
@@ -616,7 +642,9 @@ async def send_message(
     # agent (parsed by the harness, never fed to the platform LLM), and coding
     # prompts routinely trip the detector.  Attachments/filenames stay screened.
     injection_source = (
-        "api_channel" if session.channel == API_CHANNEL else "web_channel"
+        "api_channel"
+        if session.channel in SERVICE_ACCOUNT_CHANNELS
+        else "web_channel"
     )
     detector = _get_injection_detector()
     if not is_code_command(body.content):

--- a/surogates/api/routes/sessions.py
+++ b/surogates/api/routes/sessions.py
@@ -39,8 +39,10 @@ from surogates.api.session_guards import (
 from surogates.channels.constants import (
     API_CHANNEL,
     SERVICE_ACCOUNT_CHANNELS,
+    STUDIO_CHANNEL,
 )
 from surogates.coding_agents.command import is_code_command
+from surogates.tools.owner_scope import is_ops_chat_service_account
 from surogates.config import INTERRUPT_CHANNEL_PREFIX, enqueue_session
 from surogates.api.routes._commerce_turn import (
     authorize_allowance_turn,
@@ -538,12 +540,28 @@ async def create_api_session(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="This endpoint requires a service-account token.",
         )
+    channel = body.channel or API_CHANNEL
+    # Only the control plane's per-operator account may claim to be one.
+    # Membership in SERVICE_ACCOUNT_CHANNELS says the value is spellable,
+    # not that this caller is entitled to it — without the name check any
+    # third-party token could file its traffic under the operator's own
+    # conversations and take the label's meaning away.
+    if channel == STUDIO_CHANNEL and not await is_ops_chat_service_account(
+        _get_session_store(request), service_account_id,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"channel={STUDIO_CHANNEL!r} is reserved for the control "
+                "plane's operator accounts."
+            ),
+        )
     return await _create_session(
         body,
         request,
         tenant,
         agent_runtime.agent_id,
-        channel=body.channel or API_CHANNEL,
+        channel=channel,
         user_id=None,
         service_account_id=service_account_id,
     )

--- a/surogates/channels/constants.py
+++ b/surogates/channels/constants.py
@@ -13,11 +13,29 @@ from __future__ import annotations
 
 __all__ = [
     "ADAPTER_CHANNELS",
+    "API_CHANNEL",
+    "DIRECT_UI_CHANNELS",
     "END_USER_CHANNELS",
     "INBOX_NOTIFY_CHANNELS",
     "INTERACTIVE_PROMPT_CHANNELS",
+    "SERVICE_ACCOUNT_CHANNELS",
+    "STUDIO_CHANNEL",
     "multi_session_disabled",
 ]
+
+#: A programmatic client driving the agent with a service-account token.
+API_CHANNEL = "api"
+
+#: An operator talking to their own agent from the Surogate Studio Work
+#: UI.  Authenticated exactly like :data:`API_CHANNEL` (the control plane
+#: forwards with an ``ops-chat-*`` service-account token), so everything
+#: that reasons about *authentication* must treat the two alike — see
+#: :data:`SERVICE_ACCOUNT_CHANNELS`.  It is a separate channel value
+#: because it answers a different question: ``api`` means a third party
+#: integrated against the API, ``studio`` means the operator themself.
+#: Reporting the two as one channel made every operator chat look like a
+#: third-party integration.
+STUDIO_CHANNEL = "studio"
 
 
 def multi_session_disabled(config: dict) -> bool:
@@ -47,14 +65,38 @@ INTERACTIVE_PROMPT_CHANNELS = frozenset({"slack", "telegram", "whatsapp"})
 #: Channels whose sessions represent a real end-user talking to the
 #: agent — the set that drives agent-user enrollment (``agent_users``)
 #: and, via the ops control plane, the Users-page activity stats.
-#: Everything else (api, task, delegation, worker, scheduled, ambient,
-#: browser_setup) must never mint a binding or count as end-user
-#: activity.  ``teams`` is pre-registered for the Phase-2 adapter
+#: Everything else (api, studio, task, delegation, worker, scheduled,
+#: ambient, browser_setup) must never mint a binding or count as
+#: end-user activity — ``studio`` in particular is the operator talking
+#: to their own agent, not a customer of it.  ``teams`` is pre-registered for the Phase-2 adapter
 #: (``channels/teams.py`` already pins ``channel='teams'``) so shipping
 #: it cannot silently split the roster from its stats.
 END_USER_CHANNELS = frozenset(
     {"web", "website", "slack", "telegram", "teams", "whatsapp"}
 )
+
+#: Channels created by a service-account token rather than a logged-in
+#: end-user, so the session row carries ``service_account_id`` and no
+#: ``user_id``.  Governs decisions that turn on *how the caller
+#: authenticated*: the prompt-injection detector's source profile and
+#: the absence of a per-user storage scope.
+SERVICE_ACCOUNT_CHANNELS = frozenset({API_CHANNEL, STUDIO_CHANNEL})
+
+#: Channels whose client renders the conversation itself, live, as events
+#: land — as opposed to a messaging platform that only ever sees what an
+#: outbound adapter delivers to it.  Governs two behaviours that would
+#: otherwise silently regress when a channel is added:
+#:
+#: * long code runs post a throttled "still working" heartbeat to channel
+#:   sessions only, because these clients already stream progress; and
+#: * a scheduled run delivers its result back to its parent conversation
+#:   only when that parent is one of these — the messaging platforms get
+#:   the result through their own adapter instead.
+#:
+#: A channel missing from this set therefore loses scheduled-run results
+#: entirely, which is why the membership lives here rather than as a
+#: literal at each call site.
+DIRECT_UI_CHANNELS = frozenset({"web", API_CHANNEL, STUDIO_CHANNEL})
 
 #: Channels whose completed sessions raise a ``task_complete`` inbox item.
 #: Narrower than :data:`END_USER_CHANNELS` on purpose — this set is about

--- a/surogates/coding_agents/run_core.py
+++ b/surogates/coding_agents/run_core.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from typing import Any
 from uuid import uuid4
 
+from surogates.channels.constants import DIRECT_UI_CHANNELS
 from surogates.coding_agents.agents import CodeResult, build_invocation
 from surogates.coding_agents.credentials import (
     CodingAgentCredentials,
@@ -170,8 +171,8 @@ async def execute_coding_run(
     # Channel heartbeat: code-run PROGRESS renders live in the web UI but is
     # never delivered to channels, so a Slack/Telegram user sees nothing for
     # the minutes a run takes.  Post a throttled "still working" update for
-    # channel sessions (web/api render progress themselves).
-    wants_updates = getattr(session, "channel", "") not in ("web", "api")
+    # channel sessions (DIRECT_UI_CHANNELS render progress themselves).
+    wants_updates = getattr(session, "channel", "") not in DIRECT_UI_CHANNELS
     last_update = time.monotonic()
     if wants_updates:
         await store.emit_event(

--- a/surogates/db/engine.py
+++ b/surogates/db/engine.py
@@ -110,6 +110,7 @@ def run_migrations(db_settings: DatabaseSettings) -> None:
     async def _create_all() -> None:
         from surogates.db.agent_users import BACKFILL_SQL
         from surogates.db.inbox_backlog import RETIRE_UNREACHABLE_INBOX_SQL
+        from surogates.db.studio_channel import RELABEL_STUDIO_SESSIONS_SQL
 
         engine = async_engine_from_settings(db_settings)
         async with engine.begin() as conn:
@@ -123,6 +124,10 @@ def run_migrations(db_settings: DatabaseSettings) -> None:
             # rows the current emission rule would never write, so it
             # settles to a no-op instead of fighting live data.
             await conn.exec_driver_sql(RETIRE_UNREACHABLE_INBOX_SQL)
+            # Relabel operator conversations that predate the studio
+            # channel. Matches only the old label, so it settles to a
+            # no-op once every historical row has been converted.
+            await conn.exec_driver_sql(RELABEL_STUDIO_SESSIONS_SQL)
         await engine.dispose()
 
     asyncio.run(_create_all())

--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -313,6 +313,11 @@ class Session(Base):
         Index("idx_sessions_org", "org_id"),
         Index("idx_sessions_agent", "agent_id"),
         Index("idx_sessions_service_account", "service_account_id"),
+        # Walking a conversation's spawned work means recursing on
+        # parent_id, and every level of that recursion is a fresh lookup —
+        # unindexed it degrades to a sequential scan per level, which is
+        # what makes an otherwise-bounded walk expensive on a large table.
+        Index("idx_sessions_parent", "parent_id"),
         # Partial unique index: each (org, idempotency_key) is unique when
         # the key is present.  Supports fire-and-forget `POST /v1/api/prompts`
         # retries by making a duplicate insert fail fast with IntegrityError.

--- a/surogates/db/observability.sql
+++ b/surogates/db/observability.sql
@@ -32,6 +32,14 @@ CREATE INDEX IF NOT EXISTS idx_events_audit_user_time
 CREATE INDEX IF NOT EXISTS idx_events_session_type
     ON events (session_id, type);
 
+-- Retrofit for databases created before ``idx_sessions_parent`` joined the
+-- model: create_all adds missing tables, never missing indexes on tables
+-- that already exist.  Anything that walks a conversation's spawned work
+-- recurses on parent_id, and each level of that recursion is a lookup —
+-- without this it is a sequential scan per level.
+CREATE INDEX IF NOT EXISTS idx_sessions_parent
+    ON sessions (parent_id);
+
 -- Backing index for ``SessionStore.find_feedback_on_event`` — the
 -- feedback dedupe query filters on (session_id, type, target_event_id,
 -- and either rated_by_user_id or rated_by_service_account_id).  Without

--- a/surogates/db/studio_channel.py
+++ b/surogates/db/studio_channel.py
@@ -1,0 +1,39 @@
+"""Relabel historical operator conversations onto the ``studio`` channel.
+
+Every Studio Work chat used to be stamped ``channel='api'``, because the
+control plane creates it through the service-account route and that route
+hardcoded :data:`~surogates.channels.constants.API_CHANNEL`.  The label was
+wrong in a way that showed: ``api`` is meant to identify a third party
+integrated against the API, so an operator's own conversation with their
+own agent was reported as an external integration everywhere the channel
+column is read — the sessions explorer's channel filter, the agent
+overview's channel breakdown, and any per-channel analytics built on them.
+
+Callers now declare :data:`~surogates.channels.constants.STUDIO_CHANNEL`
+at creation, which fixes new rows.  This backfill fixes the existing ones.
+
+Idempotent by construction: it only ever matches rows still carrying the
+old label, so a second run is a no-op rather than a fight with live data.
+The ``ops-chat-`` account name is the discriminator because it is the only
+thing that distinguishes the two — both authenticate identically, and only
+the control plane's live-chat forwarder holds one of these accounts.
+"""
+
+from __future__ import annotations
+
+from surogates.channels.constants import API_CHANNEL, STUDIO_CHANNEL
+from surogates.tools.owner_scope import OPS_CHAT_SA_PREFIX
+
+__all__ = ["RELABEL_STUDIO_SESSIONS_SQL"]
+
+# Restricted to the old label so re-runs match nothing, and joined against
+# service_accounts rather than trusting the session row alone: a session
+# with no service account (an end-user's web chat) must never be swept up.
+RELABEL_STUDIO_SESSIONS_SQL = f"""
+UPDATE sessions AS s
+SET channel = '{STUDIO_CHANNEL}'
+FROM service_accounts AS sa
+WHERE sa.id = s.service_account_id
+  AND s.channel = '{API_CHANNEL}'
+  AND sa.name LIKE '{OPS_CHAT_SA_PREFIX}%'
+"""

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID
 
+from surogates.channels.constants import DIRECT_UI_CHANNELS
 from surogates.harness.loop_artifacts import (
     _FENCE_RE,
     _PROMOTABLE_FENCES,
@@ -528,7 +529,12 @@ class ArtifactCompletionMixin:
         return out
 
     async def _resolve_loop_result_parent(self, session: Session) -> Session | None:
-        """Return the web/api parent that should receive this loop run result."""
+        """Return the direct-UI parent that should receive this loop run result.
+
+        Messaging-platform parents are excluded on purpose: their result
+        reaches the user through the channel's own outbound adapter, so
+        delivering it here as well would double-post.
+        """
         if not _is_scheduled_run(session) or session.parent_id is None:
             return None
 
@@ -539,7 +545,7 @@ class ArtifactCompletionMixin:
         except SessionNotFoundError:
             return None
 
-        if parent.channel not in {"web", "api"}:
+        if parent.channel not in DIRECT_UI_CHANNELS:
             return None
         return parent
 

--- a/surogates/tools/owner_scope.py
+++ b/surogates/tools/owner_scope.py
@@ -27,6 +27,8 @@ import logging
 from typing import Any
 from uuid import UUID
 
+from sqlalchemy import text as sa_text
+
 logger = logging.getLogger(__name__)
 
 # Matches ops_chat_service_account_name in surogate-ops
@@ -35,6 +37,37 @@ logger = logging.getLogger(__name__)
 # accounts; creating one with a matching name requires org-admin
 # rights.
 OPS_CHAT_SA_PREFIX = "ops-chat-"
+
+
+async def is_ops_chat_service_account(
+    session_store: Any, service_account_id: UUID | None,
+) -> bool:
+    """Whether this account is one the control plane mints per operator.
+
+    The name is the proof: creating an account matching the pattern
+    requires org-admin rights, so a third-party token cannot forge one.
+    Shared by the full owner-scope check and by session creation, which
+    needs the same proof without the config half of the question.
+    """
+    if service_account_id is None:
+        return False
+    try:
+        async with session_store._sf() as db:
+            name = (
+                await db.execute(
+                    sa_text("SELECT name FROM service_accounts WHERE id = :id"),
+                    {"id": str(service_account_id)},
+                )
+            ).scalar_one_or_none()
+    except Exception:
+        # Fail closed: an unreadable account is not a proven operator.
+        logger.warning(
+            "ops-chat service-account lookup failed; treating as "
+            "principal-scoped",
+            exc_info=True,
+        )
+        return False
+    return bool(name) and name.startswith(OPS_CHAT_SA_PREFIX)
 
 
 def owner_scope_config_ok(
@@ -64,20 +97,4 @@ async def is_owner_scoped(
     """Full owner-scope check, including the service-account name proof."""
     if not owner_scope_config_ok(service_account_id, session_config):
         return False
-    try:
-        from sqlalchemy import text as sa_text
-
-        async with session_store._sf() as db:
-            row = await db.execute(
-                sa_text("SELECT name FROM service_accounts WHERE id = :id"),
-                {"id": service_account_id},
-            )
-            name = row.scalar_one_or_none()
-    except Exception:
-        logger.warning(
-            "Owner-scope service-account lookup failed; treating as "
-            "principal-scoped",
-            exc_info=True,
-        )
-        return False
-    return bool(name) and name.startswith(OPS_CHAT_SA_PREFIX)
+    return await is_ops_chat_service_account(session_store, service_account_id)

--- a/tests/test_channel_constants.py
+++ b/tests/test_channel_constants.py
@@ -11,8 +11,13 @@ from types import SimpleNamespace
 import surogates.channels.platforms  # noqa: F401  (registers every platform)
 from surogates.channels.constants import (
     ADAPTER_CHANNELS,
+    API_CHANNEL,
+    DIRECT_UI_CHANNELS,
     END_USER_CHANNELS,
+    INBOX_NOTIFY_CHANNELS,
     INTERACTIVE_PROMPT_CHANNELS,
+    SERVICE_ACCOUNT_CHANNELS,
+    STUDIO_CHANNEL,
 )
 from surogates.channels.memory_boundary import MANAGED_CHANNELS
 from surogates.channels.registry import registry
@@ -72,6 +77,54 @@ def test_whatsapp_can_still_be_switched_off():
     )
     kinds = {p.kind for p in reg.enabled_platforms(settings)}
     assert "whatsapp" not in kinds
+
+
+def test_studio_renders_its_own_conversation():
+    # Outside DIRECT_UI_CHANNELS a scheduled run's result is dropped
+    # instead of delivered to its parent conversation
+    # (_resolve_loop_result_parent), and long code runs start posting a
+    # channel heartbeat into a UI that already streams progress.
+    assert STUDIO_CHANNEL in DIRECT_UI_CHANNELS
+    assert API_CHANNEL in DIRECT_UI_CHANNELS
+    assert "web" in DIRECT_UI_CHANNELS
+
+
+def test_studio_authenticates_as_a_service_account():
+    # Drives the prompt-injection detector's source profile: a studio
+    # session carries no user_id, so it must not be screened as if a
+    # logged-in end-user typed it.
+    assert STUDIO_CHANNEL in SERVICE_ACCOUNT_CHANNELS
+    assert API_CHANNEL in SERVICE_ACCOUNT_CHANNELS
+
+
+def test_studio_is_not_an_end_user_channel():
+    # The operator talking to their own agent is not a customer of it.
+    # Inclusion would mint agent_users bindings and inflate every
+    # Users-page engagement number with the operator's own testing.
+    assert STUDIO_CHANNEL not in END_USER_CHANNELS
+    assert STUDIO_CHANNEL not in INBOX_NOTIFY_CHANNELS
+    assert STUDIO_CHANNEL not in ADAPTER_CHANNELS
+    assert STUDIO_CHANNEL not in INTERACTIVE_PROMPT_CHANNELS
+
+
+def test_studio_behaves_exactly_like_api_everywhere_but_naming():
+    # The split exists to report operator chats separately, NOT to change
+    # how they run. Any set that disagrees about the two is a behaviour
+    # change smuggled in under a naming change.
+    sets = {
+        "ADAPTER_CHANNELS": ADAPTER_CHANNELS,
+        "END_USER_CHANNELS": END_USER_CHANNELS,
+        "INBOX_NOTIFY_CHANNELS": INBOX_NOTIFY_CHANNELS,
+        "INTERACTIVE_PROMPT_CHANNELS": INTERACTIVE_PROMPT_CHANNELS,
+        "SERVICE_ACCOUNT_CHANNELS": SERVICE_ACCOUNT_CHANNELS,
+        "DIRECT_UI_CHANNELS": DIRECT_UI_CHANNELS,
+    }
+    disagree = [
+        name
+        for name, members in sets.items()
+        if (API_CHANNEL in members) != (STUDIO_CHANNEL in members)
+    ]
+    assert not disagree, f"studio diverges from api in: {disagree}"
 
 
 def test_other_kinds_still_default_off():

--- a/tests/test_studio_channel.py
+++ b/tests/test_studio_channel.py
@@ -1,0 +1,63 @@
+"""The studio channel: who may declare it, and the historical relabel.
+
+``studio`` and ``api`` authenticate identically — the only thing telling
+them apart is that the control plane's live-chat forwarder declares the
+former.  That makes two things worth pinning: an end-user must not be able
+to label their own session as an operator's, and the backfill that fixes
+historical rows must be safe to run repeatedly against live data.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from surogates.api.routes.sessions import CreateSessionRequest
+from surogates.channels.constants import (
+    API_CHANNEL,
+    SERVICE_ACCOUNT_CHANNELS,
+    STUDIO_CHANNEL,
+)
+from surogates.db.studio_channel import RELABEL_STUDIO_SESSIONS_SQL
+
+
+def test_channel_defaults_to_none_so_existing_clients_land_on_api():
+    # Every third-party client predates the field. Absent must keep
+    # meaning API_CHANNEL, which the route spells `body.channel or
+    # API_CHANNEL` — a default of "api" here would work too, but None
+    # keeps "did the caller ask?" answerable.
+    assert CreateSessionRequest().channel is None
+
+
+@pytest.mark.parametrize("channel", sorted(SERVICE_ACCOUNT_CHANNELS))
+def test_service_account_channels_are_declarable(channel):
+    assert CreateSessionRequest(channel=channel).channel == channel
+
+
+@pytest.mark.parametrize(
+    "channel",
+    ["web", "website", "slack", "telegram", "whatsapp", "task", "worker",
+     "delegation", "scheduled", "ambient", "", "STUDIO", "studio "],
+)
+def test_non_service_account_channels_are_rejected(channel):
+    # The web route hardcodes channel="web" and never reads this field,
+    # so this validator is the second line of defence rather than the
+    # first — but a caller that could declare "web" on the API route
+    # would produce a session that looks like an end-user's.
+    with pytest.raises(ValidationError):
+        CreateSessionRequest(channel=channel)
+
+
+def test_relabel_only_touches_rows_still_carrying_the_old_label():
+    # Idempotence is what makes this safe to run on every migrate: the
+    # WHERE clause must exclude rows the previous run already converted.
+    assert f"s.channel = '{API_CHANNEL}'" in RELABEL_STUDIO_SESSIONS_SQL
+    assert f"SET channel = '{STUDIO_CHANNEL}'" in RELABEL_STUDIO_SESSIONS_SQL
+
+
+def test_relabel_requires_an_ops_chat_service_account():
+    # Without the join, an end-user's web chat or a third-party API
+    # client would be swept into the operator bucket.
+    assert "service_accounts" in RELABEL_STUDIO_SESSIONS_SQL
+    assert "sa.id = s.service_account_id" in RELABEL_STUDIO_SESSIONS_SQL
+    assert "ops-chat-%" in RELABEL_STUDIO_SESSIONS_SQL

--- a/tests/test_studio_channel.py
+++ b/tests/test_studio_channel.py
@@ -61,3 +61,32 @@ def test_relabel_requires_an_ops_chat_service_account():
     assert "service_accounts" in RELABEL_STUDIO_SESSIONS_SQL
     assert "sa.id = s.service_account_id" in RELABEL_STUDIO_SESSIONS_SQL
     assert "ops-chat-%" in RELABEL_STUDIO_SESSIONS_SQL
+
+
+def test_membership_alone_does_not_entitle_a_caller_to_studio():
+    # The validator answers "is this value spellable", not "may this
+    # caller use it". The route asks the second question separately via
+    # _is_ops_chat_account, because any service-account token passes the
+    # first one — and a third party filing its traffic under the
+    # operator's own conversations would empty the label of meaning.
+    import inspect
+
+    from surogates.api.routes import sessions as route
+
+    src = inspect.getsource(route.create_api_session)
+    assert "is_ops_chat_service_account" in src
+    assert "STUDIO_CHANNEL" in src
+
+
+def test_ops_chat_proof_is_shared_with_owner_scope():
+    # One implementation of the name proof, not two: the route and the
+    # owner-scope check must never disagree about who counts as the
+    # control plane.
+    import inspect
+
+    from surogates.tools import owner_scope
+
+    assert inspect.iscoroutinefunction(owner_scope.is_ops_chat_service_account)
+    assert "is_ops_chat_service_account" in inspect.getsource(
+        owner_scope.is_owner_scoped
+    )


### PR DESCRIPTION
Every Surogate Studio conversation was stamped `channel="api"`, because the control plane creates it through the service-account route and that route hardcoded `API_CHANNEL`. The label was wrong in a way that showed: `api` is meant to identify a third party integrated against the API, so an operator talking to their own agent was reported as an external integration everywhere the channel column is read — the sessions explorer's channel filter, the agent overview's channel breakdown, and any per-channel analytics built on them.

In production it is the single largest "channel": **354 of roughly 540 real conversations in the last 90 days, and not one of them an actual API client.**

## What changes

Service-account callers may now declare which kind they are, and the control plane declares `studio`. Absent keeps meaning `api`, so every existing third-party client is unaffected, and the web route ignores the field outright — a logged-in end-user cannot label their own session as an operator's. Declaring `studio` additionally requires the `ops-chat-*` proof that `owner_scope` already used, so a third-party token cannot file its traffic under the operator's conversations.

Historical rows are relabelled by an idempotent backfill alongside the existing agent-user and inbox ones. It matches only the old label, so a second run is a no-op rather than a fight with live data, and joins `service_accounts` so an end-user's web chat can never be swept up.

## The part worth reviewing carefully

The two channels authenticate identically, so the split must not change how a session runs. Two behaviours keyed off the literal `"api"` and would have regressed silently:

- a scheduled run only delivers its result back to a parent in `{web, api}` (`loop_artifact_completion`)
- long code runs suppress their channel heartbeat for the same pair (`coding_agents/run_core`)

Both now consult `DIRECT_UI_CHANNELS`. `test_studio_behaves_exactly_like_api_everywhere_but_naming` fails if `studio` and `api` ever diverge in any channel set, so a future divergence has to be deliberate.

## Also

Indexes `sessions.parent_id`. Anything walking a conversation's spawned work recurses on that column, and unindexed each level degrades to a sequential scan. `create_all` only adds missing tables, never missing indexes on existing ones, so the retrofit rides the observability DDL.

## Merge order

**This merges first.** The companion ops PR needs a surogates release and a wheel-pin bump before its backfill can run — it deliberately does not import the new constants, so ops boots fine on the old pin either way.

Verified on the local dev database: 87 operator chats relabelled, 345 genuine API-token sessions correctly untouched.