### PR TITLE
feat(turns): decide deliverables from the workspace, not from a guess

### DIFF
--- a/surogates/harness/delivery_manifest.py
+++ b/surogates/harness/delivery_manifest.py
@@ -1,0 +1,159 @@
+"""Deterministic reconciliation of what a turn actually delivered.
+
+The turn summarizer used to hand every touched file to the base model
+and ask which one was the user's deliverable. That is a guess on the
+delivery path, paid for on every turn, and it is blind to the three ways
+a delivery goes wrong without looking wrong:
+
+* the file is **scaffolding** -- written by the agent and then executed
+  by it, i.e. a generator script rather than the thing generated;
+* the file was written but is **empty**;
+* the file is **stale** -- a same-named leftover from an earlier turn,
+  where this turn's write failed;
+* nothing was written **at all**, yet the closing message says a report
+  was delivered. There is no candidate to reject, so a model choosing
+  among candidates cannot see it.
+
+Candidates were already collected deterministically -- from ``write_file``
+/ ``patch`` / ``create_artifact`` calls plus a workspace scan. Only the
+selection was a guess, so only the selection is replaced here.
+
+Artifacts (``kind="artifact"``) are not reconciled: they are created
+through ``create_artifact``, which either succeeds or raises, so there is
+no filesystem to disagree with.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterable, Literal
+
+from surogates.harness.turn_summarizer import TurnArtifact
+
+#: Why a candidate was not counted as delivered.
+RejectionReason = Literal["missing", "empty", "stale", "scaffolding"]
+
+
+@dataclass(frozen=True)
+class RejectedDelivery:
+    """A candidate the workspace does not support as a real deliverable."""
+
+    ref: str
+    reason: RejectionReason
+
+
+@dataclass(frozen=True)
+class DeliveryManifest:
+    """What the turn actually produced, and what it only appeared to."""
+
+    delivered: list[TurnArtifact]
+    rejected: list[RejectedDelivery]
+    #: Set when the closing message asserts a delivery the manifest does
+    #: not support. Advisory -- see :func:`check_terminal_claim`.
+    unsupported_claim: str | None = None
+
+    @property
+    def has_delivery(self) -> bool:
+        return bool(self.delivered)
+
+
+def reconcile(
+    candidates: Iterable[TurnArtifact],
+    *,
+    entries_by_path: dict[str, dict[str, Any]],
+    turn_start: datetime,
+) -> DeliveryManifest:
+    """Keep the candidates the workspace actually supports.
+
+    ``entries_by_path`` is the bulk listing the candidate scan already
+    fetches, keyed by workspace-relative path; each entry carries at
+    least ``size`` and ``modified``. A file candidate survives only if it
+    is present, non-empty, and was written during this turn.
+
+    A candidate whose entry is absent from the listing is **kept**, not
+    rejected: the listing can lag a just-written object, and dropping a
+    real deliverable is worse than showing one. Only positive evidence of
+    a problem -- present-but-empty, or present-but-old -- rejects.
+    """
+    delivered: list[TurnArtifact] = []
+    rejected: list[RejectedDelivery] = []
+
+    for cand in candidates:
+        if cand.kind != "file":
+            delivered.append(cand)
+            continue
+
+        if (cand.meta or {}).get("executed_by_terminal"):
+            # The agent wrote it and then ran it: a generator script,
+            # not the thing generated. This was the summariser prompt's
+            # strongest rule and it never needed a model -- the tool
+            # stream already says whether a file was executed.
+            rejected.append(
+                RejectedDelivery(ref=cand.ref, reason="scaffolding"),
+            )
+            continue
+
+        entry = entries_by_path.get(cand.ref)
+        if entry is None:
+            # Not observable either way -- see the docstring.
+            delivered.append(cand)
+            continue
+
+        size = entry.get("size")
+        if isinstance(size, int) and size <= 0:
+            rejected.append(RejectedDelivery(ref=cand.ref, reason="empty"))
+            continue
+
+        modified = entry.get("modified")
+        if isinstance(modified, datetime) and modified < turn_start:
+            # Same name, older content: this turn's write did not land.
+            rejected.append(RejectedDelivery(ref=cand.ref, reason="stale"))
+            continue
+
+        delivered.append(cand)
+
+    return DeliveryManifest(delivered=delivered, rejected=rejected)
+
+
+# A closing message that names a file and asserts it was produced. Kept
+# narrow on purpose: this only ever adds a warning, and a warning that
+# wrongly tells someone their work failed is worse than staying quiet.
+_CLAIM_VERBS = (
+    r"saved|wrote|written|created|generated|exported|produced|"
+    r"attached|delivered"
+)
+_FILE_TOKEN = r"[\w./-]+\.[A-Za-z0-9]{1,8}"
+_CLAIM_RE = re.compile(
+    rf"\b(?:{_CLAIM_VERBS})\b[^.\n]{{0,80}}?({_FILE_TOKEN})",
+    re.IGNORECASE,
+)
+
+
+def check_terminal_claim(
+    manifest: DeliveryManifest, final_message: str | None,
+) -> DeliveryManifest:
+    """Flag a closing message that claims a delivery the manifest lacks.
+
+    This is the case no amount of candidate curation can reach: with
+    nothing written there is no candidate, so nothing reaches the model
+    to be rejected, and "here is your report" reads as success.
+
+    Only fires when the manifest delivered **nothing** -- a turn that
+    produced one file while mentioning another is ordinary prose, not a
+    false claim, and flagging it would train people to ignore the
+    warning.
+    """
+    if manifest.has_delivery or not final_message:
+        return manifest
+
+    match = _CLAIM_RE.search(final_message)
+    if match is None:
+        return manifest
+
+    return DeliveryManifest(
+        delivered=manifest.delivered,
+        rejected=manifest.rejected,
+        unsupported_claim=match.group(1),
+    )

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -16,6 +16,10 @@ from surogates.harness.loop_artifacts import (
     _coerce_tool_args,
     _derive_artifact_name,
 )
+from surogates.harness.delivery_manifest import (
+    check_terminal_claim,
+    reconcile,
+)
 from surogates.harness.loop_constants import _BACKGROUND_DRAIN_TIMEOUT_SECONDS
 from surogates.harness.loop_messages import (
     _as_aware_utc,
@@ -213,6 +217,7 @@ class ArtifactCompletionMixin:
         session_id: UUID,
         turn_id: str,
         user_message: str,
+        final_message: str = "",
     ) -> None:
         """Drain pending iteration summaries, then emit TURN_SUMMARY.
 
@@ -267,20 +272,38 @@ class ArtifactCompletionMixin:
             str((getattr(e, "data", None) or {}).get("summary") or "")
             for e in ordered
         ]
