### PR TITLE
perf(sessions): take the pod delete off the completion path

### DIFF
--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -129,6 +129,29 @@ class ArtifactCompletionMixin:
                 session.id,
             )
 
+    def _spawn_background(self, coro, *, name: str) -> None:
+        """Run *coro* detached, but still inside the end-of-turn drain.
+
+        Registering it in ``_background_tasks`` is the point: the work
+        stops delaying SESSION_COMPLETE, yet the worker still waits for
+        it (bounded) before releasing the lease, so a detached teardown
+        cannot outlive the wake that started it.
+        """
+        task = asyncio.create_task(coro, name=name)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    async def _destroy_sandbox_quietly(
+        self, sandbox_id: str | None, session_id: str,
+    ) -> None:
+        """Delete a detached sandbox; never raise into the drain."""
+        try:
+            await self._sandbox_pool.destroy_released(sandbox_id, session_id)
+        except Exception:
+            logger.debug(
+                "Sandbox cleanup failed for %s", session_id, exc_info=True,
+            )
+
     async def _drain_background_tasks(self, session_id: UUID) -> None:
         """Wait for fire-and-forget background tasks to finish before lease release.
 
@@ -723,12 +746,33 @@ class ArtifactCompletionMixin:
         ``TURN_SUMMARY`` event before ``SESSION_COMPLETE`` so the SDK
         sees the recap in the same event stream as the closing message.
         """
-        # Destroy the sandbox pod for this session.
+        # Detach the sandbox now, delete the pod after.
+        #
+        # Deleting a pod is a round trip to the cluster, and it used to sit
+        # between the agent's last word and SESSION_COMPLETE -- so the user
+        # watched a busy indicator through it. Measured over a month of
+        # production sessions: with neither a sandbox nor a turn summary the
+        # tail is 0.24s at p50, and sessions that used a sandbox reach 32s at
+        # p90. Nothing downstream reads the teardown, and a leaked pod is
+        # already reclaimed on worker shutdown.
+        #
+        # Detaching stays synchronous because it is in-memory and it carries
+        # the ordering that matters: once the mapping is gone, no later turn
+        # can resolve this session to a pod that is about to disappear.
         if self._sandbox_pool is not None:
             try:
-                await self._sandbox_pool.destroy_for_session(str(session.id))
+                sandbox_id = await self._sandbox_pool.release_for_session(
+                    str(session.id),
+                )
             except Exception:
-                logger.debug("Sandbox cleanup failed for %s", session.id, exc_info=True)
+                logger.debug(
+                    "Sandbox detach failed for %s", session.id, exc_info=True,
+                )
+            else:
+                self._spawn_background(
+                    self._destroy_sandbox_quietly(sandbox_id, str(session.id)),
+                    name=f"sandbox-teardown-{session.id}",
+                )
 
         # The browser is intentionally NOT torn down here. A turn end is
         # not a session end: an agent driving a multi-step browser flow

--- a/surogates/sandbox/pool.py
+++ b/surogates/sandbox/pool.py
@@ -127,6 +127,45 @@ class SandboxPool:
             )
         return await self._backend.execute(sandbox_id, name, input)
 
+    async def release_for_session(self, session_id: str) -> str | None:
+        """Detach the sandbox from *session_id*, returning its id.
+
+        In-memory only, so it is fast enough to stay on a latency-
+        sensitive path. Callers that then destroy the returned sandbox in
+        the background get the ordering that matters: once this returns,
+        no later turn can resolve the session to a pod that is about to
+        disappear.
+        """
+        lock = await self._session_lock(session_id)
+        async with lock:
+            self._specs.pop(session_id, None)
+            return self._mapping.pop(session_id, None)
+
+    async def destroy_released(
+        self, sandbox_id: str | None, session_id: str,
+    ) -> None:
+        """Tear down a sandbox already detached by :meth:`release_for_session`.
+
+        This is the slow half -- deleting a pod is a round trip to the
+        cluster -- and it no longer needs the session lock, because the
+        mapping is gone and nothing can resolve to this sandbox any more.
+        """
+        if sandbox_id is not None:
+            await self._backend.destroy(sandbox_id)
+            logger.info(
+                "Destroyed sandbox %s for session %s", sandbox_id, session_id,
+            )
+
+        # Optional backend-level reap (label-based), independent of the
+        # mapping above.
+        backend_reap = getattr(self._backend, "destroy_for_session", None)
+        if backend_reap is not None:
+            await backend_reap(session_id)
+
+        # Clean up the per-session lock to prevent unbounded growth.
+        async with self._global_lock:
+            self._locks.pop(session_id, None)
+
     async def destroy_for_session(self, session_id: str) -> None:
         """Destroy the sandbox for *session_id* and remove the mapping.
 
@@ -135,27 +174,8 @@ class SandboxPool:
         when this pool has no in-memory mapping (e.g. after a worker
         restart).
         """
