### PR TITLE
fix(tests): repair the suite after API, schema, and gate changes

### DIFF
--- a/surogates/api/routes/admin.py
+++ b/surogates/api/routes/admin.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 
 from surogates.db.models import ChannelIdentity, Org, User
 from surogates.tenant.auth.database import DatabaseAuthProvider
@@ -185,28 +186,24 @@ async def create_user(
                 detail=f"Organisation {org_id} not found.",
             )
 
-    # BYO Firebase collision guard. Without ``force=True``, refuse to
-    # create a row whose email matches an existing Firebase-linked user
-    # in the same org — silently shadowing such a user would be a
-    # security footgun (the admin loses the audit trail on which row a
-    # subsequent password reset applied to). Admins who explicitly want
-    # both rows (e.g. re-issuing local creds after Firebase removal) can
-    # pass ``force=True``.
-    if not body.force and body.email:
+    # Email is the org-scoped login key: ``uq_users_org_lower_email``
+    # allows exactly one account per (org, lower(email)), whatever the
+    # auth provider. Answer the collision here so the admin gets a 409
+    # naming the existing row instead of a 500 from the index.
+    if body.email:
         async with session_factory() as session:
             existing = await session.scalar(
                 select(User).where(
                     User.org_id == org_id,
-                    User.email == body.email,
-                    User.auth_provider.like("firebase:%"),
+                    func.lower(User.email) == body.email.lower(),
                 )
             )
         if existing is not None:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail=(
-                    f"Email {body.email} is already linked to a Firebase user "
-                    f"(id={existing.id}). Pass force=true to create a duplicate."
+                    f"Email {body.email} is already in use by user "
+                    f"{existing.id} (auth_provider={existing.auth_provider})."
                 ),
             )
 