-        candidate_artifacts = await self._collect_candidate_artifacts(
-            session_id=session_id, turn_id=turn_id,
+        candidate_artifacts, entries_by_path = (
+            await self._collect_candidate_artifacts(
+                session_id=session_id, turn_id=turn_id,
+            )
         )
 
+        # Which candidates are real deliverables is now decided against
+        # the workspace rather than by asking a model to pick. A file
+        # that is present-but-empty or present-but-older-than-this-turn
+        # is not a delivery, however convincing it looks in a prompt.
+        manifest = reconcile(
+            candidate_artifacts,
+            entries_by_path=entries_by_path,
+            turn_start=self._turn_started_at,
+        )
+        manifest = check_terminal_claim(manifest, final_message)
+        if manifest.rejected:
+            logger.info(
+                "Turn %s: dropped %d candidate(s) the workspace does not "
+                "support: %s",
+                turn_id, len(manifest.rejected),
+                ", ".join(f"{r.ref}({r.reason})" for r in manifest.rejected),
+            )
+
         try:
-            # Outer backstop sits above the summarizer's own 30s
-            # timeout — the turn summary runs on the base model, which
-            # is slower than the cheap auxiliary.
+            # Outer backstop sits above the summarizer's own timeout.
             result = await asyncio.wait_for(
                 self._turn_summarizer.summarize_turn(
                     turn_id=turn_id,
                     user_message=user_message,
                     iteration_summaries=iteration_summaries,
-                    candidate_artifacts=candidate_artifacts,
+                    artifacts=manifest.delivered,
                 ),
                 timeout=35.0,
             )
@@ -302,6 +325,24 @@ class ArtifactCompletionMixin:
                 {
                     "turn_id": turn_id,
                     "recap": result.recap,
+                    # Advisory, and only ever set when the turn delivered
+                    # nothing at all: the closing message claimed a file
+                    # that was never written. Surfaced rather than acted
+                    # on -- wrongly telling someone their work failed is
+                    # worse than saying nothing.
+                    **(
+                        {"unsupported_claim": manifest.unsupported_claim}
+                        if manifest.unsupported_claim
+                        else {}
+                    ),
+                    **(
+                        {"rejected": [
+                            {"ref": r.ref, "reason": r.reason}
+                            for r in manifest.rejected
+                        ]}
+                        if manifest.rejected
+                        else {}
+                    ),
                     "artifacts": [
                         {"kind": a.kind, "label": a.label, "ref": a.ref}
                         for a in result.artifacts
@@ -318,8 +359,13 @@ class ArtifactCompletionMixin:
         *,
         session_id: UUID,
         turn_id: str,
-    ) -> list[Any]:
+    ) -> tuple[list[Any], dict[str, dict[str, Any]]]:
         """Pull downloadable artifact candidates emitted during this turn.
+
+        Returns the candidates and the workspace listing they were
+        checked against -- reconciliation needs size and mtime for
+        candidates that came from tool calls, not only for the ones the
+        scan found.
 
         Returns a list of ``TurnArtifact`` instances from
         :mod:`surogates.harness.turn_summarizer` — workspace files and
@@ -425,18 +471,20 @@ class ArtifactCompletionMixin:
         # tool-call stream. Deduped against the paths already added
         # via write_file/patch so the same file isn't listed twice.
         try:
-            workspace_candidates = await self._scan_workspace_for_new_files(
-                session_id=session_id,
-                already_seen_paths={
-                    a.ref for a in out if a.kind == "file"
-                },
+            workspace_candidates, entries_by_path = (
+                await self._scan_workspace_for_new_files(
+                    session_id=session_id,
+                    already_seen_paths={
+                        a.ref for a in out if a.kind == "file"
+                    },
+                )
             )
         except Exception:
             logger.debug(
                 "Workspace mtime scan failed for %s",
                 session_id, exc_info=True,
             )
-            workspace_candidates = []
+            workspace_candidates, entries_by_path = [], {}
         out.extend(workspace_candidates)
 
         # Flag intermediate scripts: a file the agent wrote and then
@@ -463,7 +511,7 @@ class ArtifactCompletionMixin:
                 ))
             else:
                 annotated.append(art)
-        return annotated
+        return annotated, entries_by_path
 
     async def _scan_workspace_for_new_files(
         self,
@@ -487,15 +535,15 @@ class ArtifactCompletionMixin:
 
         storage = self._storage
         if storage is None or self._turn_started_at is None:
-            return []
+            return [], {}
 
         try:
             session = await self._store.get_session(session_id)
         except Exception:
-            return []
+            return [], {}
         bucket = (session.config or {}).get("storage_bucket")
         if not bucket:
-            return []
+            return [], {}
         root_id = (
             (session.config or {}).get("sandbox_root_session_id")
             or str(session.id)
@@ -509,9 +557,14 @@ class ArtifactCompletionMixin:
                 "Workspace list_entries failed for bucket %r prefix %r",
                 bucket, prefix, exc_info=True,
             )
-            return []
+            return [], {}
 
         out: list[TurnArtifact] = []
+        # Keyed by workspace-relative path and returned alongside the
+        # candidates: reconciliation needs size/mtime for candidates that
+        # came from tool calls too, and this listing is the only place
+        # they are observable without a per-file HEAD.
+        entries_by_path: dict[str, dict[str, Any]] = {}
         turn_start = self._turn_started_at
         for entry in entries:
             key = entry["key"]
@@ -521,12 +574,15 @@ class ArtifactCompletionMixin:
             if _is_internal_workspace_path(rel):
                 continue
             modified = _coerce_modified_to_datetime(entry.get("modified"))
+            entries_by_path[rel] = {
+                "size": entry.get("size"), "modified": modified,
+            }
             if modified is None or modified < turn_start:
                 continue
             out.append(
                 TurnArtifact(kind="file", label=rel, ref=rel),
             )
-        return out
+        return out, entries_by_path
 
     async def _resolve_loop_result_parent(self, session: Session) -> Session | None:
         """Return the direct-UI parent that should receive this loop run result.
@@ -773,6 +829,9 @@ class ArtifactCompletionMixin:
                     user_message=user_message
                     if user_message is not None
                     else _latest_user_message_text(messages),
+                    # The closing message is the only place a delivery
+                    # claim with nothing behind it can be seen.
+                    final_message=_last_assistant_message_excerpt(messages),
                 )
             except Exception:
                 logger.exception(

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -296,6 +296,25 @@ class ArtifactCompletionMixin:
                 ", ".join(f"{r.ref}({r.reason})" for r in manifest.rejected),
             )
 
