### PR TITLE
fix(harness): repair transcript replay, coordinator wake, and tool-schema gating

### DIFF
--- a/docs/tasks/index.md
+++ b/docs/tasks/index.md
@@ -99,13 +99,16 @@ The tick is **idempotent** under concurrent invocation across replicas: each ste
 
 ## Events emitted to the parent session
 
-When a worker session for a task ends, the parent session is woken via the existing inbox / wake mechanism. Three event types carry the outcome:
+When a worker session for a task ends, the event is written to the parent's log **and the parent is re-enqueued** on its own `(org_id, agent_id)` work queue — the parent's, not the worker's, since a task worker often runs a different `agent_def` than the coordinator that spawned it. Emitting alone is not enough: none of these signals runs inside the parent's wake, so a coordinator that is not already queued would never re-read its log.
 
 | Event | When emitted | Payload |
 |---|---|---|
 | `worker.complete` | Worker session ended (natural or via `worker_complete`) | `{worker_id, result, task_id?, metadata?}` |
 | `task.blocked` | Worker called `worker_block` | `{task_id, worker_id, reason}` |
-| `task.failed` | Tick observed crash after `attempt_count >= max_attempts` | `{task_id, worker_id, attempt_count}` |
+| `task.blocked` | Spawn hit a permanent config error and attempts are spent | `{task_id, reason}` |
+| `task.failed` | Tick observed crash after `attempt_count >= max_attempts` | `{task_id, attempt_count}` |
+
+All four go through `notify_parent_of_task_event` (`surogates/harness/worker_notify.py`), and each has a `_rebuild_messages` branch so the woken coordinator actually sees the signal as a synthetic user message.
 
 `WORKER_COMPLETE` is reused (rather than introducing a separate `TASK_COMPLETED`) so a parent agent's handling of "a child finished" stays uniform across `spawn_worker` and `spawn_task` paths. The `task_id` key is present only for task-backed sessions; plain `spawn_worker` completions omit it. When the worker called `worker_complete` explicitly, the `result` and `metadata` reflect the worker's structured handoff; when the worker completed naturally, `result` is the auto-extracted LLM final response and `metadata` is omitted.
 

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -1093,7 +1093,10 @@ class AgentHarness(
                     logger.debug("Memory manager initialization failed", exc_info=True)
 
             # 6. Rebuild the message list from the full event history.
-            messages = self._rebuild_messages(all_events)
+            messages = self._rebuild_messages(
+                all_events,
+                workspace_path=(session.config or {}).get("workspace_path"),
+            )
 
             # 6a. Kick off title generation in the background as soon as we
             # see the user's first message.  Runs in parallel with context

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -3565,6 +3565,66 @@ class AgentHarness(
         names = set(self._tools.tool_names) if tool_filter is None else set(tool_filter)
         return names - drop
 
+    def _apply_execution_context_gates(
+        self, session: Session, tool_filter: set[str] | None,
+    ) -> set[str] | None:
+        """Gate self-tools on the execution context that makes them work.
+
+        Mirror of ``worker._filter_effective_tools``, which applies these
+        exact three conditions to the PROMPT surface.  Its output feeds
+        ``PromptBuilder(available_tools=...)`` only -- the LLM-visible
+        schemas come from here -- so the two must agree.  They did not:
+        the prompt already dropped these groups for sessions lacking the
+        gate, while the schema kept advertising them, and every handler
+        behind them fails closed on the same condition
+        (``board/tools.py`` returns "(no context_group_id on this
+        session)", ``arbor.py``'s ``_require_run`` raises, the
+        ``worker_*`` tools need ``Session.task_id``).  So the model was
+        paying context for tools it was never told about and could not
+        have used.
+
+        The force-add half matters as much as the subtract: a task worker
+        under a restrictive AgentDef allowlist still needs its
+        ``worker_*`` tools.  Observed in the wild before that rule
+        existed -- a ``claude-coder`` worker could not signal failure, so
+        its refusal was filed as a successful result and the parent
+        mission stalled.
+
+        ``None`` means "every registered tool"; it is materialised here
+        because the gates have to subtract from it.
+        """
+        from surogates.runtime.governance import (
+            BOARD_SELF_TOOLS,
+            RESEARCH_SPINE_TOOLS,
+            WORKER_SELF_TOOLS,
+        )
+
+        config = session.config or {}
+        result = (
+            set(self._tools.tool_names) if tool_filter is None
+            else set(tool_filter)
+        )
+
+        is_task_worker = session.task_id is not None
+        if is_task_worker:
+            result |= WORKER_SELF_TOOLS
+        else:
+            result -= WORKER_SELF_TOOLS
+
+        if config.get("context_group_id"):
+            result |= BOARD_SELF_TOOLS
+        else:
+            result -= BOARD_SELF_TOOLS
+
+        # The research spine is never force-added: it rides the registry's
+        # full set on the coordinator and is stripped everywhere else, so
+        # executors stay tree-blind and cannot invent a second
+        # shared-state protocol between themselves.
+        if not (config.get("active_research_run_id") and not is_task_worker):
+            result -= RESEARCH_SPINE_TOOLS
+
+        return result
+
     def _tool_filter_for_session(self, session: Session) -> set[str] | None:
         """Return the tool allow-list for a session."""
         config = session.config or {}
@@ -3599,31 +3659,15 @@ class AgentHarness(
                     )
                 tool_filter = set(self._tools.tool_names) - excluded
         elif explicit_allowed:
-            from surogates.runtime.governance import (
-                BOARD_SELF_TOOLS,
-                WORKER_SELF_TOOLS,
-            )
-
             tool_filter = set(config["allowed_tools"])
-            # Execution-context self-tools ride over an AgentDef allowlist:
-            # it scopes what a worker may DO, not how it reports doing it.
-            # ``worker._filter_effective_tools`` force-adds them to the
-            # prompt surface; without the same rule here the schemas
-            # disagree with the prompt and the worker is told to call
-            # ``worker_complete`` while holding no such tool.  Observed in
-            # the wild: a ``claude-coder`` task worker could not signal
-            # failure, so its refusal was filed as a successful result and
-            # the parent mission stalled with no failure signal.
-            if session.task_id is not None:
-                tool_filter |= WORKER_SELF_TOOLS
-            if config.get("context_group_id"):
-                tool_filter |= BOARD_SELF_TOOLS
         else:
             from surogates.tools.builtin.coordinator import WORKER_EXCLUDED_TOOLS
 
             excluded = set(config.get("excluded_tools") or [])
             excluded.update(WORKER_EXCLUDED_TOOLS)
             tool_filter = set(self._tools.tool_names) - excluded
+
+        tool_filter = self._apply_execution_context_gates(session, tool_filter)
 
         # The autonomous coding tool follows the ``/code`` capability: when
         # that command is disabled the tool must also disappear from the

--- a/surogates/harness/loop_context_replay.py
+++ b/surogates/harness/loop_context_replay.py
@@ -348,6 +348,32 @@ class ContextReplayMixin:
                     "content": f"[Worker {worker_id} failed: {error}]",
                 })
 