-        lock = await self._session_lock(session_id)
-        async with lock:
-            sandbox_id = self._mapping.pop(session_id, None)
-            self._specs.pop(session_id, None)
-            if sandbox_id is not None:
-                await self._backend.destroy(sandbox_id)
-                logger.info(
-                    "Destroyed sandbox %s for session %s",
-                    sandbox_id,
-                    session_id,
-                )
-
-            # Optional backend-level reap (label-based), independent of the
-            # mapping above.
-            backend_reap = getattr(self._backend, "destroy_for_session", None)
-            if backend_reap is not None:
-                await backend_reap(session_id)
-
-        # Clean up the per-session lock to prevent unbounded growth.
-        async with self._global_lock:
-            self._locks.pop(session_id, None)
+        sandbox_id = await self.release_for_session(session_id)
+        await self.destroy_released(sandbox_id, session_id)
 
     async def destroy_all(self) -> None:
         """Tear down every sandbox managed by this pool.

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -312,3 +312,102 @@ async def test_pool_destroy_for_session_without_backend_reap_is_noop():
     pool = SandboxPool(backend)
     # Backend has no destroy_for_session — must not raise.
     await pool.destroy_for_session("root-1")
+
+
+class TestReleaseThenDestroy:
+    """Detaching is fast and ordered; deleting the pod is neither.
+
+    Pod deletion is a round trip to the cluster and used to sit between
+    the agent's last word and SESSION_COMPLETE, so the user watched a
+    busy indicator through it. Splitting the two lets the slow half move
+    off that path without loosening the guarantee that matters: once a
+    session is released, no later turn can resolve it to a pod that is
+    about to disappear.
+    """
+
+    @pytest.mark.asyncio
+    async def test_release_detaches_before_the_pod_is_gone(self):
+        backend = ProcessSandbox()
+        pool = SandboxPool(backend)
+        sandbox_id = await pool.ensure("session-r1", SandboxSpec())
+
+        released = await pool.release_for_session("session-r1")
+        assert released == sandbox_id
+
+        # Detached: a call for this session can no longer reach it, even
+        # though the sandbox itself still exists.
+        with pytest.raises(ValueError):
+            await pool.execute("session-r1", "terminal", "{}")
+        assert await backend.status(sandbox_id) == "running"
+
+        await pool.destroy_released(released, "session-r1")
+        assert await backend.status(sandbox_id) != "running"
+
+    @pytest.mark.asyncio
+    async def test_ensure_after_release_provisions_a_fresh_sandbox(self):
+        """The race the ordering exists to prevent.
+
+        A turn starting while the previous teardown is still in flight
+        must get its own sandbox, never the one being deleted.
+        """
+        backend = ProcessSandbox()
+        pool = SandboxPool(backend)
+        first = await pool.ensure("session-r2", SandboxSpec())
+        released = await pool.release_for_session("session-r2")
+
+        second = await pool.ensure("session-r2", SandboxSpec())
+        assert second != first, "reused a sandbox that was being torn down"
+
+        await pool.destroy_released(released, "session-r2")
+        # Tearing down the old one must not disturb the live one.
+        assert await backend.status(second) == "running"
+        await pool.destroy_for_session("session-r2")
+
+    @pytest.mark.asyncio
+    async def test_destroy_for_session_still_works_end_to_end(self):
+        """Other callers (shutdown, destroy_all) keep the combined form."""
+        backend = ProcessSandbox()
+        pool = SandboxPool(backend)
+        sandbox_id = await pool.ensure("session-r3", SandboxSpec())
+        await pool.destroy_for_session("session-r3")
+        assert await backend.status(sandbox_id) != "running"
+        with pytest.raises(ValueError):
+            await pool.execute("session-r3", "terminal", "{}")
+
+
+class TestCompletionDoesNotWaitForTeardown:
+    """SESSION_COMPLETE must not sit behind a pod deletion.
+
+    Measured over a month of production sessions: with neither a sandbox
+    nor a turn summary the gap from the agent's last response to
+    SESSION_COMPLETE is 0.24s at p50; sessions that used a sandbox reach
+    32s at p90. The pod delete was on that path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_slow_pod_delete_does_not_delay_release(self):
+        import time
+
+        class _SlowBackend(ProcessSandbox):
+            destroyed = False
+
+            async def destroy(self, sandbox_id):  # noqa: D102
+                await asyncio.sleep(0.6)
+                _SlowBackend.destroyed = True
+                return await super().destroy(sandbox_id)
+
+        backend = _SlowBackend()
+        pool = SandboxPool(backend)
+        await pool.ensure("session-slow", SandboxSpec())
+
+        # The half that stays on the critical path.
+        t0 = time.monotonic()
+        released = await pool.release_for_session("session-slow")
+        detach_s = time.monotonic() - t0
+
+        assert detach_s < 0.1, f"detach took {detach_s:.2f}s -- it is on the hot path"
+        assert not _SlowBackend.destroyed, "pod deleted during detach"
+
+        # And the slow half still completes when awaited (the drain).
+        await pool.destroy_released(released, "session-slow")
+        assert _SlowBackend.destroyed