+        # One question the workspace cannot answer: which of several real
+        # files the user actually asked for. Only asked when more than one
+        # survives -- the common single-file turn never makes the call.
+        delivered = manifest.delivered
+        try:
+            delivered = await asyncio.wait_for(
+                self._turn_summarizer.pick_deliverables(
+                    turn_id=turn_id,
+                    user_message=user_message,
+                    artifacts=manifest.delivered,
+                ),
+                timeout=35.0,
+            )
+        except Exception:
+            # Fail open: an extra entry on the card beats a missing one.
+            logger.debug(
+                "deliverable pick failed for %s", turn_id, exc_info=True,
+            )
+
         try:
             # Outer backstop sits above the summarizer's own timeout.
             result = await asyncio.wait_for(
@@ -303,7 +322,7 @@ class ArtifactCompletionMixin:
                     turn_id=turn_id,
                     user_message=user_message,
                     iteration_summaries=iteration_summaries,
-                    artifacts=manifest.delivered,
+                    artifacts=delivered,
                 ),
                 timeout=35.0,
             )

--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -590,6 +590,12 @@ class ArtifactCompletionMixin:
             rel = key[len(prefix):] if key.startswith(prefix) else key
             if not rel or rel in already_seen_paths:
                 continue
+            # Directory markers are not downloadable. Object stores list
+            # them as zero-byte keys ending in "/", so they only ever got
+            # dropped for being empty -- a backend that reports a size
+            # for them would have put __pycache__/ on the download card.
+            if rel.endswith("/"):
+                continue
             if _is_internal_workspace_path(rel):
                 continue
             modified = _coerce_modified_to_datetime(entry.get("modified"))

--- a/surogates/harness/turn_summarizer.py
+++ b/surogates/harness/turn_summarizer.py
@@ -92,38 +92,12 @@ _ITERATION_PROMPT = (
 )
 
 _TURN_PROMPT = (
-    "You are reviewing a completed agent turn. Return ONLY a JSON "
-    "object with two fields:\n"
-    "  recap: 1-3 short sentences in plain prose, no markdown, "
-    "summarizing what the agent accomplished\n"
-    "  artifacts: the downloadable deliverable(s) that satisfy what "
-    "the user asked for. Re-read the user request first and work "
-    "backwards from it: what file(s) did the user actually ask to "
-    "receive? List those and nothing else — usually a single file. "
-    "This list becomes the user-visible download card, so an "
-    "intermediate file here is worse than a missing one.\n"
-    "    KEEP only the final deliverable matching the request: asked "
-    "for a presentation -> the .pptx; a report -> the .pdf/.docx/.md; "
-    "a dataset -> the .csv/.xlsx; an image/video -> that media file; "
-    "a created artifact -> that artifact.\n"
-    "    DROP everything intermediate: scripts the agent wrote and "
-    "ran itself (executed_by_terminal=true is almost always "
-    "scaffolding), source-code files (.py, .sh, .js, .ts) unless the "
-    "user explicitly asked for code, assets generated only to be "
-    "embedded in the final deliverable (e.g. chart images rendered "
-    "for a .pptx), scratch files, downloads the agent fetched as "
-    "inputs, debugging output, and internal agent state (anything "
-    "under a hidden directory like .agents/ is context for future "
-    "turns, not a deliverable).\n"
-    "  Each artifact is "
-    '{"kind": "file|artifact", "label": str, "ref": str} — copy '
-    "kind and ref verbatim from the matching candidate. Return an "
-    "empty artifacts list when no candidate is a real deliverable "
-    "for this user request."
+    "You are reviewing a completed agent turn. Reply with 1-3 short "
+    "sentences of plain prose, no markdown, summarizing what the agent "
+    "accomplished for the user. Do not list files -- the deliverables "
+    "are decided elsewhere and shown separately. Reply with the "
+    "sentences only, no preamble and no JSON."
 )
-
-
-_VALID_KINDS: frozenset[str] = frozenset({"file", "artifact"})
 
 
 
@@ -430,74 +404,61 @@ class TurnSummarizer:
         turn_id: str,
         user_message: str,
         iteration_summaries: list[str],
-        candidate_artifacts: list[TurnArtifact],
+        artifacts: list[TurnArtifact],
     ) -> TurnSummary | None:
-        """Summarize a whole assistant turn into recap + artifact list.
+        """Write the turn's recap. ``artifacts`` are already decided.
 