+            # Task-layer terminal signals.  Same synthetic-user-message
+            # shape as the worker events above: without a branch here a
+            # coordinator woken by ``notify_parent_of_task_event`` replays
+            # its log, finds nothing new, and re-runs its previous turn.
+            elif etype == EventType.TASK_BLOCKED.value:
+                task_id = event.data.get("task_id", "?")
+                reason = event.data.get("reason", "no reason given")
+                messages.append({
+                    "role": "user",
+                    "content": (
+                        f"[Task {task_id} is blocked: {reason}] "
+                        "It will not run again until it is unblocked."
+                    ),
+                })
+
+            elif etype == EventType.TASK_FAILED.value:
+                task_id = event.data.get("task_id", "?")
+                attempts = event.data.get("attempt_count", "?")
+                messages.append({
+                    "role": "user",
+                    "content": (
+                        f"[Task {task_id} failed after {attempts} attempts "
+                        "and will not be retried]"
+                    ),
+                })
+
             # Coding-agent run result — surface the final message to the
             # coordinator LLM so it can follow up on what /code did.  Progress
             # events are UI-only (not replayed); STARTED is bookkeeping.

--- a/surogates/harness/loop_context_replay.py
+++ b/surogates/harness/loop_context_replay.py
@@ -14,6 +14,7 @@ from surogates.harness.loop_attachments import (
 from surogates.harness.loop_messages import _view_context_note_from_metadata
 from surogates.harness.loop_tool_recovery import collapse_repeated_tool_rounds
 from surogates.harness.sanitize import strip_budget_warnings
+from surogates.harness.tool_exec import _WORKSPACE_TOKEN
 from surogates.session.events import EventType
 
 logger = logging.getLogger(__name__)
@@ -186,12 +187,26 @@ class ContextReplayMixin:
             logger.debug("Memory prefetch failed", exc_info=True)
         return None
 
-    def _rebuild_messages(self, events: list[Event]) -> list[dict]:
+    def _rebuild_messages(
+        self, events: list[Event], workspace_path: str | None = None,
+    ) -> list[dict]:
         """Replay event log to reconstruct conversation messages.
 
         Processes events in order.  A ``CONTEXT_COMPACT`` event replaces
         all previously accumulated messages with the compacted set stored
         in its data payload.
+
+        ``workspace_path`` undoes the event-payload path sanitisation on the
+        way back in.  ``execute_tool`` hands the LLM raw paths but stores
+        ``_sanitize_paths(...)`` in the ``tool.result`` event so SSE
+        consumers never see real filesystem paths (see the comment above
+        ``sanitized_content`` in ``tool_exec.py``).  Replaying the stored
+        form verbatim would feed the model the very string that comment
+        says caused "cascades of broken commands" -- ``__WORKSPACE__``
+        treated as a real path -- and would contradict the assistant's own
+        ``tool_calls`` arguments, which ``llm.response`` stores raw.  So
+        the token is expanded here, making a replayed tool message
+        byte-identical to what the live turn returned.
 
         ``LLM_THINKING`` events are **skipped** during replay -- they are
         informational only and should not re-enter the conversation.
@@ -210,6 +225,9 @@ class ContextReplayMixin:
         ``tool_calls[*].id`` set from its ``llm.response`` until every id
         has a matching result.
         """
+        # Exact inverse of ``_sanitize_paths``, which replaces
+        # ``workspace_path.rstrip("/")``.
+        workspace_root = (workspace_path or "").rstrip("/")
         messages: list[dict] = []
         iteration_open = False
         awaiting_tool_ids: set[str] = set()
@@ -256,10 +274,13 @@ class ContextReplayMixin:
                     _flush_deferred()
 
             elif etype == EventType.TOOL_RESULT.value:
+                content = event.data.get("content", "")
+                if workspace_root and _WORKSPACE_TOKEN in content:
+                    content = content.replace(_WORKSPACE_TOKEN, workspace_root)
                 messages.append({
                     "role": "tool",
                     "tool_call_id": event.data.get("tool_call_id", ""),
-                    "content": event.data.get("content", ""),
+                    "content": content,
                 })
                 if awaiting_tool_ids:
                     awaiting_tool_ids.discard(event.data.get("tool_call_id"))

--- a/surogates/harness/worker_notify.py
+++ b/surogates/harness/worker_notify.py
@@ -30,6 +30,56 @@ logger = logging.getLogger(__name__)
 _MAX_RESULT_CHARS: int = 10_000
 
 
+async def notify_parent_of_task_event(
+    *,
+    session_store: SessionStore,
+    parent_session_id: UUID,
+    event_type: EventType,
+    payload: dict[str, Any],
+    redis: Redis | None = None,
+) -> None:
+    """Emit *event_type* into the parent's log and re-enqueue the parent.
+
+    The task layer's terminal signals (``TASK_BLOCKED``, ``TASK_FAILED``)
+    are emitted from the dispatcher tick or from ``worker_block``, neither
+    of which runs inside the parent's wake.  Emitting alone is not enough:
+    a coordinator that is not already queued has nothing to re-read the
+    event, so the fan-out stalls until an idle nudge fires — or forever,
+    for a plain ``spawn_task`` coordinator that has no nudge path.
+
+    The parent's own ``org_id``/``agent_id`` select the work queue, not
+    the worker's: a task worker frequently runs a different agent_def
+    than the coordinator that spawned it.  Failing to resolve the parent
+    is logged and swallowed — the event write is the durable part, and
+    the caller is mid-teardown.
+    """
+    try:
+        await session_store.emit_event(parent_session_id, event_type, payload)
+    except Exception:
+        logger.exception(
+            "Failed to emit %s on parent session %s",
+            event_type.value, parent_session_id,
+        )
+        return
+
+    if redis is None:
+        return
+    try:
+        parent = await session_store.get_session(parent_session_id)
+        await enqueue_session(
+            redis,
+            org_id=str(parent.org_id),
+            agent_id=parent.agent_id,
+            session_id=parent_session_id,
+        )
+    except Exception:
+        logger.exception(
+            "Emitted %s but failed to wake parent session %s; it will not "
+            "see the signal until something else enqueues it",
+            event_type.value, parent_session_id,
+        )
+
+
 async def notify_parent_on_completion(
     *,
     session_store: SessionStore,

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -28,6 +28,7 @@ from surogates.runtime.entitlements import (
 )
 from surogates.runtime.governance import (
     BOARD_SELF_TOOLS,
+    RESEARCH_SPINE_TOOLS,
     WORKER_SELF_TOOLS,
     build_governance_gate,
 )
@@ -298,9 +299,7 @@ def _filter_effective_tools(
         and getattr(session, "task_id", None) is None
     )
     if not is_research_coordinator:
-        result.discard("idea_tree")
-        result.discard("dispatch_experiments")
-        result.discard("merge_experiment")
+        result -= RESEARCH_SPINE_TOOLS
 
     return result
 

--- a/surogates/runtime/governance.py
+++ b/surogates/runtime/governance.py
@@ -62,6 +62,17 @@ BOARD_SELF_TOOLS: frozenset[str] = frozenset({
 TASK_LIFECYCLE_TOOLS: frozenset[str] = frozenset({
     "unblock_task", "cancel_task",
 })
+# The research coordinator's deterministic spine. Declared here for the
+# same reason as the sets above -- both the prompt surface
+# (``worker._filter_effective_tools``) and the model-visible schemas
+# (``AgentHarness._apply_execution_context_gates``) gate on it, and they
+# must not drift. Deliberately NOT in ``PROTECTED_TOOLS``: unlike the
+# self-tools these are never force-added, they ride the registry's full
+# set on the coordinator and are stripped everywhere else so executors
+# stay tree-blind.
+RESEARCH_SPINE_TOOLS: frozenset[str] = frozenset({
+    "idea_tree", "dispatch_experiments", "merge_experiment",
+})
 
 # Tools no agent policy may take away. The ops catalog omits these names
 # so Studio cannot offer them and the policy validator rejects them with

--- a/surogates/tasks/dispatcher.py
+++ b/surogates/tasks/dispatcher.py
@@ -33,6 +33,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from surogates.config import enqueue_session
 from surogates.db.models import Session as ORMSession, Task
+from surogates.harness.worker_notify import notify_parent_of_task_event
 from surogates.session.events import EventType
 from surogates.tasks.completion import (
     TaskAttemptOutcome,
@@ -85,6 +86,7 @@ async def _finalize_ended_sessions(
     db,
     *,
     session_store: Any,
+    redis: Any = None,
 ) -> int:
     """Walk every running Task whose Session ended, finalise its status.
 
@@ -139,24 +141,19 @@ async def _finalize_ended_sessions(
     await db.commit()
 
     # Emit TASK_FAILED events outside the txn so a slow event-write
-    # doesn't hold the row lock open.
+    # doesn't hold the row lock open.  ``notify_parent_of_task_event``
+    # also wakes the parent; it logs and swallows its own failures.
     for parent_session_id, task_id, attempt_count in failed_to_emit:
-        try:
-            await session_store.emit_event(
-                parent_session_id,
-                EventType.TASK_FAILED,
-                {
-                    "task_id": str(task_id),
-                    "attempt_count": attempt_count,
-                },
-            )
-        except Exception:
-            logger.exception(
-                "tasks_tick: failed to emit TASK_FAILED for task %s on "
-                "parent session %s; parent agent will not see the failure "
-                "until it re-reads the task row",
-                task_id, parent_session_id,
-            )
+        await notify_parent_of_task_event(
+            session_store=session_store,
+            parent_session_id=parent_session_id,
+            event_type=EventType.TASK_FAILED,
+            payload={
+                "task_id": str(task_id),
+                "attempt_count": attempt_count,
+            },
+            redis=redis,
+        )
 
     return finalized
 
@@ -264,7 +261,10 @@ async def _enqueue_ready_tasks(
                 claimed.id, exc,
             )
             failed_this_tick.add(claimed.id)
-            await _block_claim(session_factory, claimed.id, reason=str(exc))
+            await _block_claim(
+                session_factory, claimed, reason=str(exc),
+                session_store=session_store, redis=redis,
+            )
             continue
         except ValueError as exc:
             # Permanent config error, same class as UnknownAgentDefError above:
@@ -280,7 +280,10 @@ async def _enqueue_ready_tasks(
                 claimed.id, exc,
             )
             failed_this_tick.add(claimed.id)
-            await _block_claim(session_factory, claimed.id, reason=str(exc))
+            await _block_claim(
+                session_factory, claimed, reason=str(exc),
+                session_store=session_store, redis=redis,
+            )
             continue
         except Exception as exc:
             logger.exception(
@@ -290,6 +293,7 @@ async def _enqueue_ready_tasks(
             failed_this_tick.add(claimed.id)
             await _retry_or_block(
                 session_factory, claimed, reason=f"spawn failed: {exc}",
+                session_store=session_store, redis=redis,
             )
             continue
 
@@ -324,7 +328,12 @@ async def _enqueue_ready_tasks(
 
 
 async def _block_claim(
-    session_factory: async_sessionmaker, task_id: UUID, *, reason: str,
+    session_factory: async_sessionmaker,
+    task: Task,
+    *,
+    reason: str,
+    session_store: Any = None,
+    redis: Any = None,
 ) -> None:
     """Best-effort: move a claimed task to ``blocked`` with ``blocked_reason``
     (a permanent config error — the referenced agent_def does not exist).
@@ -334,12 +343,17 @@ async def _block_claim(
     unblocked (``unblock_task`` → ``ready``), it gets a clean attempt. Unlike
     ``_rollback_claim`` this leaves the task OUT of the ``ready`` pool, so the
     dispatcher stops re-attempting (and re-logging) it every tick.
+
+    The block is surfaced to a human in the UI, but the coordinator that
+    spawned the task also has to learn its fan-out lost a member —
+    otherwise it waits on a task that will never run again until someone
+    calls ``unblock_task``.  Same signal ``worker_block`` sends.
     """
     try:
         async with session_factory() as db:
             await db.execute(
                 update(Task)
-                .where(Task.id == task_id)
+                .where(Task.id == task.id)
                 .values(
                     status="blocked",
                     blocked_reason=reason[:500],
@@ -351,12 +365,27 @@ async def _block_claim(
         logger.exception(
             "tasks_tick: block for task %s failed; finalize step will "
             "recover by treating the attempt as crashed",
-            task_id,
+            task.id,
+        )
+        return
+
+    if session_store is not None:
+        await notify_parent_of_task_event(
+            session_store=session_store,
+            parent_session_id=task.parent_session_id,
+            event_type=EventType.TASK_BLOCKED,
+            payload={"task_id": str(task.id), "reason": reason[:500]},
+            redis=redis,
         )
 
 
 async def _retry_or_block(
-    session_factory: async_sessionmaker, claimed: Task, *, reason: str,
+    session_factory: async_sessionmaker,
+    claimed: Task,
+    *,
+    reason: str,
+    session_store: Any = None,
+    redis: Any = None,
 ) -> None:
     """Return a failed claim to ``ready``, or block it once attempts are spent.
 
@@ -371,7 +400,10 @@ async def _retry_or_block(
             "tasks_tick: blocking task %s after %d/%d failed spawn attempts: %s",
             claimed.id, claimed.attempt_count, claimed.max_attempts, reason,
         )
-        await _block_claim(session_factory, claimed.id, reason=reason)
+        await _block_claim(
+            session_factory, claimed, reason=reason,
+            session_store=session_store, redis=redis,
+        )
         return
     await _rollback_claim(session_factory, claimed.id)
 
@@ -543,7 +575,9 @@ async def tasks_tick(
         promoted = await _promote_todo_to_ready(db)
         await db.commit()
     async with session_factory() as db:
-        finalized = await _finalize_ended_sessions(db, session_store=session_store)
+        finalized = await _finalize_ended_sessions(
+            db, session_store=session_store, redis=redis,
+        )
     enqueued = await _enqueue_ready_tasks(
         session_factory=session_factory,
         redis=redis,

--- a/surogates/tasks/tools.py
+++ b/surogates/tasks/tools.py
@@ -776,17 +776,22 @@ async def _worker_block_handler(arguments: dict[str, Any], **kwargs: Any) -> str
         parent_session_id = task.parent_session_id
         await db.commit()
 
-    # Tell the parent so its next wake sees the block as inbox-equivalent.
+    # Tell the parent and wake it.  The interrupt below stops THIS
+    # session, not the parent's, so without the enqueue a coordinator
+    # that is not already queued never learns the task blocked.
+    from surogates.harness.worker_notify import notify_parent_of_task_event
     from surogates.session.events import EventType
 
-    await session_store.emit_event(
-        parent_session_id,
-        EventType.TASK_BLOCKED,
-        {
+    await notify_parent_of_task_event(
+        session_store=session_store,
+        parent_session_id=parent_session_id,
+        event_type=EventType.TASK_BLOCKED,
+        payload={
             "task_id": str(task_id),
             "worker_id": str(session_id),
             "reason": reason_clean,
         },
+        redis=redis,
     )
     # Cleanly terminate this Session via the same interrupt mechanism
     # stop_worker uses; the harness loop exits between iterations.

--- a/tests/integration/tasks/test_unblock_cancel_block.py
+++ b/tests/integration/tasks/test_unblock_cancel_block.py
@@ -383,6 +383,21 @@ async def test_worker_block_marks_blocked_emits_event_publishes_interrupt(
     channel = redis.publish.call_args[0][0]
     assert channel == f"{INTERRUPT_CHANNEL_PREFIX}{worker_session_id}"
 
+    # The parent must also be WOKEN, not just written to: the interrupt
+    # above stops the worker, and nothing else enqueues the coordinator.
+    from surogates.config import SHARED_WORK_QUEUE_KEY, encode_queue_member
+
+    redis.zadd.assert_called_once()
+    key, mapping = redis.zadd.call_args[0]
+    assert key == SHARED_WORK_QUEUE_KEY
+    # The PARENT's queue tuple, not the worker's — a task worker often
+    # runs a different agent_def than the coordinator that spawned it.
+    assert encode_queue_member(
+        org_id=str(parent_session.org_id),
+        agent_id=str(parent_session.agent_id),
+        session_id=str(parent_session.id),
+    ) in mapping
+
 
 @pytest.mark.asyncio(loop_scope="session")
 async def test_worker_block_refuses_when_session_has_no_task(

--- a/tests/test_execution_context_tool_gates.py
+++ b/tests/test_execution_context_tool_gates.py
@@ -1,0 +1,113 @@
+"""The schema filter and the prompt filter must gate on the same conditions.
+
+``worker._filter_effective_tools`` builds the PROMPT surface;
+``AgentHarness._tool_filter_for_session`` builds the LLM-visible SCHEMAS.
+They ran different rules: the prompt already dropped the board / worker /
+research self-tools for sessions lacking their gate, while the schema kept
+advertising them — so a plain web session paid context for tools it was
+never told about and whose handlers fail closed on the same condition.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from surogates.harness.loop import AgentHarness
+from surogates.orchestrator.worker import _filter_effective_tools
+from surogates.runtime.governance import (
+    BOARD_SELF_TOOLS,
+    RESEARCH_SPINE_TOOLS,
+    WORKER_SELF_TOOLS,
+)
+
+ALL_TOOLS = (
+    {"read_file", "terminal", "memory"}
+    | set(WORKER_SELF_TOOLS) | set(BOARD_SELF_TOOLS) | set(RESEARCH_SPINE_TOOLS)
+)
+GATED = set(WORKER_SELF_TOOLS) | set(BOARD_SELF_TOOLS) | set(RESEARCH_SPINE_TOOLS)
+
+
+def _harness() -> SimpleNamespace:
+    return SimpleNamespace(_tools=SimpleNamespace(tool_names=set(ALL_TOOLS)))
+
+
+def _session(**kw) -> SimpleNamespace:
+    return SimpleNamespace(
+        task_id=kw.pop("task_id", None),
+        channel=kw.pop("channel", "web"),
+        config=kw.pop("config", {}),
+        **kw,
+    )
+
+
+def _gate(session) -> set[str]:
+    return AgentHarness._apply_execution_context_gates(
+        _harness(), session, None,
+    )
+
+
+def test_plain_web_session_is_offered_none_of_the_gated_tools() -> None:
+    assert _gate(_session()) & GATED == set()
+
+
+def test_task_worker_keeps_its_self_tools_under_a_restrictive_allowlist() -> None:
+    # An AgentDef whose `tools` list is just its domain tools: the worker
+    # still needs to be able to signal completion or failure.
+    result = AgentHarness._apply_execution_context_gates(
+        _harness(), _session(task_id="t-1"), {"read_file"},
+    )
+    assert WORKER_SELF_TOOLS <= result
+    assert result & set(BOARD_SELF_TOOLS) == set()
+
+
+def test_board_tools_appear_only_for_a_coordination_group_member() -> None:
+    member = _gate(_session(config={"context_group_id": "g-1"}))
+    assert BOARD_SELF_TOOLS <= member
+
+
+def test_research_spine_is_coordinator_only_and_never_force_added() -> None:
+    coordinator = _gate(_session(config={"active_research_run_id": "r-1"}))
+    assert RESEARCH_SPINE_TOOLS <= coordinator
+
+    # A task worker inside the same run stays tree-blind.
+    executor = _gate(
+        _session(task_id="t-1", config={"active_research_run_id": "r-1"}),
+    )
+    assert executor & set(RESEARCH_SPINE_TOOLS) == set()
+
+    # Never force-added: absent from the allowlist means absent.
+    restricted = AgentHarness._apply_execution_context_gates(
+        _harness(), _session(config={"active_research_run_id": "r-1"}),
+        {"read_file"},
+    )
+    assert restricted & set(RESEARCH_SPINE_TOOLS) == set()
+
+
+@pytest.mark.parametrize("config,task_id", [
+    ({}, None),
+    ({"context_group_id": "g-1"}, None),
+    ({"active_research_run_id": "r-1"}, None),
+    ({}, "t-1"),
+    ({"context_group_id": "g-1", "active_research_run_id": "r-1"}, "t-1"),
+])
+def test_schema_filter_agrees_with_the_prompt_filter(config, task_id) -> None:
+    """The invariant this change exists to restore.
+
+    If these two ever disagree the model is told about a tool it does not
+    hold, or holds one it was never told about. Observed in the wild: a
+    claude-coder task worker could not signal failure, so its refusal was
+    filed as a successful result and the parent mission stalled.
+    """
+    session = _session(config=config, task_id=task_id)
+    schemas = AgentHarness._apply_execution_context_gates(
+        _harness(), session, None,
+    )
+    prompt = _filter_effective_tools(
+        tools=set(ALL_TOOLS),
+        tenant=SimpleNamespace(user_id="u-1", service_account_id=None),
+        session=session,
+        use_api_for_harness_tools=True,
+    )
+    assert schemas & GATED == prompt & GATED

--- a/tests/test_path_handling.py
+++ b/tests/test_path_handling.py
@@ -368,3 +368,72 @@ async def test_terminal_command_can_contain_dollar_var() -> None:
     )
 
     handler.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Replay round-trip: the sanitised event must expand back to the live string.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replayed_tool_result_matches_what_the_llm_saw_live() -> None:
+    """A resumed session must see the same tool content as the live turn.
+
+    ``execute_single_tool`` stores the sanitised form in the event and
+    returns the raw form to the LLM.  Replay reads the event, so without
+    expansion every wake after the first feeds the model
+    ``__WORKSPACE__`` — exactly the confusion the sanitisation comment in
+    ``tool_exec.py`` says caused cascades of broken commands.
+    """
+    from surogates.harness.loop import AgentHarness
+
+    workspace = "/workspace"
+    raw_output = f"wrote {workspace}/foo.py (12 bytes)"
+    registry = _make_terminal_registry(raw_output)
+    store = _make_store()
+
+    live = await execute_single_tool(
+        {
+            "id": "tc_1",
+            "function": {
+                "name": "terminal",
+                "arguments": '{"command": "pwd"}',
+            },
+        },
+        session=_make_session(workspace),
+        lease=_make_lease(),
+        store=store,
+        tools=registry,
+        tenant=MagicMock(asset_root="/tmp/test"),
+    )
+
+    payload = next(
+        c.args[2] for c in store.emit_event.call_args_list
+        if c.args[1] is EventType.TOOL_RESULT
+    )
+    # Precondition: the stored payload really is the sanitised form.
+    assert "__WORKSPACE__" in payload["content"]
+
+    event = SimpleNamespace(
+        type=EventType.TOOL_RESULT.value, data=payload, id=1,
+    )
+    replayed = AgentHarness._rebuild_messages(
+        SimpleNamespace(), [event], workspace_path=workspace,
+    )
+
+    assert replayed[0]["content"] == live["content"]
+    assert "__WORKSPACE__" not in replayed[0]["content"]
+    assert replayed[0]["content"] == raw_output
+
+
+def test_replay_leaves_the_token_alone_without_a_workspace_path() -> None:
+    """No workspace on the session config — nothing to expand to."""
+    from surogates.harness.loop import AgentHarness
+
+    event = SimpleNamespace(
+        type=EventType.TOOL_RESULT.value,
+        data={"tool_call_id": "tc_1", "content": "wrote __WORKSPACE__/foo.py"},
+        id=1,
+    )
+    replayed = AgentHarness._rebuild_messages(SimpleNamespace(), [event])
+    assert replayed[0]["content"] == "wrote __WORKSPACE__/foo.py"

--- a/tests/test_task_signal_replay.py
+++ b/tests/test_task_signal_replay.py
@@ -1,0 +1,45 @@
+"""A coordinator woken by a task signal must SEE that signal on replay.
+
+``notify_parent_of_task_event`` wakes the parent, but a wake only helps if
+``_rebuild_messages`` renders the event.  Without a branch the coordinator
+replays its log, finds nothing new, and re-runs its previous turn — the
+same silent stall the missing enqueue caused.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from surogates.harness.loop import AgentHarness
+from surogates.session.events import EventType
+
+
+def _replay(event_type: EventType, data: dict) -> str:
+    event = SimpleNamespace(type=event_type.value, data=data, id=1)
+    messages = AgentHarness._rebuild_messages(SimpleNamespace(), [event])
+    assert len(messages) == 1, f"{event_type.value} rendered {len(messages)} messages"
+    assert messages[0]["role"] == "user"
+    return messages[0]["content"]
+
+
+def test_task_blocked_is_visible_to_the_coordinator() -> None:
+    content = _replay(
+        EventType.TASK_BLOCKED,
+        {"task_id": "t-1", "worker_id": "w-1", "reason": "rate limit key unclear"},
+    )
+    assert "t-1" in content
+    assert "rate limit key unclear" in content
+
+
+def test_task_failed_is_visible_to_the_coordinator() -> None:
+    content = _replay(
+        EventType.TASK_FAILED, {"task_id": "t-2", "attempt_count": 3},
+    )
+    assert "t-2" in content
+    assert "3" in content
+
+
+def test_task_signals_survive_a_payload_missing_its_optional_fields() -> None:
+    # _block_claim emits no worker_id; the dispatcher emits no reason.
+    assert _replay(EventType.TASK_BLOCKED, {"task_id": "t-3"})
+    assert _replay(EventType.TASK_FAILED, {"task_id": "t-4"})


### PR DESCRIPTION
Three harness correctness bugs surfaced while studying [prime-agent](https://github.com/PrimeIntellect-ai/prime-agent) for features worth porting. None of them is a ported feature — the comparison just made them visible.

### 1. `__WORKSPACE__` corrupted every resumed transcript

`execute_tool` hands the LLM raw filesystem paths but stores `_sanitize_paths(...)` in the `tool.result` event so SSE consumers never see real paths. The comment above `sanitized_content` (`tool_exec.py:1619-1628`) explains that giving the LLM the sanitized form caused "cascades of broken commands (literal `$HOME` directories, `__WORKSPACE__` treated as a real path)".

`_rebuild_messages` then rebuilt tool messages from `event.data["content"]` verbatim — so **every wake after the first fed the model exactly that string**. Nothing in the codebase ever expanded the token back. `llm.response` stores the assistant message raw, so a replayed transcript was internally inconsistent: the assistant's own `tool_calls` argument said `/workspace/x.py` while its tool result said `__WORKSPACE__/x.py`.

Fixed on the **read** side, not the write side: the event log, SSE payloads, audit and `jobs/training_collector.py` are untouched, and already-written events repair on their next replay.

### 2. A blocked or failed task never woke its coordinator

`TASK_BLOCKED` / `TASK_FAILED` were written to the parent's event log but the parent was never re-enqueued — and neither signal is emitted from inside the parent's wake. `worker_block`'s interrupt stops the *worker*; the dispatcher tick runs outside any session. A coordinator that wasn't already queued never re-read its log. `dispatcher.py:155` even logged the admission: *"parent agent will not see the failure until it re-reads the task row"* — and there is no coordinator-visible tool to read a task row (`worker_context` is stripped by `COORDINATOR_IMPLEMENTATION_TOOLS`).

A `/mission` coordinator only recovered via `nudge_idle_missions` after an idle timeout; a plain `spawn_task` coordinator stalled forever.

Root cause was three sites, not one — `_block_claim` emitted **nothing at all**. All three now route through `notify_parent_of_task_event`, which enqueues on the **parent's** `(org_id, agent_id)`: a task worker frequently runs a different `agent_def` than its coordinator. Replay branches added too, without which the wake finds no new message and the coordinator just re-runs its previous turn.

Also corrects `docs/tasks/index.md`, which claimed the parent was already woken and had the wrong payload shape for `task.failed`.

### 3. The schema filter and the prompt filter gated on different rules

`worker._filter_effective_tools` already strips the board / worker / research self-tools from sessions lacking their gate — but its output feeds `PromptBuilder(available_tools=...)` only. The LLM-visible schemas come from `_tool_filter_for_session`, which never applied the subtraction. The comment at `worker.py:1845` says so outright: *"This keeps the PROMPT fragments in sync; the LLM-visible schema is gated separately in the harness."*

So a plain web session carried ~2.5K tokens of schema for tools it was never told about and whose handlers fail closed on the same condition (`board/tools.py` returns `"(no context_group_id on this session)"`, arbor's `_require_run` raises, the `worker_*` tools need `Session.task_id`).

The three conditions are now one helper applied to every branch, and the research spine moved into `runtime/governance.py` beside the other two sets — the module that already documents itself as *"the single declaration for both layers that care"*. The force-add half is preserved: a task worker under a restrictive AgentDef allowlist keeps its `worker_*` tools (the regression that once let a `claude-coder` worker file a refusal as a successful result).

## Testing

New: `tests/test_execution_context_tool_gates.py` (9, including a parametrized invariant that the two filters agree), `tests/test_task_signal_replay.py` (3), plus a replay round-trip test and a parent-wake assertion on the existing `worker_block` test.

`tests/test_path_handling.py` (14), `tests/integration/tasks/` + `tests/tasks/` (101) and `tests/test_coordinator.py` all pass. The two pre-existing guard assertions at `test_path_handling.py:166` and `:198` still pass unchanged — if either flipped, the fix went in on the write side by mistake.

Full-suite failures were diffed against `master` and are identical (reportlab missing, browser-storage signatures, firebase, slack, codex auth) — none introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