### PR DESCRIPTION
Sessions hang after the agent's last word. This is half the cause.

## Measured

A month of production sessions, gap from the last `llm.response` to `session.complete`:

| turn summary | sandbox | n | p50 | p90 |
|---|---|---:|---:|---:|
| yes | no | 5 | 14.60s | 18.94s |
| yes | yes | 55 | 5.41s | 18.67s |
| no | yes | 87 | 3.87s | **32.32s** |
| **no** | **no** | 18 | **0.24s** | 2.98s |

With neither, completion is effectively instant — so the lag is entirely these two, and they are independent. Pod deletion owns the worst cases; the turn summary owns the median.

By channel the same tail shows up everywhere: slack p50 8.99s, scheduled 5.34s, studio 4.78s, api 2.09s. `delegation` sessions are 0.02s — they have no sandbox and no summary, which is the control.

## What changed

`_complete_session` deleted the sandbox pod before emitting `SESSION_COMPLETE`, so a cluster round trip sat between the agent finishing and the UI clearing its busy indicator.

The teardown is now split:

- **`release_for_session`** — detach the mapping. In-memory, stays synchronous, and carries the ordering that matters: once it returns, no later turn can resolve the session to a pod that is about to disappear.
- **`destroy_released`** — delete the pod. Moves to a background task, registered in the existing drain set so the worker still waits for it (bounded by `_BACKGROUND_DRAIN_TIMEOUT_SECONDS`) before releasing the lease.

So a detached teardown cannot outlive the wake that started it, and a leaked pod was already reclaimed on worker shutdown regardless.

`destroy_for_session` keeps its previous behaviour for shutdown and `destroy_all` — it is now the two halves called in order.

## Deliberately not changed

The turn summary is the other half of the tail. It is emitted before `SESSION_COMPLETE` so the SDK sees the recap in the same event stream — a UI contract, not an oversight. Moving it is a product decision, not a patch, so it is left for its own change.

Billing settlement also stays on the path: it is correctness, it runs concurrently, and the 0.24s baseline shows it costs nothing measurable.

## Tests

- Detach makes the sandbox unreachable while the pod still exists, then `destroy_released` finishes the job.
- **The race the ordering prevents**: `ensure` after a release provisions a *fresh* sandbox rather than reusing the one being torn down, and tearing the old one down does not disturb it.
- With a deliberately slow backend (0.6s delete), detach returns in <0.1s and the pod is provably not yet deleted.
- **Mutation-tested**: putting the delete back inside `release_for_session` fails the timing test.
- 5,548 passed. The 4 `reportlab` failures are pre-existing and fail identically on a clean tree.