-        Returns ``None`` when the turn has nothing worth summarizing, the
-        model returns invalid JSON, or the recap and artifact list both
-        end up empty after filtering.
+        Curation used to happen here: every touched file went into the
+        prompt and the base model picked the user's deliverable. That is
+        now reconciled against the workspace (see
+        :mod:`surogates.harness.delivery_manifest`), so this call only
+        writes prose -- which is what the cheap summary model is for, and
+        it is the reason the call no longer runs on the base model.
+
+        Returns ``None`` when the turn has nothing worth summarizing or
+        the model returns nothing usable.
         """
-        if not iteration_summaries and not candidate_artifacts:
+        if not iteration_summaries and not artifacts:
             return None
 
-        cand_lines = "\n".join(
-            f"- kind={a.kind} label={a.label!r} ref={a.ref!r}"
-            + (
-                " executed_by_terminal=true"
-                if (a.meta or {}).get("executed_by_terminal")
-                else ""
-            )
-            for a in candidate_artifacts
-        )
         user_block_parts: list[str] = [f"User asked: {user_message[:1000]}"]
         if iteration_summaries:
             user_block_parts.append(
                 "Iteration summaries:\n"
                 + "\n".join(f"- {s}" for s in iteration_summaries)
             )
-        if cand_lines:
-            user_block_parts.append(f"Candidate artifacts:\n{cand_lines}")
+        if artifacts:
+            user_block_parts.append(
+                "Delivered:\n"
+                + "\n".join(f"- {a.label}" for a in artifacts)
+            )
         user_block = "\n\n".join(user_block_parts)
 
-        kwargs: dict[str, Any] = {
-            "model": self._base_model,
-            "messages": [
-                {"role": "system", "content": _TURN_PROMPT},
-                {"role": "user", "content": user_block},
-            ],
-            "max_tokens": _MAX_TURN_SUMMARY_TOKENS,
-            "temperature": 0.3,
-            "stream": False,
-            "response_format": {"type": "json_object"},
-        }
+        # Prose only, so the cheap auxiliary is enough. Falling back to
+        # the base model keeps recaps working where no summary model is
+        # configured, rather than dropping them.
+        client = self._summary_client or self._base_client
+        model = self._summary_model or self._base_model
 
         content = await self._chat_completion(
-            self._base_client,
-            kwargs,
+            client,
+            {
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": _TURN_PROMPT},
+                    {"role": "user", "content": user_block},
+                ],
+                "max_tokens": _MAX_TURN_SUMMARY_TOKENS,
+                "temperature": 0.3,
+                "stream": False,
+            },
             label=f"turn {turn_id}",
             timeout=_TURN_SUMMARY_TIMEOUT_SECONDS,
         )
-        if not content:
-            return None
-
-        # Fence-tolerant: gateways that ignore ``response_format``
-        # return the object wrapped in ```json fences — a strict parse
-        # here once silenced recaps entirely.
-        parsed = parse_json_object(content)
-        if parsed is None:
-            logger.warning(
-                "turn summary returned no JSON object for %s: %r",
-                turn_id,
-                content[:200],
-            )
-            return None
-
-        recap = str(parsed.get("recap") or "").strip()
-        artifacts = self._parse_artifacts(parsed.get("artifacts"))
+        recap = (content or "").strip()
         if not recap and not artifacts:
             return None
-        return TurnSummary(recap=recap, artifacts=artifacts)
+        return TurnSummary(recap=recap, artifacts=list(artifacts))
 
     # ------------------------------------------------------------------
     # Internals
@@ -585,34 +546,4 @@ class TurnSummarizer:
                 f"[{index}] tool={name} args={args_snippet}\n"
                 f"    returned: {result_snippet}"
             )
-        return out
-
-    @staticmethod
-    def _parse_artifacts(raw: Any) -> list[TurnArtifact]:
-        if not isinstance(raw, list):
-            return []
-        out: list[TurnArtifact] = []
-        for item in raw:
-            if not isinstance(item, dict):
-                continue
-            kind = item.get("kind")
-            label = item.get("label")
-            ref = item.get("ref")
-            if kind not in _VALID_KINDS:
-                continue
-            if not isinstance(label, str) or not isinstance(ref, str):
-                continue
-            if not label or not ref:
-                continue
-            # The summary card only presents downloadable artifacts.
-            # The LLM occasionally smuggles a web URL through as
-            # kind=file; an absolute URL is not downloadable from the
-            # workspace, so drop it rather than render a dead entry.
-            if ref.startswith(("http://", "https://")):
-                continue
-            # Candidates are pre-filtered, but the model can still
-            # invent refs — never let internal paths reach the card.
-            if kind == "file" and _is_internal_workspace_path(ref):
-                continue
-            out.append(TurnArtifact(kind=kind, label=label, ref=ref))
         return out

--- a/surogates/harness/turn_summarizer.py
+++ b/surogates/harness/turn_summarizer.py
@@ -91,6 +91,19 @@ _ITERATION_PROMPT = (
     'Return ONLY a JSON object: {"caption": "<the one line>"}.'
 )
 
+_PICK_PROMPT = (
+    "The agent produced several files for one request. Name the ones the "
+    "user actually asked to receive -- usually one.\n"
+    "Work backwards from the request: a presentation means the .pptx, a "
+    "report means the .pdf/.docx/.md, a dataset means the .csv/.xlsx. "
+    "Leave out anything made along the way: source files unless code was "
+    "what was asked for, images rendered only to be embedded in a "
+    "document, scratch and debug output.\n"
+    "Reply with one path per line, copied exactly, and nothing else. If "
+    "every file looks like part of the answer, list them all."
+)
+
+
 _TURN_PROMPT = (
     "You are reviewing a completed agent turn. Reply with 1-3 short "
     "sentences of plain prose, no markdown, summarizing what the agent "
@@ -397,6 +410,80 @@ class TurnSummarizer:
             )
             return None
         return text
+
+    async def pick_deliverables(
+        self,
+        *,
+        turn_id: str,
+        user_message: str,
+        artifacts: list[TurnArtifact],
+    ) -> list[TurnArtifact]:
+        """Narrow several surviving files to the ones actually asked for.
+
+        The deterministic filters answer "is this a real file this turn
+        produced". They cannot answer "is this what the user wanted" --
+        that is a question about the request, not the workspace, and it
+        is the one rule from the retired curation prompt that does not
+        reduce to bookkeeping.
+
+        So it is asked, but only when it is actually a question: with one
+        surviving file there is nothing to choose between, and the common
+        turn skips the call entirely.
+
+        Fails open. A timeout, a refusal, or an unrecognisable reply
+        returns everything -- showing an extra file costs a cluttered
+        card, dropping a real one costs the user their work.
+        """
+        files = [a for a in artifacts if a.kind == "file"]
+        if len(files) < 2:
+            return artifacts
+
+        client = self._summary_client or self._base_client
+        model = self._summary_model or self._base_model
+        listing = "\n".join(a.ref for a in files)
+
+        content = await self._chat_completion(
+            client,
+            {
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": _PICK_PROMPT},
+                    {
+                        "role": "user",
+                        "content": (
+                            f"Request: {user_message[:1000]}\n\n"
+                            f"Files:\n{listing}"
+                        ),
+                    },
+                ],
+                "max_tokens": 200,
+                "temperature": 0,
+                "stream": False,
+            },
+            label=f"pick {turn_id}",
+            timeout=_TURN_SUMMARY_TIMEOUT_SECONDS,
+        )
+        if not content:
+            return artifacts
+
+        # Intersect with what we offered rather than trusting the reply:
+        # a model that invents a path cannot add one to the card, and a
+        # reply that matches nothing falls through to "keep everything".
+        offered = {a.ref: a for a in files}
+        chosen = [
+            offered[line]
+            for line in (ln.strip().strip("-* `") for ln in content.splitlines())
+            if line in offered
+        ]
+        if not chosen:
+            logger.debug(
+                "deliverable pick for %s matched no candidate: %r",
+                turn_id, content[:200],
+            )
+            return artifacts
+
+        keep = {a.ref for a in chosen}
+        return [a for a in artifacts if a.kind != "file" or a.ref in keep]
 
     async def summarize_turn(
         self,

--- a/tests/test_delivery_manifest.py
+++ b/tests/test_delivery_manifest.py
@@ -1,0 +1,135 @@
+"""What a turn delivered is decided by the workspace, not by a guess.
+
+The summarizer used to hand every touched file to the base model and ask
+which was the user's deliverable. These are the cases that guess cannot
+see, because a candidate that is empty, stale, or absent looks exactly
+like a real one once it is a line in a prompt.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from surogates.harness.delivery_manifest import (
+    check_terminal_claim,
+    reconcile,
+)
+from surogates.harness.turn_summarizer import TurnArtifact
+
+T0 = datetime(2026, 8, 27, 12, 0, 0)
+
+
+def _entry(size: int, offset_s: float) -> dict:
+    return {"size": size, "modified": T0 + timedelta(seconds=offset_s)}
+
+
+class TestReconcile:
+    def test_real_deliverable_survives(self):
+        m = reconcile(
+            [TurnArtifact("file", "report.pdf", "report.pdf")],
+            entries_by_path={"report.pdf": _entry(1200, 30)},
+            turn_start=T0,
+        )
+        assert [a.ref for a in m.delivered] == ["report.pdf"]
+        assert m.rejected == []
+        assert m.has_delivery
+
+    def test_empty_file_is_not_a_delivery(self):
+        """A zero-byte file reads as success in a prompt."""
+        m = reconcile(
+            [TurnArtifact("file", "out.csv", "out.csv")],
+            entries_by_path={"out.csv": _entry(0, 30)},
+            turn_start=T0,
+        )
+        assert m.delivered == []
+        assert [(r.ref, r.reason) for r in m.rejected] == [("out.csv", "empty")]
+
+    def test_stale_same_named_file_is_not_a_delivery(self):
+        """The write failed; last turn's file is still sitting there."""
+        m = reconcile(
+            [TurnArtifact("file", "report.pdf", "report.pdf")],
+            entries_by_path={"report.pdf": _entry(5000, -7200)},
+            turn_start=T0,
+        )
+        assert m.delivered == []
+        assert m.rejected[0].reason == "stale"
+
+    def test_executed_script_is_scaffolding(self):
+        """A file the agent wrote and then ran generated the deliverable."""
+        m = reconcile(
+            [
+                TurnArtifact("file", "report.pdf", "report.pdf"),
+                TurnArtifact(
+                    "file", "make.py", "make.py",
+                    {"executed_by_terminal": True},
+                ),
+            ],
+            entries_by_path={
+                "report.pdf": _entry(900, 5), "make.py": _entry(400, 3),
+            },
+            turn_start=T0,
+        )
+        assert [a.ref for a in m.delivered] == ["report.pdf"]
+        assert m.rejected[0].reason == "scaffolding"
+
+    def test_unlisted_candidate_is_kept(self):
+        """A listing that lags a just-written file must not lose it.
+
+        Only positive evidence of a problem rejects -- dropping a real
+        deliverable is worse than showing an extra one.
+        """
+        m = reconcile(
+            [TurnArtifact("file", "fresh.md", "fresh.md")],
+            entries_by_path={},
+            turn_start=T0,
+        )
+        assert [a.ref for a in m.delivered] == ["fresh.md"]
+
+    def test_artifacts_bypass_reconciliation(self):
+        """create_artifact either succeeded or raised; no file to check."""
+        m = reconcile(
+            [TurnArtifact("artifact", "chart", "art-1")],
+            entries_by_path={},
+            turn_start=T0,
+        )
+        assert [a.ref for a in m.delivered] == ["art-1"]
+
+
+class TestTerminalClaim:
+    """The failure a candidate-curating model structurally cannot see.
+
+    With nothing written there is no candidate, so nothing reaches the
+    model to reject, and "here is your report" reads as success.
+    """
+
+    @staticmethod
+    def _empty():
+        return reconcile([], entries_by_path={}, turn_start=T0)
+
+    @pytest.mark.parametrize("message,expected", [
+        ("I saved the analysis to report.pdf for you.", "report.pdf"),
+        ("I have written summary.md with the findings.", "summary.md"),
+        ("Generated output.xlsx as requested.", "output.xlsx"),
+    ])
+    def test_claim_with_nothing_delivered_is_flagged(self, message, expected):
+        assert check_terminal_claim(self._empty(), message).unsupported_claim == expected
+
+    @pytest.mark.parametrize("message", [
+        "Done. Let me know if you need anything else.",
+        "The config lives in settings.yaml, but I did not change it.",
+        "",
+    ])
+    def test_ordinary_prose_is_not_flagged(self, message):
+        """A false warning is worse than none -- it trains people to ignore it."""
+        assert check_terminal_claim(self._empty(), message).unsupported_claim is None
+
+    def test_a_real_delivery_silences_the_check(self):
+        """Mentioning another file while delivering one is normal prose."""
+        m = reconcile(
+            [TurnArtifact("file", "report.pdf", "report.pdf")],
+            entries_by_path={"report.pdf": _entry(900, 5)},
+            turn_start=T0,
+        )
+        assert check_terminal_claim(m, "Saved to notes.md too").unsupported_claim is None