@@ -226,7 +223,14 @@ async def create_user(
 
     async with session_factory() as session:
         session.add(new_user)
-        await session.commit()
+        try:
+            await session.commit()
+        except IntegrityError as exc:
+            # Lost the race with a concurrent create on the same email.
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Email {body.email} is already in use.",
+            ) from exc
         await session.refresh(new_user)
 
     return UserResponse(

--- a/surogates/api/routes/auth.py
+++ b/surogates/api/routes/auth.py
@@ -408,10 +408,22 @@ async def firebase_exchange(
             session.add(user)
             try:
                 await session.commit()
-            except IntegrityError:
+            except IntegrityError as exc:
+                await session.rollback()
+                if "uq_users_org_lower_email" in str(getattr(exc, "orig", exc)):
+                    # The email is the org-scoped login key and already
+                    # belongs to another account — most often a manual
+                    # ``database`` row, which we deliberately never link
+                    # to Firebase. Refuse rather than shadow it.
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail=(
+                            "That email already belongs to an account in this "
+                            "organisation. Sign in with its existing method."
+                        ),
+                    ) from exc
                 # The username unique index caught a concurrent claim;
                 # retry once without it — account creation wins.
-                await session.rollback()
                 user.username = None
                 session.add(user)
                 await session.commit()

--- a/surogates/session/store.py
+++ b/surogates/session/store.py
@@ -1553,7 +1553,17 @@ class SessionStore:
         async with self._sf() as db:
             claimed = (await db.execute(
                 update(ApprovalGrant)
-                .where(ApprovalGrant.id == live)
+                # The liveness predicates are repeated on the target row,
+                # not left to the subquery alone: an uncorrelated scalar
+                # subquery is an InitPlan evaluated once, so Postgres'
+                # concurrent-update recheck would re-test only ``id`` and
+                # let a second racer spend an already-exhausted grant.
+                .where(
+                    ApprovalGrant.id == live,
+                    ApprovalGrant.revoked_at.is_(None),
+                    ApprovalGrant.expires_at > now,
+                    ApprovalGrant.used_count < ApprovalGrant.max_uses,
+                )
                 .values(used_count=ApprovalGrant.used_count + 1)
                 .returning(ApprovalGrant.id)
                 .execution_options(synchronize_session=False)

--- a/surogates/tenant/models.py
+++ b/surogates/tenant/models.py
@@ -55,13 +55,6 @@ class UserCreate(BaseModel):
     display_name: str = Field(..., min_length=1, max_length=256)
     password: str | None = None
     auth_provider: str = "database"
-    # Opt-in override for the Firebase-collision guard. When False
-    # (default), admin attempts to create a user whose email is already
-    # linked to a BYO Firebase user are rejected with 409. Setting
-    # ``force=True`` deliberately creates a duplicate row so an admin
-    # can re-issue local credentials to a self-registered user (e.g.
-    # after the project's Firebase config is removed).
-    force: bool = False
 
 
 class UserResponse(BaseModel):

--- a/tests/integration/inbox_e2e_helpers.py
+++ b/tests/integration/inbox_e2e_helpers.py
@@ -31,6 +31,7 @@ class UserSession:
 class StubTenant:
     org_id: UUID
     user_id: UUID
+    service_account_id: UUID | None = None
 
 
 AGENT_ID = "test-agent"

--- a/tests/integration/test_admin_user_firebase_collision.py
+++ b/tests/integration/test_admin_user_firebase_collision.py
@@ -78,7 +78,6 @@ async def test_manual_create_refuses_existing_firebase_email(
         ))
         await session.commit()
 
-    # Without force: refused with 409 + pointer to the existing user.
     response = await admin_client.post(
         f"/v1/admin/orgs/{org_id}/users",
         json={
@@ -91,29 +90,17 @@ async def test_manual_create_refuses_existing_firebase_email(
     )
     assert response.status_code == 409, response.text
     body = response.json()
-    assert "already linked" in body["detail"].lower()
+    assert "already in use" in body["detail"].lower()
 
-    # With force: succeeds and creates a second row.
-    response = await admin_client.post(
-        f"/v1/admin/orgs/{org_id}/users",
-        json={
-            "email": "dup@example.com",
-            "display_name": "Manual",
-            "auth_provider": "database",
-            "password": "hunter2",
-            "force": True,
-        },
-        headers=headers,
-    )
-    assert response.status_code == 201, response.text
-
+    # No escape hatch: ``uq_users_org_lower_email`` allows exactly one
+    # account per (org, email), so the existing row stays alone.
     async with session_factory() as session:
         rows = (await session.execute(
             select(User).where(
                 User.org_id == org_id, User.email == "dup@example.com",
             )
         )).scalars().all()
-    assert len(rows) == 2
+    assert len(rows) == 1
 
 
 async def test_manual_create_succeeds_when_no_firebase_collision(
@@ -136,12 +123,12 @@ async def test_manual_create_succeeds_when_no_firebase_collision(
     assert response.status_code == 201, response.text
 
 
-async def test_manual_create_only_blocks_on_firebase_provider(
+async def test_manual_create_blocks_on_any_provider(
     admin_client, session_factory,
 ):
-    """Two manual ``database`` users with the same email is the pre-existing
-    behaviour — the guard MUST NOT change it. Only Firebase-namespaced
-    ``auth_provider`` rows trigger the collision check."""
+    """The collision guard is provider-agnostic: email is the org-scoped
+    login key, so a second ``database`` row on the same address is refused
+    with a 409 rather than 500-ing on the unique index."""
     org_id, headers = await _admin_token(session_factory)
     async with session_factory() as session:
         session.add(User(
@@ -164,4 +151,5 @@ async def test_manual_create_only_blocks_on_firebase_provider(
         },
         headers=headers,
     )
-    assert response.status_code == 201, response.text
+    assert response.status_code == 409, response.text
+    assert "already in use" in response.json()["detail"].lower()

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -119,7 +119,7 @@ async def _create_scheduled_run_session(app, session_factory, org_id, user_id):
         org_id=org_id,
         agent_id=TEST_AGENT_ID,
         channel="scheduled",
-        model=app.state.settings.llm.model,
+        # No model: the worker stamps the resolved bundle model at wake.
         config={
             "storage_bucket": app.state.settings.storage.bucket,
             "scheduled_session_id": str(uuid.uuid4()),

--- a/tests/integration/test_auth_firebase_self_registration.py
+++ b/tests/integration/test_auth_firebase_self_registration.py
@@ -359,10 +359,11 @@ async def test_firebase_exchange_does_not_link_manual_database_user(
         json={"id_token": "firebase-token"},
     )
 
-    # A brand-new firebase-provider row is provisioned (self-registration),
-    # but the pre-existing manual ``database`` row is left untouched: no
-    # silent link of a password account to Firebase.
-    assert response.status_code == 200, response.text
+    # Email is the org-scoped login key (``uq_users_org_lower_email``), so
+    # there is no second row to provision either: the exchange is refused
+    # and the manual ``database`` row is left untouched — no silent link of
+    # a password account to Firebase.
+    assert response.status_code == 409, response.text
     async with session_factory() as session:
         manual = await session.scalar(
             select(User).where(

--- a/tests/integration/test_inbox_progress_hook.py
+++ b/tests/integration/test_inbox_progress_hook.py
@@ -23,6 +23,7 @@ pytestmark = pytest.mark.asyncio(loop_scope="session")
 class _StubTenant:
     org_id: UUID
     user_id: UUID
+    service_account_id: UUID | None = None
 
 
 async def _setup_harness(session_store, session_factory, *, interval):

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -794,7 +794,8 @@ async def test_policy_allowed_emitted_when_log_allowed_true(
         ).mappings().one()
 
     assert row["data"]["tool"] == "write_file"
-    assert row["data"]["check"] == "workspace_sandbox"
+    # The bare workspace-sandbox check became the full governance gate.
+    assert row["data"]["check"] == "governance_gate"
 
 
 async def test_session_tool_allow_list_blocks_disallowed_tool(

--- a/tests/test_browser_image.py
+++ b/tests/test_browser_image.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def test_browser_image_autostarts_neko_live_view() -> None:
+def test_browser_image_serves_live_view_over_websockify() -> None:
+    """neko stays off: its WebRTC media path needs UDP/TURN the cluster
+    cannot provide, so the live view is x11vnc + websockify on :8080."""
     dockerfile = Path("images/browser/Dockerfile").read_text()
-    assert "autostart=true" in dockerfile
+    assert "autostart=false" in dockerfile
     assert "/etc/supervisor/conf.d/services/neko.conf" in dockerfile
+    assert "x11vnc" in dockerfile
+    assert "websockify" in dockerfile

--- a/tests/test_browser_tool_storage.py
+++ b/tests/test_browser_tool_storage.py
@@ -1,32 +1,52 @@
 """Verify the browser tool composes prefixed keys and source refs."""
 
+from surogates.storage.tenant import workspace_session_shim
 from surogates.tools.builtin.browser import (
     build_browser_session_source_ref,
     build_browser_screenshot_key,
 )
 
 
+def _session(config):
+    return workspace_session_shim(config, "s-1")
+
+
 def test_source_ref_without_prefix():
     ref = build_browser_session_source_ref(
         storage_bucket="b",
-        storage_key_prefix="",
+        session=_session({}),
         session_id="s-1",
     )
-    assert ref == "s3://b/s-1"
+    assert ref == "s3://b/s-1/"
 
 
 def test_source_ref_with_prefix():
     ref = build_browser_session_source_ref(
         storage_bucket="b",
-        storage_key_prefix="p-1/a-1",
+        session=_session({"storage_key_prefix": "p-1/a-1"}),
         session_id="s-1",
     )
-    assert ref == "s3://b/p-1/a-1/s-1"
+    assert ref == "s3://b/p-1/a-1/s-1/"
+
+
+def test_source_ref_on_managed_channel_uses_the_boundary_workspace():
+    # A slack thread shares one workspace across its participants, so the
+    # browser lands under the boundary prefix, not a per-session one.
+    ref = build_browser_session_source_ref(
+        storage_bucket="b",
+        session=_session({
+            "storage_key_prefix": "p-1/a-1",
+            "channel": "slack",
+            "memory_boundary": "slack:c:C1",
+        }),
+        session_id="s-1",
+    )
+    assert ref == "s3://b/p-1/a-1/boundaries/slack:c:C1/workspace/"
 
 
 def test_screenshot_key_without_prefix():
     key = build_browser_screenshot_key(
-        storage_key_prefix="",
+        session=_session({}),
         session_id="s-1",
         relative_path="browser-screenshots/x.png",
     )
@@ -35,7 +55,7 @@ def test_screenshot_key_without_prefix():
 
 def test_screenshot_key_with_prefix():
     key = build_browser_screenshot_key(
-        storage_key_prefix="p-1/a-1",
+        session=_session({"storage_key_prefix": "p-1/a-1"}),
         session_id="s-1",
         relative_path="browser-screenshots/x.png",
     )
@@ -44,7 +64,7 @@ def test_screenshot_key_with_prefix():
 
 def test_screenshot_key_strips_leading_slash_on_relative_path():
     key = build_browser_screenshot_key(
-        storage_key_prefix="p-1/a-1",
+        session=_session({"storage_key_prefix": "p-1/a-1"}),
         session_id="s-1",
         relative_path="/leading/slash.png",
     )

--- a/tests/test_channel_files_route.py
+++ b/tests/test_channel_files_route.py
@@ -22,6 +22,8 @@ def _session(*, channel="slack", bucket="b"):
     return SimpleNamespace(
         id=uuid4(),
         org_id=uuid4(),
+        agent_id="a1",
+        parent_id=None,
         channel=channel,
         config={"channel_identifier": "T1", "slack_channel_id": "C1",
                 "storage_bucket": bucket},

--- a/tests/test_channel_messages_route.py
+++ b/tests/test_channel_messages_route.py
@@ -18,7 +18,8 @@ class _Store:
 
 def _session(*, channel="slack", config=None):
     return SimpleNamespace(
-        id=uuid4(), org_id=uuid4(), channel=channel,
+        id=uuid4(), org_id=uuid4(), agent_id="a1", parent_id=None,
+        channel=channel,
         config=config if config is not None
         else {"channel_identifier": "T1", "slack_channel_id": "C1"},
     )

--- a/tests/test_channel_session_workspace.py
+++ b/tests/test_channel_session_workspace.py
@@ -10,7 +10,6 @@ Without those fields the worker mounts no workspace and attachments are skipped.
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest import mock
 from uuid import uuid4
 
 from surogates.channels.identity import get_or_create_channel_session
@@ -67,23 +66,19 @@ class TestChannelSessionWorkspace:
     async def test_provisions_workspace_when_storage_and_settings_given(self):
         store = _Store()
         storage = _Storage()
-        with mock.patch(
-            "surogates.session.provisioning.get_model_info",
-            return_value=SimpleNamespace(supports_vision=False),
-        ):
-            await get_or_create_channel_session(
-                store,
-                None,
-                session_key="agent:slack:dm:D1",
-                user_id=uuid4(),
-                org_id=uuid4(),
-                agent_id="a1",
-                channel="slack",
-                config={"slack_channel_id": "D1", "memory_boundary": "slack:d:D1"},
-                session_factory=_SessionFactory(),
-                storage=storage,
-                settings=_settings(),
-            )
+        await get_or_create_channel_session(
+            store,
+            None,
+            session_key="agent:slack:dm:D1",
+            user_id=uuid4(),
+            org_id=uuid4(),
+            agent_id="a1",
+            channel="slack",
+            config={"slack_channel_id": "D1", "memory_boundary": "slack:d:D1"},
+            session_factory=_SessionFactory(),
+            storage=storage,
+            settings=_settings(),
+        )
         cfg = store.created["config"]
         sid = store.created["session_id"]
         assert cfg["storage_bucket"] == "surogate-workspaces-dev"
@@ -107,23 +102,19 @@ class TestChannelSessionWorkspace:
                 return f"/ws/{sid}"
 
         store = _Store()
-        with mock.patch(
-            "surogates.session.provisioning.get_model_info",
-            return_value=SimpleNamespace(supports_vision=False),
-        ):
-            sid = await get_or_create_channel_session(
-                store,
-                None,
-                session_key="agent:slack:dm:D2",
-                user_id=uuid4(),
-                org_id=uuid4(),
-                agent_id="a1",
-                channel="slack",
-                config={"slack_channel_id": "D2"},
-                session_factory=_SessionFactory(),
-                storage=_FailStorage(),
-                settings=_settings(),
-            )
+        sid = await get_or_create_channel_session(
+            store,
+            None,
+            session_key="agent:slack:dm:D2",
+            user_id=uuid4(),
+            org_id=uuid4(),
+            agent_id="a1",
+            channel="slack",
+            config={"slack_channel_id": "D2"},
+            session_factory=_SessionFactory(),
+            storage=_FailStorage(),
+            settings=_settings(),
+        )
         # Session still created (no exception propagated), just without a workspace.
         assert sid == store.created["session_id"]
         cfg = store.created["config"]

--- a/tests/test_chat_attachments.py
+++ b/tests/test_chat_attachments.py
@@ -345,7 +345,9 @@ def patched_send_message(monkeypatch):
             session_id=session.id,
             body=body,
             request=request,  # type: ignore[arg-type]
-            tenant=SimpleNamespace(),  # type: ignore[arg-type]
+            # Anonymous web caller: no user_id, so the commerce/allowance
+            # gates short-circuit and the test stays on the attachment path.
+            tenant=SimpleNamespace(user_id=None),  # type: ignore[arg-type]
             agent_runtime=_agent_runtime(),
         )
         return result, store, active_detector

--- a/tests/test_code_command_mixin.py
+++ b/tests/test_code_command_mixin.py
@@ -71,6 +71,8 @@ class _Harness(CodeCommandMixin):
         self._credential_vault = vault
         self._sandbox_pool = sandbox_pool
         self._interrupt_requested = False
+        self._summary_client = None
+        self._summary_model = ""
 
     async def _ensure_code_sandbox(self, session, sandbox_owner):
         # Bypass the real SandboxSpec builder in unit tests.

--- a/tests/test_code_command_repo.py
+++ b/tests/test_code_command_repo.py
@@ -78,6 +78,8 @@ class _Harness(CodeCommandMixin):
         self._credential_vault = vault
         self._sandbox_pool = sandbox_pool
         self._interrupt_requested = False
+        self._summary_client = None
+        self._summary_model = ""
 
     async def _ensure_code_sandbox(self, session, sandbox_owner):
         await self._sandbox_pool.ensure(sandbox_owner, None)

--- a/tests/test_harness_resilience.py
+++ b/tests/test_harness_resilience.py
@@ -331,9 +331,8 @@ class TestDynamicLoopToolPolicy:
 
     def test_coordinator_without_strict_flag_keeps_all_tools(self) -> None:
         """Legacy behaviour: a coordinator session with no strict flag
-        and no excluded_tools gets the full registry (no filter applied).
-        This protects AgentDef-driven coordinators from a silent shape
-        change."""
+        and no excluded_tools sees the full registry.  This protects
+        AgentDef-driven coordinators from a silent shape change."""
         from surogates.tools.registry import ToolRegistry, ToolSchema
 
         reg = ToolRegistry()
@@ -348,9 +347,10 @@ class TestDynamicLoopToolPolicy:
 
         tool_names = harness._tool_filter_for_session(session)
 
-        # ``None`` here means "no filter applied" — the LLM sees every
-        # tool the registry knows about.
-        assert tool_names is None
+        # The execution-context gates materialise the implicit "everything"
+        # filter so they can subtract from it, so the answer is the whole
+        # registry rather than ``None`` — the LLM still sees every tool.
+        assert tool_names == {"spawn_task", "terminal", "read_file"}
 
     def test_strict_coordinator_strips_implementation_tools(self) -> None:
         """/mission sets strict_coordinator=True so implementation tools

--- a/tests/test_title_generator.py
+++ b/tests/test_title_generator.py
@@ -19,6 +19,38 @@ from surogates.harness.loop import AgentHarness
 from surogates.session.models import Event, Session, SessionLease
 
 
+def _wake_harness(store, *, tenant_org_id, tenant_user_id) -> AgentHarness:
+    """A real ``AgentHarness`` with mocked collaborators, ready for ``wake``."""
+    from surogates.harness.context import ContextCompressor
+    from surogates.harness.prompt import PromptBuilder
+    from surogates.harness.budget import IterationBudget
+    from surogates.sandbox.pool import SandboxPool
+    from surogates.tenant.context import TenantContext
+    from surogates.tools.registry import ToolRegistry
+
+    return AgentHarness(
+        session_store=store,
+        tool_registry=ToolRegistry(),
+        llm_client=AsyncMock(),
+        tenant=TenantContext(
+            org_id=tenant_org_id,
+            user_id=tenant_user_id,
+            org_config={},
+            user_preferences={},
+            permissions=frozenset(),
+            asset_root="/tmp/test",
+        ),
+        worker_id="test-worker",
+        budget=IterationBudget(max_total=10),
+        context_compressor=MagicMock(spec=ContextCompressor),
+        prompt_builder=MagicMock(spec=PromptBuilder),
+        sandbox_pool=MagicMock(spec=SandboxPool),
+        default_model="gpt-4o",
+        vision_client=None,
+        vision_model="",
+    )
+
+
 def _response(content: str):
     return SimpleNamespace(
         choices=[
@@ -464,20 +496,6 @@ async def test_wake_kicks_off_title_for_loop_command(monkeypatch) -> None:
         {"role": "user", "content": "/loop check bitcoin volatility"},
     ]
 
-    harness = AgentHarness.__new__(AgentHarness)
-    harness._llm = AsyncMock()
-    harness._worker_id = "test-worker"
-    harness._default_model = "gpt-4o"
-    harness._streaming_enabled = True
-    harness._memory_manager = None
-    harness._tenant = SimpleNamespace(org_id=session.org_id, user_id=session.user_id)
-    harness._summary_client = None
-    harness._summary_model = ""
-    harness._session_factory = None
-    harness._bundle = None
-    harness._prompt = MagicMock()
-    harness._background_tasks = set()
-
     store = AsyncMock()
     store.get_session = AsyncMock(return_value=session)
     store.try_acquire_lease = AsyncMock(return_value=lease)
@@ -486,7 +504,12 @@ async def test_wake_kicks_off_title_for_loop_command(monkeypatch) -> None:
     store.emit_event = AsyncMock(return_value=2)
     store.release_lease = AsyncMock()
     store.renew_lease = AsyncMock()
-    harness._store = store
+
+    # A real harness, not a hand-populated ``__new__`` shell: ``wake`` keeps
+    # growing new constructor-set attributes and a partial stub only fails
+    # once one of them is read.
+    harness = _wake_harness(store, tenant_org_id=session.org_id,
+                            tenant_user_id=session.user_id)
 
     harness._renew_lease_forever = AsyncMock()
     harness._rebuild_messages = MagicMock(return_value=rebuilt_messages)

--- a/tests/test_worker_channel_token.py
+++ b/tests/test_worker_channel_token.py
@@ -24,7 +24,12 @@ from surogates.tenant.context import TenantContext
 # ---------------------------------------------------------------------------
 
 
-def _tenant(*, user_id: UUID | None = None, tmp_path: Path) -> TenantContext:
+def _tenant(
+    *,
+    user_id: UUID | None = None,
+    service_account_id: UUID | None = None,
+    tmp_path: Path,
+) -> TenantContext:
     return TenantContext(
         org_id=uuid4(),
         user_id=user_id,
@@ -32,7 +37,7 @@ def _tenant(*, user_id: UUID | None = None, tmp_path: Path) -> TenantContext:
         user_preferences={},
         permissions=frozenset(),
         asset_root=str(tmp_path),
-        service_account_id=None,
+        service_account_id=service_account_id,
         session_scope_id=None,
     )
 
@@ -73,8 +78,8 @@ class TestSelectHarnessToken:
     ):
         from surogates.orchestrator.worker import _select_harness_token
 
-        tenant = _tenant(tmp_path=tmp_path)
         sa_id = uuid4()
+        tenant = _tenant(service_account_id=sa_id, tmp_path=tmp_path)
         session = _session(channel="api", service_account_id=sa_id)
 
         token = _select_harness_token(
@@ -221,11 +226,12 @@ class TestFilterEffectiveTools:
         """Regression: SA sessions retain memory/skill_manage."""
         from surogates.orchestrator.worker import _filter_effective_tools
 
+        sa_id = uuid4()
         tools = {"create_artifact", "memory", "skill_manage"}
         result = _filter_effective_tools(
             tools=tools,
-            tenant=_tenant(tmp_path=tmp_path),
-            session=_session(channel="api", service_account_id=uuid4()),
+            tenant=_tenant(service_account_id=sa_id, tmp_path=tmp_path),
+            session=_session(channel="api", service_account_id=sa_id),
             use_api_for_harness_tools=True,
         )
         assert "memory" in result


### PR DESCRIPTION
The suite had drifted 37 failures behind the code. Most were test doubles and assertions left behind by refactors; three were real gaps the tests were pointing at.

Whole suite now green: **5,939 passed, 11 skipped, 0 failed** (5,206 unit + 733 integration).

## Stale tests (34)

| Area | What moved |
|---|---|
| `test_browser_tool_storage` | storage helpers moved to boundary-partitioned prefixes |
| `test_code_command_mixin`, `test_code_command_repo` | the `/code` mixin now needs `_summary_client` / `_summary_model` |
| `test_chat_attachments`, `test_channel_files_route`, `test_channel_messages_route`, `test_worker_channel_token`, `inbox_e2e_helpers`, `test_inbox_progress_hook` | `SimpleNamespace` stubs missing `agent_id` / `user_id` / `service_account_id` that production reads |
| `test_channel_session_workspace`, `test_api` | `provisioning.get_model_info` is gone; `llm.model` is rejected at config load |
| `test_browser_image` | asserted `autostart=true` when the image deliberately keeps neko off (no UDP/TURN) |
| `test_harness_resilience` | the execution-context gates materialise the implicit "all tools" filter, so it is a set, not `None` |
| `test_observability` | `policy.allowed` now names `governance_gate`, not `workspace_sandbox` |
| `test_title_generator` | the wake test built a hand-populated `__new__` shell that broke on every attribute `wake` gained; it now builds a real harness |

## Real gaps behind the failures (3)

- **`admin.create_user`** — `uq_users_org_lower_email` had made the `force` flag unreachable and turned an email collision into a 500. The guard is now provider-agnostic (email is the org-scoped login key whatever the provider) and `force` is deleted, with an `IntegrityError` → 409 backstop for the concurrent-create race.
- **`firebase_exchange`** — its `IntegrityError` handler assumed the *username* index and retried an email collision straight into a second 500. It now 409s, leaving the pre-existing manual `database` row untouched (the no-silent-link rule still holds; under the index there is simply no second row to create).
- **`consume_approval_grant`** — the liveness predicates lived only in an uncorrelated scalar subquery, i.e. an InitPlan evaluated once, so Postgres' concurrent-update recheck re-tested only `id` and a second racer could spend an already-exhausted grant. The predicates are now repeated on the target row.

## Caveat

The approval-grant overspend only failed under full-suite load — it did not reproduce on an idle box even at 64 racers. The fix is verified as correct-by-construction plus a green suite, not by a red-to-green repro.

## Note

Run this suite with `/work/surogates/.venv/bin/python`: `reportlab` (the PDF fixture builder) is only installed there. The repo has no CI workflow running tests, which is why the suite drifted this far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)