### PR TITLE
fix(release): build the wheel at the tag's version, and fail if it isn't

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,49 @@ jobs:
         with:
           python-version: "3.12"
 
+      # The version comes from the tag being released, NOT from
+      # setuptools-scm's `git describe`. Describe is unreliable here for two
+      # compounding reasons, and v2.13.3 shipped a wheel named 2.13.2 because
+      # of them:
+      #
+      #   1. Several tags can sit on one commit (v2.9.3, v2.13.2 and v2.13.3
+      #      all point at 8d949552), so describe has more than one exact match
+      #      to choose between.
+      #   2. actions/checkout fetches the pushed tag as a LIGHTWEIGHT ref,
+      #      dropping the annotation, so describe can prefer a different
+      #      annotated tag on the same commit over the one being released.
+      #
+      # Pinning it removes the guesswork: a release tagged vX.Y.Z produces a
+      # wheel named X.Y.Z, whatever the tag topology looks like. The images
+      # job already derives its tag from GITHUB_REF_NAME the same way, which
+      # is why the container tags were right while the wheel names were not.
+      - name: Resolve version from the tag
+        id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Build wheel and sdist
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.version.outputs.value }}
         run: uv build
+
+      # A wheel whose name disagrees with its tag is worse than a failed
+      # release: the download URL in every consumer's pin is built from the
+      # tag, so it 404s, and anyone who "fixes" the URL by hand pins a version
+      # string that does not match what they think they are installing.
+      # Fail here instead, while it is still cheap to re-cut.
+      - name: Verify the artifacts match the tag
+        run: |
+          set -euo pipefail
+          expected="${{ steps.version.outputs.value }}"
+          for ext in "py3-none-any.whl" "tar.gz"; do
+            if [ ! -f "dist/surogates-${expected}-${ext}" ] \
+               && [ ! -f "dist/surogates-${expected}.${ext}" ]; then
+              echo "::error::expected an artifact for version ${expected}, got:"
+              ls -1 dist/
+              exit 1
+            fi
+          done
+          ls -1 dist/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
`v2.13.3` published a wheel named **`surogates-2.13.2`**. `v2.13.2` before it published **`surogates-2.9.3`**.

That matters because every consumer pin is built from the tag:

```
.../releases/download/v2.13.3/surogates-2.13.3-py3-none-any.whl   <- 404
```

So the URL doesn't exist, and anyone who repairs it by hand ends up pinning a version string that doesn't describe what they're installing. surogate-ops pins exactly this way.

## Root cause

The version came from setuptools-scm's `git describe`, which is unreliable here for two compounding reasons:

1. **Several tags sit on one commit.** `v2.9.3`, `v2.13.2` and `v2.13.3` all point at `8d949552`, so describe has more than one exact match to choose between.
2. **`actions/checkout` fetches the pushed tag as a lightweight ref**, dropping the annotation — so describe can prefer a *different annotated tag on the same commit* over the one being released.

Locally `git describe` on that commit resolves correctly to `v2.13.3`, which is why this only ever reproduced in CI.

## Fix

Take the version from `GITHUB_REF_NAME` via `SETUPTOOLS_SCM_PRETEND_VERSION` — the same source the `images` job already uses, which is precisely why the **container tags were correct** while the wheel names were not.

Verified locally against the ambiguous tag topology:

| build | artifact |
|---|---|
| plain (describe) | `surogates-2.13.4.dev3+g2f285bc15.d20260810` |
| version pinned | `surogates-2.13.4` |

## Guard

A verification step fails the release when the artifacts don't carry the tag's version. Checked against the real failure — given tag `2.13.3` and wheels named `2.13.2`, it exits non-zero and prints what it found:

```
FAIL: expected artifacts for 2.13.3, got: surogates-2.13.2-py3-none-any.whl ...
```

Failing while a re-cut is cheap beats publishing a release whose download URL doesn't exist.

## Not addressed here

The duplicate tags themselves. `v2.9.3` pointing at a 2.13-era commit is separately wrong and worth deleting — but with the version pinned it can no longer change what a release publishes.

**Note:** the images for `2.13.3` are fine and already published (`ghcr.io/invergent-ai/surogates-worker:2.13.3`), since those tags never went through describe. Only the wheel/sdist names were affected.