--- a/tests/test_turn_summarizer.py
+++ b/tests/test_turn_summarizer.py
@@ -169,64 +169,6 @@ async def test_summarize_iteration_returns_none_on_client_exception() -> None:
     )
     assert result is None
 
-
-@pytest.mark.asyncio
-async def test_summarize_turn_returns_recap_and_downloadable_artifacts() -> None:
-    # The model echoing a url-kind entry must not survive parsing —
-    # the summary card only presents downloadable artifacts.
-    payload = (
-        '{"recap": "Reworked the hero around brain/hands.",'
-        ' "artifacts": ['
-        '   {"kind": "file", "label": "landing.html", "ref": "landing.html"},'
-        '   {"kind": "url", "label": "example.com", "ref": "https://example.com"}'
-        ' ]}'
-    )
-    client = _StubClient(payload)
-    summarizer = _turn_summarizer(client, "base-model")
-
-    result = await summarizer.summarize_turn(
-        turn_id="t1",
-        user_message="please update the hero",
-        iteration_summaries=["Rework hero paragraph"],
-        candidate_artifacts=[
-            TurnArtifact(kind="file", label="landing.html", ref="landing.html"),
-        ],
-    )
-
-    assert isinstance(result, TurnSummary)
-    assert result.recap.startswith("Reworked the hero")
-    assert len(result.artifacts) == 1
-    assert result.artifacts[0].kind == "file"
-    assert result.artifacts[0].label == "landing.html"
-    # The turn summary runs on the base model, not the cheap one.
-    assert client.chat.completions.calls[0]["model"] == "base-model"
-
-
-@pytest.mark.asyncio
-async def test_summarize_turn_drops_web_urls_smuggled_as_files() -> None:
-    payload = (
-        '{"recap": "Fetched the paper.",'
-        ' "artifacts": ['
-        '   {"kind": "file", "label": "paper", "ref": "https://example.com/p.pdf"},'
-        '   {"kind": "file", "label": "report.pdf", "ref": "report.pdf"}'
-        ' ]}'
-    )
-    client = _StubClient(payload)
-    summarizer = _turn_summarizer(client)
-
-    result = await summarizer.summarize_turn(
-        turn_id="t1",
-        user_message="x",
-        iteration_summaries=["s"],
-        candidate_artifacts=[
-            TurnArtifact(kind="file", label="report.pdf", ref="report.pdf"),
-        ],
-    )
-
-    assert result is not None
-    assert [a.ref for a in result.artifacts] == ["report.pdf"]
-
-
 @pytest.mark.asyncio
 async def test_summarize_iteration_skipped_without_summary_model() -> None:
     """No cheap summary model configured: iteration summaries are
@@ -243,47 +185,6 @@ async def test_summarize_iteration_skipped_without_summary_model() -> None:
     assert result is None
     assert base.chat.completions.calls == []
 
-
-@pytest.mark.asyncio
-async def test_summarize_turn_drops_unknown_artifact_kinds() -> None:
-    payload = (
-        '{"recap": "Did stuff.",'
-        ' "artifacts": ['
-        '   {"kind": "file", "label": "good.txt", "ref": "good.txt"},'
-        '   {"kind": "weirdo", "label": "bad", "ref": "bad"}'
-        ' ]}'
-    )
-    client = _StubClient(payload)
-    summarizer = _turn_summarizer(client)
-
-    result = await summarizer.summarize_turn(
-        turn_id="t1",
-        user_message="x",
-        iteration_summaries=["s"],
-        candidate_artifacts=[
-            TurnArtifact(kind="file", label="good.txt", ref="good.txt"),
-        ],
-    )
-
-    assert result is not None
-    assert len(result.artifacts) == 1
-    assert result.artifacts[0].kind == "file"
-
-
-@pytest.mark.asyncio
-async def test_summarize_turn_returns_none_on_invalid_json() -> None:
-    client = _StubClient("not JSON at all")
-    summarizer = _turn_summarizer(client)
-
-    result = await summarizer.summarize_turn(
-        turn_id="t1",
-        user_message="hi",
-        iteration_summaries=["s"],
-        candidate_artifacts=[],
-    )
-    assert result is None
-
-
 @pytest.mark.asyncio
 async def test_summarize_turn_returns_none_when_inputs_empty() -> None:
     client = _StubClient("noise")
@@ -293,138 +194,11 @@ async def test_summarize_turn_returns_none_when_inputs_empty() -> None:
         turn_id="t1",
         user_message="hi",
         iteration_summaries=[],
-        candidate_artifacts=[],
+        artifacts=[],
     )
     assert result is None
     # Skip the model call entirely when there's nothing to summarize.
     assert client.chat.completions.calls == []
-
-
-@pytest.mark.asyncio
-async def test_summarize_turn_returns_none_when_recap_and_artifacts_empty() -> None:
-    """LLM returned a structurally-valid response but empty fields."""
-    client = _StubClient('{"recap": "", "artifacts": []}')
-    summarizer = _turn_summarizer(client)
-    result = await summarizer.summarize_turn(
-        turn_id="t1",
-        user_message="x",
-        iteration_summaries=["s"],
-        candidate_artifacts=[],
-    )
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_summarize_turn_drops_internal_workspace_paths() -> None:
-    """Even if the model echoes an internal path (e.g. the
-    /product-marketing skill's .agents/ context file), it must not
-    reach the user-visible download card."""
-    payload = (
-        '{"recap": "Built the marketing context.",'
-        ' "artifacts": ['
-        '   {"kind": "file", "label": ".agents/product-marketing.md",'
-        '    "ref": ".agents/product-marketing.md"}'
-        ' ]}'
-    )
-    client = _StubClient(payload)
-    summarizer = _turn_summarizer(client)
-
-    result = await summarizer.summarize_turn(
-        turn_id="t1",
-        user_message="create a marketing document",
-        iteration_summaries=["Write product marketing context"],
-        candidate_artifacts=[
-            TurnArtifact(kind="file", label="x", ref="x"),
-        ],
-    )
-
-    # recap survives; the internal file does not.
-    assert result is not None
-    assert result.artifacts == []
-
-
-@pytest.mark.asyncio
-async def test_summarize_turn_parses_markdown_fenced_json() -> None:
-    # The exact failure shape that silenced recaps in production:
-    # Claude via an OpenAI-compatible gateway ignores
-    # response_format=json_object and wraps the object in a ```json
-    # fence. The recap must still land.
-    payload = (
-        "```json\n"
-        '{\n  "recap": "Quizzed the user on 5 Greek verbs and updated '
-        'the progress tracker.",\n  "artifacts": []\n}\n'
-        "```"
-    )
-    client = _StubClient(payload)
-    summarizer = _turn_summarizer(client)
-
-    result = await summarizer.summarize_turn(
-        turn_id="t1",
-        user_message="help me practice greek verbs",
-        iteration_summaries=["Quiz user on verbs"],
-        candidate_artifacts=[],
-    )
-
-    assert isinstance(result, TurnSummary)
-    assert result.recap.startswith("Quizzed the user")
-    assert result.artifacts == []
-
-
-@pytest.mark.asyncio
-async def test_summarize_turn_parses_json_with_surrounding_prose() -> None:
-    payload = (
-        "Here is the summary you asked for:\n"
-        "```json\n"
-        '{"recap": "Built the report.", "artifacts": '
-        '[{"kind": "file", "label": "report.pdf", "ref": "report.pdf"}]}\n'
-        "```\n"
-        "Let me know if you need anything else."
-    )
-    client = _StubClient(payload)
-    summarizer = _turn_summarizer(client)
-
-    result = await summarizer.summarize_turn(
-        turn_id="t1",
-        user_message="make me a report",
-        iteration_summaries=["Write report"],
-        candidate_artifacts=[
-            TurnArtifact(kind="file", label="report.pdf", ref="report.pdf"),
-        ],
-    )
-
-    assert isinstance(result, TurnSummary)
-    assert result.recap == "Built the report."
-    assert [a.ref for a in result.artifacts] == ["report.pdf"]
-
-
-@pytest.mark.asyncio
-async def test_summarize_turn_returns_none_on_truncated_fenced_json() -> None:
-    # A max_tokens cutoff mid-object stays unparseable — no recap
-    # beats a silently wrong one.
-    payload = '```json\n{"recap": "The agent loaded the PostHog analytics'
-    client = _StubClient(payload)
-    summarizer = _turn_summarizer(client)
-
-    result = await summarizer.summarize_turn(
-        turn_id="t1",
-        user_message="stats please",
-        iteration_summaries=["Run queries"],
-        candidate_artifacts=[],
-    )
-
-    assert result is None
-
-
-# ----------------------------------------------------------------------
-# Malformed-reply rejection
-#
-# The cheap summary model periodically completes the prompt's transcript
-# instead of captioning it. Whatever it returns becomes the iteration's
-# user-visible label, so every structural failure shape observed in
-# production is rejected here; the caller then emits no event and the
-# chat client falls back to its deterministic tool-derived label.
-# ----------------------------------------------------------------------
-
 
 def _calls(*names: str) -> list[dict[str, Any]]:
     """One tool call per name, ids ``c0``, ``c1``, … to match _results."""
@@ -981,3 +755,46 @@ async def test_server_errors_and_rate_limits_do_not_disable_json_mode(
 
     assert result is None
     assert len(client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_summarize_turn_writes_prose_on_the_cheap_model() -> None:
+    """Curation moved out, so this call is prose -- and prose is what the
+    cheap auxiliary is for. It ran on the base model only because it also
+    had to pick the user's deliverable out of intermediate files."""
+    base = _StubClient("base recap")
+    summary = _StubClient("Built the report and saved it.")
+    summarizer = TurnSummarizer(
+        base_client=base, base_model="base-model",
+        summary_client=summary, summary_model="cheap-model",
+    )
+
+    result = await summarizer.summarize_turn(
+        turn_id="t1",
+        user_message="make me a report",
+        iteration_summaries=["wrote the report"],
+        artifacts=[TurnArtifact("file", "report.pdf", "report.pdf")],
+    )
+
+    assert result is not None
+    assert result.recap == "Built the report and saved it."
+    # Artifacts pass through untouched -- already decided by the manifest.
+    assert [a.ref for a in result.artifacts] == ["report.pdf"]
+    assert base.chat.completions.calls == [], "still hitting the base model"
+    assert summary.chat.completions.calls[0]["model"] == "cheap-model"
+
+
+@pytest.mark.asyncio
+async def test_summarize_turn_falls_back_to_base_without_a_summary_model() -> None:
+    """No auxiliary configured must mean a recap on the base model, not
+    no recap."""
+    base = _StubClient("Did the thing.")
+    summarizer = TurnSummarizer(base_client=base, base_model="base-model")
+
+    result = await summarizer.summarize_turn(
+        turn_id="t1", user_message="do it",
+        iteration_summaries=["did it"], artifacts=[],
+    )
+
+    assert result is not None and result.recap == "Did the thing."
+    assert base.chat.completions.calls[0]["model"] == "base-model"

--- a/tests/test_turn_summarizer.py
+++ b/tests/test_turn_summarizer.py
@@ -798,3 +798,97 @@ async def test_summarize_turn_falls_back_to_base_without_a_summary_model() -> No
 
     assert result is not None and result.recap == "Did the thing."
     assert base.chat.completions.calls[0]["model"] == "base-model"
+
+
+class TestPickDeliverables:
+    """The one curation rule that is not bookkeeping.
+
+    "Is this a real file this turn produced" is answerable from the
+    workspace. "Is this what the user wanted" is a question about the
+    request, so it is asked -- but only when it is actually a question.
+    """
+
+    @staticmethod
+    def _files(*refs):
+        return [TurnArtifact("file", r, r) for r in refs]
+
+    @pytest.mark.asyncio
+    async def test_single_file_skips_the_call_entirely(self):
+        """The common turn must not pay for a choice with one option."""
+        client = _StubClient("report.pdf")
+        s = TurnSummarizer(
+            base_client=_StubClient("x"), base_model="base",
+            summary_client=client, summary_model="cheap",
+        )
+        out = await s.pick_deliverables(
+            turn_id="t", user_message="make a report",
+            artifacts=self._files("report.pdf"),
+        )
+        assert [a.ref for a in out] == ["report.pdf"]
+        assert client.chat.completions.calls == []
+
+    @pytest.mark.asyncio
+    async def test_narrows_several_files_to_the_one_asked_for(self):
+        client = _StubClient("slides.pptx")
+        s = TurnSummarizer(
+            base_client=_StubClient("x"), base_model="base",
+            summary_client=client, summary_model="cheap",
+        )
+        out = await s.pick_deliverables(
+            turn_id="t", user_message="make me a deck",
+            artifacts=self._files("slides.pptx", "chart1.png", "data.csv"),
+        )
+        assert [a.ref for a in out] == ["slides.pptx"]
+        assert client.chat.completions.calls[0]["model"] == "cheap"
+
+    @pytest.mark.asyncio
+    async def test_artifacts_are_never_dropped_by_the_pick(self):
+        """Only files are being chosen between; artifacts pass through."""
+        client = _StubClient("a.md")
+        s = TurnSummarizer(
+            base_client=_StubClient("x"), base_model="base",
+            summary_client=client, summary_model="cheap",
+        )
+        out = await s.pick_deliverables(
+            turn_id="t", user_message="write it up",
+            artifacts=[*self._files("a.md", "b.md"),
+                       TurnArtifact("artifact", "chart", "art-1")],
+        )
+        assert [a.ref for a in out] == ["a.md", "art-1"]
+
+    @pytest.mark.asyncio
+    async def test_invented_paths_cannot_reach_the_card(self):
+        """The reply is intersected with what was offered, not trusted."""
+        client = _StubClient("totally-made-up.pdf")
+        s = TurnSummarizer(
+            base_client=_StubClient("x"), base_model="base",
+            summary_client=client, summary_model="cheap",
+        )
+        offered = self._files("a.md", "b.md")
+        out = await s.pick_deliverables(
+            turn_id="t", user_message="write it up", artifacts=offered,
+        )
+        # Nothing matched -> keep everything, invent nothing.
+        assert [a.ref for a in out] == ["a.md", "b.md"]
+
+    @pytest.mark.asyncio
+    async def test_failure_keeps_every_file(self):
+        """Fail open: an extra card entry beats losing the user's work."""
+        class _Boom:
+            class chat:
+                class completions:
+                    calls: list = []
+
+                    @staticmethod
+                    async def create(**_kw):
+                        raise RuntimeError("provider down")
+
+        s = TurnSummarizer(
+            base_client=_StubClient("x"), base_model="base",
+            summary_client=_Boom(), summary_model="cheap",
+        )
+        out = await s.pick_deliverables(
+            turn_id="t", user_message="write it up",
+            artifacts=self._files("a.md", "b.md"),
+        )
+        assert [a.ref for a in out] == ["a.md", "b.md"]

--- a/tests/test_turn_summary_emit.py
+++ b/tests/test_turn_summary_emit.py
@@ -523,3 +523,44 @@ async def test_complete_session_skips_drain_for_research_session(
     emit_types = [c.args[1] for c in store.emit_event.await_args_list]
     assert EventType.TURN_SUMMARY not in emit_types
     assert EventType.SESSION_COMPLETE in emit_types
+
+
+@pytest.mark.asyncio
+async def test_collect_candidate_artifacts_skips_directory_markers() -> None:
+    """A directory is not a deliverable, whatever size the backend reports.
+
+    Object stores list directories as keys ending in "/". A real run put
+    ``__pycache__/`` in front of reconciliation, where it survived only
+    because its size happened to be zero.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    store = AsyncMock()
+    store.get_events = AsyncMock(return_value=[])
+    fake_session = SimpleNamespace(
+        id=uuid4(), config={"storage_bucket": "bucket-1"},
+    )
+    store.get_session = AsyncMock(return_value=fake_session)
+    turn_start = datetime.now(timezone.utc)
+
+    class _FakeStorage:
+        async def list_entries(self, _bucket, prefix=""):
+            return [
+                {"key": "out.csv", "modified": turn_start + timedelta(seconds=5),
+                 "size": 120},
+                # Non-zero size on purpose: the old code only dropped these
+                # for being empty.
+                {"key": "__pycache__/", "modified": turn_start + timedelta(seconds=5),
+                 "size": 4096},
+            ]
+
+    harness = _make_loop_harness(session_store=store, turn_summarizer=None)
+    harness._storage = _FakeStorage()
+    harness._turn_started_at = turn_start
+
+    candidates, _entries = await harness._collect_candidate_artifacts(
+        session_id=fake_session.id, turn_id="turn-D",
+    )
+    refs = [c.ref for c in candidates]
+    assert any("out.csv" in r for r in refs)
+    assert all(not r.endswith("/") for r in refs), refs

--- a/tests/test_turn_summary_emit.py
+++ b/tests/test_turn_summary_emit.py
@@ -202,16 +202,16 @@ async def test_drain_passes_iteration_summaries_and_candidates(
     # downloadable — the summary card only presents downloadable
     # artifacts) and the .agents/ write (internal agent state) are
     # dropped.
-    candidate_kinds = [a.kind for a in call["candidate_artifacts"]]
+    candidate_kinds = [a.kind for a in call["artifacts"]]
     assert "file" in candidate_kinds
     assert "url" not in candidate_kinds
-    assert all(a.label != "x.md" for a in call["candidate_artifacts"])
+    assert all(a.label != "x.md" for a in call["artifacts"])
     assert all(
-        "example.com" not in a.ref for a in call["candidate_artifacts"]
+        "example.com" not in a.ref for a in call["artifacts"]
     )
     assert all(
         not a.ref.startswith(".agents/")
-        for a in call["candidate_artifacts"]
+        for a in call["artifacts"]
     )
 
 
@@ -379,7 +379,7 @@ async def test_collect_candidate_artifacts_includes_workspace_mtime_files() -> N
     harness._storage = _FakeStorage()
     harness._turn_started_at = turn_start
 
-    candidates = await harness._collect_candidate_artifacts(
+    candidates, entries_by_path = await harness._collect_candidate_artifacts(
         session_id=fake_session.id, turn_id="turn-X",
     )
 
@@ -388,6 +388,13 @@ async def test_collect_candidate_artifacts_includes_workspace_mtime_files() -> N
     # The post-turn-start file appears; the pre-turn-start file doesn't.
     assert any("Summary.docx" in r for r in refs)
     assert all("old.txt" not in r for r in refs)
+
+    # The listing comes back too: reconciliation needs size and mtime for
+    # candidates that came from tool calls, which the scan never sees.
+    assert entries_by_path, "listing not returned alongside the candidates"
+    assert all(
+        "size" in e and "modified" in e for e in entries_by_path.values()
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follows [#222](https://github.com/invergent-ai/surogates/pull/222), which took the pod delete off the completion path. This takes the other half: the base-model call.

## The call being replaced

Every turn ran one base-model call doing two jobs — write a recap, and pick the user's deliverable out of everything touched. The second is a guess on the delivery path, and it cannot see the ways a delivery fails without looking like it:

| | |
|---|---|
| **scaffolding** | the agent wrote the file and then ran it — a generator, not the thing generated |
| **empty** | written, zero bytes; identical to a real file once it is a line in a prompt |
| **stale** | same name, older content: this turn's write never landed |
| **absent** | nothing written at all, yet the closing message says a report was delivered |

That last one is the interesting case: with nothing written there is no candidate, so nothing reaches the model to reject, and "here is your report" reads as success. No amount of curation quality fixes it — it is an absence, and the model only ever sees presences.

## What changed

Candidates were already deterministic — `write_file` / `patch` / `create_artifact` plus a workspace mtime scan. **Only the selection was a guess, so only the selection changes.**

The scan already read `size` and `modified` from the bulk listing and discarded them; it now returns them, so candidates that came from tool calls get checked too, not just the ones the scan found.

A candidate **absent** from the listing is kept, not rejected — a listing can lag a just-written object, and losing a real deliverable is worse than showing an extra one. Only positive evidence rejects.

Three of the old prompt's four rules reduce to bookkeeping and are now deterministic. **The fourth does not**: "asked for a presentation → the .pptx, not the .csv you made along the way" is a question about the request, not the workspace. So it is still asked — but only when more than one file survives, which means the common single-file turn makes no call at all, and when it does run it is the cheap auxiliary rather than the base model.

Two properties of that pick matter more than the choice itself:

- **The reply is intersected with what was offered.** A model that invents a path cannot put it on the card, and a reply matching nothing falls through to keeping everything.
- **It fails open.** Timeout, provider error, unparseable reply — all keep every file. An extra entry costs clutter; a missing one costs the user their work.

With curation out of it, the recap is prose, which is what the cheap auxiliary is for. It ran on the base model only because it also had to choose. Falls back to the base model when no summary model is configured, so a recap is never simply dropped.

## Expected effect

Measured before this change, gap from last `llm.response` to `session.complete`:

| turn summary | sandbox | p50 |
|---|---|---:|
| yes | no | **14.60s** |
| no | no | 0.24s |

The base-model call was that cost. Worth re-measuring with the same query after deploy rather than taking the estimate.

## Tests

- 13 manifest tests: every rejection reason, artifacts bypassing reconciliation, unlisted candidates kept, claim check firing only on a genuinely empty delivery.
- 5 pick tests: single file skips the call, several narrow to one, artifacts never dropped, invented paths cannot reach the card, provider failure keeps everything.
- Summarizer asserted to run on the cheap model, with a base-model fallback.
- The emit path asserts the listing comes back alongside the candidates.
- Removed 9 tests of the retired JSON-curation contract.
- 5,555 passed. The 4 `reportlab` failures are pre-existing and fail identically on a clean tree.
