### PR TITLE
fix(tools,skills): repair two silent file-read failures in PROD

### DIFF
--- a/surogates/api/routes/skills.py
+++ b/surogates/api/routes/skills.py
@@ -271,11 +271,7 @@ async def _stage_skill_for_session(
     directory (i.e. it came from the bundle's ``skills/{name}/`` tree),
     we stage from the bundle instead of failing.
     """
-    from surogates.tools.loader import (
-        SKILL_SOURCE_ORG,
-        SKILL_SOURCE_PLATFORM,
-        SKILL_SOURCE_USER,
-    )
+    from surogates.tools.loader import SKILL_SOURCE_PLATFORM
 
     if not has_stageable_assets(linked_files):
         return None
@@ -296,21 +292,23 @@ async def _stage_skill_for_session(
             bundle=bundle,
         )
 
-    if skill_def.source in (SKILL_SOURCE_USER, SKILL_SOURCE_ORG):
-        ts = _get_tenant_storage(request, tenant)
-        existing = await ts.skill_exists(skill_def.name)
-        if not existing:
-            return None
-        return await stager.stage_from_object_store(
-            session_id=session_id,
-            skill_name=skill_def.name,
-            source_bucket=request.app.state.settings.storage.bucket,
-            source_prefix=existing["key_prefix"],
-        )
-
-    # DB-backed skills have no linked files beyond what is in the content
-    # column itself, so there is nothing to stage.
-    return None
+    # Everything else is tenant-bucket-backed.  Resolve by asking the
+    # bucket rather than by matching a source constant: the loader emits
+    # ``org_db``/``user_db`` for DB-backed skills, never ``org``, so the
+    # old membership test was unreachable and a DB row carrying a
+    # ``hub_ref`` (a project skill with references/ and templates/) never
+    # got staged.  A skill with nothing in the bucket returns None here,
+    # which is the correct answer for a content-only DB row.
+    ts = _get_tenant_storage(request, tenant)
+    existing = await ts.skill_exists(skill_def.name)
+    if not existing:
+        return None
+    return await stager.stage_from_object_store(
+        session_id=session_id,
+        skill_name=skill_def.name,
+        source_bucket=request.app.state.settings.storage.bucket,
+        source_prefix=existing["key_prefix"],
+    )
 
 
 def _parse_frontmatter(content: str, fallback_name: str) -> dict[str, Any]:
@@ -536,7 +534,7 @@ async def view_skill(
     preamble is prepended to ``content`` so the LLM can resolve relative
     paths (``scripts/foo.py``) against the staged directory.
     """
-    from surogates.tools.loader import SKILL_SOURCE_PLATFORM, SKILL_SOURCE_USER
+    from surogates.tools.loader import SKILL_SOURCE_PLATFORM
 
     loader = _resource_loader(request)
     session_factory = request.app.state.session_factory
@@ -574,14 +572,21 @@ async def view_skill(
     if skill_def.is_expert:
         _populate_expert_detail(detail, skill=skill_def)
 
-    # Populate linked_files from the skill's source layer.
-    if skill_def.source == SKILL_SOURCE_USER:
+    # Populate linked_files from the skill's source layer.  Everything
+    # that is not bundle-backed lives in the tenant bucket, so mirror
+    # ``read_skill_file``: special-case ``platform`` and fall through for
+    # every other source.  Matching source constants here instead used to
+    # miss the DB-backed layers -- the loader emits ``org_db``/``user_db``,
+    # never ``org``, so a project skill with a ``hub_ref`` reported no
+    # linked files, skipped staging entirely, and left the model reading
+    # a ``.skills/{name}/`` tree that was never materialised.
+    if skill_def.source != SKILL_SOURCE_PLATFORM:
         ts = _get_tenant_storage(request, tenant)
         existing = await ts.skill_exists(name)
         if existing:
             files = await ts.list_skill_files(existing["key_prefix"])
             detail.linked_files = [f for f in files if f != "SKILL.md"]
-    elif skill_def.source == SKILL_SOURCE_PLATFORM and bundle is not None:
+    elif bundle is not None:
         # Bundle-backed platform skill: enumerate the bundle's
         # ``skills/{name}/`` prefix.  SKILL.md is excluded so the list
         # contains only the auxiliary files that get auto-staged.

--- a/surogates/tools/builtin/file_ops.py
+++ b/surogates/tools/builtin/file_ops.py
@@ -16,6 +16,7 @@ import difflib
 import errno
 import json
 import logging
+import multiprocessing
 import os
 import re
 import shutil
@@ -65,6 +66,25 @@ _USE_SUBPROCESS_PARSE: bool = (
 )
 _parse_pool: ProcessPoolExecutor | None = None
 _parse_pool_lock = threading.Lock()
+
+
+def _use_subprocess_parse() -> bool:
+    """Whether to parse in the pool rather than a thread.
+
+    A daemonic process may not fork children, so building the pool there
+    raises ``AssertionError: daemonic processes are not allowed to have
+    children`` and every document read fails.  That is exactly where
+    ``read_file`` runs in production: the sandbox tool executor forks a
+    daemon child per ``/execute`` (see
+    :func:`surogates.sandbox.executor_server.execute_in_child`), which
+    already gives the process isolation the pool exists to provide — so
+    the thread path is both the only option and the right one.
+
+    Checked per call, not at import: the executor daemon imports this
+    module at boot to warm the registry, *before* it forks, so an
+    import-time check would always read the non-daemon parent.
+    """
+    return _USE_SUBPROCESS_PARSE and not multiprocessing.current_process().daemon
 
 
 def _get_parse_pool() -> ProcessPoolExecutor:
@@ -323,7 +343,7 @@ async def _parse_document_to_text(path: Path) -> str:
     may still complete the parse in the background — that's fine, the
     result is just discarded.
     """
-    if _USE_SUBPROCESS_PARSE:
+    if _use_subprocess_parse():
         loop = asyncio.get_running_loop()
         future = loop.run_in_executor(
             _get_parse_pool(), _convert_to_text_sync, path,
@@ -331,9 +351,9 @@ async def _parse_document_to_text(path: Path) -> str:
         awaitable: asyncio.Future | asyncio.Task = asyncio.shield(future)
         on_timeout_cancel = future
     else:
-        # Thread-based fallback (tests, or explicit opt-out).  GIL
-        # contention is acceptable here because the test environment
-        # isn't on the critical liveness-probe path.
+        # Thread-based fallback: the sandbox executor's daemon child
+        # (where GIL contention can't reach the serving loop — it is a
+        # separate process), tests, or an explicit opt-out.
         awaitable = asyncio.create_task(
             asyncio.to_thread(_convert_to_text_sync, path),
         )

--- a/tests/test_skill_staging.py
+++ b/tests/test_skill_staging.py
@@ -520,3 +520,62 @@ class TestRedisLockIsUsedWhenProvided:
 
         assert len(recorded_keys) == 1
         assert recorded_keys[0] == f"surogates:skill-stage:{session_id}:k"
+
+
+class TestDbBackedSkillStaging:
+    """A DB-backed skill whose files live in the tenant bucket must stage.
+
+    The loader labels project/org DB skills ``org_db`` (and per-user ones
+    ``user_db``) -- never ``org``.  Matching source constants here meant a
+    DB row carrying a ``hub_ref``, with a real ``references/`` tree in the
+    tenant bucket, silently skipped staging: ``.skills/{name}/`` never
+    appeared in the workspace while SKILL.md kept telling the model to read
+    from it.
+    """
+
+    async def _stage(self, backend: LocalBackend, org_id, source: str):
+        from surogates.api.routes.skills import _stage_skill_for_session
+
+        class _Skill:
+            name = "posthog-analytics"
+
+        _Skill.source = source
+
+        class _Tenant:
+            pass
+
+        _Tenant.org_id = org_id
+        _Tenant.user_id = None
+
+        return await _stage_skill_for_session(
+            request=_MockRequest(backend),  # type: ignore[arg-type]
+            tenant=_Tenant(),  # type: ignore[arg-type]
+            skill_def=_Skill(),
+            session_id=uuid4(),
+            linked_files=["references/daily-report.md"],
+        )
+
+    @pytest.mark.parametrize("source", ["org_db", "user_db", "org"])
+    async def test_db_backed_skill_with_bucket_files_is_staged(
+        self, tmp_path: Path, source: str,
+    ):
+        backend = LocalBackend(base_path=str(tmp_path / "storage"))
+        await backend.create_bucket(STORAGE_BUCKET)
+        org_id = uuid4()
+        prefix = f"tenants/{org_id}/shared/skills/posthog-analytics"
+        await backend.write_text(STORAGE_BUCKET, f"{prefix}/SKILL.md", "body")
+        await backend.write_text(
+            STORAGE_BUCKET, f"{prefix}/references/daily-report.md", "# daily",
+        )
+
+        staged = await self._stage(backend, org_id, source)
+        assert staged is not None, f"source={source} was not staged"
+        assert staged.endswith("/.skills/posthog-analytics/")
+
+    async def test_content_only_db_skill_still_stages_nothing(
+        self, tmp_path: Path,
+    ):
+        """No bucket tree -> None, the correct answer for a content-only row."""
+        backend = LocalBackend(base_path=str(tmp_path / "storage"))
+        await backend.create_bucket(STORAGE_BUCKET)
+        assert await self._stage(backend, uuid4(), "org_db") is None

--- a/tests/tools/test_file_ops_documents.py
+++ b/tests/tools/test_file_ops_documents.py
@@ -10,11 +10,13 @@ Layered as:
 from __future__ import annotations
 
 import json
+import multiprocessing
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from surogates.tools.builtin import file_ops as file_ops_module
 from surogates.tools.builtin.file_ops import _read_file_handler
 from tests.tools.fixtures.build_documents import (
     build_minimal_docx,
@@ -403,3 +405,60 @@ def test_read_file_description_mentions_native_document_handling() -> None:
     # Negative guard: the old "Cannot read images or binary files" wording
     # would tell the LLM to avoid the tool for these inputs.
     assert "cannot read images" not in desc
+
+
+# ---------------------------------------------------------------------------
+# Parse backend selection inside a daemonic process
+# ---------------------------------------------------------------------------
+
+
+def _probe_use_subprocess_parse(conn) -> None:
+    """Report the daemon flag and backend choice from a forked child."""
+    from surogates.tools.builtin import file_ops
+
+    # tests/conftest.py forces the env opt-out on, which would make the
+    # predicate return False for the wrong reason.  Force it back so the
+    # daemon guard is the only thing under test.
+    file_ops._USE_SUBPROCESS_PARSE = True
+    try:
+        conn.send(
+            {
+                "daemon": multiprocessing.current_process().daemon,
+                "use_subprocess": file_ops._use_subprocess_parse(),
+            }
+        )
+    finally:
+        conn.close()
+
+
+def test_parse_uses_thread_inside_daemonic_process(monkeypatch) -> None:
+    """A daemon child must not reach for the pool.
+
+    The sandbox tool executor forks a daemon child per ``/execute``, and a
+    daemonic process cannot fork children -- building the pool there raises
+    ``AssertionError: daemonic processes are not allowed to have children``
+    and every PDF/docx/xlsx/pptx read fails.
+    """
+    ctx = multiprocessing.get_context("fork")
+    parent_conn, child_conn = ctx.Pipe(duplex=False)
+    proc = ctx.Process(
+        target=_probe_use_subprocess_parse, args=(child_conn,), daemon=True,
+    )
+    proc.start()
+    child_conn.close()
+    try:
+        assert parent_conn.poll(30), "daemon child produced no result"
+        result = parent_conn.recv()
+    finally:
+        parent_conn.close()
+        proc.join(10)
+        if proc.is_alive():
+            proc.kill()
+
+    assert result["daemon"] is True, "child was not daemonic; test is vacuous"
+    assert result["use_subprocess"] is False
+
+    # Same flag, non-daemonic process: the pool is still the default, so
+    # the assertion above pins the daemon guard rather than a constant.
+    monkeypatch.setattr(file_ops_module, "_USE_SUBPROCESS_PARSE", True)
+    assert file_ops_module._use_subprocess_parse() is True


### PR DESCRIPTION
Two unrelated defects found by measuring 30 days of PROD `tool.result` events, not by a report. Both made `read_file` fail while looking like model error.

## 1. Document reads are dead in every sandbox session (`279ca92f`)

`read_file` is a SANDBOX tool, so it runs inside the tool executor's forked **daemon** child (`execute_in_child`). A daemonic process cannot fork children, so `_get_parse_pool()`'s `ProcessPoolExecutor` raised `AssertionError: daemonic processes are not allowed to have children` before parsing anything. **Every PDF/DOCX/XLSX/PPTX read has been failing** — 11 occurrences in the sample window.

Backend is now selected per call rather than per import: the executor daemon imports tool modules at boot to warm the registry, *before* it forks, so an import-time check reads the non-daemon parent and never fires.

The thread path it falls back to already existed and is not a downgrade here — the executor child is already a separate process, which is the isolation the pool exists to provide.

Never caught in CI because `tests/conftest.py` forces `SUROGATES_DOCUMENT_PARSE_USE_SUBPROCESS=0`, leaving the pool path with zero coverage. The new test drives a real forked daemon child instead of the env flag.

## 2. DB-backed skills with a `hub_ref` never stage (`47b83834`)

A project skill stored as a DB row can carry a `hub_ref` pointing at a full bundle with `references/`, `templates/`. Those files live in the tenant bucket but were never staged, so `.skills/{name}/` was absent from the workspace while SKILL.md kept pointing the model at it.

Both halves resolved source by matching constants the loader does not emit — it labels DB-backed skills `org_db`/`user_db`, never `org`:

- `view_skill` populated `linked_files` for `user` and `platform` only, so the list came back empty;
- `_stage_skill_for_session` then returned at its `has_stageable_assets` guard **before any logging**, which is why the staging logs show every other skill and never this one;
- its `SKILL_SOURCE_ORG` branch was unreachable regardless.

Now resolved by asking the bucket, mirroring what `read_skill_file` already did: special-case `platform`, fall through for everything else. A skill with nothing in the bucket still returns `None` — the right answer for a content-only DB row. Also fixes `user_db`, which had the identical hole.

Impact: 54 failed tool calls across 23 sessions of one scheduled agent in a month, recurring daily.

## Verification

- **Mutation-tested.** Reverting each guard fails exactly the new tests (for #2: `org_db` and `user_db` fail, `org` still passes).
- **End-to-end** for #1: forked a daemon child and read a real `.docx` — the exact PROD error string before, extracted content after.
- 128 passed across the skill suites; 83 across `tests/tools/`. Two `reportlab` failures are pre-existing and also fail on unmodified `master`.

## Not included

`write_file`'s `No path provided` errors were investigated and closed as not-a-bug: a single burst on 2026-07-27 from a tool call truncated mid-stream, a shape nothing in the tree produces, zero occurrences since.