### PR TITLE
fix(web): keep the composer attached to the keyboard on a phone

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,9 +5,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- `interactive-widget=resizes-content` makes Chrome on Android shrink
+         the layout viewport when the keyboard opens instead of sliding the
+         page up behind it, which keeps the composer attached to the top of
+         the keyboard. iOS ignores it; there use-visual-viewport handles the
+         same thing from JS. -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <meta name="description" content="Chat with your assistant." />
 

--- a/web/src/app/routes/__root.tsx
+++ b/web/src/app/routes/__root.tsx
@@ -17,11 +17,14 @@ function RootLayout() {
 
   return (
     <AppProvider>
+      {/* Fixed to the visual viewport, not just sized to it: opening the
+          keyboard also scrolls the layout viewport out from under a shell
+          that is merely the right height. See use-visual-viewport. */}
       <div
         className={
           isBare
-            ? "h-(--viewport-h,100dvh) bg-background text-foreground"
-            : "flex h-(--viewport-h,100dvh) overflow-hidden bg-background text-foreground"
+            ? "fixed inset-x-0 top-(--viewport-top,0px) h-(--viewport-h,100dvh) overflow-y-auto bg-background text-foreground"
+            : "fixed inset-x-0 top-(--viewport-top,0px) flex h-(--viewport-h,100dvh) overflow-hidden bg-background text-foreground"
         }
       >
         <Suspense fallback={null}>

--- a/web/src/hooks/use-visual-viewport.ts
+++ b/web/src/hooks/use-visual-viewport.ts
@@ -2,18 +2,32 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 import { useEffect } from "react";
 
-// Writes the visible viewport height (accounting for the on-screen keyboard
-// on iOS Safari / mobile Chrome) to a CSS custom property `--viewport-h` on
-// the <html> element. The chat composer reads it to stay pinned above the
-// keyboard. Idempotent — safe to mount multiple times.
+// Writes the visible viewport (accounting for the on-screen keyboard on iOS
+// Safari / mobile Chrome) to `--viewport-h` and `--viewport-top` on the
+// <html> element. The shell is a fixed box sized and positioned from these,
+// so the composer stays pinned above the keyboard.
+//
+// The height alone is not enough: focusing an input near the bottom also
+// makes the browser scroll the *layout* viewport up under the visual one, so
+// a correctly-sized shell that still starts at the top of the layout viewport
+// ends up shifted up with blank page below it — which is the "everything
+// jumps up and the input is somewhere above the keyboard" bug.
+// `visualViewport.offsetTop` is that scroll distance.
+//
+// Idempotent — safe to mount multiple times.
 export function useVisualViewport() {
   useEffect(() => {
     const root = document.documentElement;
     const vv = window.visualViewport;
 
     function update() {
-      const h = vv?.height ?? window.innerHeight;
+      // A pinch-zoom shrinks `height` too, and the shell is sized from it —
+      // so only the unzoomed measurement means "the keyboard covers this".
+      const zoomed = vv != null && Math.abs(vv.scale - 1) > 0.01;
+      const h = zoomed || !vv ? window.innerHeight : vv.height;
+      const top = zoomed || !vv ? 0 : Math.max(0, vv.offsetTop);
       root.style.setProperty("--viewport-h", `${h}px`);
+      root.style.setProperty("--viewport-top", `${top}px`);
     }
 
     update();

--- a/web/src/hooks/use-visual-viewport.ts
+++ b/web/src/hooks/use-visual-viewport.ts
@@ -24,8 +24,9 @@ export function useVisualViewport() {
       // A pinch-zoom shrinks `height` too, and the shell is sized from it —
       // so only the unzoomed measurement means "the keyboard covers this".
       const zoomed = vv != null && Math.abs(vv.scale - 1) > 0.01;
-      const h = zoomed || !vv ? window.innerHeight : vv.height;
-      const top = zoomed || !vv ? 0 : Math.max(0, vv.offsetTop);
+      const unusable = zoomed || !vv;
+      const h = unusable ? window.innerHeight : vv.height;
+      const top = unusable ? 0 : Math.max(0, vv.offsetTop);
       root.style.setProperty("--viewport-h", `${h}px`);
       root.style.setProperty("--viewport-top", `${top}px`);
     }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -220,6 +220,16 @@
   body {
     @apply bg-background text-foreground;
   }
+  html,
+  body {
+    /* The shell is a fixed box over the visual viewport, so the document
+       itself must never scroll: a scrollable document is what lets a phone
+       push the page up when the keyboard opens and strand the composer
+       off-screen. Every scroll in the app happens inside the shell. */
+    height: 100%;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
   html {
     @apply font-sans;
     /* Landscape rotation on iOS otherwise inflates every font size. */


### PR DESCRIPTION
The chat's own half of the keyboard fix. Companion to the surogate-ops PR, which carries the same change for Studio.

Sizing the shell to `visualViewport.height` was only half of it. Focusing the composer also makes the phone scroll the *layout* viewport up under the visual one, and the shell still started at the top of the layout viewport — so the whole chat jumped up, the composer ended up that far above the keyboard, and the gap below it was blank page you had to scroll back down through to reach the input again.

- `use-visual-viewport` now publishes `visualViewport.offsetTop` alongside the height, and ignores a pinch-zoom the way Studio's copy already did (a pinch shrinks `height` too, and the shell is sized from it).
- The shell is `position: fixed` at that offset, so it sits exactly over the visible strip.
- `html, body` are locked from scrolling: a scrollable document is what lets a phone push the page up in the first place. Every scroll in the app already happens inside the shell.
- The viewport meta gets `interactive-widget=resizes-content`, which makes Chrome on Android shrink the layout viewport instead of sliding it behind the keyboard. iOS ignores it; there the JS above does the same job.

The bare routes (login, link) gain their own `overflow-y-auto` — they used to rely on the document scrolling, which no longer happens.

## Checks

`npm run typecheck` clean, `vite build` clean.

Verified in headless Chromium: with the shell fed a 508px-tall viewport offset by 180px it lands at exactly top 180 / bottom 688 — before the change it ended at 508, which is the 180px gap this fixes.

---

Companion: invergent-ai/surogate-ops#349 carries the same fix for Studio, plus the rest of the mobile pass.
