### PR TITLE
fix(sdk): composer view-mode switch, corners, and the context panel

### DIFF
--- a/sdk/agent-chat-react/src/components/ai-elements/context.tsx
+++ b/sdk/agent-chat-react/src/components/ai-elements/context.tsx
@@ -8,6 +8,7 @@ import { createContext, useContext, useMemo } from "react";
 import { getUsage } from "tokenlens";
 
 const PERCENT_MAX = 100;
+const NEARLY_FULL = 0.9;
 const ICON_RADIUS = 10;
 const ICON_VIEWBOX = 24;
 const ICON_CENTER = 12;
@@ -126,19 +127,44 @@ export const ContextContentHeader = ({
     notation: "compact",
   }).format(maxTokens);
 
+  // A bar that looks the same at 30% as at 95% reports without warning. The
+  // last tenth of the window is where a turn starts losing its earlier
+  // history, so that is where the bar stops being decorative.
+  const nearlyFull = usedPercent >= NEARLY_FULL;
+
   return (
-    <div className={cn("w-full space-y-2 p-3", className)} {...props}>
+    <div className={cn("w-full space-y-2 px-3 py-2.5", className)} {...props}>
       {children ?? (
         <>
-          <div className="flex items-center justify-between gap-3 text-xs">
-            <p>{displayPct}</p>
-            <p className=" text-muted-foreground">
+          <div className="flex items-baseline justify-between gap-3">
+            <p
+              className={cn(
+                "text-sm font-medium tabular-nums",
+                nearlyFull && "text-destructive",
+              )}
+            >
+              {displayPct}
+            </p>
+            <p className="text-xs text-muted-foreground tabular-nums">
               {used} / {total}
             </p>
           </div>
-          <div className="space-y-2">
-            <Progress className="bg-muted" value={usedPercent * PERCENT_MAX} />
-          </div>
+          <Progress
+            className={cn(
+              // The primitive only clips its x-axis, which leaves the fill's
+              // square end poking out of the pill at both ends.
+              "h-1 overflow-hidden rounded-full bg-muted",
+              // Amber, not `bg-primary`: primary is the host app's colour, and
+              // the two hosts disagree — the agent web app is amber, Studio is
+              // near-black — so the same bar came out black beside a Send
+              // button the composer hardcodes amber. This is the composer's
+              // own accent, so it reads the same wherever it is embedded.
+              "[&>[data-slot=progress-indicator]]:bg-amber-500",
+              nearlyFull &&
+                "[&>[data-slot=progress-indicator]]:bg-destructive",
+            )}
+            value={usedPercent * PERCENT_MAX}
+          />
         </>
       )}
     </div>
@@ -152,7 +178,7 @@ export const ContextContentBody = ({
   className,
   ...props
 }: ContextContentBodyProps) => (
-  <div className={cn("w-full p-3", className)} {...props}>
+  <div className={cn("w-full space-y-1.5 px-3 py-2.5", className)} {...props}>
     {children}
   </div>
 );

--- a/sdk/agent-chat-react/src/components/ai-elements/prompt-input.tsx
+++ b/sdk/agent-chat-react/src/components/ai-elements/prompt-input.tsx
@@ -945,8 +945,19 @@ export const PromptInput = ({
         ref={formRef}
         {...props}
       >
-        <BrandBeam size="line" active={beamActive} strength={0.7} borderRadius={24}>
-          <InputGroup className="overflow-hidden rounded-3xl border border-input bg-white px-4 py-2 shadow-sm dark:bg-card dark:shadow-none dark:ring-1 dark:ring-white/5 has-[textarea]:rounded-3xl has-[>[data-align=block-end]]:rounded-3xl has-[>[data-align=block-start]]:rounded-3xl">
+        {/* No explicit borderRadius: the beam wraps this box in a rounded
+            clip, and any radius that does not match the box's own erases
+            its corners — a clip wider than the corner cuts the whole arc
+            away and leaves four straight edges that stop short. `rounded-3xl`
+            is theme-derived (`--radius * 2.2`), so no literal can track it;
+            the beam measures the child instead. */}
+        <BrandBeam size="line" active={beamActive} strength={0.7}>
+          {/* The radius overrides repeat InputGroup's own `has-data-[align=…]`
+              variants, not just the `has-[>[data-align=…]]` spelling: those are
+              distinct keys to tailwind-merge, so a mismatched pair leaves both
+              the base `rounded-none` and this `rounded-3xl` on the element and
+              stylesheet order — not this file — decides which one lands. */}
+          <InputGroup className="overflow-hidden rounded-3xl border border-input bg-white px-4 py-2 shadow-sm dark:bg-card dark:shadow-none dark:ring-1 dark:ring-white/5 has-[textarea]:rounded-3xl has-data-[align=block-end]:rounded-3xl has-data-[align=block-start]:rounded-3xl has-[>[data-align=block-end]]:rounded-3xl has-[>[data-align=block-start]]:rounded-3xl">
             {children}
           </InputGroup>
         </BrandBeam>

--- a/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
@@ -47,7 +47,6 @@ import {
 } from "../ai-elements/context";
 import { Button } from "../ui/button";
 import { cn } from "../../lib/utils";
-import { ButtonGroup } from "../ui/button-group";
 import {
   Item,
   ItemActions,
@@ -88,6 +87,22 @@ type SlashCommand = AgentChatSlashCommand;
 // only targets, and in a bottom sheet they are what the thumb lands on.
 const TOOLS_ITEM_CLASS =
   "gap-3 rounded-md px-3 py-2 pointer-coarse:min-h-11 pointer-coarse:text-[15px]";
+
+// The two halves of the view-mode switch, in the order they are shown.
+const VIEW_MODE_SEGMENTS = [
+  {
+    mode: "simple" as const,
+    label: "Simple",
+    icon: MessageSquareIcon,
+    tooltip: "Simple — just the conversation",
+  },
+  {
+    mode: "expert" as const,
+    label: "Advanced",
+    icon: ListTreeIcon,
+    tooltip: "Advanced — every step the agent took",
+  },
+];
 
 // ── Props ────────────────────────────────────────────────────────────
 
@@ -780,42 +795,49 @@ function ChatComposerInner({
   // awaiting-answer session with no panes has exactly nothing.
   const showToolsPanel = canAttach || showPaneToggles || canPickProfile;
 
+  // A segmented control, not two buttons that happen to touch: one track,
+  // two segments, only the selected one filled. The words are the label a
+  // cursor gets — they read at a glance and cost nothing at that width. A
+  // phone has no room for them beside Send, so there the icons stand in and
+  // the words move to the accessible name (which both widths carry anyway).
+  //
+  // Plain <div> rather than ButtonGroup: the group squares off the inner
+  // edges of every child, which fights the pill and leaves each segment
+  // outlined inside an outline.
   const viewModeToggle = onViewModeChange ? (
-    <ButtonGroup
+    <div
+      role="group"
       aria-label="Chat view mode"
-      className="overflow-hidden rounded-full border border-border bg-muted/40 p-0.5"
+      className="flex shrink-0 items-center gap-0.5 rounded-full bg-muted/60 p-0.5"
     >
-      <PromptInputButton
-        aria-label="Simple view"
-        aria-pressed={viewMode === "simple"}
-        tooltip="Simple — just the conversation"
-        variant={viewMode === "simple" ? "secondary" : "ghost"}
-        onClick={() => onViewModeChange("simple")}
-        className={cn(
-          // 32px is a comfortable segment for a cursor and a miss for a
-          // thumb, so touch takes both halves to the 44px floor.
-          "size-8 rounded-full pointer-coarse:size-11",
-          viewMode === "simple" && "shadow-sm",
-        )}
-      >
-        <MessageSquareIcon className="size-[18px] pointer-coarse:size-5" />
-      </PromptInputButton>
-      <PromptInputButton
-        aria-label="Advanced view"
-        aria-pressed={viewMode === "expert"}
-        tooltip="Advanced — every step the agent took"
-        variant={viewMode === "expert" ? "secondary" : "ghost"}
-        onClick={() => onViewModeChange("expert")}
-        className={cn(
-          // 32px is a comfortable segment for a cursor and a miss for a
-          // thumb, so touch takes both halves to the 44px floor.
-          "size-8 rounded-full pointer-coarse:size-11",
-          viewMode === "expert" && "shadow-sm",
-        )}
-      >
-        <ListTreeIcon className="size-[18px] pointer-coarse:size-5" />
-      </PromptInputButton>
-    </ButtonGroup>
+      {VIEW_MODE_SEGMENTS.map(({ mode, label, icon: Icon, tooltip }) => {
+        const selected = viewMode === mode;
+        return (
+          <PromptInputButton
+            key={mode}
+            size="sm"
+            aria-label={`${label} view`}
+            aria-pressed={selected}
+            tooltip={tooltip}
+            variant="ghost"
+            onClick={() => onViewModeChange(mode)}
+            className={cn(
+              // Icon-width on a phone, word-width with a cursor; the coarse
+              // bump takes the segment to the 44px touch floor either way.
+              // Words, not the shouted uppercase the button base defaults to —
+              // this is a label on a switch, not a call to action.
+              "h-8 gap-1.5 rounded-full border-0 bg-transparent px-3.5 text-xs font-normal capitalize tracking-normal md:px-3 pointer-coarse:h-11 pointer-coarse:px-5",
+              selected
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
+            )}
+          >
+            <Icon className="size-4 md:hidden" />
+            <span className="hidden md:inline">{label}</span>
+          </PromptInputButton>
+        );
+      })}
+    </div>
   ) : null;
 
   return (

--- a/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-composer.tsx
@@ -20,6 +20,7 @@ import {
   MessageSquareIcon,
   PaperclipIcon,
   PlusIcon,
+  ShrinkIcon,
   SparklesIcon,
   TerminalIcon,
   type LucideIcon,
@@ -36,13 +37,9 @@ import type {
 import { useAgentChatAdapterContext } from "../../adapter-context";
 import { splitComposerFiles } from "../../lib/split-composer-files";
 import {
-  ContextCacheUsage,
   ContextContentBody,
   ContextContentHeader,
   ContextIcon,
-  ContextInputUsage,
-  ContextOutputUsage,
-  ContextReasoningUsage,
   ContextValueProvider,
 } from "../ai-elements/context";
 import { Button } from "../ui/button";
@@ -771,6 +768,22 @@ function ChatComposerInner({
     ? `${Math.min(100, Math.round((tokenUsage.totalTokens / tokenUsage.contextWindow) * 100))}%`
     : "0%";
 
+  // Input and output are the shape of every turn, so they are listed even at
+  // zero. Reasoning and cache are model-dependent — a zero row for a model
+  // that has neither is a line that says nothing.
+  const contextBreakdown = tokenUsage
+    ? [
+        { label: "Input", tokens: tokenUsage.inputTokens },
+        { label: "Output", tokens: tokenUsage.outputTokens },
+        ...(tokenUsage.reasoningTokens > 0
+          ? [{ label: "Reasoning", tokens: tokenUsage.reasoningTokens }]
+          : []),
+        ...(tokenUsage.cachedInputTokens > 0
+          ? [{ label: "Cache", tokens: tokenUsage.cachedInputTokens }]
+          : []),
+      ]
+    : [];
+
   // ── What the tools panel contains ──────────────────────────────────
   //
   // Attach, the pane toggles and the profile picker were four buttons in a
@@ -1074,46 +1087,35 @@ function ChatComposerInner({
                     <ContextContentHeader />
                     <ContextContentBody>
                       {tokenUsage.totalTokens > 0 ? (
-                        <>
-                          <ContextInputUsage>
-                            <div className="flex items-center justify-between text-xs">
-                              <span className="text-muted-foreground">Input</span>
-                              <span>{tokenUsage.inputTokens.toLocaleString()}</span>
-                            </div>
-                          </ContextInputUsage>
-                          <ContextOutputUsage>
-                            <div className="flex items-center justify-between text-xs">
-                              <span className="text-muted-foreground">Output</span>
-                              <span>{tokenUsage.outputTokens.toLocaleString()}</span>
-                            </div>
-                          </ContextOutputUsage>
-                          {tokenUsage.reasoningTokens > 0 && (
-                            <ContextReasoningUsage>
-                              <div className="flex items-center justify-between text-xs">
-                                <span className="text-muted-foreground">Reasoning</span>
-                                <span>{tokenUsage.reasoningTokens.toLocaleString()}</span>
-                              </div>
-                            </ContextReasoningUsage>
-                          )}
-                          {tokenUsage.cachedInputTokens > 0 && (
-                            <ContextCacheUsage>
-                              <div className="flex items-center justify-between text-xs">
-                                <span className="text-muted-foreground">Cache</span>
-                                <span>{tokenUsage.cachedInputTokens.toLocaleString()}</span>
-                              </div>
-                            </ContextCacheUsage>
-                          )}
-                        </>
+                        contextBreakdown.map(({ label, tokens }) => (
+                          <div
+                            key={label}
+                            className="flex items-center justify-between gap-4 text-xs"
+                          >
+                            <span className="text-muted-foreground">{label}</span>
+                            <span className="tabular-nums">
+                              {tokens.toLocaleString()}
+                            </span>
+                          </div>
+                        ))
                       ) : (
                         <p className="text-xs text-muted-foreground text-center py-1">Empty</p>
                       )}
                     </ContextContentBody>
                     {tokenUsage.totalTokens > 0 && (
-                      <div className="flex w-full items-center justify-end gap-3 bg-secondary p-2">
+                      // The action the panel exists for, so it gets the panel's
+                      // width rather than a filled block shoved into the corner
+                      // of a grey bar — that bar was a second surface inside a
+                      // small popover, squaring its own corners off against the
+                      // rounded ones around it. It keeps a rule of its own
+                      // because the sheet form has no divide-y, and the one
+                      // division worth drawing is between reading and acting.
+                      <div className="space-y-1.5 border-t border-border px-3 py-2.5">
                         <Button
                           type="button"
-                          size="xs"
-                          className="pointer-coarse:h-11 pointer-coarse:px-4 pointer-coarse:text-sm"
+                          size="sm"
+                          variant="outline"
+                          className="w-full"
                           onClick={() => {
                             // The sheet does not close itself on a plain
                             // button the way it does on a menu selection.
@@ -1121,8 +1123,12 @@ function ChatComposerInner({
                             onSend("/compress");
                           }}
                         >
+                          <ShrinkIcon />
                           Compress
                         </Button>
+                        <p className="text-center text-[11px] leading-snug text-muted-foreground">
+                          Sums up the thread to free the window
+                        </p>
                       </div>
                     )}
                   </ResponsivePanel>

--- a/sdk/agent-chat-react/tests/composer-context-panel.test.tsx
+++ b/sdk/agent-chat-react/tests/composer-context-panel.test.tsx
@@ -121,6 +121,66 @@ describe("composer session context", () => {
     expect(document.body.textContent).not.toContain("Input");
   });
 
+  it("lists reasoning and cache only once they have run", async () => {
+    const dom = mount(
+      <ChatComposer
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        isRunning={false}
+        tokenUsage={{ ...tokenUsage, reasoningTokens: 250 }}
+      />,
+    );
+    await act(async () => {
+      contextTrigger(dom).click();
+      await Promise.resolve();
+    });
+    expect(document.body.textContent).toContain("Reasoning");
+    expect(document.body.textContent).toContain("250");
+    // Cache stayed at zero, so it is a row that would say nothing.
+    expect(document.body.textContent).not.toContain("Cache");
+  });
+
+  it("turns the readout destructive in the last tenth of the window", async () => {
+    const dom = mount(
+      <ChatComposer
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        isRunning={false}
+        tokenUsage={{ ...tokenUsage, inputTokens: 14000, totalTokens: 15000 }}
+      />,
+    );
+    await act(async () => {
+      contextTrigger(dom).click();
+      await Promise.resolve();
+    });
+    const panel = document.querySelector("[data-slot='popover-content']")!;
+    const percent = panel.querySelector("p")!;
+    expect(percent.textContent).toBe("93.8%");
+    expect(percent.className).toContain("text-destructive");
+    expect(panel.querySelector("[data-slot='progress']")?.className).toContain(
+      "[&>[data-slot=progress-indicator]]:bg-destructive",
+    );
+  });
+
+  it("keeps the readout unalarmed below that", async () => {
+    const dom = mount(
+      <ChatComposer
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        isRunning={false}
+        tokenUsage={tokenUsage}
+      />,
+    );
+    await act(async () => {
+      contextTrigger(dom).click();
+      await Promise.resolve();
+    });
+    const panel = document.querySelector("[data-slot='popover-content']")!;
+    expect(panel.querySelector("p")?.className).not.toContain(
+      "text-destructive",
+    );
+  });
+
   it("renders nothing without a known context window", () => {
     const dom = mount(
       <ChatComposer onSend={vi.fn()} onStop={vi.fn()} isRunning={false} />,

--- a/sdk/agent-chat-react/tests/composer-view-mode-toggle.test.tsx
+++ b/sdk/agent-chat-react/tests/composer-view-mode-toggle.test.tsx
@@ -87,12 +87,46 @@ describe("Composer view-mode toggle", () => {
     expect(group).not.toBeNull();
     const buttons = group!.querySelectorAll("button");
     expect(buttons.length).toBe(2);
-    // The labels are icons now, so they live on aria-label rather than in
-    // the text — the accessible name is the only name these buttons have.
+    // The accessible name is the same at every width; the icon (phone) and
+    // the word (cursor) are two renderings of it, and both are in the DOM
+    // with only a media query deciding which one shows.
     expect(Array.from(buttons).map((b) => b.getAttribute("aria-label"))).toEqual([
       "Simple view",
       "Advanced view",
     ]);
+    expect(Array.from(buttons).map((b) => b.textContent?.trim())).toEqual([
+      "Simple",
+      "Advanced",
+    ]);
+    for (const button of buttons) {
+      const word = button.querySelector("span");
+      const icon = button.querySelector("svg");
+      expect(word?.className).toContain("hidden");
+      expect(word?.className).toContain("md:inline");
+      expect(icon?.getAttribute("class")).toContain("md:hidden");
+    }
+  });
+
+  it("keeps the segments pill-shaped — no squared inner edges", () => {
+    const dom = mount(
+      <ChatComposer
+        onSend={sendFn}
+        onStop={stopFn}
+        isRunning={false}
+        viewMode="simple"
+        onViewModeChange={vi.fn()}
+      />,
+    );
+    const group = dom.querySelector("[role='group'][aria-label='Chat view mode']")!;
+    // ButtonGroup squares off the inner edges of everything it holds, which
+    // leaves each segment outlined inside the track's own outline. A plain
+    // track keeps both halves round; nothing may reintroduce the group.
+    expect(group.getAttribute("data-slot")).not.toBe("button-group");
+    for (const button of group.querySelectorAll("button")) {
+      expect(button.className).toContain("rounded-full");
+      expect(button.className).not.toMatch(/rounded-[lr]-none/);
+      expect(button.className).toContain("border-0");
+    }
   });
 
   it("shows the current mode as aria-pressed", () => {

--- a/sdk/agent-chat-react/tests/prompt-input-rounding.test.tsx
+++ b/sdk/agent-chat-react/tests/prompt-input-rounding.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * The composer box keeps its rounded corners.
+ *
+ * Two separate things erase them, and both have bitten:
+ *
+ * 1. InputGroup's own base class carries `rounded-none` under
+ *    `has-data-[align=…]` variants. tailwind-merge only drops a base class
+ *    when the override repeats the *same* variant key, so overriding just
+ *    the `has-[>[data-align=…]]` spelling leaves both `rounded-none` and
+ *    `rounded-3xl` on the element and stylesheet order decides the winner.
+ * 2. The border beam wraps the box in `overflow: hidden` plus its own
+ *    radius. A clip radius wider than the box's corner cuts the whole arc
+ *    away, leaving four straight edges that stop short of each corner —
+ *    which is what "the corners disappeared" looks like. The beam measures
+ *    the child, so no literal radius may be passed.
+ */
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  PromptInput,
+  PromptInputBody,
+  PromptInputFooter,
+  PromptInputTextarea,
+} from "../src/components/ai-elements/prompt-input";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+function mount(node: ReactElement): HTMLDivElement {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root?.render(node));
+  return container;
+}
+
+function mountComposer(beamActive: boolean): HTMLDivElement {
+  return mount(
+    <PromptInput onSubmit={() => {}} beamActive={beamActive}>
+      <PromptInputBody>
+        <PromptInputTextarea placeholder="Send a message..." />
+      </PromptInputBody>
+      <PromptInputFooter>
+        <button type="button">send</button>
+      </PromptInputFooter>
+    </PromptInput>,
+  );
+}
+
+describe("Composer rounding", () => {
+  it("leaves no rounded-none on the box, in any variant", () => {
+    const box = mountComposer(false).querySelector<HTMLElement>(
+      "[data-slot='input-group']",
+    )!;
+    expect(box.className).toContain("rounded-3xl");
+    expect(box.className).not.toContain("rounded-none");
+  });
+
+  it("rounds the box whether the footer is matched as a child or a descendant", () => {
+    const box = mountComposer(false).querySelector<HTMLElement>(
+      "[data-slot='input-group']",
+    )!;
+    // `has-data-[align=…]` matches any descendant, `has-[>[data-align=…]]`
+    // only a direct child. Both spellings must round, or a future wrapper
+    // around the footer silently squares the box off.
+    for (const variant of [
+      "has-data-[align=block-end]:rounded-3xl",
+      "has-data-[align=block-start]:rounded-3xl",
+      "has-[>[data-align=block-end]]:rounded-3xl",
+      "has-[>[data-align=block-start]]:rounded-3xl",
+      "has-[textarea]:rounded-3xl",
+    ]) {
+      expect(box.className).toContain(variant);
+    }
+  });
+
+  it("lets the beam measure the box instead of clipping it to a fixed radius", () => {
+    const wrapper = mountComposer(true).querySelector<HTMLElement>("[data-beam]")!;
+    // jsdom reports no radius for the child, so the beam falls back to its
+    // preset — the assertion that matters is that nothing overrode the
+    // measurement with a literal, which is what mismatched the box.
+    expect(wrapper.style.borderRadius).toBe("");
+    expect(document.querySelector("style")?.textContent ?? "").not.toContain(
+      "border-radius: 24px",
+    );
+  });
+});


### PR DESCRIPTION
Three things in the chat composer, all in `sdk/agent-chat-react`.

## The Simple/Advanced switch

It had become two icons in a `ButtonGroup`. The group squares off the inner
edges of everything it holds, which beat the segments' own `rounded-full`, and
`PromptInputButton` gives each child a border and an accent fill — so both
halves sat outlined inside the track's own outline, cramped at 32px.

It is a plain track now, two segments, only the selected one filled. With a
cursor the words are back (`Simple` / `Advanced`, normal weight, not the
button base's shouted uppercase); a phone has no room for them beside Send, so
there the icons stand in and the segments widen.

| | shows | segment |
|---|---|---|
| `md` and up | the words | 62×40, 79×40 |
| below `md` | the icons | 56×44 |

The accessible name is the same at both widths, so the existing tests still
assert on it.

## The composer's corners

Reported as "the corners disappeared", not reproducible on demand. Two
independent causes, both closed:

1. **The `rounded-none` in `InputGroup`'s base was never merged away.** The
   base carries it under `has-data-[align=…]` variants; the override in
   `prompt-input.tsx` only spelled `has-[>[data-align=…]]`. Those are distinct
   keys to tailwind-merge, so *both* classes stayed on the element and
   stylesheet order picked the winner. It happens to land on `rounded-3xl` in
   every build checked (web dev/prod, ops dev/prod) — but nothing pinned it,
   and a wrapper around the footer would flip it too, since the base variant
   matches any descendant while the override needs a direct child. The
   override now repeats every variant key the base uses.

2. **The border beam clipped them off.** It wraps the box in `overflow: hidden`
   plus its own radius, hardcoded at 24px, while the box is `rounded-3xl` =
   `--radius * 2.2` — theme-derived, so no literal can track it. A clip wider
   than the corner cuts the whole arc away and leaves four straight edges
   stopping short, which is exactly the screenshot. Reproduced by rendering the
   real composer at clip radii 18/22/24/30; at 30 the corners vanish
   identically. The beam measures the child instead now.

This also explains why it would not reproduce: the beam only exists while the
agent is streaming.

## The session-context panel

Compress sat in a grey bar pinned to the panel's bottom — a second surface
inside a 240px popover, squaring its own corners off against the rounded ones
around it, with a filled amber block in its corner. It is the only thing the
panel does, so it gets the panel's width, an outline instead of a fill, an
icon and a line saying what it will do. One rule separates reading from
acting; the sheet form never had one, because `divide-y` is popover-only.

Around it: the percentage leads at `text-sm`, the bar is a 4px pill that clips
its own fill, rows are spaced and tabular, and the last tenth of the window
turns both the number and the bar destructive.

The bar is amber rather than `bg-primary`. Primary is the *host's* colour and
the two hosts disagree — the agent web app is amber, Studio is near-black — so
the same bar rendered black beside a Send button the composer hardcodes amber.
That was the whole of "ops looks different from web".

The four usage rows were four near-identical blocks wrapped in `Context*Usage`
components whose own rendering was overridden by the children handed to them.
They are one list now.

## Verification

- 514 SDK tests pass; typecheck clean in the SDK, `surogates/web` and
  `surogate-ops/frontend`.
- The three new rounding tests fail against the pre-fix file (checked by
  stashing it), so they are load-bearing.
- Rendered in a real browser at 1100px/DPR 1 and 390px/DPR 2, in both the web
  app's theme and Studio's, with the panel open at 17.7% and at 93%.

## Studio

No change needed in `surogate-ops`: it pins `@invergent/agent-chat-react`
at `^2.13.0`, so it picks this up on the next SDK publish + `npm install`.
Verified locally against a build of this branch dropped into its
`node_modules` — dev CSS, production CSS, typecheck and production build all
green, and the panel renders identically to the web app.
