### PR TITLE
fix(summary): render a skill load as "Reading skill <name>", not the raw transcript

### DIFF
--- a/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
@@ -1109,6 +1109,11 @@ function deriveIterationLabel(message: ChatMessageType): string | null {
   if (calls.length === 0) {
     return message.reasoning ? "Thought through the problem" : null;
   }
+  // Skill loads name themselves, one or many, so they never fall
+  // through to the generic "Skill × 3".
+  if (calls.every((tc) => tc.toolName === "skill_view")) {
+    return skillViewLabel(calls);
+  }
   if (calls.length === 1) {
     const tc = calls[0]!;
     return deriveSingleToolLabel(tc);
@@ -1117,7 +1122,6 @@ function deriveIterationLabel(message: ChatMessageType): string | null {
   const firstName = calls[0]!.toolName;
   const allSame = calls.every((tc) => tc.toolName === firstName);
   if (allSame) {
-    if (firstName === "skill_view") return skillViewLabel(calls);
     const human = cancelledToolLabel(firstName);
     return `${human} × ${calls.length}`;
   }
@@ -1125,30 +1129,31 @@ function deriveIterationLabel(message: ChatMessageType): string | null {
 }
 
 /**
- * Label for one or more ``skill_view`` calls.
+ * Label for one or more ``skill_view`` calls — see
+ * SIMPLE_MODE_HIDDEN_TOOLS for why skill loads get a deterministic row.
  *
- * A skill load is the agent reaching for its own instructions, so the
- * skill's name *is* the story of the iteration — "Reading skill
- * copywriting" carries more than any prose summary of the same call,
- * and carries it deterministically, with no model in the loop. Shared
- * by the collapsed header, the expanded body row and the live shimmer
- * so the row never renames itself as the iteration completes.
+ * Shared by the collapsed header, the expanded body row and the live
+ * shimmer so the row never renames itself as the iteration completes.
  */
 function skillViewLabel(calls: ToolCallInfo[]): string {
-  const names = calls
-    .map((tc) => parseArgs<{ name?: string; skill?: string }>(tc.args))
-    .map((args) => args?.name ?? args?.skill)
+  const args = calls.map((tc) =>
+    parseArgs<{ name?: string; skill?: string; file_path?: string }>(tc.args),
+  );
+  const names = args
+    .map((a) => a?.name ?? a?.skill)
     .filter((name): name is string => typeof name === "string" && name !== "");
   // Args stream in a character at a time, so a call can be mid-flight
   // with no parseable name yet; fall back to a countable phrasing
-  // rather than rendering a half-written name.
+  // rather than rendering a half-written name. ``names.length === 0``
+  // also keeps the function total: callers reach it through an
+  // ``every`` test, which an empty list passes.
   if (names.length !== calls.length || names.length === 0) {
     return calls.length > 1
       ? `Reading ${calls.length} skills`
       : "Reading a skill";
   }
   if (calls.length === 1) {
-    const path = parseArgs<{ file_path?: string }>(calls[0]!.args)?.file_path;
+    const path = args[0]?.file_path;
     return path
       ? `Reading skill ${names[0]} · ${lastPathSegment(path)}`
       : `Reading skill ${names[0]}`;
@@ -1165,7 +1170,6 @@ function skillViewLabel(calls: ToolCallInfo[]): string {
  * still appears in the expanded body via _toolRowLabel.
  */
 function deriveSingleToolLabel(tc: ToolCallInfo): string {
-  if (tc.toolName === "skill_view") return skillViewLabel([tc]);
   const name = cancelledToolLabel(tc.toolName);
   if (_HEADER_HIDES_DETAIL.has(tc.toolName)) {
     return _HEADER_GENERIC_VERB[tc.toolName] ?? name;
@@ -1373,9 +1377,12 @@ function liveIterationLabel(message: ChatMessageType): string {
     (tc) => tc.status === "running" && !isHiddenSimpleTool(tc),
   );
   if (running.length === 0) return "Thinking…";
+  // Same wording as the finished row, so it does not rename itself.
+  if (running.every((tc) => tc.toolName === "skill_view")) {
+    return `${skillViewLabel(running)}…`;
+  }
   if (running.length === 1) {
     const tc = running[0]!;
-    if (tc.toolName === "skill_view") return `${skillViewLabel([tc])}…`;
     const name = cancelledToolLabel(tc.toolName);
     const detail = extractToolDetail(tc);
     return detail ? `Running ${name} · ${detail}…` : `Running ${name}…`;
@@ -1383,7 +1390,6 @@ function liveIterationLabel(message: ChatMessageType): string {
   const firstName = running[0]!.toolName;
   const allSame = running.every((tc) => tc.toolName === firstName);
   if (allSame) {
-    if (firstName === "skill_view") return `${skillViewLabel(running)}…`;
     return `Running ${cancelledToolLabel(firstName)} × ${running.length}…`;
   }
   return `Running ${running.length} tools…`;

--- a/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
@@ -1125,14 +1125,6 @@ function deriveIterationLabel(message: ChatMessageType): string | null {
 }
 
 /**
- * Header label for a single-tool iteration. Most tools surface a
- * short detail (path basename, query, URL) so the header reads
- * "Read · landing.html". Tools whose detail is structurally noisy —
- * shell commands, arbitrary code blocks, raw memory keys — drop the
- * detail entirely and use a generic verb instead; the full detail
- * still appears in the expanded body via _toolRowLabel.
- */
-/**
  * Label for one or more ``skill_view`` calls.
  *
  * A skill load is the agent reaching for its own instructions, so the
@@ -1164,6 +1156,14 @@ function skillViewLabel(calls: ToolCallInfo[]): string {
   return `Reading skills ${names.join(", ")}`;
 }
 
+/**
+ * Header label for a single-tool iteration. Most tools surface a
+ * short detail (path basename, query, URL) so the header reads
+ * "Read · landing.html". Tools whose detail is structurally noisy —
+ * shell commands, arbitrary code blocks, raw memory keys — drop the
+ * detail entirely and use a generic verb instead; the full detail
+ * still appears in the expanded body via _toolRowLabel.
+ */
 function deriveSingleToolLabel(tc: ToolCallInfo): string {
   if (tc.toolName === "skill_view") return skillViewLabel([tc]);
   const name = cancelledToolLabel(tc.toolName);

--- a/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
@@ -1090,16 +1090,6 @@ function deriveIterationLabel(message: ChatMessageType): string | null {
 }
 
 
-
-
-/**
- * Tools that are hidden from Simple mode. These are either pure
- * exploration ("listed the directory"), internal infrastructure
- * (browser_*, process), or scratchpad-style state changes (todo,
- * memory) that don't help the user understand what the agent
- * *did*. Users who care can switch to Expert mode to see them.
- */
-
 /**
  * The subset of an iteration's tool calls that should surface in
  * Simple mode: skips internal/infrastructure tools and any call

--- a/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
@@ -1117,6 +1117,7 @@ function deriveIterationLabel(message: ChatMessageType): string | null {
   const firstName = calls[0]!.toolName;
   const allSame = calls.every((tc) => tc.toolName === firstName);
   if (allSame) {
+    if (firstName === "skill_view") return skillViewLabel(calls);
     const human = cancelledToolLabel(firstName);
     return `${human} × ${calls.length}`;
   }
@@ -1131,7 +1132,40 @@ function deriveIterationLabel(message: ChatMessageType): string | null {
  * detail entirely and use a generic verb instead; the full detail
  * still appears in the expanded body via _toolRowLabel.
  */
+/**
+ * Label for one or more ``skill_view`` calls.
+ *
+ * A skill load is the agent reaching for its own instructions, so the
+ * skill's name *is* the story of the iteration — "Reading skill
+ * copywriting" carries more than any prose summary of the same call,
+ * and carries it deterministically, with no model in the loop. Shared
+ * by the collapsed header, the expanded body row and the live shimmer
+ * so the row never renames itself as the iteration completes.
+ */
+function skillViewLabel(calls: ToolCallInfo[]): string {
+  const names = calls
+    .map((tc) => parseArgs<{ name?: string; skill?: string }>(tc.args))
+    .map((args) => args?.name ?? args?.skill)
+    .filter((name): name is string => typeof name === "string" && name !== "");
+  // Args stream in a character at a time, so a call can be mid-flight
+  // with no parseable name yet; fall back to a countable phrasing
+  // rather than rendering a half-written name.
+  if (names.length !== calls.length || names.length === 0) {
+    return calls.length > 1
+      ? `Reading ${calls.length} skills`
+      : "Reading a skill";
+  }
+  if (calls.length === 1) {
+    const path = parseArgs<{ file_path?: string }>(calls[0]!.args)?.file_path;
+    return path
+      ? `Reading skill ${names[0]} · ${lastPathSegment(path)}`
+      : `Reading skill ${names[0]}`;
+  }
+  return `Reading skills ${names.join(", ")}`;
+}
+
 function deriveSingleToolLabel(tc: ToolCallInfo): string {
+  if (tc.toolName === "skill_view") return skillViewLabel([tc]);
   const name = cancelledToolLabel(tc.toolName);
   if (_HEADER_HIDES_DETAIL.has(tc.toolName)) {
     return _HEADER_GENERIC_VERB[tc.toolName] ?? name;
@@ -1341,6 +1375,7 @@ function liveIterationLabel(message: ChatMessageType): string {
   if (running.length === 0) return "Thinking…";
   if (running.length === 1) {
     const tc = running[0]!;
+    if (tc.toolName === "skill_view") return `${skillViewLabel([tc])}…`;
     const name = cancelledToolLabel(tc.toolName);
     const detail = extractToolDetail(tc);
     return detail ? `Running ${name} · ${detail}…` : `Running ${name}…`;
@@ -1348,6 +1383,7 @@ function liveIterationLabel(message: ChatMessageType): string {
   const firstName = running[0]!.toolName;
   const allSame = running.every((tc) => tc.toolName === firstName);
   if (allSame) {
+    if (firstName === "skill_view") return `${skillViewLabel(running)}…`;
     return `Running ${cancelledToolLabel(firstName)} × ${running.length}…`;
   }
   return `Running ${running.length} tools…`;
@@ -1424,7 +1460,7 @@ function _toolRowLabel(tc: ToolCallInfo): string {
     case "session_search":
       return detail ? `Searched session for "${detail}"` : "Searched session";
     case "skill_view":
-      return detail ? `Read the ${detail} skill` : "Read a skill";
+      return skillViewLabel([tc]);
     case "skills_list":
       return "Listed available skills";
     case "skill_manage":

--- a/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
+++ b/sdk/agent-chat-react/src/components/chat/chat-thread.tsx
@@ -53,6 +53,13 @@ import {
 } from "./tools/ask-user-question-tool";
 import { parseTerminalResult } from "./tools/terminal-tool";
 import { statusColorClass, effectiveStatus, toolErrorSummary, parseArgs } from "./tools/shared";
+import {
+  cancelledToolLabel,
+  deriveSingleToolLabel,
+  extractToolDetail,
+  skillViewLabel,
+  toolRowLabel,
+} from "./simple-labels";
 import { ChatMessage } from "./chat-message";
 import { renderInlineMarkdown } from "./inline-markdown";
 import { ChatComposer } from "./chat-composer";
@@ -61,7 +68,6 @@ import { useAgentChatAdapterContext } from "../../adapter-context";
 import { ResearchSourcesPanel } from "../research/research-sources-panel";
 import { TurnFeedback } from "./turn-feedback";
 import { useSmoothStream } from "./use-smooth-stream";
-import { formatMcpToolLabel } from "../../lib/format";
 import { stripAndParseNextAction } from "../../lib/next-action";
 import { ArtifactBlock } from "./artifacts/artifact-block";
 import { ErrorMessage } from "./error-message";
@@ -695,51 +701,6 @@ function OrphanSystemMarker({
 
 // ── Cancelled tool row (parallel-batch sibling-error cancellation) ──
 
-function cancelledToolLabel(toolName: string): string {
-  const map: Record<string, string> = {
-    terminal: "Command",
-    execute_code: "Execute code",
-    read_file: "Read",
-    write_file: "Write",
-    patch: "Patch",
-    search_files: "Search files",
-    list_files: "List files",
-    web_search: "Web search",
-    web_extract: "Web fetch",
-    web_crawl: "Web crawl",
-    session_search: "Session search",
-    memory: "Memory",
-    todo: "Todo",
-    skills_list: "Skills",
-    skill_view: "Skill",
-    consult_expert: "Expert",
-    delegate_task: "Delegate task",
-    ask_user_question: "Ask User Question",
-    process: "Process",
-    create_artifact: "Create artifact",
-    run_coding_agent: "Coding agent",
-    code_run: "Coding agent",
-    // ``Research memory`` reads as a noun ("memory of research") and
-    // makes the shimmer awkward ("Running Research memory…").  The
-    // one-liner renderer shows just ``Research`` as the label, so
-    // mirror that here so the live shimmer matches the row that
-    // replaces it on completion.
-    research_memory: "Research",
-    research_outline: "Research",
-    generate_image: "image generation",
-    generate_video: "video generation",
-    // Arbor research-mission tools (the /auto-research coordinator loop).
-    idea_tree: "Idea tree",
-    dispatch_experiments: "Dispatch experiments",
-    merge_experiment: "Merge experiment",
-
-  };
-  if (map[toolName]) return map[toolName];
-  // MCP tools arrive as `mcp__{server}__{tool}`; show a clean label rather
-  // than the raw prefixed name (matches the Expert-mode MCP renderer).
-  if (toolName.startsWith("mcp__")) return formatMcpToolLabel(toolName);
-  return toolName;
-}
 
 function CancelledToolRow({ tc }: { tc: ToolCallInfo }) {
   return (
@@ -1128,196 +1089,8 @@ function deriveIterationLabel(message: ChatMessageType): string | null {
   return `Used ${calls.length} tools`;
 }
 
-/**
- * Label for one or more ``skill_view`` calls — see
- * SIMPLE_MODE_HIDDEN_TOOLS for why skill loads get a deterministic row.
- *
- * Shared by the collapsed header, the expanded body row and the live
- * shimmer so the row never renames itself as the iteration completes.
- */
-function skillViewLabel(calls: ToolCallInfo[]): string {
-  const args = calls.map((tc) =>
-    parseArgs<{ name?: string; skill?: string; file_path?: string }>(tc.args),
-  );
-  const names = args
-    .map((a) => a?.name ?? a?.skill)
-    .filter((name): name is string => typeof name === "string" && name !== "");
-  // Args stream in a character at a time, so a call can be mid-flight
-  // with no parseable name yet; fall back to a countable phrasing
-  // rather than rendering a half-written name. ``names.length === 0``
-  // also keeps the function total: callers reach it through an
-  // ``every`` test, which an empty list passes.
-  if (names.length !== calls.length || names.length === 0) {
-    return calls.length > 1
-      ? `Reading ${calls.length} skills`
-      : "Reading a skill";
-  }
-  if (calls.length === 1) {
-    const path = args[0]?.file_path;
-    return path
-      ? `Reading skill ${names[0]} · ${lastPathSegment(path)}`
-      : `Reading skill ${names[0]}`;
-  }
-  return `Reading skills ${names.join(", ")}`;
-}
 
-/**
- * Header label for a single-tool iteration. Most tools surface a
- * short detail (path basename, query, URL) so the header reads
- * "Read · landing.html". Tools whose detail is structurally noisy —
- * shell commands, arbitrary code blocks, raw memory keys — drop the
- * detail entirely and use a generic verb instead; the full detail
- * still appears in the expanded body via _toolRowLabel.
- */
-function deriveSingleToolLabel(tc: ToolCallInfo): string {
-  const name = cancelledToolLabel(tc.toolName);
-  if (_HEADER_HIDES_DETAIL.has(tc.toolName)) {
-    return _HEADER_GENERIC_VERB[tc.toolName] ?? name;
-  }
-  const detail = extractToolDetail(tc);
-  return detail ? `${name} · ${detail}` : name;
-}
 
-const _HEADER_HIDES_DETAIL: ReadonlySet<string> = new Set([
-  "terminal",
-  "execute_code",
-  "memory",
-]);
-
-const _HEADER_GENERIC_VERB: Record<string, string> = {
-  terminal: "Ran a command",
-  execute_code: "Executed code",
-  memory: "Updated memory",
-};
-
-/**
- * Pull a short, human-readable detail string from a tool call's
- * arguments. Defensive against unparseable / partial JSON during
- * streaming.
- */
-function extractToolDetail(tc: ToolCallInfo): string | null {
-  const args = parseArgs<Record<string, unknown>>(tc.args);
-  if (!args) return null;
-  // Prefer the most-meaningful arg per tool family.
-  const stringArg = (key: string): string | null => {
-    const v = args[key];
-    return typeof v === "string" && v.length > 0 ? v : null;
-  };
-  switch (tc.toolName) {
-    case "read_file":
-    case "write_file":
-    case "patch":
-    case "list_files":
-    case "search_files": {
-      const path = stringArg("path") ?? stringArg("file_path");
-      return path ? lastPathSegment(path) : null;
-    }
-    case "terminal": {
-      const cmd = stringArg("command");
-      return cmd ? truncate(cmd, 40) : null;
-    }
-    case "execute_code": {
-      const code = stringArg("code");
-      return code ? truncate(code.split("\n")[0] ?? "", 40) : null;
-    }
-    case "web_search":
-    case "web_crawl":
-      return stringArg("query");
-    case "web_extract": {
-      const url = stringArg("url");
-      if (!url) return null;
-      // Hostname is much more readable in a one-line chip than the
-      // full URL; falls back to the raw value for unparseable inputs
-      // (file://, data:, etc.).
-      try {
-        return new URL(url).hostname.replace(/^www\./, "");
-      } catch {
-        return truncate(url, 40);
-      }
-    }
-    case "skill_view":
-    case "skill_manage":
-      return stringArg("name") ?? stringArg("skill");
-    case "create_artifact":
-    case "consult_expert":
-    case "delegate_task":
-      return stringArg("name") ?? stringArg("task") ?? stringArg("title");
-    case "run_coding_agent":
-    case "code_run": {
-      const prompt = stringArg("prompt");
-      return prompt ? truncate(prompt, 60) : null;
-    }
-    case "idea_tree":
-      // The action ("add", "view", "report", …) is the meaningful verb;
-      // the header reads "Idea tree · report".
-      return stringArg("action");
-    case "dispatch_experiments": {
-      const keys = args.node_keys;
-      if (Array.isArray(keys) && keys.length > 0) {
-        return truncate(keys.map((k) => String(k)).join(", "), 40);
-      }
-      return stringArg("action");
-    }
-    case "merge_experiment":
-      return stringArg("node_key") ?? stringArg("action");
-    case "memory":
-      return stringArg("action") ?? stringArg("key");
-    case "research_memory": {
-      // ``add`` carries url+title; ``retrieve`` carries query; ``list``
-      // carries nothing useful.  The Simple-mode row prefers a human
-      // anchor over the raw action verb.
-      const action = stringArg("action");
-      if (action === "add") {
-        const title = stringArg("title");
-        if (title) return truncate(title, 60);
-        const url = stringArg("url");
-        if (url) {
-          try {
-            return new URL(url).hostname.replace(/^www\./, "");
-          } catch {
-            return truncate(url, 40);
-          }
-        }
-        return null;
-      }
-      if (action === "retrieve") {
-        return stringArg("query");
-      }
-      return action;
-    }
-    case "research_outline": {
-      const action = stringArg("action");
-      if (action === "set") {
-        // Count level-2+ markdown headings in the outline so the row
-        // surfaces "set outline (10 sections)" rather than the bare
-        // tool name.  Mirrors ``outline_sections`` on the Python side.
-        const outline = stringArg("outline");
-        if (outline) {
-          const sections = outline
-            .split(/\r?\n/)
-            .filter((line) => /^#{2,6}\s+\S/.test(line)).length;
-          if (sections > 0) {
-            return `${sections} ${sections === 1 ? "section" : "sections"}`;
-          }
-        }
-        return "outline";
-      }
-      return action;
-    }
-    default:
-      return null;
-  }
-}
-
-function lastPathSegment(path: string): string {
-  const cleaned = path.replace(/\/+$/, "");
-  const idx = cleaned.lastIndexOf("/");
-  return idx >= 0 ? cleaned.slice(idx + 1) : cleaned;
-}
-
-function truncate(s: string, max: number): string {
-  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
-}
 
 /**
  * Tools that are hidden from Simple mode. These are either pure
@@ -1432,108 +1205,6 @@ function _toolRowIcon(toolName: string): LucideIcon {
   return _TOOL_ROW_ICON[toolName] ?? WrenchIcon;
 }
 
-/**
- * Verb-first prose line for a tool call ("Edited landing.html",
- * "Read the frontend-design skill"). Falls back to the human tool
- * name when we can't extract a useful detail from the args.
- */
-function _toolRowLabel(tc: ToolCallInfo): string {
-  const detail = extractToolDetail(tc);
-  switch (tc.toolName) {
-    case "read_file":
-      return detail ? `Read ${detail}` : "Read a file";
-    case "write_file":
-      return detail ? `Wrote ${detail}` : "Wrote a file";
-    case "patch":
-      return detail ? `Edited ${detail}` : "Edited a file";
-    case "list_files":
-      return detail ? `Listed ${detail}` : "Listed files";
-    case "search_files":
-      return detail ? `Searched files for "${detail}"` : "Searched files";
-    case "terminal":
-      // Raw shell commands carry too much noise (paths, escapes,
-      // chained pipes) to read well even as a body row. The Expert
-      // view has the full block with output if the user needs it.
-      return "Ran a command";
-    case "execute_code":
-      return "Executed code";
-    case "web_search":
-      return detail ? `Searched the web for "${detail}"` : "Searched the web";
-    case "web_crawl":
-      return detail ? `Crawled "${detail}"` : "Crawled the web";
-    case "web_extract":
-      return detail ? `Fetched ${detail}` : "Fetched a page";
-    case "session_search":
-      return detail ? `Searched session for "${detail}"` : "Searched session";
-    case "skill_view":
-      return skillViewLabel([tc]);
-    case "skills_list":
-      return "Listed available skills";
-    case "skill_manage":
-      return detail ? `Updated skill ${detail}` : "Managed skills";
-    case "consult_expert":
-      return detail ? `Consulted ${detail} expert` : "Consulted an expert";
-    case "delegate_task":
-      return detail ? `Delegated: ${detail}` : "Delegated a task";
-    case "create_artifact":
-      return detail ? `Created artifact "${detail}"` : "Created an artifact";
-    case "memory":
-      return detail ? `Memory ${detail}` : "Updated memory";
-    case "todo":
-      return detail ? `Todo ${detail}` : "Updated todo list";
-    case "run_coding_agent":
-    case "code_run": {
-      const a = parseArgs<{ agent?: string; provider?: string }>(tc.args);
-      const agent =
-        a?.agent ??
-        (a?.provider === "openai"
-          ? "codex"
-          : a?.provider === "anthropic"
-            ? "claude"
-            : undefined);
-      const name =
-        agent === "codex"
-          ? "Codex"
-          : agent === "claude"
-            ? "Claude Code"
-            : "coding agent";
-      return detail ? `${name}: ${detail}` : `Ran ${name}`;
-    }
-    case "research_memory": {
-      // ``detail`` already encodes the action's anchor (title /
-      // hostname for add, query for retrieve, raw verb otherwise);
-      // wrap it in the verb-first prose the rest of the row family
-      // uses.
-      const args = parseArgs<{ action?: string }>(tc.args);
-      const action = args?.action;
-      if (action === "add") {
-        return detail ? `Stored source "${detail}"` : "Stored a source";
-      }
-      if (action === "retrieve") {
-        return detail
-          ? `Retrieved sources for "${detail}"`
-          : "Retrieved sources";
-      }
-      if (action === "list") {
-        return "Listed sources";
-      }
-      return "Updated research memory";
-    }
-    case "research_outline": {
-      const args = parseArgs<{ action?: string }>(tc.args);
-      const action = args?.action;
-      if (action === "set") {
-        return detail ? `Updated outline (${detail})` : "Updated outline";
-      }
-      if (action === "get") {
-        return "Read outline";
-      }
-      return "Touched outline";
-    }
-    default:
-      return cancelledToolLabel(tc.toolName);
-  }
-}
 
 interface SimpleDetailRowProps {
   icon: LucideIcon;
@@ -1668,7 +1339,7 @@ function IterationExpanded({
         }
         return (
           <SimpleDetailRow key={tc.id} icon={_toolRowIcon(tc.toolName)}>
-            <span>{_toolRowLabel(tc)}</span>
+            <span>{toolRowLabel(tc)}</span>
           </SimpleDetailRow>
         );
       })}

--- a/sdk/agent-chat-react/src/components/chat/simple-labels.ts
+++ b/sdk/agent-chat-react/src/components/chat/simple-labels.ts
@@ -16,6 +16,19 @@ import { formatMcpToolLabel } from "../../lib/format";
 import { parseArgs } from "./tools/shared";
 import type { ToolCallInfo } from "../../types";
 
+/**
+ * A tool argument, only if the model actually sent a non-empty string.
+ *
+ * ``parseArgs`` is a ``JSON.parse`` behind an unchecked generic, so
+ * every field can arrive as any type — or half-written, mid-stream.
+ * Nothing here may throw: the SDK has no ErrorBoundary, so one bad row
+ * unmounts the whole thread.
+ */
+function stringField(args: Record<string, unknown> | null, key: string): string | null {
+  const value = args?.[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
 export function cancelledToolLabel(toolName: string): string {
   const map: Record<string, string> = {
     terminal: "Command",
@@ -70,12 +83,10 @@ export function cancelledToolLabel(toolName: string): string {
  * shimmer so the row never renames itself as the iteration completes.
  */
 export function skillViewLabel(calls: ToolCallInfo[]): string {
-  const args = calls.map((tc) =>
-    parseArgs<{ name?: string; skill?: string; file_path?: string }>(tc.args),
-  );
+  const args = calls.map((tc) => parseArgs<Record<string, unknown>>(tc.args));
   const names = args
-    .map((a) => a?.name ?? a?.skill)
-    .filter((name): name is string => typeof name === "string" && name !== "");
+    .map((a) => stringField(a, "name") ?? stringField(a, "skill"))
+    .filter((name): name is string => name !== null);
   // Args stream in a character at a time, so a call can be mid-flight
   // with no parseable name yet; fall back to a countable phrasing
   // rather than rendering a half-written name. ``names.length === 0``
@@ -87,7 +98,7 @@ export function skillViewLabel(calls: ToolCallInfo[]): string {
       : "Reading a skill";
   }
   if (calls.length === 1) {
-    const path = args[0]?.file_path;
+    const path = stringField(args[0] ?? null, "file_path");
     return path
       ? `Reading skill ${names[0]} · ${lastPathSegment(path)}`
       : `Reading skill ${names[0]}`;
@@ -133,10 +144,7 @@ export function extractToolDetail(tc: ToolCallInfo): string | null {
   const args = parseArgs<Record<string, unknown>>(tc.args);
   if (!args) return null;
   // Prefer the most-meaningful arg per tool family.
-  const stringArg = (key: string): string | null => {
-    const v = args[key];
-    return typeof v === "string" && v.length > 0 ? v : null;
-  };
+  const stringArg = (key: string): string | null => stringField(args, key);
   switch (tc.toolName) {
     case "read_file":
     case "write_file":
@@ -278,9 +286,11 @@ export function toolRowLabel(tc: ToolCallInfo): string {
       if (!detail) return "Searched files";
       // ``target`` picks the axis: file *contents* (the default) or
       // file *names*. Naming the wrong one misreports what the agent
-      // actually looked at.
-      const target = parseArgs<{ target?: string }>(tc.args)?.target;
-      return target === "files"
+      // actually looked at. The server accepts "find"/"grep" as legacy
+      // aliases and maps them before searching, so the raw argument the
+      // model emitted can carry either spelling.
+      const target = stringField(parseArgs(tc.args), "target");
+      return target === "files" || target === "find"
         ? `Looked for files named "${detail}"`
         : `Searched files for "${detail}"`;
     }

--- a/sdk/agent-chat-react/src/components/chat/simple-labels.ts
+++ b/sdk/agent-chat-react/src/components/chat/simple-labels.ts
@@ -1,0 +1,371 @@
+// Copyright (c) 2026, Invergent SA, developed by Flavius Burca
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// The Simple-mode label vocabulary: pure functions that turn a tool
+// call into the words a user reads.
+//
+// Simple mode draws a tool call as prose ("Edited landing.html",
+// "Reading skill copywriting") rather than as the per-tool blocks the
+// Expert view uses, so every tool needs an entry here. The vocabulary
+// is deliberately complete — it covers tools that
+// SIMPLE_MODE_HIDDEN_TOOLS currently filters out of the view too,
+// because that policy changes (``skill_view`` moved across it) and an
+// entry that was never exercised is an entry that was never right.
+
+import { formatMcpToolLabel } from "../../lib/format";
+import { parseArgs } from "./tools/shared";
+import type { ToolCallInfo } from "../../types";
+
+export function cancelledToolLabel(toolName: string): string {
+  const map: Record<string, string> = {
+    terminal: "Command",
+    execute_code: "Execute code",
+    read_file: "Read",
+    write_file: "Write",
+    patch: "Patch",
+    search_files: "Search files",
+    list_files: "List files",
+    web_search: "Web search",
+    web_extract: "Web fetch",
+    web_crawl: "Web crawl",
+    session_search: "Session search",
+    memory: "Memory",
+    todo: "Todo",
+    skills_list: "Skills",
+    skill_view: "Skill",
+    consult_expert: "Expert",
+    delegate_task: "Delegate task",
+    ask_user_question: "Ask User Question",
+    process: "Process",
+    create_artifact: "Create artifact",
+    run_coding_agent: "Coding agent",
+    code_run: "Coding agent",
+    // ``Research memory`` reads as a noun ("memory of research") and
+    // makes the shimmer awkward ("Running Research memory…").  The
+    // one-liner renderer shows just ``Research`` as the label, so
+    // mirror that here so the live shimmer matches the row that
+    // replaces it on completion.
+    research_memory: "Research",
+    research_outline: "Research",
+    generate_image: "image generation",
+    generate_video: "video generation",
+    // Arbor research-mission tools (the /auto-research coordinator loop).
+    idea_tree: "Idea tree",
+    dispatch_experiments: "Dispatch experiments",
+    merge_experiment: "Merge experiment",
+
+  };
+  if (map[toolName]) return map[toolName];
+  // MCP tools arrive as `mcp__{server}__{tool}`; show a clean label rather
+  // than the raw prefixed name (matches the Expert-mode MCP renderer).
+  if (toolName.startsWith("mcp__")) return formatMcpToolLabel(toolName);
+  return toolName;
+}
+
+/**
+ * Label for one or more ``skill_view`` calls — see
+ * SIMPLE_MODE_HIDDEN_TOOLS for why skill loads get a deterministic row.
+ *
+ * Shared by the collapsed header, the expanded body row and the live
+ * shimmer so the row never renames itself as the iteration completes.
+ */
+export function skillViewLabel(calls: ToolCallInfo[]): string {
+  const args = calls.map((tc) =>
+    parseArgs<{ name?: string; skill?: string; file_path?: string }>(tc.args),
+  );
+  const names = args
+    .map((a) => a?.name ?? a?.skill)
+    .filter((name): name is string => typeof name === "string" && name !== "");
+  // Args stream in a character at a time, so a call can be mid-flight
+  // with no parseable name yet; fall back to a countable phrasing
+  // rather than rendering a half-written name. ``names.length === 0``
+  // also keeps the function total: callers reach it through an
+  // ``every`` test, which an empty list passes.
+  if (names.length !== calls.length || names.length === 0) {
+    return calls.length > 1
+      ? `Reading ${calls.length} skills`
+      : "Reading a skill";
+  }
+  if (calls.length === 1) {
+    const path = args[0]?.file_path;
+    return path
+      ? `Reading skill ${names[0]} · ${lastPathSegment(path)}`
+      : `Reading skill ${names[0]}`;
+  }
+  return `Reading skills ${names.join(", ")}`;
+}
+
+/**
+ * Header label for a single-tool iteration. Most tools surface a
+ * short detail (path basename, query, URL) so the header reads
+ * "Read · landing.html". Tools whose detail is structurally noisy —
+ * shell commands, arbitrary code blocks, raw memory keys — drop the
+ * detail entirely and use a generic verb instead; the full detail
+ * still appears in the expanded body via toolRowLabel.
+ */
+export function deriveSingleToolLabel(tc: ToolCallInfo): string {
+  const name = cancelledToolLabel(tc.toolName);
+  if (_HEADER_HIDES_DETAIL.has(tc.toolName)) {
+    return _HEADER_GENERIC_VERB[tc.toolName] ?? name;
+  }
+  const detail = extractToolDetail(tc);
+  return detail ? `${name} · ${detail}` : name;
+}
+
+const _HEADER_HIDES_DETAIL: ReadonlySet<string> = new Set([
+  "terminal",
+  "execute_code",
+  "memory",
+]);
+
+const _HEADER_GENERIC_VERB: Record<string, string> = {
+  terminal: "Ran a command",
+  execute_code: "Executed code",
+  memory: "Updated memory",
+};
+
+/**
+ * Pull a short, human-readable detail string from a tool call's
+ * arguments. Defensive against unparseable / partial JSON during
+ * streaming.
+ */
+export function extractToolDetail(tc: ToolCallInfo): string | null {
+  const args = parseArgs<Record<string, unknown>>(tc.args);
+  if (!args) return null;
+  // Prefer the most-meaningful arg per tool family.
+  const stringArg = (key: string): string | null => {
+    const v = args[key];
+    return typeof v === "string" && v.length > 0 ? v : null;
+  };
+  switch (tc.toolName) {
+    case "read_file":
+    case "write_file":
+    case "patch":
+    case "list_files": {
+      const path = stringArg("path") ?? stringArg("file_path");
+      return path ? lastPathSegment(path) : null;
+    }
+    // ``pattern`` is the query; ``path`` is the optional root to search
+    // under. Reading ``path`` here labelled the search *directory* as
+    // the query, and dropped the label entirely for the common
+    // whole-workspace search that omits it.
+    case "search_files":
+      return stringArg("pattern") ?? stringArg("query");
+    case "terminal": {
+      const cmd = stringArg("command");
+      return cmd ? truncate(cmd, 40) : null;
+    }
+    case "execute_code": {
+      const code = stringArg("code");
+      return code ? truncate(code.split("\n")[0] ?? "", 40) : null;
+    }
+    case "web_search":
+    case "web_crawl":
+      return stringArg("query");
+    case "web_extract": {
+      const url = stringArg("url");
+      if (!url) return null;
+      // Hostname is much more readable in a one-line chip than the
+      // full URL; falls back to the raw value for unparseable inputs
+      // (file://, data:, etc.).
+      try {
+        return new URL(url).hostname.replace(/^www\./, "");
+      } catch {
+        return truncate(url, 40);
+      }
+    }
+    case "skill_view":
+    case "skill_manage":
+      return stringArg("name") ?? stringArg("skill");
+    case "create_artifact":
+    case "consult_expert":
+    case "delegate_task":
+      return stringArg("name") ?? stringArg("task") ?? stringArg("title");
+    case "run_coding_agent":
+    case "code_run": {
+      const prompt = stringArg("prompt");
+      return prompt ? truncate(prompt, 60) : null;
+    }
+    case "idea_tree":
+      // The action ("add", "view", "report", …) is the meaningful verb;
+      // the header reads "Idea tree · report".
+      return stringArg("action");
+    case "dispatch_experiments": {
+      const keys = args.node_keys;
+      if (Array.isArray(keys) && keys.length > 0) {
+        return truncate(keys.map((k) => String(k)).join(", "), 40);
+      }
+      return stringArg("action");
+    }
+    case "merge_experiment":
+      return stringArg("node_key") ?? stringArg("action");
+    case "memory":
+      return stringArg("action") ?? stringArg("key");
+    case "research_memory": {
+      // ``add`` carries url+title; ``retrieve`` carries query; ``list``
+      // carries nothing useful.  The Simple-mode row prefers a human
+      // anchor over the raw action verb.
+      const action = stringArg("action");
+      if (action === "add") {
+        const title = stringArg("title");
+        if (title) return truncate(title, 60);
+        const url = stringArg("url");
+        if (url) {
+          try {
+            return new URL(url).hostname.replace(/^www\./, "");
+          } catch {
+            return truncate(url, 40);
+          }
+        }
+        return null;
+      }
+      if (action === "retrieve") {
+        return stringArg("query");
+      }
+      return action;
+    }
+    case "research_outline": {
+      const action = stringArg("action");
+      if (action === "set") {
+        // Count level-2+ markdown headings in the outline so the row
+        // surfaces "set outline (10 sections)" rather than the bare
+        // tool name.  Mirrors ``outline_sections`` on the Python side.
+        const outline = stringArg("outline");
+        if (outline) {
+          const sections = outline
+            .split(/\r?\n/)
+            .filter((line) => /^#{2,6}\s+\S/.test(line)).length;
+          if (sections > 0) {
+            return `${sections} ${sections === 1 ? "section" : "sections"}`;
+          }
+        }
+        return "outline";
+      }
+      return action;
+    }
+    default:
+      return null;
+  }
+}
+
+function lastPathSegment(path: string): string {
+  const cleaned = path.replace(/\/+$/, "");
+  const idx = cleaned.lastIndexOf("/");
+  return idx >= 0 ? cleaned.slice(idx + 1) : cleaned;
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
+/**
+ * Verb-first prose line for a tool call ("Edited landing.html",
+ * "Read the frontend-design skill"). Falls back to the human tool
+ * name when we can't extract a useful detail from the args.
+ */
+export function toolRowLabel(tc: ToolCallInfo): string {
+  const detail = extractToolDetail(tc);
+  switch (tc.toolName) {
+    case "read_file":
+      return detail ? `Read ${detail}` : "Read a file";
+    case "write_file":
+      return detail ? `Wrote ${detail}` : "Wrote a file";
+    case "patch":
+      return detail ? `Edited ${detail}` : "Edited a file";
+    case "list_files":
+      return detail ? `Listed ${detail}` : "Listed files";
+    case "search_files": {
+      if (!detail) return "Searched files";
+      // ``target`` picks the axis: file *contents* (the default) or
+      // file *names*. Naming the wrong one misreports what the agent
+      // actually looked at.
+      const target = parseArgs<{ target?: string }>(tc.args)?.target;
+      return target === "files"
+        ? `Looked for files named "${detail}"`
+        : `Searched files for "${detail}"`;
+    }
+    case "terminal":
+      // Raw shell commands carry too much noise (paths, escapes,
+      // chained pipes) to read well even as a body row. The Expert
+      // view has the full block with output if the user needs it.
+      return "Ran a command";
+    case "execute_code":
+      return "Executed code";
+    case "web_search":
+      return detail ? `Searched the web for "${detail}"` : "Searched the web";
+    case "web_crawl":
+      return detail ? `Crawled "${detail}"` : "Crawled the web";
+    case "web_extract":
+      return detail ? `Fetched ${detail}` : "Fetched a page";
+    case "session_search":
+      return detail ? `Searched session for "${detail}"` : "Searched session";
+    case "skill_view":
+      return skillViewLabel([tc]);
+    case "skills_list":
+      return "Listed available skills";
+    case "skill_manage":
+      return detail ? `Updated skill ${detail}` : "Managed skills";
+    case "consult_expert":
+      return detail ? `Consulted ${detail} expert` : "Consulted an expert";
+    case "delegate_task":
+      return detail ? `Delegated: ${detail}` : "Delegated a task";
+    case "create_artifact":
+      return detail ? `Created artifact "${detail}"` : "Created an artifact";
+    case "memory":
+      return detail ? `Memory ${detail}` : "Updated memory";
+    case "todo":
+      return detail ? `Todo ${detail}` : "Updated todo list";
+    case "run_coding_agent":
+    case "code_run": {
+      const a = parseArgs<{ agent?: string; provider?: string }>(tc.args);
+      const agent =
+        a?.agent ??
+        (a?.provider === "openai"
+          ? "codex"
+          : a?.provider === "anthropic"
+            ? "claude"
+            : undefined);
+      const name =
+        agent === "codex"
+          ? "Codex"
+          : agent === "claude"
+            ? "Claude Code"
+            : "coding agent";
+      return detail ? `${name}: ${detail}` : `Ran ${name}`;
+    }
+    case "research_memory": {
+      // ``detail`` already encodes the action's anchor (title /
+      // hostname for add, query for retrieve, raw verb otherwise);
+      // wrap it in the verb-first prose the rest of the row family
+      // uses.
+      const args = parseArgs<{ action?: string }>(tc.args);
+      const action = args?.action;
+      if (action === "add") {
+        return detail ? `Stored source "${detail}"` : "Stored a source";
+      }
+      if (action === "retrieve") {
+        return detail
+          ? `Retrieved sources for "${detail}"`
+          : "Retrieved sources";
+      }
+      if (action === "list") {
+        return "Listed sources";
+      }
+      return "Updated research memory";
+    }
+    case "research_outline": {
+      const args = parseArgs<{ action?: string }>(tc.args);
+      const action = args?.action;
+      if (action === "set") {
+        return detail ? `Updated outline (${detail})` : "Updated outline";
+      }
+      if (action === "get") {
+        return "Read outline";
+      }
+      return "Touched outline";
+    }
+    default:
+      return cancelledToolLabel(tc.toolName);
+  }
+}
+

--- a/sdk/agent-chat-react/src/components/chat/simple-labels.ts
+++ b/sdk/agent-chat-react/src/components/chat/simple-labels.ts
@@ -378,4 +378,3 @@ export function toolRowLabel(tc: ToolCallInfo): string {
       return cancelledToolLabel(tc.toolName);
   }
 }
-

--- a/sdk/agent-chat-react/src/runtime/orb-state.ts
+++ b/sdk/agent-chat-react/src/runtime/orb-state.ts
@@ -48,6 +48,8 @@ const TOOL_ORB_STATES: Readonly<Record<string, OrbState>> = {
   kb_read_page: "searching",
   search_files: "searching",
   list_files: "searching",
+  skill_view: "searching",
+  skills_list: "searching",
   research_memory: "searching",
   fetch_channel_messages: "searching",
   fetch_channel_file: "searching",

--- a/sdk/agent-chat-react/src/runtime/simple-mode.ts
+++ b/sdk/agent-chat-react/src/runtime/simple-mode.ts
@@ -9,12 +9,15 @@
 import type { AgentChatToolCallInfo } from "../types";
 import type { OrbDerivationOptions } from "./orb-state";
 
+// ``skill_view`` is deliberately absent: a skill load is the agent
+// reaching for its own instructions, and naming the skill tells the
+// user more about the turn than any prose summary of the same call
+// could. It renders as a deterministic "Reading skill <name>" row.
 export const SIMPLE_MODE_HIDDEN_TOOLS: ReadonlySet<string> = new Set([
   "list_files",
   "search_files",
   "session_search",
   "skills_list",
-  "skill_view",
   "skill_manage",
   "process",
   "memory",

--- a/sdk/agent-chat-react/src/runtime/simple-mode.ts
+++ b/sdk/agent-chat-react/src/runtime/simple-mode.ts
@@ -13,9 +13,10 @@ import type { OrbDerivationOptions } from "./orb-state";
 // reaching for its own instructions, so naming the skill tells the
 // user more about the turn than any prose summary of the same call
 // could — it renders as a deterministic "Reading skill <name>" row
-// built by ``skillViewLabel`` in chat-thread.tsx. The harness knows
-// the same thing and skips the model caption for those iterations
-// (``_is_self_describing_iteration`` in harness/turn_summarizer.py).
+// built by ``skillViewLabel`` in ../components/chat/simple-labels.ts.
+// The harness knows the same thing and skips the model caption for
+// those iterations (``_is_self_describing_iteration`` in
+// harness/turn_summarizer.py).
 export const SIMPLE_MODE_HIDDEN_TOOLS: ReadonlySet<string> = new Set([
   "list_files",
   "search_files",

--- a/sdk/agent-chat-react/src/runtime/simple-mode.ts
+++ b/sdk/agent-chat-react/src/runtime/simple-mode.ts
@@ -9,10 +9,13 @@
 import type { AgentChatToolCallInfo } from "../types";
 import type { OrbDerivationOptions } from "./orb-state";
 
-// ``skill_view`` is deliberately absent: a skill load is the agent
-// reaching for its own instructions, and naming the skill tells the
+// ``skill_view`` is deliberately absent. A skill load is the agent
+// reaching for its own instructions, so naming the skill tells the
 // user more about the turn than any prose summary of the same call
-// could. It renders as a deterministic "Reading skill <name>" row.
+// could — it renders as a deterministic "Reading skill <name>" row
+// built by ``skillViewLabel`` in chat-thread.tsx. The harness knows
+// the same thing and skips the model caption for those iterations
+// (``_is_self_describing_iteration`` in harness/turn_summarizer.py).
 export const SIMPLE_MODE_HIDDEN_TOOLS: ReadonlySet<string> = new Set([
   "list_files",
   "search_files",

--- a/sdk/agent-chat-react/tests/iteration-group.test.tsx
+++ b/sdk/agent-chat-react/tests/iteration-group.test.tsx
@@ -529,6 +529,165 @@ describe("IterationGroup", () => {
     expect(dom.textContent).not.toContain("Done");
   });
 
+  // ── skill_view: a deterministic row, never a model caption ──────
+  //
+  // A skill load is the agent reaching for its own instructions, so
+  // the skill's name is the whole story of the iteration. The harness
+  // deliberately emits no summary for these iterations; the label is
+  // derived from the args so it is instant, free and never wrong.
+
+  it("labels a completed skill_view with the skill name", () => {
+    const message = buildMessage({
+      turnId: "t-1",
+      iterationIndex: 0,
+      toolCalls: [
+        {
+          id: "c1",
+          toolName: "skill_view",
+          args: '{"name":"copywriting"}',
+          status: "complete",
+        },
+      ],
+    });
+    const dom = mount(
+      <IterationGroup
+        message={message}
+        sessionId="s-1"
+        artifactFallbacks={{}}
+      />,
+    );
+    expect(dom.textContent).toContain("Reading skill copywriting");
+  });
+
+  it("appends the file when skill_view opens a linked skill file", () => {
+    const message = buildMessage({
+      turnId: "t-1",
+      iterationIndex: 0,
+      toolCalls: [
+        {
+          id: "c1",
+          toolName: "skill_view",
+          args: '{"name":"copywriting","file_path":"reference/tone.md"}',
+          status: "complete",
+        },
+      ],
+    });
+    const dom = mount(
+      <IterationGroup
+        message={message}
+        sessionId="s-1"
+        artifactFallbacks={{}}
+      />,
+    );
+    expect(dom.textContent).toContain("Reading skill copywriting · tone.md");
+  });
+
+  it("names every skill when one iteration loads several", () => {
+    const message = buildMessage({
+      turnId: "t-1",
+      iterationIndex: 0,
+      toolCalls: [
+        {
+          id: "c1",
+          toolName: "skill_view",
+          args: '{"name":"copywriting"}',
+          status: "complete",
+        },
+        {
+          id: "c2",
+          toolName: "skill_view",
+          args: '{"name":"social"}',
+          status: "complete",
+        },
+      ],
+    });
+    const dom = mount(
+      <IterationGroup
+        message={message}
+        sessionId="s-1"
+        artifactFallbacks={{}}
+      />,
+    );
+    expect(dom.textContent).toContain("Reading skills copywriting, social");
+  });
+
+  it("falls back to a countable label when the skill name is unparseable", () => {
+    // Args stream in a character at a time; a half-written name must
+    // never reach the row.
+    const message = buildMessage({
+      turnId: "t-1",
+      iterationIndex: 0,
+      toolCalls: [
+        { id: "c1", toolName: "skill_view", args: '{"na', status: "complete" },
+      ],
+    });
+    const dom = mount(
+      <IterationGroup
+        message={message}
+        sessionId="s-1"
+        artifactFallbacks={{}}
+      />,
+    );
+    expect(dom.textContent).toContain("Reading a skill");
+  });
+
+  it("uses the same wording for the live shimmer as for the finished row", () => {
+    const message = buildMessage({
+      turnId: "t-1",
+      iterationIndex: 0,
+      status: "streaming",
+      toolCalls: [
+        {
+          id: "c1",
+          toolName: "skill_view",
+          args: '{"name":"copywriting"}',
+          status: "running",
+        },
+      ],
+    });
+    const dom = mount(
+      <IterationGroup
+        message={message}
+        sessionId="s-1"
+        artifactFallbacks={{}}
+      />,
+    );
+    // "Reading skill copywriting…" while live, "Reading skill
+    // copywriting" once done — the row must not rename itself.
+    expect(dom.textContent).toContain("Reading skill copywriting");
+    expect(dom.textContent).not.toContain("Running Skill");
+  });
+
+  it("keeps skill_view out of a mixed batch's generic label", () => {
+    // skill_view is visible now, so a mixed batch counts it.
+    const message = buildMessage({
+      turnId: "t-1",
+      iterationIndex: 0,
+      toolCalls: [
+        {
+          id: "c1",
+          toolName: "skill_view",
+          args: '{"name":"copywriting"}',
+          status: "complete",
+        },
+        {
+          id: "c2",
+          toolName: "web_search",
+          args: '{"query":"dashboards"}',
+          status: "complete",
+        },
+      ],
+    });
+    const dom = mount(
+      <IterationGroup
+        message={message}
+        sessionId="s-1"
+        artifactFallbacks={{}}
+      />,
+    );
+    expect(dom.textContent).toContain("Used 2 tools");
+  });
+
   it("renders nothing when complete, no summary, no tools, no reasoning", () => {
     // Empty iteration — nothing to derive. The surrounding
     // SimpleAssistantGroup still renders any final text + the

--- a/sdk/agent-chat-react/tests/orb-state.test.ts
+++ b/sdk/agent-chat-react/tests/orb-state.test.ts
@@ -62,6 +62,8 @@ describe("toolOrbState", () => {
       "search_files",
       "list_files",
       "research_memory",
+      "skill_view",
+      "skills_list",
     ]) {
       expect(toolOrbState(name)).toBe("searching");
     }

--- a/sdk/agent-chat-react/tests/simple-labels.test.ts
+++ b/sdk/agent-chat-react/tests/simple-labels.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The Simple-mode label vocabulary.
+ *
+ * These are the words a user actually reads for a tool call, and they
+ * are derived from the call's arguments alone — no model involved. The
+ * vocabulary covers tools that SIMPLE_MODE_HIDDEN_TOOLS currently
+ * filters out of the view as well, because that policy moves
+ * (``skill_view`` crossed it) and an entry nobody exercised is an entry
+ * nobody checked.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  extractToolDetail,
+  toolRowLabel,
+} from "../src/components/chat/simple-labels";
+import type { ToolCallInfo } from "../src/types";
+
+function call(toolName: string, args: unknown): ToolCallInfo {
+  return { id: "c1", toolName, args: JSON.stringify(args), status: "complete" };
+}
+
+describe("search_files", () => {
+  // ``pattern`` is the query; ``path`` is the optional root to search
+  // under. Reading ``path`` labelled the search *directory* as the
+  // query, and dropped the label entirely for the whole-workspace
+  // search that omits it — which is the common case.
+  it("takes the query from pattern, not path", () => {
+    expect(
+      extractToolDetail(call("search_files", { pattern: "product-marketing" })),
+    ).toBe("product-marketing");
+  });
+
+  it("keeps the query when a search root is also given", () => {
+    expect(
+      extractToolDetail(
+        call("search_files", { pattern: "invoice", path: "src/billing" }),
+      ),
+    ).toBe("invoice");
+  });
+
+  it("names a content search", () => {
+    expect(toolRowLabel(call("search_files", { pattern: "invoice" }))).toBe(
+      'Searched files for "invoice"',
+    );
+  });
+
+  it("names a filename search differently", () => {
+    // target=files matches names, not contents; calling that "searched
+    // files for X" misreports what the agent looked at.
+    expect(
+      toolRowLabel(call("search_files", { pattern: "*.py", target: "files" })),
+    ).toBe('Looked for files named "*.py"');
+  });
+
+  it("falls back when the pattern has not streamed in yet", () => {
+    expect(toolRowLabel(call("search_files", {}))).toBe("Searched files");
+  });
+});
+
+describe("the rest of the vocabulary still reads correctly", () => {
+  it("labels path-based tools by their basename", () => {
+    expect(toolRowLabel(call("patch", { path: "src/app/landing.html" }))).toBe(
+      "Edited landing.html",
+    );
+    expect(toolRowLabel(call("list_files", { path: "src/lib" }))).toBe(
+      "Listed lib",
+    );
+  });
+
+  it("labels a skill load by its skill", () => {
+    expect(toolRowLabel(call("skill_view", { name: "copywriting" }))).toBe(
+      "Reading skill copywriting",
+    );
+  });
+
+  it("drops structurally noisy detail from shell and code tools", () => {
+    expect(toolRowLabel(call("terminal", { command: "rm -rf ./tmp" }))).toBe(
+      "Ran a command",
+    );
+  });
+});

--- a/sdk/agent-chat-react/tests/simple-labels.test.ts
+++ b/sdk/agent-chat-react/tests/simple-labels.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   extractToolDetail,
+  skillViewLabel,
   toolRowLabel,
 } from "../src/components/chat/simple-labels";
 import type { ToolCallInfo } from "../src/types";
@@ -78,5 +79,42 @@ describe("the rest of the vocabulary still reads correctly", () => {
     expect(toolRowLabel(call("terminal", { command: "rm -rf ./tmp" }))).toBe(
       "Ran a command",
     );
+  });
+});
+
+describe("arguments are model output, not a contract", () => {
+  // parseArgs is a JSON.parse behind an unchecked generic, so any field
+  // can arrive as any type. A label helper must never throw: there is
+  // no ErrorBoundary in the SDK, so one bad row unmounts the thread.
+  it("survives a non-string file_path", () => {
+    expect(
+      skillViewLabel([call("skill_view", { name: "x", file_path: ["a"] })]),
+    ).toBe("Reading skill x");
+  });
+
+  it("survives a non-string pattern", () => {
+    expect(extractToolDetail(call("search_files", { pattern: 42 }))).toBe(null);
+  });
+
+  it("survives a non-string path", () => {
+    expect(toolRowLabel(call("patch", { path: { nested: true } }))).toBe(
+      "Edited a file",
+    );
+  });
+});
+
+describe("legacy target aliases", () => {
+  // The server maps {grep: content, find: files} before running the
+  // search, so the raw argument the model emitted can be either name.
+  it("treats target=find as a filename search", () => {
+    expect(
+      toolRowLabel(call("search_files", { pattern: "*.py", target: "find" })),
+    ).toBe('Looked for files named "*.py"');
+  });
+
+  it("treats target=grep as a content search", () => {
+    expect(
+      toolRowLabel(call("search_files", { pattern: "invoice", target: "grep" })),
+    ).toBe('Searched files for "invoice"');
   });
 });

--- a/sdk/agent-chat-react/tests/simple-mode-hidden-tools.test.ts
+++ b/sdk/agent-chat-react/tests/simple-mode-hidden-tools.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Simple mode's hidden-tool policy.
+ *
+ * The set is the single source of truth shared by the thread's labels,
+ * the expanded body rows and the orb-state derivation, so a change here
+ * silently changes three surfaces at once. These assertions pin the
+ * membership decisions that carry a rationale.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  SIMPLE_MODE_HIDDEN_TOOLS,
+  isHiddenSimpleTool,
+} from "../src/runtime/simple-mode";
+import type { AgentChatToolCallInfo } from "../src/types";
+
+function call(toolName: string): AgentChatToolCallInfo {
+  return { id: "c1", toolName, args: "{}", status: "complete" };
+}
+
+describe("SIMPLE_MODE_HIDDEN_TOOLS", () => {
+  it("keeps skill_view visible", () => {
+    // A skill load is the agent reaching for its own instructions —
+    // naming the skill tells the user more about the turn than any
+    // prose summary of the same call. It renders as a deterministic
+    // "Reading skill <name>" row instead of being suppressed.
+    expect(SIMPLE_MODE_HIDDEN_TOOLS.has("skill_view")).toBe(false);
+    expect(isHiddenSimpleTool(call("skill_view"))).toBe(false);
+  });
+
+  it("still hides pure exploration and infrastructure plumbing", () => {
+    for (const name of [
+      "list_files",
+      "search_files",
+      "session_search",
+      "skills_list",
+      "skill_manage",
+      "process",
+      "memory",
+      "terminal",
+      "execute_code",
+    ]) {
+      expect(isHiddenSimpleTool(call(name))).toBe(true);
+    }
+  });
+
+  it("hides every browser_* tool by prefix", () => {
+    expect(isHiddenSimpleTool(call("browser_click"))).toBe(true);
+    expect(isHiddenSimpleTool(call("browser_navigate"))).toBe(true);
+  });
+
+  it("shows user-facing tools", () => {
+    for (const name of [
+      "web_search",
+      "write_file",
+      "patch",
+      "todo",
+      "create_artifact",
+      "consult_expert",
+      "ask_user_question",
+    ]) {
+      expect(isHiddenSimpleTool(call(name))).toBe(false);
+    }
+  });
+});

--- a/sdk/agent-chat-react/tests/simple-mode-hidden-tools.test.ts
+++ b/sdk/agent-chat-react/tests/simple-mode-hidden-tools.test.ts
@@ -8,10 +8,7 @@
  */
 import { describe, expect, it } from "vitest";
 
-import {
-  SIMPLE_MODE_HIDDEN_TOOLS,
-  isHiddenSimpleTool,
-} from "../src/runtime/simple-mode";
+import { isHiddenSimpleTool } from "../src/runtime/simple-mode";
 import type { AgentChatToolCallInfo } from "../src/types";
 
 function call(toolName: string): AgentChatToolCallInfo {
@@ -20,11 +17,9 @@ function call(toolName: string): AgentChatToolCallInfo {
 
 describe("SIMPLE_MODE_HIDDEN_TOOLS", () => {
   it("keeps skill_view visible", () => {
-    // A skill load is the agent reaching for its own instructions —
-    // naming the skill tells the user more about the turn than any
-    // prose summary of the same call. It renders as a deterministic
-    // "Reading skill <name>" row instead of being suppressed.
-    expect(SIMPLE_MODE_HIDDEN_TOOLS.has("skill_view")).toBe(false);
+    // The decision this branch makes: a skill load renders as a
+    // deterministic "Reading skill <name>" row instead of being
+    // suppressed as internal plumbing.
     expect(isHiddenSimpleTool(call("skill_view"))).toBe(false);
   });
 
@@ -47,19 +42,5 @@ describe("SIMPLE_MODE_HIDDEN_TOOLS", () => {
   it("hides every browser_* tool by prefix", () => {
     expect(isHiddenSimpleTool(call("browser_click"))).toBe(true);
     expect(isHiddenSimpleTool(call("browser_navigate"))).toBe(true);
-  });
-
-  it("shows user-facing tools", () => {
-    for (const name of [
-      "web_search",
-      "write_file",
-      "patch",
-      "todo",
-      "create_artifact",
-      "consult_expert",
-      "ask_user_question",
-    ]) {
-      expect(isHiddenSimpleTool(call(name))).toBe(false);
-    }
   });
 });

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -39,6 +39,7 @@ from surogates.harness.llm_call import apply_developer_role, call_llm_with_retry
 from surogates.harness.message_utils import (
     coerce_message_content,
     make_skipped_tool_result,
+    message_texts,
 )
 from surogates.harness.prompt_cache import SystemPromptCache, mark_prefix_cacheable
 from surogates.harness.rate_limit_guard import ProviderRateLimitGuard
@@ -3444,21 +3445,7 @@ class AgentHarness(
 
     @staticmethod
     def _extract_chat_message_content(response: Any) -> str:
-        choice = response.choices[0]
-        message = choice.message
-        if isinstance(message, dict):
-            return str(
-                message.get("content")
-                or message.get("reasoning_content")
-                or message.get("reasoning")
-                or ""
-            )
-        return str(
-            getattr(message, "content", None)
-            or getattr(message, "reasoning_content", None)
-            or getattr(message, "reasoning", None)
-            or ""
-        )
+        return next(iter(message_texts(response.choices[0].message)), "")
 
     @staticmethod
     def _parse_json_object(content: str) -> dict[str, Any]:

--- a/surogates/harness/loop_mission_evaluator.py
+++ b/surogates/harness/loop_mission_evaluator.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from surogates.harness.message_utils import message_texts
 from surogates.harness.structured_output import generate_structured, parse_json_object
 from surogates.session.events import EventType
 
@@ -325,20 +326,7 @@ def _build_mission_judge(
             raise MissionJudgeParseError(
                 f"judge returned an unexpected shape: {exc}",
             ) from exc
-        if isinstance(message, dict):
-            raw = (
-                message.get("content")
-                or message.get("reasoning_content")
-                or message.get("reasoning")
-                or ""
-            )
-        else:
-            raw = (
-                getattr(message, "content", None)
-                or getattr(message, "reasoning_content", None)
-                or getattr(message, "reasoning", None)
-                or ""
-            )
+        raw = next(iter(message_texts(message)), "")
         if not raw or not str(raw).strip():
             raise MissionJudgeParseError("judge returned empty content")
         try:

--- a/surogates/harness/message_utils.py
+++ b/surogates/harness/message_utils.py
@@ -9,9 +9,35 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterator
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+def message_texts(message: Any) -> Iterator[str]:
+    """Non-empty reply-text channels of ``message``, in preference order.
+
+    Providers disagree about which field carries the answer.
+    OpenAI-style gateways use ``content``; reasoning models (DeepSeek-R1,
+    Qwen3 with thinking, GLM) can spend the token budget thinking and
+    leave ``content`` empty with the answer in ``reasoning_content``;
+    OpenRouter surfaces the same thing as ``reasoning``. The SDK hands
+    some callers an object and some a plain dict.
+
+    Yields rather than returning the first hit so a caller looking for
+    structure (rather than prose) can keep scanning: a chatty
+    ``content`` must not hide an answer sitting in a later channel.
+    Callers that just want text take the first.
+    """
+    for key in ("content", "reasoning_content", "reasoning"):
+        value = (
+            message.get(key)
+            if isinstance(message, dict)
+            else getattr(message, key, None)
+        )
+        if isinstance(value, str) and value.strip():
+            yield value
 
 
 def message_to_dict(message: Any) -> dict:

--- a/surogates/harness/structured_output.py
+++ b/surogates/harness/structured_output.py
@@ -9,6 +9,8 @@ from typing import Any, TypeVar
 
 from pydantic import BaseModel
 
+from surogates.harness.message_utils import message_texts
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
@@ -210,23 +212,16 @@ async def _try_openai_json_mode(
         return None
     message = getattr(response.choices[0], "message", None)
 
-    # Reasoning-mode models (DeepSeek-R1, Qwen3 with thinking on, GLM 5.1
-    # with enable_thinking=True) often put visible text in
-    # ``message.content`` and the JSON we asked for in
-    # ``message.reasoning_content`` -- empty content alone isn't a failure
-    # if the JSON is sitting in the reasoning channel.  Both channels are
-    # tried, and within each, every embedded object -- leaked reasoning
-    # can contain draft objects before the real answer, and the schema
-    # is the only reliable way to tell them apart.
-    for attr in ("content", "reasoning_content"):
-        for parsed in iter_json_objects(getattr(message, attr, None)):
+    # Every reply channel is tried (see ``message_texts``), and within
+    # each, every embedded object -- leaked reasoning can contain draft
+    # objects before the real answer, and the schema is the only
+    # reliable way to tell them apart.
+    for text in message_texts(message):
+        for parsed in iter_json_objects(text):
             try:
                 return output_model.model_validate(parsed)
             except Exception as exc:
-                logger.debug(
-                    "JSON-mode fallback validation failed on %s: %s",
-                    attr, exc,
-                )
+                logger.debug("JSON-mode fallback validation failed: %s", exc)
     return None
 
 

--- a/surogates/harness/turn_summarizer.py
+++ b/surogates/harness/turn_summarizer.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -172,6 +173,26 @@ def _all_self_describing(tool_calls: list[dict[str, Any]]) -> bool:
     return True
 
 
+# The prompt forbids a narrator opener and the model uses one anyway in
+# 6.6% of replies. Both observed forms are followed by a past-tense verb
+# ("The agent reviewed…", "Agent found…"), never by a noun, so the
+# prefix strips cleanly.
+_NARRATOR_OPENER_RE = re.compile(r"^(?:the\s+)?agent\s+", re.IGNORECASE)
+
+
+def _normalize_caption(text: str) -> str:
+    """Drop the narrator prefix so the row reads as a caption.
+
+    "The agent reviewed the rubric" → "Reviewed the rubric". The row
+    already sits under the agent's own turn; naming it again is noise
+    that costs a third of the line's visible width.
+    """
+    stripped = _NARRATOR_OPENER_RE.sub("", text, count=1)
+    if stripped == text or not stripped:
+        return text
+    return stripped[0].upper() + stripped[1:]
+
+
 def _valid_iteration_summary(text: str) -> bool:
     """True when ``text`` is a usable one-line caption.
 
@@ -302,7 +323,7 @@ class TurnSummarizer:
         )
         if content is None:
             return None
-        text = content.strip().strip('"').rstrip(".")
+        text = _normalize_caption(content.strip().strip('"').rstrip("."))
         if not _valid_iteration_summary(text):
             logger.warning(
                 "discarding malformed iteration summary for %s: %r",

--- a/surogates/harness/turn_summarizer.py
+++ b/surogates/harness/turn_summarizer.py
@@ -119,17 +119,6 @@ _TURN_PROMPT = (
 _VALID_KINDS: frozenset[str] = frozenset({"file", "artifact"})
 
 
-# ``skill_view`` is the one tool whose arguments fully describe the
-# iteration: chat clients render it as "Reading skill <name>", which is
-# faster, free and never wrong. Summarizing such an iteration spends a
-# model call to produce a worse row, and lets a stray reply override the
-# client's own presentation of the tool.
-#
-# The other discovery tools stay summarized. Clients hide *those* from
-# the condensed view, so with no summary the iteration has nothing left
-# to draw — the caption is the only thing standing between the user and
-# a silent gap.
-_CLIENT_RENDERED_TOOLS: frozenset[str] = frozenset({"skill_view"})
 
 # Openers that mark the summary model role-playing the agent instead of
 # captioning it ("I'll load the skill…", "Let me check…"). Matched
@@ -149,50 +138,34 @@ _MARKUP_LEAK_MARKERS: tuple[str, ...] = (
 )
 
 
-def _echoes_transcript(lowered: str) -> bool:
-    """True when the reply repeats the transcript it was handed.
-
-    Matched on co-occurring field markers rather than on ``call:`` or
-    ``result:`` alone, because those words turn up in ordinary captions
-    ("Search returns no result: falls back to pypdf") while no caption
-    ever pairs ``tool=`` with ``args=``.
-    """
-    if lowered.startswith(("call:", "tools called", "[1] tool=")):
-        return True
-    if "tool=" in lowered and "args=" in lowered:
-        return True
-    return "call:" in lowered and "result:" in lowered
-
-# A caption is one short line. Anything appreciably longer is the model
-# dumping the transcript back rather than summarizing it; the render
-# surface truncates past this anyway, so a long reply is never shown in
-# full.
-_MAX_SUMMARY_WORDS: int = 30
-
-
-def _client_renders_iteration(
+def _is_self_describing_iteration(
     tool_calls: list[dict[str, Any]],
     tool_results: list[dict[str, Any]],
 ) -> bool:
-    """True when the client can label this iteration without a model.
+    """True when the iteration's arguments already say everything.
 
-    Every call must be client-rendered *and* have succeeded. A failed
-    call is dropped from the client's condensed view, so skipping the
-    caption for one would erase the iteration outright and the user
-    would never learn the call failed — the iteration prompt asks for
-    the opposite ("if a call failed, say so").
+    A successful ``skill_view`` is the only such iteration: its whole
+    content is *which skill was loaded*, which the arguments state
+    exactly. A caption can only restate that, less reliably, for the
+    price of a model call.
 
-    An empty batch is never client-rendered: a text-only iteration has
-    no tool calls to draw and still needs a caption. Neither is a batch
-    whose results were not captured, since success cannot be confirmed.
+    The qualifiers all guard against a caption that would have carried
+    real information:
+
+    * an empty batch is a text-only iteration — nothing to restate;
+    * uncaptured results cannot be confirmed successful;
+    * a *failed* load is news, and consumers that drop errored calls
+      would otherwise show nothing at all. The prompt asks for exactly
+      this ("if a call failed, say so").
     """
     if not tool_calls or not tool_results:
         return False
-    for tc in tool_calls:
-        fn = tc.get("function") or {}
-        name = fn.get("name") or tc.get("name") or ""
-        if name not in _CLIENT_RENDERED_TOOLS:
-            return False
+    names = {
+        (tc.get("function") or {}).get("name") or tc.get("name")
+        for tc in tool_calls
+    }
+    if names != {"skill_view"}:
+        return False
     return not any(_is_error_result(tr) for tr in tool_results)
 
 
@@ -211,9 +184,9 @@ def _normalize_caption(text: str) -> str:
     that costs a third of the line's visible width.
     """
     stripped = _NARRATOR_OPENER_RE.sub("", text, count=1)
-    if stripped == text or not stripped:
+    if stripped == text:
         return text
-    return stripped[0].upper() + stripped[1:]
+    return stripped[:1].upper() + stripped[1:]
 
 
 def _valid_iteration_summary(text: str) -> bool:
@@ -237,7 +210,15 @@ def _valid_iteration_summary(text: str) -> bool:
     # Typographic apostrophes are normalized so a curly "I\u2019ll load the
     # skill" is caught by the same openers as the ASCII form.
     lowered = text.lower().replace("\u2019", "'")
-    if _echoes_transcript(lowered):
+    # The reply repeating the transcript it was handed. Keyed on
+    # co-occurring field markers, because ``call:`` and ``result:`` turn
+    # up in ordinary captions ("Search returns no result: falls back to
+    # pypdf") while no caption ever pairs ``tool=`` with ``args=``.
+    if (
+        ("tool=" in lowered and "args=" in lowered)
+        or ("call:" in lowered and "result:" in lowered)
+        or lowered.startswith(("call:", "tools called"))
+    ):
         return False
     if any(marker in lowered for marker in _MARKUP_LEAK_MARKERS):
         return False
@@ -249,7 +230,10 @@ def _valid_iteration_summary(text: str) -> bool:
         return False
     if lowered.startswith(_ROLE_PLAY_OPENERS):
         return False
-    if len(text.split()) > _MAX_SUMMARY_WORDS:
+    # A caption is one short line. Anything appreciably longer is the
+    # model dumping the transcript back rather than summarizing it, and
+    # the render surface truncates past this regardless.
+    if len(text.split()) > 30:
         return False
     return True
 
@@ -310,11 +294,7 @@ class TurnSummarizer:
             return None
         if not reasoning and not tool_calls:
             return None
-        # A skill load is labelled better, and for free, by the
-        # client's deterministic renderer. Skipping the call here also
-        # stops a stray model reply from overriding the client's
-        # presentation of that tool.
-        if _client_renders_iteration(tool_calls, tool_results or []):
+        if _is_self_describing_iteration(tool_calls, tool_results or []):
             return None
 
         tool_lines = self._format_tool_calls(tool_calls, tool_results or [])
@@ -494,7 +474,7 @@ class TurnSummarizer:
                         parts.append(p["text"])
                 results_by_id[call_id] = "\n".join(parts)
         out: list[str] = []
-        for tc in tool_calls:
+        for index, tc in enumerate(tool_calls, 1):
             fn = tc.get("function") or {}
             name = fn.get("name") or tc.get("name") or "?"
             args = fn.get("arguments") or tc.get("arguments") or ""
@@ -508,7 +488,7 @@ class TurnSummarizer:
             # a transcript line must not read like a plausible caption,
             # or the model completes the list instead of summarizing it.
             out.append(
-                f"[{len(out) + 1}] tool={name} args={args_snippet}\n"
+                f"[{index}] tool={name} args={args_snippet}\n"
                 f"    returned: {result_snippet}"
             )
         return out

--- a/surogates/harness/turn_summarizer.py
+++ b/surogates/harness/turn_summarizer.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from surogates.harness.streaming_executor import _is_error_result
+from surogates.harness.message_utils import message_texts
 from surogates.harness.structured_output import (
     iter_json_objects,
     parse_json_object,
@@ -182,33 +183,34 @@ def _is_self_describing_iteration(
 _NARRATOR_OPENER_RE = re.compile(r"^(?:the\s+)?agent\s+", re.IGNORECASE)
 
 
+def _rejects_response_format(exc: BaseException) -> bool:
+    """True when the provider refused the request, not the network.
+
+    Only a 4xx that is not a rate limit means *this request* was
+    malformed for *this provider* — and ``response_format`` is the only
+    thing about it that varies by provider. A dropped connection, a
+    timeout or a 5xx is transient, and latching on one of those would
+    let a single blip degrade the rest of the session's captions to
+    unvalidated prose.
+    """
+    status = getattr(exc, "status_code", None)
+    if not isinstance(status, int):
+        status = getattr(exc, "status", None)
+    return isinstance(status, int) and 400 <= status < 500 and status != 429
+
+
 def _extract_caption(content: str) -> str:
     """Pull the caption out of the model's reply.
 
-    The call asks for ``{"caption": str}`` under ``response_format``,
-    which is what makes most of the structural failures impossible: a
-    reply constrained to an object cannot *be* an echoed transcript
-    line, a bullet list or a markup dump.
+    Returns raw text rather than ``None`` on a miss: a gateway that
+    ignores ``response_format`` answers in prose, and captions
+    degrading to unvalidated prose is recoverable where every caption
+    on that deployment vanishing is not.
 
-    Gateways vary in how well they honour that, so all three shapes
-    resolve here. A conforming one returns the bare object; one that
-    ignores the constraint returns it fenced or wrapped in prose, which
-    ``parse_json_object`` already handles; one that ignores it outright
-    returns plain prose, which is used as-is. That last path is why
-    this returns text rather than ``None`` on a parse miss — captions
-    degrading to unvalidated prose is recoverable, every caption on the
-    deployment vanishing is not.
-
-    Every embedded object is scanned, not just the first: leaked
-    reasoning restates the tool arguments as an object before the real
-    answer, and stopping at the first would drop the caption and send
-    the whole reply down the prose path — where a single-line echo
-    passes validation and becomes the label.
-
-    An object *without* a usable caption field is not treated as prose:
-    the most common such reply is the echoed tool result, and its raw
-    body must never become the label. Returning it unchanged lets the
-    validator reject it on its leading brace.
+    An object *without* a usable caption field is deliberately not
+    treated as prose. The most common such reply is the echoed tool
+    result, and its raw body must never become the label — returning it
+    unchanged lets the validator reject it on its leading brace.
     """
     for parsed in iter_json_objects(content):
         caption = parsed.get("caption")
@@ -315,7 +317,7 @@ class TurnSummarizer:
         self._base_model = base_model
         self._summary_client = summary_client
         self._summary_model = summary_model
-        # Cleared for the process the first time a provider rejects
+        # Cleared the first time this summarizer's provider rejects
         # ``response_format``; see :meth:`summarize_iteration`.
         self._iteration_json_mode = True
 
@@ -367,7 +369,8 @@ class TurnSummarizer:
         }
 
         label = f"iteration {iteration_id}"
-        if self._iteration_json_mode:
+        json_mode = self._iteration_json_mode
+        if json_mode:
             kwargs["response_format"] = {"type": "json_object"}
         try:
             content = await self._chat_completion(
@@ -375,16 +378,27 @@ class TurnSummarizer:
                 kwargs,
                 label=label,
                 timeout=_ITERATION_SUMMARY_TIMEOUT_SECONDS,
-                reraise=self._iteration_json_mode,
+                reraise=json_mode,
             )
-        except Exception:
+        except Exception as exc:
+            if not _rejects_response_format(exc):
+                return None
             # ``response_format`` is a request, not a guarantee, and the
             # summary slot is configured separately from the base model
             # that has always used it. A provider that rejects the
-            # parameter would otherwise silence every caption on the
-            # deployment — worse than an unvalidated one — so drop the
-            # constraint for the rest of the process and retry once.
-            # Plain prose still goes through the validator.
+            # parameter would otherwise silence every caption it serves
+            # — worse than an unvalidated one — so drop the constraint
+            # and retry once. Plain prose still goes through the
+            # validator.
+            #
+            # The latch is per-summarizer, which is per-session: the
+            # summary endpoint is resolved per tenant
+            # (build_summary_auxiliary_llm reads org overrides), so a
+            # process-wide latch would let one tenant's gateway disable
+            # JSON mode for every other tenant. If this is ever seen
+            # firing per-session in volume, the endpoint-keyed home for
+            # it is AuxiliaryLLM, which is shared by every auxiliary
+            # caller of the same provider.
             logger.warning(
                 "summary provider rejected response_format; "
                 "falling back to plain-text captions",
@@ -528,18 +542,7 @@ class TurnSummarizer:
             logger.warning("summary response had unexpected shape for %s", label)
             return None
 
-        content = getattr(message, "content", None)
-        if isinstance(content, str) and content.strip():
-            return content
-        # Reasoning-mode models (DeepSeek-R1, Qwen3 with thinking, GLM)
-        # spend the budget thinking and leave ``content`` empty with the
-        # answer in ``reasoning_content``; an empty content channel
-        # alone is not a failure. Same reason structured_output's
-        # JSON-mode fallback reads both.
-        reasoning = getattr(message, "reasoning_content", None)
-        if isinstance(reasoning, str) and reasoning.strip():
-            return reasoning
-        return None
+        return next(iter(message_texts(message)), None)
 
     @staticmethod
     def _format_tool_calls(

--- a/surogates/harness/turn_summarizer.py
+++ b/surogates/harness/turn_summarizer.py
@@ -37,7 +37,10 @@ logger = logging.getLogger(__name__)
 _ITERATION_SUMMARY_TIMEOUT_SECONDS: float = 10.0
 _TURN_SUMMARY_TIMEOUT_SECONDS: float = 30.0
 
-_MAX_ITERATION_SUMMARY_TOKENS: int = 64
+# The ``{"caption": …}`` wrapper costs tokens the caption used to have
+# to itself, and a reply truncated mid-object parses to nothing at all
+# where a truncated string was still usable.
+_MAX_ITERATION_SUMMARY_TOKENS: int = 96
 _MAX_TURN_SUMMARY_TOKENS: int = 512
 
 TurnArtifactKind = Literal["file", "artifact"]
@@ -79,9 +82,9 @@ _ITERATION_PROMPT = (
     "end, no leading 'The agent', max 12 words.\n"
     "You are an observer writing a caption, not the agent. Never "
     "continue the agent's work, never speak as the agent ('I will…', "
-    "'Let me…'), and never call a tool. Reply with the caption text "
-    "alone: one line, no newlines, no bullet points, no JSON, no "
-    "markup, and never repeat the transcript lines you were given."
+    "'Let me…'), and never call a tool, and never repeat the "
+    "transcript lines you were given.\n"
+    'Return ONLY a JSON object: {"caption": "<the one line>"}.'
 )
 
 _TURN_PROMPT = (
@@ -174,6 +177,36 @@ def _is_self_describing_iteration(
 # ("The agent reviewed…", "Agent found…"), never by a noun, so the
 # prefix strips cleanly.
 _NARRATOR_OPENER_RE = re.compile(r"^(?:the\s+)?agent\s+", re.IGNORECASE)
+
+
+def _extract_caption(content: str) -> str:
+    """Pull the caption out of the model's reply.
+
+    The call asks for ``{"caption": str}`` under ``response_format``,
+    which is what makes most of the structural failures impossible: a
+    reply constrained to an object cannot *be* an echoed transcript
+    line, a bullet list or a markup dump.
+
+    Gateways vary in how well they honour that, so all three shapes
+    resolve here. A conforming one returns the bare object; one that
+    ignores the constraint returns it fenced or wrapped in prose, which
+    ``parse_json_object`` already handles; one that ignores it outright
+    returns plain prose, which is used as-is. That last path is why
+    this returns text rather than ``None`` on a parse miss — captions
+    degrading to unvalidated prose is recoverable, every caption on the
+    deployment vanishing is not.
+
+    An object *without* a usable caption field is not treated as prose:
+    the most common such reply is the echoed tool result, and its raw
+    body must never become the label. Returning it unchanged lets the
+    validator reject it on its leading brace.
+    """
+    parsed = parse_json_object(content)
+    if isinstance(parsed, dict):
+        caption = parsed.get("caption")
+        if isinstance(caption, str) and caption.strip():
+            return caption
+    return content
 
 
 def _normalize_caption(text: str) -> str:
@@ -320,6 +353,7 @@ class TurnSummarizer:
             "max_tokens": _MAX_ITERATION_SUMMARY_TOKENS,
             "temperature": 0.2,
             "stream": False,
+            "response_format": {"type": "json_object"},
         }
 
         content = await self._chat_completion(
@@ -330,7 +364,8 @@ class TurnSummarizer:
         )
         if content is None:
             return None
-        text = _normalize_caption(content.strip().strip('"').rstrip("."))
+        caption = _extract_caption(content)
+        text = _normalize_caption(caption.strip().strip('"').rstrip("."))
         if not _valid_iteration_summary(text):
             logger.warning(
                 "discarding malformed iteration summary for %s: %r",

--- a/surogates/harness/turn_summarizer.py
+++ b/surogates/harness/turn_summarizer.py
@@ -27,6 +27,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from surogates.harness.streaming_executor import _is_error_result
 from surogates.harness.structured_output import parse_json_object
 
 logger = logging.getLogger(__name__)
@@ -118,18 +119,17 @@ _TURN_PROMPT = (
 _VALID_KINDS: frozenset[str] = frozenset({"file", "artifact"})
 
 
-# Tools whose arguments alone fully describe what happened. The chat
-# clients render these deterministically ("Reading skill copywriting"),
-# which is faster, free, and never wrong — so an iteration built only
-# from them gets no LLM summary at all. Emitting one would spend a
-# model call to produce a worse label, and would override the client's
-# own presentation policy for these tools.
-_SELF_DESCRIBING_TOOLS: frozenset[str] = frozenset({
-    "skill_view",
-    "skills_list",
-    "list_files",
-    "search_files",
-})
+# ``skill_view`` is the one tool whose arguments fully describe the
+# iteration: chat clients render it as "Reading skill <name>", which is
+# faster, free and never wrong. Summarizing such an iteration spends a
+# model call to produce a worse row, and lets a stray reply override the
+# client's own presentation of the tool.
+#
+# The other discovery tools stay summarized. Clients hide *those* from
+# the condensed view, so with no summary the iteration has nothing left
+# to draw — the caption is the only thing standing between the user and
+# a silent gap.
+_CLIENT_RENDERED_TOOLS: frozenset[str] = frozenset({"skill_view"})
 
 # Openers that mark the summary model role-playing the agent instead of
 # captioning it ("I'll load the skill…", "Let me check…"). Matched
@@ -137,18 +137,31 @@ _SELF_DESCRIBING_TOOLS: frozenset[str] = frozenset({
 _ROLE_PLAY_OPENERS: tuple[str, ...] = (
     "i'll ", "i will ", "i am ", "i'm ", "i need ", "i should ",
     "i can ", "i cannot ", "i've ", "i have ", "let me ", "let's ",
-    "based on ", "first, ", "next, ", "now ",
+    "based on ", "first, ", "next, ",
 )
 
-# Fragments that only ever appear when the reply leaks structure rather
-# than prose: the transcript scaffolding fed in as input, or a model's
-# native tool-call markup surfacing as literal text. ``｜`` (U+FF5C) is
-# the DeepSeek delimiter; ``<tool_call``/``<invoke``/``<function`` cover
-# the XML-style dialects.
-_STRUCTURAL_LEAK_MARKERS: tuple[str, ...] = (
-    "call:", "result:", "tools called", "<tool_call", "<invoke",
-    "<function", "\uff5c", "```",
+# Markup that only ever appears when a model's native tool-call syntax
+# surfaces as literal text instead of being parsed. ``｜`` (U+FF5C) is
+# the DeepSeek delimiter; the angle-bracket forms cover the XML-style
+# dialects; a fence means the reply is a code block, not a caption.
+_MARKUP_LEAK_MARKERS: tuple[str, ...] = (
+    "<tool_call", "<invoke", "<function", "\uff5c", "```",
 )
+
+
+def _echoes_transcript(lowered: str) -> bool:
+    """True when the reply repeats the transcript it was handed.
+
+    Matched on co-occurring field markers rather than on ``call:`` or
+    ``result:`` alone, because those words turn up in ordinary captions
+    ("Search returns no result: falls back to pypdf") while no caption
+    ever pairs ``tool=`` with ``args=``.
+    """
+    if lowered.startswith(("call:", "tools called", "[1] tool=")):
+        return True
+    if "tool=" in lowered and "args=" in lowered:
+        return True
+    return "call:" in lowered and "result:" in lowered
 
 # A caption is one short line. Anything appreciably longer is the model
 # dumping the transcript back rather than summarizing it; the render
@@ -157,20 +170,30 @@ _STRUCTURAL_LEAK_MARKERS: tuple[str, ...] = (
 _MAX_SUMMARY_WORDS: int = 30
 
 
-def _all_self_describing(tool_calls: list[dict[str, Any]]) -> bool:
-    """True when every call in the batch is client-renderable on its own.
+def _client_renders_iteration(
+    tool_calls: list[dict[str, Any]],
+    tool_results: list[dict[str, Any]],
+) -> bool:
+    """True when the client can label this iteration without a model.
 
-    An empty batch is *not* self-describing: a text-only iteration has
-    no tool calls to render and still needs a summary.
+    Every call must be client-rendered *and* have succeeded. A failed
+    call is dropped from the client's condensed view, so skipping the
+    caption for one would erase the iteration outright and the user
+    would never learn the call failed — the iteration prompt asks for
+    the opposite ("if a call failed, say so").
+
+    An empty batch is never client-rendered: a text-only iteration has
+    no tool calls to draw and still needs a caption. Neither is a batch
+    whose results were not captured, since success cannot be confirmed.
     """
-    if not tool_calls:
+    if not tool_calls or not tool_results:
         return False
     for tc in tool_calls:
         fn = tc.get("function") or {}
         name = fn.get("name") or tc.get("name") or ""
-        if name not in _SELF_DESCRIBING_TOOLS:
+        if name not in _CLIENT_RENDERED_TOOLS:
             return False
-    return True
+    return not any(_is_error_result(tr) for tr in tool_results)
 
 
 # The prompt forbids a narrator opener and the model uses one anyway in
@@ -211,8 +234,12 @@ def _valid_iteration_summary(text: str) -> bool:
     # (transcript echo, bullet list, markup dump) is multi-line.
     if "\n" in text or "\r" in text:
         return False
-    lowered = text.lower()
-    if any(marker in lowered for marker in _STRUCTURAL_LEAK_MARKERS):
+    # Typographic apostrophes are normalized so a curly "I\u2019ll load the
+    # skill" is caught by the same openers as the ASCII form.
+    lowered = text.lower().replace("\u2019", "'")
+    if _echoes_transcript(lowered):
+        return False
+    if any(marker in lowered for marker in _MARKUP_LEAK_MARKERS):
         return False
     stripped = text.lstrip()
     # A JSON/array body, or a markdown bullet, is structure not prose.
@@ -283,11 +310,11 @@ class TurnSummarizer:
             return None
         if not reasoning and not tool_calls:
             return None
-        # Discovery-only iterations are labelled better, and for free,
-        # by the client's deterministic renderer. Skipping the call
-        # here also stops a stray model reply from overriding the
-        # client's presentation policy for those tools.
-        if _all_self_describing(tool_calls):
+        # A skill load is labelled better, and for free, by the
+        # client's deterministic renderer. Skipping the call here also
+        # stops a stray model reply from overriding the client's
+        # presentation of that tool.
+        if _client_renders_iteration(tool_calls, tool_results or []):
             return None
 
         tool_lines = self._format_tool_calls(tool_calls, tool_results or [])

--- a/surogates/harness/turn_summarizer.py
+++ b/surogates/harness/turn_summarizer.py
@@ -74,7 +74,12 @@ _ITERATION_PROMPT = (
     "do different things; distinguish them by their result. If a call "
     "failed, say so (e.g. 'Find pdftotext fails — falling back to "
     "pypdf'). Be specific and concrete. No quotes, no period at the "
-    "end, no leading 'The agent', max 12 words."
+    "end, no leading 'The agent', max 12 words.\n"
+    "You are an observer writing a caption, not the agent. Never "
+    "continue the agent's work, never speak as the agent ('I will…', "
+    "'Let me…'), and never call a tool. Reply with the caption text "
+    "alone: one line, no newlines, no bullet points, no JSON, no "
+    "markup, and never repeat the transcript lines you were given."
 )
 
 _TURN_PROMPT = (
@@ -110,6 +115,95 @@ _TURN_PROMPT = (
 
 
 _VALID_KINDS: frozenset[str] = frozenset({"file", "artifact"})
+
+
+# Tools whose arguments alone fully describe what happened. The chat
+# clients render these deterministically ("Reading skill copywriting"),
+# which is faster, free, and never wrong — so an iteration built only
+# from them gets no LLM summary at all. Emitting one would spend a
+# model call to produce a worse label, and would override the client's
+# own presentation policy for these tools.
+_SELF_DESCRIBING_TOOLS: frozenset[str] = frozenset({
+    "skill_view",
+    "skills_list",
+    "list_files",
+    "search_files",
+})
+
+# Openers that mark the summary model role-playing the agent instead of
+# captioning it ("I'll load the skill…", "Let me check…"). Matched
+# case-insensitively against the first words of the reply.
+_ROLE_PLAY_OPENERS: tuple[str, ...] = (
+    "i'll ", "i will ", "i am ", "i'm ", "i need ", "i should ",
+    "i can ", "i cannot ", "i've ", "i have ", "let me ", "let's ",
+    "based on ", "first, ", "next, ", "now ",
+)
+
+# Fragments that only ever appear when the reply leaks structure rather
+# than prose: the transcript scaffolding fed in as input, or a model's
+# native tool-call markup surfacing as literal text. ``｜`` (U+FF5C) is
+# the DeepSeek delimiter; ``<tool_call``/``<invoke``/``<function`` cover
+# the XML-style dialects.
+_STRUCTURAL_LEAK_MARKERS: tuple[str, ...] = (
+    "call:", "result:", "tools called", "<tool_call", "<invoke",
+    "<function", "\uff5c", "```",
+)
+
+# A caption is one short line. Anything appreciably longer is the model
+# dumping the transcript back rather than summarizing it; the render
+# surface truncates past this anyway, so a long reply is never shown in
+# full.
+_MAX_SUMMARY_WORDS: int = 30
+
+
+def _all_self_describing(tool_calls: list[dict[str, Any]]) -> bool:
+    """True when every call in the batch is client-renderable on its own.
+
+    An empty batch is *not* self-describing: a text-only iteration has
+    no tool calls to render and still needs a summary.
+    """
+    if not tool_calls:
+        return False
+    for tc in tool_calls:
+        fn = tc.get("function") or {}
+        name = fn.get("name") or tc.get("name") or ""
+        if name not in _SELF_DESCRIBING_TOOLS:
+            return False
+    return True
+
+
+def _valid_iteration_summary(text: str) -> bool:
+    """True when ``text`` is a usable one-line caption.
+
+    The cheap summary model periodically completes the prompt's
+    transcript instead of captioning it: it echoes the ``call: … /
+    result: …`` lines verbatim, returns the raw JSON tool result, emits
+    its own tool-call markup as literal text, or continues the turn in
+    the agent's first-person voice. All of those reach the user as the
+    iteration's visible label, so they are rejected here and the caller
+    emits no event — chat clients then fall back to their deterministic
+    tool-derived label, which is what the row should have said anyway.
+    """
+    if not text:
+        return False
+    # A caption is a single line. Every observed structural failure
+    # (transcript echo, bullet list, markup dump) is multi-line.
+    if "\n" in text or "\r" in text:
+        return False
+    lowered = text.lower()
+    if any(marker in lowered for marker in _STRUCTURAL_LEAK_MARKERS):
+        return False
+    stripped = text.lstrip()
+    # A JSON/array body, or a markdown bullet, is structure not prose.
+    if stripped[:1] in {"{", "[", "#", "|"}:
+        return False
+    if stripped[:2] in {"- ", "* ", "> "}:
+        return False
+    if lowered.startswith(_ROLE_PLAY_OPENERS):
+        return False
+    if len(text.split()) > _MAX_SUMMARY_WORDS:
+        return False
+    return True
 
 
 def _is_internal_workspace_path(path: str) -> bool:
@@ -168,6 +262,12 @@ class TurnSummarizer:
             return None
         if not reasoning and not tool_calls:
             return None
+        # Discovery-only iterations are labelled better, and for free,
+        # by the client's deterministic renderer. Skipping the call
+        # here also stops a stray model reply from overriding the
+        # client's presentation policy for those tools.
+        if _all_self_describing(tool_calls):
+            return None
 
         tool_lines = self._format_tool_calls(tool_calls, tool_results or [])
         user_block_parts: list[str] = []
@@ -203,7 +303,14 @@ class TurnSummarizer:
         if content is None:
             return None
         text = content.strip().strip('"').rstrip(".")
-        return text or None
+        if not _valid_iteration_summary(text):
+            logger.warning(
+                "discarding malformed iteration summary for %s: %r",
+                iteration_id,
+                text[:200],
+            )
+            return None
+        return text
 
     async def summarize_turn(
         self,
@@ -349,8 +456,12 @@ class TurnSummarizer:
             # Keep result snippets short — the summarizer only needs
             # enough to tell two calls apart, not the full output.
             result_snippet = result[:300] if result else "(no result captured)"
+            # Numbered and field-labelled rather than ``call: …`` —
+            # a transcript line must not read like a plausible caption,
+            # or the model completes the list instead of summarizing it.
             out.append(
-                f"call: {name}({args_snippet})\n  result: {result_snippet}"
+                f"[{len(out) + 1}] tool={name} args={args_snippet}\n"
+                f"    returned: {result_snippet}"
             )
         return out
 

--- a/surogates/harness/turn_summarizer.py
+++ b/surogates/harness/turn_summarizer.py
@@ -28,7 +28,10 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from surogates.harness.streaming_executor import _is_error_result
-from surogates.harness.structured_output import parse_json_object
+from surogates.harness.structured_output import (
+    iter_json_objects,
+    parse_json_object,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -196,13 +199,18 @@ def _extract_caption(content: str) -> str:
     degrading to unvalidated prose is recoverable, every caption on the
     deployment vanishing is not.
 
+    Every embedded object is scanned, not just the first: leaked
+    reasoning restates the tool arguments as an object before the real
+    answer, and stopping at the first would drop the caption and send
+    the whole reply down the prose path — where a single-line echo
+    passes validation and becomes the label.
+
     An object *without* a usable caption field is not treated as prose:
     the most common such reply is the echoed tool result, and its raw
     body must never become the label. Returning it unchanged lets the
     validator reject it on its leading brace.
     """
-    parsed = parse_json_object(content)
-    if isinstance(parsed, dict):
+    for parsed in iter_json_objects(content):
         caption = parsed.get("caption")
         if isinstance(caption, str) and caption.strip():
             return caption
@@ -307,6 +315,9 @@ class TurnSummarizer:
         self._base_model = base_model
         self._summary_client = summary_client
         self._summary_model = summary_model
+        # Cleared for the process the first time a provider rejects
+        # ``response_format``; see :meth:`summarize_iteration`.
+        self._iteration_json_mode = True
 
     async def summarize_iteration(
         self,
@@ -353,15 +364,39 @@ class TurnSummarizer:
             "max_tokens": _MAX_ITERATION_SUMMARY_TOKENS,
             "temperature": 0.2,
             "stream": False,
-            "response_format": {"type": "json_object"},
         }
 
-        content = await self._chat_completion(
-            self._summary_client,
-            kwargs,
-            label=f"iteration {iteration_id}",
-            timeout=_ITERATION_SUMMARY_TIMEOUT_SECONDS,
-        )
+        label = f"iteration {iteration_id}"
+        if self._iteration_json_mode:
+            kwargs["response_format"] = {"type": "json_object"}
+        try:
+            content = await self._chat_completion(
+                self._summary_client,
+                kwargs,
+                label=label,
+                timeout=_ITERATION_SUMMARY_TIMEOUT_SECONDS,
+                reraise=self._iteration_json_mode,
+            )
+        except Exception:
+            # ``response_format`` is a request, not a guarantee, and the
+            # summary slot is configured separately from the base model
+            # that has always used it. A provider that rejects the
+            # parameter would otherwise silence every caption on the
+            # deployment — worse than an unvalidated one — so drop the
+            # constraint for the rest of the process and retry once.
+            # Plain prose still goes through the validator.
+            logger.warning(
+                "summary provider rejected response_format; "
+                "falling back to plain-text captions",
+            )
+            self._iteration_json_mode = False
+            kwargs.pop("response_format", None)
+            content = await self._chat_completion(
+                self._summary_client,
+                kwargs,
+                label=label,
+                timeout=_ITERATION_SUMMARY_TIMEOUT_SECONDS,
+            )
         if content is None:
             return None
         caption = _extract_caption(content)
@@ -461,11 +496,17 @@ class TurnSummarizer:
         *,
         label: str,
         timeout: float,
+        reraise: bool = False,
     ) -> str | None:
         """Run a single chat completion under the given timeout.
 
         Returns the message content on success, ``None`` on any failure
         (timeout, network error, malformed response shape).
+
+        ``reraise`` propagates provider errors instead of swallowing
+        them, so a caller can tell a rejected request parameter from a
+        slow provider — a timeout never reraises, since retrying it
+        without the parameter would blame the wrong thing.
         """
         try:
             response = await asyncio.wait_for(
@@ -477,13 +518,28 @@ class TurnSummarizer:
             return None
         except Exception as exc:
             logger.warning("summary call failed for %s: %r", label, exc)
+            if reraise:
+                raise
             return None
 
         try:
-            return response.choices[0].message.content
+            message = response.choices[0].message
         except (AttributeError, IndexError, TypeError):
             logger.warning("summary response had unexpected shape for %s", label)
             return None
+
+        content = getattr(message, "content", None)
+        if isinstance(content, str) and content.strip():
+            return content
+        # Reasoning-mode models (DeepSeek-R1, Qwen3 with thinking, GLM)
+        # spend the budget thinking and leave ``content`` empty with the
+        # answer in ``reasoning_content``; an empty content channel
+        # alone is not a failure. Same reason structured_output's
+        # JSON-mode fallback reads both.
+        reasoning = getattr(message, "reasoning_content", None)
+        if isinstance(reasoning, str) and reasoning.strip():
+            return reasoning
+        return None
 
     @staticmethod
     def _format_tool_calls(

--- a/tests/test_message_texts.py
+++ b/tests/test_message_texts.py
@@ -1,0 +1,53 @@
+"""Reply-channel reading, shared by every caller that reads model text.
+
+Providers disagree about which field carries the answer: OpenAI-style
+gateways use ``content``, reasoning models leave that empty and put the
+answer in ``reasoning_content``, and OpenRouter uses ``reasoning``. The
+SDK hands some callers an object and some a plain dict. Four places in
+the harness were each reading this their own way; they now share one.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from surogates.harness.message_utils import message_texts
+
+
+def _msg(**fields: Any) -> Any:
+    return type("Msg", (), fields)()
+
+
+def test_content_is_preferred() -> None:
+    msg = _msg(content="answer", reasoning_content="thinking", reasoning="r")
+    assert list(message_texts(msg)) == ["answer", "thinking", "r"]
+
+
+def test_empty_content_falls_through_to_the_reasoning_channels() -> None:
+    msg = _msg(content="", reasoning_content="answer")
+    assert next(iter(message_texts(msg)), None) == "answer"
+
+
+def test_whitespace_only_channels_are_skipped() -> None:
+    msg = _msg(content="   ", reasoning_content="\n\t", reasoning="answer")
+    assert list(message_texts(msg)) == ["answer"]
+
+
+def test_openrouter_reasoning_channel() -> None:
+    assert list(message_texts(_msg(content=None, reasoning="answer"))) == ["answer"]
+
+
+def test_dict_shaped_messages() -> None:
+    msg = {"content": None, "reasoning_content": "answer"}
+    assert list(message_texts(msg)) == ["answer"]
+
+
+def test_non_string_channels_are_skipped() -> None:
+    # Tool-call replies carry a list content; it is not reply text.
+    msg = _msg(content=[{"type": "text", "text": "x"}], reasoning="answer")
+    assert list(message_texts(msg)) == ["answer"]
+
+
+def test_nothing_usable_yields_nothing() -> None:
+    assert list(message_texts(_msg(content=None))) == []
+    assert list(message_texts(None)) == []

--- a/tests/test_turn_summarizer.py
+++ b/tests/test_turn_summarizer.py
@@ -425,24 +425,34 @@ async def test_summarize_turn_returns_none_on_truncated_fenced_json() -> None:
 # ----------------------------------------------------------------------
 
 
-def _patch_call() -> list[dict[str, Any]]:
+def _calls(*names: str) -> list[dict[str, Any]]:
+    """One tool call per name, ids ``c0``, ``c1``, … to match _results."""
     return [
-        {
-            "id": "c1",
-            "function": {"name": "patch", "arguments": '{"path": "a.py"}'},
-        },
+        {"id": f"c{i}", "function": {"name": n, "arguments": '{"path": "a.py"}'}}
+        for i, n in enumerate(names)
     ]
 
 
+def _results(*contents: str) -> list[dict[str, Any]]:
+    return [
+        {"tool_call_id": f"c{i}", "content": c}
+        for i, c in enumerate(contents)
+    ]
+
+
+_OK = '{"success": true, "name": "x"}'
+
+
 async def _summarize_with(content: str) -> str | None:
+    """Run one patch iteration through the summarizer stubbed to reply."""
     client = _StubClient(content)
     summarizer = _iteration_summarizer(client)
     return await summarizer.summarize_iteration(
         iteration_id="i0",
         reasoning="",
-        tool_calls=_patch_call(),
+        tool_calls=_calls("patch"),
         prior_iteration_summaries=[],
-        tool_results=[{"tool_call_id": "c1", "content": "patched"}],
+        tool_results=_results("patched"),
     )
 
 
@@ -571,20 +581,6 @@ async def test_summarize_iteration_strips_then_validates() -> None:
 # ----------------------------------------------------------------------
 
 
-def _calls(*names: str) -> list[dict[str, Any]]:
-    return [
-        {"id": f"c{i}", "function": {"name": n, "arguments": "{}"}}
-        for i, n in enumerate(names)
-    ]
-
-
-def _ok(*ids: str) -> list[dict[str, Any]]:
-    return [
-        {"tool_call_id": i, "content": '{"success": true, "name": "x"}'}
-        for i in ids
-    ]
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("names", [("skill_view",), ("skill_view", "skill_view")])
 async def test_successful_skill_loads_skip_the_model(
@@ -598,7 +594,7 @@ async def test_successful_skill_loads_skip_the_model(
         reasoning="I should load the skill first",
         tool_calls=_calls(*names),
         prior_iteration_summaries=[],
-        tool_results=_ok(*[f"c{i}" for i in range(len(names))]),
+        tool_results=_results(*([_OK] * len(names))),
     )
 
     assert result is None
@@ -607,108 +603,53 @@ async def test_successful_skill_loads_skip_the_model(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "names",
-    [("skills_list",), ("list_files",), ("search_files",), ("session_search",)],
-)
-async def test_other_discovery_tools_are_still_summarized(
-    names: tuple[str, ...],
-) -> None:
-    # Clients hide these from the condensed view, so with no caption the
-    # iteration has nothing left to draw. Only skill_view has a
-    # deterministic row to fall back to.
-    client = _StubClient("Found three invoice templates")
-    summarizer = _iteration_summarizer(client)
-
-    result = await summarizer.summarize_iteration(
-        iteration_id="i0",
-        reasoning="",
-        tool_calls=_calls(*names),
-        prior_iteration_summaries=[],
-        tool_results=_ok("c0"),
-    )
-
-    assert result == "Found three invoice templates"
-    assert len(client.chat.completions.calls) == 1
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "failure",
+    ("label", "reasoning", "calls", "results"),
     [
-        '{"success": false, "error": "Skill \'copywritting\' not found."}',
-        '{"error": "No tenant context available"}',
+        # Consumers hide these from the condensed view, so with no
+        # caption the iteration has nothing left to draw. Only
+        # skill_view has a deterministic row to fall back to.
+        ("skills_list", "", _calls("skills_list"), _results(_OK)),
+        ("list_files", "", _calls("list_files"), _results(_OK)),
+        ("search_files", "", _calls("search_files"), _results(_OK)),
+        ("session_search", "", _calls("session_search"), _results(_OK)),
+        # One call nothing can render on its own is enough: the batch
+        # is no longer self-describing.
+        ("mixed batch", "", _calls("skill_view", "web_extract"),
+         _results(_OK, "Starter 19 EUR")),
+        # A failed load is news. Consumers drop errored calls, so
+        # skipping the caption would erase the iteration outright.
+        ("failed skill load", "", _calls("skill_view"),
+         _results('{"success": false, "error": "Skill not found."}')),
+        ("skill load with no tenant", "", _calls("skill_view"),
+         _results('{"error": "No tenant context available"}')),
+        # Success cannot be confirmed with no results in hand, so the
+        # caption is produced rather than gambled away.
+        ("skill load, results not captured", "", _calls("skill_view"), []),
+        # No tool calls at all is not self-describing — there is
+        # nothing to draw, so the reasoning still needs a caption.
+        ("text-only iteration", "Weighing whether to ship behind a flag",
+         [], []),
     ],
 )
-async def test_a_failed_skill_load_is_still_summarized(failure: str) -> None:
-    # The client drops errored calls from its condensed view, so
-    # skipping the caption here would erase the iteration outright and
-    # the user would never learn the skill load failed.
-    client = _StubClient("Skill copywritting not found")
+async def test_iterations_that_still_need_a_caption(
+    label: str,
+    reasoning: str,
+    calls: list[dict[str, Any]],
+    results: list[dict[str, Any]],
+) -> None:
+    client = _StubClient("Loaded the grading rubric")
     summarizer = _iteration_summarizer(client)
 
     result = await summarizer.summarize_iteration(
         iteration_id="i0",
-        reasoning="",
-        tool_calls=_calls("skill_view"),
+        reasoning=reasoning,
+        tool_calls=calls,
         prior_iteration_summaries=[],
-        tool_results=[{"tool_call_id": "c0", "content": failure}],
+        tool_results=results,
     )
 
-    assert result == "Skill copywritting not found"
-    assert len(client.chat.completions.calls) == 1
-
-
-@pytest.mark.asyncio
-async def test_skill_load_without_captured_results_is_summarized() -> None:
-    # Success cannot be confirmed with no results in hand, so the
-    # caption is produced rather than gambled away.
-    client = _StubClient("Loaded the copywriting skill")
-    summarizer = _iteration_summarizer(client)
-
-    result = await summarizer.summarize_iteration(
-        iteration_id="i0",
-        reasoning="",
-        tool_calls=_calls("skill_view"),
-        prior_iteration_summaries=[],
-    )
-
-    assert result == "Loaded the copywriting skill"
-
-
-@pytest.mark.asyncio
-async def test_mixed_batch_still_summarizes() -> None:
-    # One call the client cannot render is enough: it cannot label the
-    # batch on its own, so the caption still earns its model call.
-    client = _StubClient("Fetch the pricing page after loading the skill")
-    summarizer = _iteration_summarizer(client)
-
-    result = await summarizer.summarize_iteration(
-        iteration_id="i0",
-        reasoning="",
-        tool_calls=_calls("skill_view", "web_extract"),
-        prior_iteration_summaries=[],
-        tool_results=_ok("c0", "c1"),
-    )
-
-    assert result == "Fetch the pricing page after loading the skill"
-    assert len(client.chat.completions.calls) == 1
-
-
-@pytest.mark.asyncio
-async def test_text_only_iteration_still_summarizes() -> None:
-    # No tool calls at all is not client-rendered — there is nothing for
-    # the client to draw, so the reasoning still needs a caption.
-    client = _StubClient("Weigh two rollout options")
-    summarizer = _iteration_summarizer(client)
-
-    result = await summarizer.summarize_iteration(
-        iteration_id="i0",
-        reasoning="Considering whether to ship behind a flag",
-        tool_calls=[],
-        prior_iteration_summaries=[],
-    )
-
-    assert result == "Weigh two rollout options"
+    assert result == "Loaded the grading rubric", label
+    assert len(client.chat.completions.calls) == 1, label
 
 
 @pytest.mark.asyncio
@@ -722,9 +663,9 @@ async def test_transcript_lines_are_not_caption_shaped() -> None:
     await summarizer.summarize_iteration(
         iteration_id="i0",
         reasoning="",
-        tool_calls=_patch_call(),
+        tool_calls=_calls("patch"),
         prior_iteration_summaries=[],
-        tool_results=[{"tool_call_id": "c1", "content": "patched"}],
+        tool_results=_results("patched"),
     )
 
     user_block = client.chat.completions.calls[0]["messages"][1]["content"]

--- a/tests/test_turn_summarizer.py
+++ b/tests/test_turn_summarizer.py
@@ -511,6 +511,26 @@ async def _summarize_with(content: str) -> str | None:
             "transcript dumped past the word cap",
             " ".join(f"word{i}" for i in range(40)),
         ),
+        # Typographic apostrophes are the model's default; matching only
+        # the ASCII form let every curly-quoted role-play through.
+        (
+            "role-play with a typographic apostrophe",
+            "I\u2019ll load the copywriting skill next",
+        ),
+        (
+            "let-us role-play with a typographic apostrophe",
+            "Let\u2019s review the grading protocol",
+        ),
+        # The transcript format changed in the same commit; a one-line
+        # echo of the new shape has no newline to catch it.
+        (
+            "single-line echo of the reshaped transcript",
+            'tool=patch args={"path": "a.py"} returned: patched',
+        ),
+        (
+            "single-line echo of the old transcript",
+            'call: skill_view({"name": "x"}) result: {"ok": 1}',
+        ),
     ],
 )
 async def test_summarize_iteration_rejects_malformed_reply(
@@ -529,6 +549,11 @@ async def test_summarize_iteration_rejects_malformed_reply(
         # An em-dash clause and a colon are ordinary caption prose and
         # must not trip the structural markers.
         "Cloned the repo: 3 submodules initialised",
+        # ``result:`` and ``call:`` occur in real captions; only their
+        # co-occurrence marks a transcript echo.
+        "Search returns no result: falls back to pypdf",
+        "Retry after the failed call: pdftotext is missing",
+        "Now searching the workspace for the invoice template",
     ],
 )
 async def test_summarize_iteration_keeps_well_formed_reply(reply: str) -> None:
@@ -553,19 +578,16 @@ def _calls(*names: str) -> list[dict[str, Any]]:
     ]
 
 
+def _ok(*ids: str) -> list[dict[str, Any]]:
+    return [
+        {"tool_call_id": i, "content": '{"success": true, "name": "x"}'}
+        for i in ids
+    ]
+
+
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "names",
-    [
-        ("skill_view",),
-        ("skills_list",),
-        ("list_files",),
-        ("search_files",),
-        ("skill_view", "skill_view"),
-        ("skill_view", "search_files"),
-    ],
-)
-async def test_self_describing_iterations_skip_the_model(
+@pytest.mark.parametrize("names", [("skill_view",), ("skill_view", "skill_view")])
+async def test_successful_skill_loads_skip_the_model(
     names: tuple[str, ...],
 ) -> None:
     client = _StubClient("Reviews the copywriting skill")
@@ -576,6 +598,7 @@ async def test_self_describing_iterations_skip_the_model(
         reasoning="I should load the skill first",
         tool_calls=_calls(*names),
         prior_iteration_summaries=[],
+        tool_results=_ok(*[f"c{i}" for i in range(len(names))]),
     )
 
     assert result is None
@@ -583,9 +606,79 @@ async def test_self_describing_iterations_skip_the_model(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "names",
+    [("skills_list",), ("list_files",), ("search_files",), ("session_search",)],
+)
+async def test_other_discovery_tools_are_still_summarized(
+    names: tuple[str, ...],
+) -> None:
+    # Clients hide these from the condensed view, so with no caption the
+    # iteration has nothing left to draw. Only skill_view has a
+    # deterministic row to fall back to.
+    client = _StubClient("Found three invoice templates")
+    summarizer = _iteration_summarizer(client)
+
+    result = await summarizer.summarize_iteration(
+        iteration_id="i0",
+        reasoning="",
+        tool_calls=_calls(*names),
+        prior_iteration_summaries=[],
+        tool_results=_ok("c0"),
+    )
+
+    assert result == "Found three invoice templates"
+    assert len(client.chat.completions.calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    [
+        '{"success": false, "error": "Skill \'copywritting\' not found."}',
+        '{"error": "No tenant context available"}',
+    ],
+)
+async def test_a_failed_skill_load_is_still_summarized(failure: str) -> None:
+    # The client drops errored calls from its condensed view, so
+    # skipping the caption here would erase the iteration outright and
+    # the user would never learn the skill load failed.
+    client = _StubClient("Skill copywritting not found")
+    summarizer = _iteration_summarizer(client)
+
+    result = await summarizer.summarize_iteration(
+        iteration_id="i0",
+        reasoning="",
+        tool_calls=_calls("skill_view"),
+        prior_iteration_summaries=[],
+        tool_results=[{"tool_call_id": "c0", "content": failure}],
+    )
+
+    assert result == "Skill copywritting not found"
+    assert len(client.chat.completions.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_skill_load_without_captured_results_is_summarized() -> None:
+    # Success cannot be confirmed with no results in hand, so the
+    # caption is produced rather than gambled away.
+    client = _StubClient("Loaded the copywriting skill")
+    summarizer = _iteration_summarizer(client)
+
+    result = await summarizer.summarize_iteration(
+        iteration_id="i0",
+        reasoning="",
+        tool_calls=_calls("skill_view"),
+        prior_iteration_summaries=[],
+    )
+
+    assert result == "Loaded the copywriting skill"
+
+
+@pytest.mark.asyncio
 async def test_mixed_batch_still_summarizes() -> None:
-    # One non-self-describing call is enough: the client cannot label
-    # the batch on its own, so the summary still earns its model call.
+    # One call the client cannot render is enough: it cannot label the
+    # batch on its own, so the caption still earns its model call.
     client = _StubClient("Fetch the pricing page after loading the skill")
     summarizer = _iteration_summarizer(client)
 
@@ -594,6 +687,7 @@ async def test_mixed_batch_still_summarizes() -> None:
         reasoning="",
         tool_calls=_calls("skill_view", "web_extract"),
         prior_iteration_summaries=[],
+        tool_results=_ok("c0", "c1"),
     )
 
     assert result == "Fetch the pricing page after loading the skill"
@@ -602,8 +696,8 @@ async def test_mixed_batch_still_summarizes() -> None:
 
 @pytest.mark.asyncio
 async def test_text_only_iteration_still_summarizes() -> None:
-    # No tool calls at all is not "self-describing" — there is nothing
-    # for the client to render, so the reasoning still needs a caption.
+    # No tool calls at all is not client-rendered — there is nothing for
+    # the client to draw, so the reasoning still needs a caption.
     client = _StubClient("Weigh two rollout options")
     summarizer = _iteration_summarizer(client)
 

--- a/tests/test_turn_summarizer.py
+++ b/tests/test_turn_summarizer.py
@@ -19,36 +19,36 @@ from surogates.harness.turn_summarizer import (
 
 @dataclass
 class _StubResponse:
-    content: str
+    content: Any
+    reasoning: Any = None
 
     @property
     def choices(self):
-        return [
-            type(
-                "Choice", (),
-                {"message": type("Msg", (), {"content": self.content})()},
-            )()
-        ]
+        message = type(
+            "Msg", (),
+            {"content": self.content, "reasoning_content": self.reasoning},
+        )()
+        return [type("Choice", (), {"message": message})()]
 
 
 class _StubChatCompletions:
-    def __init__(self, content: str) -> None:
-        self._content = content
+    def __init__(self, content: Any, reasoning: Any = None) -> None:
+        self._content, self._reasoning = content, reasoning
         self.calls: list[dict[str, Any]] = []
 
     async def create(self, **kwargs: Any) -> _StubResponse:
         self.calls.append(kwargs)
-        return _StubResponse(self._content)
+        return _StubResponse(self._content, self._reasoning)
 
 
 class _StubChat:
-    def __init__(self, content: str) -> None:
-        self.completions = _StubChatCompletions(content)
+    def __init__(self, content: Any, reasoning: Any = None) -> None:
+        self.completions = _StubChatCompletions(content, reasoning)
 
 
 class _StubClient:
-    def __init__(self, content: str) -> None:
-        self.chat = _StubChat(content)
+    def __init__(self, content: Any, reasoning: Any = None) -> None:
+        self.chat = _StubChat(content, reasoning)
 
 
 def _iteration_summarizer(client: Any, model: str = "m") -> TurnSummarizer:
@@ -444,9 +444,9 @@ def _results(*contents: str) -> list[dict[str, Any]]:
 _OK = '{"success": true, "name": "x"}'
 
 
-async def _summarize_with(content: str) -> str | None:
+async def _summarize_with(content: Any, reasoning: Any = None) -> str | None:
     """Run one patch iteration through the summarizer stubbed to reply."""
-    client = _StubClient(content)
+    client = _StubClient(content, reasoning)
     summarizer = _iteration_summarizer(client)
     return await summarizer.summarize_iteration(
         iteration_id="i0",
@@ -805,43 +805,6 @@ async def test_malformed_json_replies_are_discarded(
 # ----------------------------------------------------------------------
 
 
-class _StubMessage:
-    def __init__(self, content: Any, reasoning: Any = None) -> None:
-        self.content = content
-        self.reasoning_content = reasoning
-
-
-class _ChannelResponse:
-    def __init__(self, content: Any, reasoning: Any = None) -> None:
-        self.choices = [type("Choice", (), {"message": _StubMessage(content, reasoning)})()]
-
-
-class _ChannelCompletions:
-    def __init__(self, content: Any, reasoning: Any = None) -> None:
-        self._content, self._reasoning = content, reasoning
-        self.calls: list[dict[str, Any]] = []
-
-    async def create(self, **kwargs: Any) -> _ChannelResponse:
-        self.calls.append(kwargs)
-        return _ChannelResponse(self._content, self._reasoning)
-
-
-class _ChannelClient:
-    def __init__(self, content: Any, reasoning: Any = None) -> None:
-        self.chat = type("Chat", (), {"completions": _ChannelCompletions(content, reasoning)})()
-
-
-async def _summarize_channels(content: Any, reasoning: Any = None) -> str | None:
-    summarizer = _iteration_summarizer(_ChannelClient(content, reasoning))
-    return await summarizer.summarize_iteration(
-        iteration_id="i0",
-        reasoning="",
-        tool_calls=_calls("patch"),
-        prior_iteration_summaries=[],
-        tool_results=_results("patched"),
-    )
-
-
 @pytest.mark.asyncio
 async def test_caption_survives_an_object_printed_before_it() -> None:
     # Leaked reasoning restates the tool arguments as an object. Taking
@@ -858,21 +821,21 @@ async def test_caption_survives_an_object_printed_before_it() -> None:
 async def test_caption_is_read_from_the_reasoning_channel() -> None:
     # Reasoning-mode models spend the token budget thinking and leave
     # ``content`` empty with the object in ``reasoning_content``.
-    assert await _summarize_channels(
+    assert await _summarize_with(
         "", '{"caption": "Patched the loader"}',
     ) == "Patched the loader"
 
 
 @pytest.mark.asyncio
 async def test_content_channel_wins_when_both_are_present() -> None:
-    assert await _summarize_channels(
+    assert await _summarize_with(
         '{"caption": "From content"}', '{"caption": "From reasoning"}',
     ) == "From content"
 
 
 @pytest.mark.asyncio
 async def test_both_channels_empty_yields_no_caption() -> None:
-    assert await _summarize_channels("   ", None) is None
+    assert await _summarize_with("   ", None) is None
 
 
 # ----------------------------------------------------------------------
@@ -881,18 +844,24 @@ async def test_both_channels_empty_yields_no_caption() -> None:
 
 
 class _RejectsResponseFormat:
-    """A provider that 400s on ``response_format`` and works without it."""
+    """A provider that 400s on ``response_format`` and works without it.
+
+    The 400 is the whole signal: it is what separates "this request is
+    malformed for this provider" from a blip. Real SDK errors carry it
+    as ``status_code``.
+    """
 
     def __init__(self, reply: str) -> None:
         self._reply = reply
         self.calls: list[dict[str, Any]] = []
         self.chat = type("Chat", (), {"completions": self})()
-        self.completions = self
 
     async def create(self, **kwargs: Any) -> _StubResponse:
         self.calls.append(kwargs)
         if "response_format" in kwargs:
-            raise ValueError("unsupported parameter: response_format")
+            raise type(
+                "BadRequestError", (Exception,), {"status_code": 400},
+            )("unsupported parameter: response_format")
         return _StubResponse(self._reply)
 
 
@@ -932,7 +901,6 @@ async def test_a_timeout_does_not_disable_json_mode() -> None:
         def __init__(self) -> None:
             self.calls: list[dict[str, Any]] = []
             self.chat = type("Chat", (), {"completions": self})()
-            self.completions = self
 
         async def create(self, **kwargs: Any) -> _StubResponse:
             self.calls.append(kwargs)
@@ -951,3 +919,65 @@ async def test_a_timeout_does_not_disable_json_mode() -> None:
     assert result is None
     assert len(client.calls) == 1
     assert "response_format" in client.calls[0]
+
+
+@pytest.mark.asyncio
+async def test_a_transient_error_does_not_disable_json_mode() -> None:
+    # A dropped connection is not a rejected parameter. Latching on any
+    # exception would let one network blip degrade a whole session's
+    # captions to unvalidated prose.
+    class _Flaky:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+            self.chat = type("Chat", (), {"completions": self})()
+
+        async def create(self, **kwargs: Any) -> _StubResponse:
+            self.calls.append(kwargs)
+            if len(self.calls) == 1:
+                raise ConnectionError("connection reset by peer")
+            return _StubResponse('{"caption": "Patched the loader"}')
+
+    client = _Flaky()
+    summarizer = _iteration_summarizer(client)
+
+    async def run() -> str | None:
+        return await summarizer.summarize_iteration(
+            iteration_id="i0",
+            reasoning="",
+            tool_calls=_calls("patch"),
+            prior_iteration_summaries=[],
+            tool_results=_results("patched"),
+        )
+
+    assert await run() is None
+    assert await run() == "Patched the loader"
+    # Still asking for the object: the blip cost one call, not the mode.
+    assert all("response_format" in c for c in client.calls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [500, 502, 429])
+async def test_server_errors_and_rate_limits_do_not_disable_json_mode(
+    status: int,
+) -> None:
+    class _Failing:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+            self.chat = type("Chat", (), {"completions": self})()
+
+        async def create(self, **kwargs: Any) -> _StubResponse:
+            self.calls.append(kwargs)
+            raise type("ApiError", (Exception,), {"status_code": status})()
+
+    client = _Failing()
+    summarizer = _iteration_summarizer(client)
+    result = await summarizer.summarize_iteration(
+        iteration_id="i0",
+        reasoning="",
+        tool_calls=_calls("patch"),
+        prior_iteration_summaries=[],
+        tool_results=_results("patched"),
+    )
+
+    assert result is None
+    assert len(client.calls) == 1

--- a/tests/test_turn_summarizer.py
+++ b/tests/test_turn_summarizer.py
@@ -702,3 +702,93 @@ async def test_summarize_iteration_strips_the_narrator_prefix() -> None:
     assert await _summarize_with(
         "The agent reviewed the copywriting skill guidelines",
     ) == "Reviewed the copywriting skill guidelines"
+
+
+# ----------------------------------------------------------------------
+# JSON-mode captions
+#
+# The iteration call asks for ``{"caption": str}`` under
+# ``response_format``, the same mechanism ``summarize_turn`` already
+# uses. A conforming gateway cannot echo the transcript, leak tool-call
+# markup, or return a bullet list — the reply has to be an object. A
+# gateway that ignores the constraint still returns prose, which is
+# used as-is so captions degrade rather than disappear.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_iteration_call_asks_for_a_json_object() -> None:
+    client = _StubClient('{"caption": "Patched the loader"}')
+    summarizer = _iteration_summarizer(client)
+
+    await summarizer.summarize_iteration(
+        iteration_id="i0",
+        reasoning="",
+        tool_calls=_calls("patch"),
+        prior_iteration_summaries=[],
+        tool_results=_results("patched"),
+    )
+
+    kwargs = client.chat.completions.calls[0]
+    assert kwargs["response_format"] == {"type": "json_object"}
+    # The wrapper costs tokens the caption used to have to itself; a
+    # reply truncated mid-object parses to nothing at all.
+    assert kwargs["max_tokens"] >= 96
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("label", "reply"),
+    [
+        ("bare object", '{"caption": "Patched the loader"}'),
+        (
+            "fenced object — gateways that ignore response_format",
+            '```json\n{"caption": "Patched the loader"}\n```',
+        ),
+        (
+            "object with surrounding prose",
+            'Here you go: {"caption": "Patched the loader"}',
+        ),
+        ("quoted caption value", '{"caption": "\\"Patched the loader\\""}'),
+        ("trailing period", '{"caption": "Patched the loader."}'),
+        # A gateway that ignores response_format outright still returns
+        # a usable caption; losing those would be worse than the echoes
+        # this whole guard exists to stop.
+        ("plain prose fallback", "Patched the loader"),
+    ],
+)
+async def test_caption_is_extracted_from_the_reply(
+    label: str, reply: str,
+) -> None:
+    assert await _summarize_with(reply) == "Patched the loader", label
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("label", "reply"),
+    [
+        # The echoed tool result is itself a JSON object, so it parses —
+        # but it carries no caption field, and the raw body must not
+        # become the label either.
+        (
+            "echoed tool result",
+            '{"success": true, "name": "social", "description": "..."}',
+        ),
+        ("caption is not a string", '{"caption": {"text": "hi"}}'),
+        ("caption is empty", '{"caption": "   "}'),
+        # Structure inside the caption field still has to be rejected:
+        # response_format constrains the envelope, not the contents.
+        (
+            "transcript echoed inside the caption",
+            '{"caption": "call: patch({}) result: patched"}',
+        ),
+        (
+            "role-play inside the caption",
+            '{"caption": "I\\u2019ll patch the loader next"}',
+        ),
+    ],
+)
+async def test_malformed_json_replies_are_discarded(
+    label: str, reply: str,
+) -> None:
+    assert await _summarize_with(reply) is None, label

--- a/tests/test_turn_summarizer.py
+++ b/tests/test_turn_summarizer.py
@@ -11,6 +11,7 @@ from surogates.harness.turn_summarizer import (
     TurnArtifact,
     TurnSummarizer,
     TurnSummary,
+    _normalize_caption,
     _valid_iteration_summary,
 )
 
@@ -635,3 +636,34 @@ async def test_transcript_lines_are_not_caption_shaped() -> None:
     user_block = client.chat.completions.calls[0]["messages"][1]["content"]
     assert "tool=patch" in user_block
     assert not _valid_iteration_summary(user_block)
+
+
+# ----------------------------------------------------------------------
+# Narrator-prefix normalization
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("The agent reviewed the rubric", "Reviewed the rubric"),
+        ("Agent found AMLR regulation page on EUR-Lex",
+         "Found AMLR regulation page on EUR-Lex"),
+        ("the agent read Article 5", "Read Article 5"),
+        # Nothing to strip — left exactly as written.
+        ("Reviewed the rubric", "Reviewed the rubric"),
+        ("Agents coordinate through the board", "Agents coordinate through the board"),
+        ("", ""),
+        # A bare opener with no body must not become an empty caption.
+        ("Agent", "Agent"),
+    ],
+)
+def test_normalize_caption(raw: str, expected: str) -> None:
+    assert _normalize_caption(raw) == expected
+
+
+@pytest.mark.asyncio
+async def test_summarize_iteration_strips_the_narrator_prefix() -> None:
+    assert await _summarize_with(
+        "The agent reviewed the copywriting skill guidelines",
+    ) == "Reviewed the copywriting skill guidelines"

--- a/tests/test_turn_summarizer.py
+++ b/tests/test_turn_summarizer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import Any
 
@@ -792,3 +793,161 @@ async def test_malformed_json_replies_are_discarded(
     label: str, reply: str,
 ) -> None:
     assert await _summarize_with(reply) is None, label
+
+
+# ----------------------------------------------------------------------
+# Reply-channel and embedded-object handling
+#
+# Mirrors what structured_output's JSON-mode fallback already does, and
+# for the same reasons: leaked reasoning can restate the tool arguments
+# as an object before the real answer, and reasoning-mode models put the
+# object in a different channel than the prose.
+# ----------------------------------------------------------------------
+
+
+class _StubMessage:
+    def __init__(self, content: Any, reasoning: Any = None) -> None:
+        self.content = content
+        self.reasoning_content = reasoning
+
+
+class _ChannelResponse:
+    def __init__(self, content: Any, reasoning: Any = None) -> None:
+        self.choices = [type("Choice", (), {"message": _StubMessage(content, reasoning)})()]
+
+
+class _ChannelCompletions:
+    def __init__(self, content: Any, reasoning: Any = None) -> None:
+        self._content, self._reasoning = content, reasoning
+        self.calls: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> _ChannelResponse:
+        self.calls.append(kwargs)
+        return _ChannelResponse(self._content, self._reasoning)
+
+
+class _ChannelClient:
+    def __init__(self, content: Any, reasoning: Any = None) -> None:
+        self.chat = type("Chat", (), {"completions": _ChannelCompletions(content, reasoning)})()
+
+
+async def _summarize_channels(content: Any, reasoning: Any = None) -> str | None:
+    summarizer = _iteration_summarizer(_ChannelClient(content, reasoning))
+    return await summarizer.summarize_iteration(
+        iteration_id="i0",
+        reasoning="",
+        tool_calls=_calls("patch"),
+        prior_iteration_summaries=[],
+        tool_results=_results("patched"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_caption_survives_an_object_printed_before_it() -> None:
+    # Leaked reasoning restates the tool arguments as an object. Taking
+    # only the *first* embedded object loses the caption and drops the
+    # whole reply onto the prose path, where a single-line echo passes
+    # validation and becomes the visible label.
+    assert await _summarize_with(
+        'Tool args were {"path": "a.py"} so the caption is'
+        ' {"caption": "Patched the loader"}',
+    ) == "Patched the loader"
+
+
+@pytest.mark.asyncio
+async def test_caption_is_read_from_the_reasoning_channel() -> None:
+    # Reasoning-mode models spend the token budget thinking and leave
+    # ``content`` empty with the object in ``reasoning_content``.
+    assert await _summarize_channels(
+        "", '{"caption": "Patched the loader"}',
+    ) == "Patched the loader"
+
+
+@pytest.mark.asyncio
+async def test_content_channel_wins_when_both_are_present() -> None:
+    assert await _summarize_channels(
+        '{"caption": "From content"}', '{"caption": "From reasoning"}',
+    ) == "From content"
+
+
+@pytest.mark.asyncio
+async def test_both_channels_empty_yields_no_caption() -> None:
+    assert await _summarize_channels("   ", None) is None
+
+
+# ----------------------------------------------------------------------
+# response_format is a request, not a guarantee
+# ----------------------------------------------------------------------
+
+
+class _RejectsResponseFormat:
+    """A provider that 400s on ``response_format`` and works without it."""
+
+    def __init__(self, reply: str) -> None:
+        self._reply = reply
+        self.calls: list[dict[str, Any]] = []
+        self.chat = type("Chat", (), {"completions": self})()
+        self.completions = self
+
+    async def create(self, **kwargs: Any) -> _StubResponse:
+        self.calls.append(kwargs)
+        if "response_format" in kwargs:
+            raise ValueError("unsupported parameter: response_format")
+        return _StubResponse(self._reply)
+
+
+@pytest.mark.asyncio
+async def test_a_provider_rejecting_json_mode_still_produces_captions() -> None:
+    # Silently losing every caption on the deployment is the one outcome
+    # worse than an unvalidated one, so the constraint is dropped and
+    # the call retried in plain-text mode.
+    client = _RejectsResponseFormat("Patched the loader")
+    summarizer = _iteration_summarizer(client)
+
+    async def run() -> str | None:
+        return await summarizer.summarize_iteration(
+            iteration_id="i0",
+            reasoning="",
+            tool_calls=_calls("patch"),
+            prior_iteration_summaries=[],
+            tool_results=_results("patched"),
+        )
+
+    assert await run() == "Patched the loader"
+    assert "response_format" in client.calls[0]
+    assert "response_format" not in client.calls[1]
+
+    # The rejection is remembered, so the next iteration does not pay
+    # for the failed attempt again.
+    assert await run() == "Patched the loader"
+    assert len(client.calls) == 3
+    assert "response_format" not in client.calls[2]
+
+
+@pytest.mark.asyncio
+async def test_a_timeout_does_not_disable_json_mode() -> None:
+    # A slow provider is not a non-conforming one; giving up the
+    # constraint on the first timeout would lose it permanently.
+    class _Slow:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+            self.chat = type("Chat", (), {"completions": self})()
+            self.completions = self
+
+        async def create(self, **kwargs: Any) -> _StubResponse:
+            self.calls.append(kwargs)
+            raise asyncio.TimeoutError
+
+    client = _Slow()
+    summarizer = _iteration_summarizer(client)
+    result = await summarizer.summarize_iteration(
+        iteration_id="i0",
+        reasoning="",
+        tool_calls=_calls("patch"),
+        prior_iteration_summaries=[],
+        tool_results=_results("patched"),
+    )
+
+    assert result is None
+    assert len(client.calls) == 1
+    assert "response_format" in client.calls[0]

--- a/tests/test_turn_summarizer.py
+++ b/tests/test_turn_summarizer.py
@@ -11,6 +11,7 @@ from surogates.harness.turn_summarizer import (
     TurnArtifact,
     TurnSummarizer,
     TurnSummary,
+    _valid_iteration_summary,
 )
 
 
@@ -410,3 +411,227 @@ async def test_summarize_turn_returns_none_on_truncated_fenced_json() -> None:
     )
 
     assert result is None
+
+
+# ----------------------------------------------------------------------
+# Malformed-reply rejection
+#
+# The cheap summary model periodically completes the prompt's transcript
+# instead of captioning it. Whatever it returns becomes the iteration's
+# user-visible label, so every structural failure shape observed in
+# production is rejected here; the caller then emits no event and the
+# chat client falls back to its deterministic tool-derived label.
+# ----------------------------------------------------------------------
+
+
+def _patch_call() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "c1",
+            "function": {"name": "patch", "arguments": '{"path": "a.py"}'},
+        },
+    ]
+
+
+async def _summarize_with(content: str) -> str | None:
+    client = _StubClient(content)
+    summarizer = _iteration_summarizer(client)
+    return await summarizer.summarize_iteration(
+        iteration_id="i0",
+        reasoning="",
+        tool_calls=_patch_call(),
+        prior_iteration_summaries=[],
+        tool_results=[{"tool_call_id": "c1", "content": "patched"}],
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("label", "reply"),
+    [
+        (
+            "verbatim transcript echo",
+            'call: skill_view({"name": "copywriting"})\n'
+            '  result: {"success": true, "name": "copywriting"}',
+        ),
+        (
+            "reshaped transcript echo",
+            '[1] tool=patch args={"path": "a.py"}\n    returned: patched',
+        ),
+        (
+            "prompt header echo",
+            "Tools called (with result snippets):\ncall: patch({})",
+        ),
+        (
+            "raw json result",
+            '{"success": true, "name": "social", "description": "..."}',
+        ),
+        (
+            "json array",
+            '[{"path": "a.py"}]',
+        ),
+        (
+            "deepseek tool-call markup",
+            "I'll load the skill.\n\n<｜DSML｜tool_calls>",
+        ),
+        (
+            "xml tool-call markup",
+            '<tool_call>{"name": "patch"}</tool_call>',
+        ),
+        (
+            "fenced code block",
+            "```json\n{}\n```",
+        ),
+        (
+            "markdown bullet list",
+            "- Searched Camillo Borghese\n- Searched Alfonso Visconti",
+        ),
+        (
+            "single leading bullet",
+            "- Searched for the Borghese page",
+        ),
+        (
+            "first-person role-play",
+            "I'll start by creating the directory and making the calls",
+        ),
+        (
+            "let-me role-play",
+            "Let me check what tools are available instead",
+        ),
+        (
+            "based-on role-play",
+            "Based on the brief, I will now review the grading protocol",
+        ),
+        (
+            "multi-line prose dump",
+            "Setup repo and clone it\n\nList files in working tree",
+        ),
+        (
+            "transcript dumped past the word cap",
+            " ".join(f"word{i}" for i in range(40)),
+        ),
+    ],
+)
+async def test_summarize_iteration_rejects_malformed_reply(
+    label: str, reply: str,
+) -> None:
+    assert await _summarize_with(reply) is None, label
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reply",
+    [
+        "Patch the loader to skip empty rows",
+        "Find pdftotext fails — falling back to pypdf",
+        "Reviews copywriting skill guidelines for tone and structure",
+        # An em-dash clause and a colon are ordinary caption prose and
+        # must not trip the structural markers.
+        "Cloned the repo: 3 submodules initialised",
+    ],
+)
+async def test_summarize_iteration_keeps_well_formed_reply(reply: str) -> None:
+    assert await _summarize_with(reply) == reply
+
+
+@pytest.mark.asyncio
+async def test_summarize_iteration_strips_then_validates() -> None:
+    # Quote-stripping runs first, so a quoted echo is still rejected.
+    assert await _summarize_with('"call: patch({})"') is None
+
+
+# ----------------------------------------------------------------------
+# Self-describing iterations are not summarized at all
+# ----------------------------------------------------------------------
+
+
+def _calls(*names: str) -> list[dict[str, Any]]:
+    return [
+        {"id": f"c{i}", "function": {"name": n, "arguments": "{}"}}
+        for i, n in enumerate(names)
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "names",
+    [
+        ("skill_view",),
+        ("skills_list",),
+        ("list_files",),
+        ("search_files",),
+        ("skill_view", "skill_view"),
+        ("skill_view", "search_files"),
+    ],
+)
+async def test_self_describing_iterations_skip_the_model(
+    names: tuple[str, ...],
+) -> None:
+    client = _StubClient("Reviews the copywriting skill")
+    summarizer = _iteration_summarizer(client)
+
+    result = await summarizer.summarize_iteration(
+        iteration_id="i0",
+        reasoning="I should load the skill first",
+        tool_calls=_calls(*names),
+        prior_iteration_summaries=[],
+    )
+
+    assert result is None
+    assert client.chat.completions.calls == []
+
+
+@pytest.mark.asyncio
+async def test_mixed_batch_still_summarizes() -> None:
+    # One non-self-describing call is enough: the client cannot label
+    # the batch on its own, so the summary still earns its model call.
+    client = _StubClient("Fetch the pricing page after loading the skill")
+    summarizer = _iteration_summarizer(client)
+
+    result = await summarizer.summarize_iteration(
+        iteration_id="i0",
+        reasoning="",
+        tool_calls=_calls("skill_view", "web_extract"),
+        prior_iteration_summaries=[],
+    )
+
+    assert result == "Fetch the pricing page after loading the skill"
+    assert len(client.chat.completions.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_text_only_iteration_still_summarizes() -> None:
+    # No tool calls at all is not "self-describing" — there is nothing
+    # for the client to render, so the reasoning still needs a caption.
+    client = _StubClient("Weigh two rollout options")
+    summarizer = _iteration_summarizer(client)
+
+    result = await summarizer.summarize_iteration(
+        iteration_id="i0",
+        reasoning="Considering whether to ship behind a flag",
+        tool_calls=[],
+        prior_iteration_summaries=[],
+    )
+
+    assert result == "Weigh two rollout options"
+
+
+@pytest.mark.asyncio
+async def test_transcript_lines_are_not_caption_shaped() -> None:
+    # The transcript the model sees must not look like a valid answer,
+    # or it completes the list instead of summarizing it. Guarded by
+    # feeding each rendered line back through the reply validator.
+    client = _StubClient("Patch the loader")
+    summarizer = _iteration_summarizer(client)
+
+    await summarizer.summarize_iteration(
+        iteration_id="i0",
+        reasoning="",
+        tool_calls=_patch_call(),
+        prior_iteration_summaries=[],
+        tool_results=[{"tool_call_id": "c1", "content": "patched"}],
+    )
+
+    user_block = client.chat.completions.calls[0]["messages"][1]["content"]
+    assert "tool=patch" in user_block
+    assert not _valid_iteration_summary(user_block)


### PR DESCRIPTION
## The bug

A skill load rendered as the raw transcript the summary model was handed:

> *call: skill_view({"name": "copywriting"}) result: Retrieved copywriting skill with guidelines for tone, structure, and audience t…*

That string is not a caption. It is `_format_tool_calls`' own output, echoed back
by the model that was asked to summarize it, truncated by `max_tokens=64`, and
emitted verbatim as the iteration's user-visible label.

It is not rare, and it is not limited to `skill_view`. Across the 5,043 stored
`iteration.summary` rows:

| defect | rows | % |
|---|---|---|
| echoes the `call:` / `result:` transcript | 18 | 0.36% |
| leaks the model's own tool-call markup (`<｜DSML｜tool_calls>`) | 7 | 0.14% |
| raw JSON blob | 23 | 0.46% |
| first-person role-play ("I'll load the skill…") | 115 | 2.28% |
| multi-line — a "one-liner" with newlines | 275 | 5.45% |
| markdown bullet list | 332 | 6.58% |
| opens with "The agent" (the prompt forbids it) | 334 | 6.62% |
| **any structural violation** | **564** | **11.2%** |

Reproduced live against the configured summary model (`@preset/summary` →
`deepseek/deepseek-v4-flash-0731`): **13 of 108** calls on the echo-prone cases,
in four distinct shapes — verbatim echo, raw JSON, the prompt header repeated,
and the model role-playing the agent and inventing tool calls that do not exist.

## What it says now

```
Reading skill copywriting
Reading skill copywriting · tone.md      (a linked skill file)
Reading skills copywriting, social       (several in one iteration)
Reading a skill                          (args still streaming)
```

Derived from the call's own arguments — no model in the loop, so it cannot be
echoed, truncated, or written in the agent's voice. The same string is used for
the live shimmer and the finished row, so it does not rename itself mid-turn.

## How

Three layers, in order of how much each removes.

**The harness no longer summarizes a skill load.** A successful `skill_view`-only
iteration is fully described by its arguments, so no model call is made and no
event is emitted. Saves a call per skill load and hands the row to the client.
The skip requires *captured, successful* results — a failed load is news, and
consumers drop errored calls from the condensed view, so skipping its caption
would erase the iteration outright.

**Replies are validated before they leave the summarizer.** Multi-line bodies,
transcript scaffolding, JSON, tool-call markup, bullets, role-play openers and
over-long dumps are discarded with a warning. The event is simply not emitted and
the client falls back to its derived label — the same graceful path a summarizer
timeout already takes.

**The transcript the model sees is no longer caption-shaped.** `[n] tool=… args=…`
cannot be mistaken for a plausible answer the way `call: …` could, and the prompt
now states the observer role explicitly. This is the fix that addresses the cause
rather than the symptom; the validator is the net beneath it.

Plus: `skill_view` leaves `SIMPLE_MODE_HIDDEN_TOOLS` so the derived row actually
renders, joins the retrieval orb states, and the narrator prefix ("The agent
reviewed…" → "Reviewed…") is stripped deterministically.

## Verification

- **Corpus**: 5,055 stored summaries replayed through the guard — 88.3% kept, and
  **zero** of the previously-observed defects slip through. The false-positive
  audit turned up only genuinely-bad rows.
- **Live**, against the real summary model:

  | case | before | after |
  |---|---|---|
  | `skill_view`-only | 2–3/12 echoed | 0 model calls, 8/8 skipped |
  | mixed batch | 3/12 echoed | 23/24 kept, 1 discarded, **0 leaked** |
  | browser batch | 3/12 echoed | 24/24 kept, **0 leaked** |

- **Suites**: `surogates` 6,231 passed / 11 skipped. SDK 536 passed, `tsc` clean.
  `surogates/web` typecheck clean.
- Two rounds of `/code-review high` + `/simplify`, both applied in-branch. Round
  two found the sharpest bug in the PR: `parse_json_object` returns only the
  *first* embedded object, so a reply that printed anything JSON-ish before the
  caption lost it and fell through to the prose path — where a single-line echo
  passes validation and becomes the label. That is the exact failure this branch
  exists to stop, and it is plausible here, since gateway-inlined thinking
  routinely restates the tool `args={…}` before answering.

## Along the way

Reading the model's reply turned out to be done four different ways in the
harness, and the copy this branch added was the most wrong of them — two channels
where `loop.py` knew about three, object-shaped messages only, and a comment
claiming to mirror `structured_output` which by then behaved differently again.
`message_utils.message_texts()` is now the single reader; every caller picks up
all three channels and both message shapes, and `structured_output` picks up the
`reasoning` channel it had been missing.

## Considered, measured, and done

**JSON mode for `summarize_iteration`.** `summarize_turn` in the same class has
always asked for `response_format: {"type": "json_object"}`; the iteration call was
left taking free-form text, which is what let the model answer with the transcript
it was handed. It now asks for `{"caption": str}`. A reply constrained to an object
cannot *be* an echoed transcript line, a bullet list, or a markup dump — the
structural failures stop at the provider instead of being filtered afterwards.

Measured on the three batches that used to echo 3-in-12: **71 of 72 replies kept,
the one loss a timeout, and zero rejected by the validator.**

Three gateway behaviours all resolve: a conforming one returns the bare object; one
that ignores the constraint returns it fenced or wrapped in prose (`parse_json_object`
already handles both — that is why it exists); one that ignores it outright returns
plain prose, used as-is. Captions degrading to unvalidated prose on a non-conforming
gateway is recoverable; every caption on that deployment vanishing is not. An object
*without* a caption field is deliberately not treated as prose — the most common such
reply is the echoed tool result, and its raw body must never become the label.

The validator stays, as the net rather than the primary defence: `response_format`
constrains the envelope, not the contents, and the plain-prose path has no envelope.
`max_tokens` 64 → 96, since the wrapper costs tokens the caption used to have to
itself and a reply truncated mid-object parses to nothing.

**`search_files` detail extraction.** It read `path` where the query lives in
`pattern`, so a search of `src/billing` for "invoice" read `Searched files for
"billing"`, and the whole-workspace search that omits `path` got no label at all.
`target` also picks the axis — contents or filenames — and calling a filename match
"searched files for X" misreports what the agent looked at.

The branch was unreachable (all three call sites run on `visibleToolCalls`, which
filters `search_files` out) and that is precisely why it was wrong: nothing ever
exercised it. `skill_view` crossing `SIMPLE_MODE_HIDDEN_TOOLS` in this same branch
proves the policy moves, and a wrong entry ships the moment it does. So the
vocabulary moved out of `chat-thread.tsx` into `simple-labels.ts`, where it is
tested directly instead of only through whichever rows the current hiding policy
happens to render. Pure functions, no behaviour change; `chat-thread.tsx` loses
~300 lines.

## Deploying

The harness change ships in a `surogates` wheel. The SDK change reaches
`surogates/web` immediately (`file:` dep) but reaches ops Studio only via an npm
publish plus a pin bump — Studio pins `^2.14.0` from the registry. Release version
comes from the git tag, so nothing to bump in-tree.
