### PR TITLE
feat(whiteboard): make the board legible and safe to draw on

### DIFF
--- a/sdk/agent-chat-react/src/agent-chat.tsx
+++ b/sdk/agent-chat-react/src/agent-chat.tsx
@@ -193,6 +193,10 @@ export function AgentChat({
   //     base agent's "turn" there is a single ``delegate_task`` call;
   //     the final artifact IS the recap.  An extra summary card just
   //     repeats the work in a less useful form.
+  //   * boards.  The canvas is the deliverable and it is already on
+  //     screen, so the card's only content is ``_whiteboard/canvas.json``
+  //     -- the board's own backing file, named with the ``_`` prefix
+  //     precisely to keep it out of the user's way.
   const orchestratesDeepResearch = useMemo(
     () => runtime.messages.some(
       (m) => m.toolCalls?.some(
@@ -203,7 +207,9 @@ export function AgentChat({
     [runtime.messages],
   );
   const hideTurnSummary =
-    isSubAgentSession(runtime.session) || orchestratesDeepResearch;
+    isSubAgentSession(runtime.session)
+    || orchestratesDeepResearch
+    || isBoardSession(runtime.session);
   const browserState = runtime.state.browser;
   // A "closed" browser state is functionally the same as no browser — the
   // BrowserPane would otherwise render an empty "preview unavailable" panel.

--- a/sdk/agent-chat-react/src/components/whiteboard/agent-whiteboard.tsx
+++ b/sdk/agent-chat-react/src/components/whiteboard/agent-whiteboard.tsx
@@ -14,13 +14,19 @@ import type {
   AgentChatViewMode,
 } from "../../types";
 import { Button } from "../ui/button";
+import { Spinner } from "../ui/spinner";
 import {
   type AtlasExtras,
   type Rect,
   atlasMetadata,
   buildAtlas,
+  agentObjectReport,
+  contentBeyond,
   contentBounds,
+  inkHeight,
   mapHotspots,
+  OCCUPANCY_GRID,
+  occupancyCells,
   planAtlas,
 } from "./atlas";
 import {
@@ -83,6 +89,12 @@ const ERASER_SCALE = 4;
 
 const TEXT_FONT_SIZE = 24;
 const TEXT_MAX_WIDTH = 320;
+
+/** How long a canvas load may take before the board says so. */
+const RESTORE_HINT_DELAY_MS = 250;
+
+/** `PointerEvent.button` for the middle button / wheel click. */
+const MIDDLE_BUTTON = 1;
 
 /** Mirrors the composer's segments so the two switches read alike. */
 const VIEW_MODE_LABELS: Record<AgentChatViewMode, string> = {
@@ -163,6 +175,10 @@ export function WhiteboardSurface({
   // Set by "New board" so the resume effect does not immediately pull
   // the user back into the board they just left.
   const [wantFresh, setWantFresh] = useState(false);
+  // Which button started the turn in flight. `deep` is many
+  // round-trips and worth naming; `sketch` is one and should not
+  // advertise a wait that is about to be over.
+  const [askMode, setAskMode] = useState<"sketch" | "deep">("sketch");
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
@@ -199,6 +215,11 @@ export function WhiteboardSurface({
   // rendering of it back out of the atlas.
   const typedRef = useRef<string[]>([]);
   const dirtyRef = useRef<Rect | null>(null);
+  // Object ids as they stood at the last Ask. What is local and not in
+  // here is what the user has added since -- which is how ink drawn
+  // around one of the agent's answers is told apart from ink that was
+  // always there.
+  const seenAtLastAsk = useRef<Set<string>>(new Set());
 
   const repaintRef = useRef<() => void>(() => undefined);
   const formulaCache = useMemo(
@@ -260,6 +281,39 @@ export function WhiteboardSurface({
   // replayed objects.
   const loadedSession = useRef<string | null | undefined>(undefined);
 
+  // Whether the canvas on screen reflects the stored one yet.  Autosave
+  // is held until it does.
+  //
+  // A remount starts from `emptyDoc()`, and the fold effect below
+  // immediately replays the agent's draw calls onto it -- so for the
+  // moment before the load resolves, the live document is a real,
+  // non-empty board holding the agent's objects and none of the user's.
+  // Saving in that window writes it over the stored board, destroying
+  // the ink the load was about to restore, and the load then returns
+  // what was just written.  That is why the loss needed an agent reply
+  // to reproduce: with nothing to fold the document stays empty, and
+  // `useDebouncedSave` already declines to save an empty one.
+  const [canvasReady, setCanvasReady] = useState(false);
+
+  // The veil is shown only once a load is slow enough to be worth
+  // mentioning.  A warm switch back resolves well inside this, and a
+  // spinner flashing on every toggle of the view is worse than showing
+  // nothing at all.  Blocking input is NOT delayed -- that has to hold
+  // from the first frame, or the strokes it exists to protect are the
+  // ones that get eaten.
+  const [restoringVisible, setRestoringVisible] = useState(false);
+  useEffect(() => {
+    if (canvasReady) {
+      setRestoringVisible(false);
+      return;
+    }
+    const timer = setTimeout(
+      () => setRestoringVisible(true),
+      RESTORE_HINT_DELAY_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [canvasReady]);
+
   useEffect(() => {
     // Once a session exists again the "fresh" intent is spent; without
     // clearing it, every later return to the board starts blank.
@@ -276,15 +330,21 @@ export function WhiteboardSurface({
       // adopting the session its own first Ask created, and everything
       // drawn before that question is still the live document.
       if (!sessionId && previous) setDoc(emptyDoc());
+      // Nothing to wait for: the document on screen is the live one.
+      setCanvasReady(true);
       return;
     }
 
+    // Switching to a different session re-arms the gate, so the outgoing
+    // board's document can never be saved under the incoming session's id.
+    setCanvasReady(false);
     let cancelled = false;
     void loadDoc(adapter, sessionId as string, runtime.messages).then(
       (loaded) => {
         if (cancelled) return;
         loadedSession.current = sessionId;
         setDoc(loaded);
+        setCanvasReady(true);
       },
     );
     return () => {
@@ -295,11 +355,20 @@ export function WhiteboardSurface({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [adapter, sessionId]);
 
+  // Held until the stored board is in hand.  Folding onto the empty
+  // document a remount starts from would paint the agent's objects
+  // alone -- a board the user never had, shown for as long as the fetch
+  // takes and then replaced.  `loadDoc` folds the same calls itself, so
+  // nothing is skipped by waiting; the load simply arrives complete.
   useEffect(() => {
+    if (!canvasReady) return;
     setDoc((d) => foldToolCalls(d, runtime.messages));
-  }, [runtime.messages]);
+  }, [runtime.messages, canvasReady]);
 
-  useDebouncedSave(adapter, sessionId, doc);
+  // A null session id is what `useDebouncedSave` already treats as
+  // "nothing to write to", so the gate reuses it rather than growing a
+  // second way to say the same thing.
+  useDebouncedSave(adapter, canvasReady ? sessionId : null, doc);
 
   // The transcript views are only worth offering once there is a
   // transcript. Before the agent's first answer, switching to Simple or
@@ -373,6 +442,15 @@ export function WhiteboardSurface({
     return () => ro.disconnect();
   }, []);
 
+  // The frame the next Ask will capture. Memoised because it walks every
+  // object, and paint runs on every pointer sample. `latest` is left out
+  // deliberately: it lives in a ref, so it could not invalidate this,
+  // and while the board fits the frame it makes no difference anyway.
+  const gridRect = useMemo(
+    () => planAtlas(doc, null, view, size, services).sourceRect,
+    [doc, view, size, services],
+  );
+
   const paint = useCallback(() => {
     const canvas = canvasRef.current;
     const ctx = canvas?.getContext("2d");
@@ -389,6 +467,40 @@ export function WhiteboardSurface({
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.clearRect(0, 0, size.w, size.h);
     renderDoc(ctx, doc, view, size, services, dpr);
+
+    // The same cells the agent is sent, drawn under the ink so the two
+    // of you are looking at one reference frame: "the answer goes in
+    // 9,6" means the same square to both. Painted here rather than
+    // written to the document, so it can never reach the atlas twice or
+    // be mistaken for something drawn.
+    if (gridRect) {
+      const px = 1 / (view.zoom * dpr);
+      const cw = gridRect.w / OCCUPANCY_GRID;
+      const ch = gridRect.h / OCCUPANCY_GRID;
+      ctx.save();
+      ctx.strokeStyle = "rgba(37, 99, 235, 0.16)";
+      ctx.lineWidth = px;
+      ctx.beginPath();
+      for (let i = 0; i <= OCCUPANCY_GRID; i++) {
+        ctx.moveTo(gridRect.x + i * cw, gridRect.y);
+        ctx.lineTo(gridRect.x + i * cw, gridRect.y + gridRect.h);
+        ctx.moveTo(gridRect.x, gridRect.y + i * ch);
+        ctx.lineTo(gridRect.x + gridRect.w, gridRect.y + i * ch);
+      }
+      ctx.stroke();
+      // Counter-scaled so the labels stay a constant size on screen
+      // however far the board is zoomed.
+      ctx.fillStyle = "rgba(37, 99, 235, 0.5)";
+      ctx.font = `${11 / view.zoom}px system-ui, sans-serif`;
+      ctx.textBaseline = "top";
+      for (let i = 0; i < OCCUPANCY_GRID; i++) {
+        ctx.fillText(String(i), gridRect.x + i * cw + 3 * px, gridRect.y + 2 * px);
+        if (i > 0) {
+          ctx.fillText(String(i), gridRect.x + 3 * px, gridRect.y + i * ch + 2 * px);
+        }
+      }
+      ctx.restore();
+    }
 
     // The marquee is interface, not content: painted here in screen
     // space and never written to the document, so it can never reach
@@ -446,7 +558,7 @@ export function WhiteboardSurface({
       ctx.lineJoin = "round";
       ctx.stroke();
     }
-  }, [doc, view, size, services, color, width, marquee, tool]);
+  }, [doc, view, size, services, color, width, marquee, tool, gridRect]);
 
   repaintRef.current = paint;
 
@@ -484,6 +596,19 @@ export function WhiteboardSurface({
       if (disabled) return;
       const screen = localPoint(e);
       const logical = screenToLogical(screen, view);
+
+      // Checked before any tool: the middle button pans whatever is in
+      // hand, so moving the board mid-drawing costs nothing. Putting it
+      // after the tool branches would let `text` open an editor and
+      // `pen` start a stroke on a middle-click first.
+      if (e.button === MIDDLE_BUTTON) {
+        // Suppresses the browser's middle-click autoscroll, which would
+        // otherwise take over the drag with its own scrolling puck.
+        e.preventDefault();
+        e.currentTarget.setPointerCapture(e.pointerId);
+        panFrom.current = screen;
+        return;
+      }
 
       if (tool === "text") {
         // No pointer capture and no default action. The browser focuses
@@ -745,11 +870,30 @@ export function WhiteboardSurface({
   const ask = useCallback(
     async (mode: "sketch" | "deep") => {
       if (!canvasRef.current) return;
+      setAskMode(mode);
       const latest = dirtyRef.current;
       const plan = planAtlas(doc, latest, view, size, services);
       const atlas = buildAtlas(doc, plan, services);
       const hotspots = mapHotspots(plan.sourceRect, hotspotsRef.current);
-      const extras: AtlasExtras = { mode };
+      const extras: AtlasExtras = {
+        mode,
+        inkHeight: inkHeight(doc, services),
+        // Read off the live document, which is the only record of what
+        // the user moved, resized or deleted -- none of which reaches
+        // the transcript.
+        occupied: occupancyCells(doc, plan.sourceRect, services),
+        beyond: contentBeyond(doc, plan.sourceRect, services),
+        agentObjects: agentObjectReport(doc, services, {
+          newLocalIds: new Set(
+            doc.objects
+              .filter(
+                (o) => o.origin === "local" && !seenAtLastAsk.current.has(o.id),
+              )
+              .map((o) => o.id),
+          ),
+        }),
+      };
+      seenAtLastAsk.current = new Set(doc.objects.map((o) => o.id));
       if (typedRef.current.length > 0) {
         extras.typedInput = typedRef.current.join("\n\n");
       }
@@ -812,7 +956,22 @@ export function WhiteboardSurface({
     return byId;
   }, [runtime.messages]);
 
-  const busy = runtime.isRunning || disabled;
+  // Asking against a board that is still loading would send an atlas of
+  // the half-restored document -- the agent's objects without the ink
+  // they answer.
+  const busy = runtime.isRunning || disabled || !canvasReady;
+
+  // The newest thing the agent has said it is doing. A sketch turn is a
+  // single round-trip and never produces one; a deep turn produces one
+  // per iteration, and without them a minute of real work is
+  // indistinguishable from a hang.
+  const progress = useMemo(() => {
+    for (let i = runtime.messages.length - 1; i >= 0; i--) {
+      const summary = runtime.messages[i].iterationSummary?.summary?.trim();
+      if (summary) return summary;
+    }
+    return null;
+  }, [runtime.messages]);
 
   return (
     <div className="flex h-full w-full flex-col">
@@ -842,6 +1001,17 @@ export function WhiteboardSurface({
             className={cn(
               "h-full w-full touch-none bg-white",
               tool === "pan" ? "cursor-grab" : "cursor-crosshair",
+              // Held from the first frame, not from when the veil
+              // appears: the load resolves by replacing the document
+              // wholesale, so anything drawn before it lands is thrown
+              // away.  Better to decline the stroke than to eat it.
+              //
+              // Held again while the agent works. The atlas and the
+              // occupied cells it is answering were captured when Ask
+              // was pressed, so ink added now is invisible to it — it
+              // places its answer against a board that no longer
+              // matches, and can land on top of what was just drawn.
+              (!canvasReady || runtime.isRunning) && "pointer-events-none",
             )}
             style={{ width: size.w, height: size.h }}
             onPointerDown={onPointerDown}
@@ -858,6 +1028,47 @@ export function WhiteboardSurface({
             }}
             onWheel={onWheel}
           />
+
+          {/* The board is held while the agent works, and says so. The
+              atlas it is answering was captured at Ask, so a stroke
+              added now is invisible to it -- and blocking without
+              showing it is worse than not blocking, because the ink
+              simply would not appear.
+
+              The label sits at the bottom edge, next to the controls
+              that started the turn, rather than over the middle: unlike
+              the restoring veil there is real content underneath that
+              the user is waiting to see answered. A sketch turn shows
+              only that it is thinking; a deep turn reports each step,
+              which is the difference between a slow answer and an
+              apparent hang. */}
+          {runtime.isRunning ? (
+            <div className="pointer-events-none absolute inset-0 bg-black/10">
+              <div className="absolute inset-x-0 bottom-2 flex justify-center px-12">
+                <span className="flex max-w-full items-center gap-2 rounded-full border bg-background px-4 py-1.5 text-sm text-muted-foreground shadow-sm">
+                  <Spinner className="size-4 shrink-0" />
+                  <span className="truncate">
+                    {progress ??
+                      (askMode === "deep" ? "Thinking harder…" : "Thinking…")}
+                  </span>
+                </span>
+              </div>
+            </div>
+          ) : null}
+
+          {/* The veil covers a blank canvas, not a half-drawn one: the
+              fold is held until the load lands, so there is nothing
+              underneath to show through. It reads as the surface being
+              busy, which is what a loading state is for. Tinted, not
+              blurred -- there is nothing to blur. */}
+          {restoringVisible ? (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/10">
+              <span className="flex items-center gap-3 rounded-full border bg-background px-6 py-3 text-sm font-medium text-muted-foreground shadow-md">
+                <Spinner className="size-5" />
+                Restoring board…
+              </span>
+            </div>
+          ) : null}
 
           {/* A canvas cannot host an iframe, so artifacts render as
               positioned DOM above it. The canvas carries a frame in
@@ -922,8 +1133,13 @@ export function WhiteboardSurface({
       </div>
 
       <div className="flex items-center gap-2 border-t p-2">
+        {/* Bounded rather than `flex-1`: filling the row pushed the
+            buttons onto the right edge, under the host's floating
+            Copilot button. Everything now packs left and the corner
+            stays clear. `min-w-0` keeps it shrinking on a narrow
+            window instead of forcing the buttons off the end. */}
         <input
-          className="min-w-0 flex-1 rounded border bg-background px-2 py-1 text-sm"
+          className="w-64 min-w-0 shrink rounded border bg-background px-2 py-1 text-sm"
           placeholder="Ask about the board (optional)"
           value={question}
           disabled={busy}

--- a/sdk/agent-chat-react/src/components/whiteboard/atlas.ts
+++ b/sdk/agent-chat-react/src/components/whiteboard/atlas.ts
@@ -11,7 +11,7 @@
  * `surogates/harness/loop_messages.py`. Renaming one silently shortens
  * the note the model sees rather than failing.
  */
-import type { WbDoc } from "./doc";
+import type { WbDoc, WbObject } from "./doc";
 import { objectBounds, renderDoc } from "./render";
 import type { RenderServices, View, ViewportSize } from "./render";
 
@@ -31,6 +31,30 @@ const MIN_CAPTURE_SPAN = 600;
 /** Fraction of the capture span added as margin around the content. */
 const CAPTURE_MARGIN = 0.25;
 
+/**
+ * Widest capture sent, in canvas units.
+ *
+ * Matched to the atlas caps so a capture at the limit still renders 1:1.
+ * Past it the board would be squeezed to fit -- a 6800-unit board came
+ * out at imageScale 0.30, where the model's own 55-unit answers are 16px
+ * tall and it places new work on top of old by squinting.
+ *
+ * The board is infinite; the capture is not. What falls outside is
+ * reported by {@link contentBeyond} rather than shrunk into
+ * illegibility.
+ */
+const MAX_CAPTURE_SPAN_W = MAX_ATLAS_WIDTH;
+const MAX_CAPTURE_SPAN_H = MAX_ATLAS_HEIGHT;
+
+/**
+ * Cells per side of the occupancy grid laid over the capture.
+ *
+ * Fixed, so the cost of describing a board is the same whether it holds
+ * three objects or three hundred -- which is the whole point of sending
+ * a grid instead of a list of rectangles.
+ */
+export const OCCUPANCY_GRID = 16;
+
 export interface Rect {
   x: number;
   y: number;
@@ -48,6 +72,9 @@ export interface AtlasPlan {
 
 const clamp = (v: number, lo: number, hi: number) =>
   Math.min(hi, Math.max(lo, v));
+
+/** Two decimals is plenty for a cell size and keeps the note short. */
+const round2 = (v: number) => Math.round(v * 100) / 100;
 
 /** Union of every object's bounds, or null when the board is empty. */
 export function contentBounds(
@@ -70,6 +97,60 @@ export function contentBounds(
   return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
 }
 
+/**
+ * Roughly how tall the user's handwriting is, in canvas units.
+ *
+ * The model is otherwise blind to scale: the note tells it where the
+ * capture is and what it covers, but nothing about how big the strokes
+ * in it are, so it picks a font size out of the air. On a real board of
+ * ~250-unit digits it chose 90, and its answer landed a quarter the size
+ * of the sum it was answering.
+ *
+ * Flat marks carry no height information -- the bars of an `=`, a minus,
+ * the dot of an `i` -- and counting them drags the figure toward zero,
+ * so strokes far shorter than typical are dropped. The cutoff is taken
+ * from the median rather than the tallest: against the tallest, one
+ * outsized stroke (a bracket, a long divider) excludes the very writing
+ * being measured. Taking the median twice is what makes both the flat
+ * marks and the outlier harmless.
+ *
+ * ponytail: fixed 25%-of-median cutoff, tuned on handwriting; revisit if
+ * boards mixing two writing sizes read badly.
+ */
+export function inkHeight(doc: WbDoc, services: RenderServices): number | null {
+  const heights: number[] = [];
+  for (const obj of doc.objects) {
+    if (obj.kind !== "ink") continue;
+    const b = objectBounds(obj, services);
+    if (b && b.h > 0) heights.push(b.h);
+  }
+  if (heights.length === 0) return null;
+  const upright = heights.filter((h) => h >= median(heights) * 0.25);
+  return upright.length === 0 ? null : median(upright);
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/** The smallest rectangle covering both, or whichever one exists. */
+function union(a: Rect | null, b: Rect | null): Rect | null {
+  if (!a) return b;
+  if (!b) return a;
+  const x = Math.min(a.x, b.x);
+  const y = Math.min(a.y, b.y);
+  return {
+    x,
+    y,
+    w: Math.max(a.x + a.w, b.x + b.w) - x,
+    h: Math.max(a.y + a.h, b.y + b.h) - y,
+  };
+}
+
 /** The viewport as a logical rectangle. */
 function viewportRect(view: View, size: ViewportSize): Rect {
   return {
@@ -83,9 +164,22 @@ function viewportRect(view: View, size: ViewportSize): Rect {
 /**
  * Choose the capture rectangle and its image scale.
  *
- * Priority: the latest input if there is one, else all content, else the
- * current viewport. Whatever is chosen is padded and floored to a
- * minimum span. Nothing is clamped: the canvas has no edges.
+ * The capture is what the user is looking at, plus a margin of the board
+ * around it, and always the latest input. Not the whole board: content
+ * is unbounded and the atlas is not, so framing on everything squeezes a
+ * long board into the same pixels until the model is placing objects by
+ * squinting at a thumbnail. A 6800-unit board arrived at imageScale 0.30
+ * -- 55-unit text rendered 16px tall -- and the model wrote its answer
+ * on top of an earlier one. What falls outside is reported by
+ * {@link contentBeyond} instead.
+ *
+ * Nor is it framed on the latest input alone. That is the *attention*
+ * signal, carried by `latestInput` and the hotspot trail; framing on it
+ * cropped away the very thing it referred to. A user who added `=` to a
+ * finished sum got back two bare horizontal lines, which the model
+ * reasonably read as a "menu / list icon?".
+ *
+ * Nothing is clamped to a canvas rectangle: the canvas has no edges.
  */
 export function planAtlas(
   doc: WbDoc,
@@ -94,18 +188,42 @@ export function planAtlas(
   viewport: ViewportSize,
   services: RenderServices,
 ): AtlasPlan {
-  const base =
-    latest ?? contentBounds(doc, services) ?? viewportRect(view, viewport);
+  const seen = viewportRect(view, viewport);
+  // The margin is what lets an answer reference something just past the
+  // edge of the screen, which is where the user's own eye already is.
+  const around: Rect = {
+    x: seen.x - seen.w * CAPTURE_MARGIN,
+    y: seen.y - seen.h * CAPTURE_MARGIN,
+    w: seen.w * (1 + CAPTURE_MARGIN * 2),
+    h: seen.h * (1 + CAPTURE_MARGIN * 2),
+  };
 
-  // Grow to the minimum span about the base's centre, then add margin,
-  // so a 4px tick mark still arrives with context around it.
+  // A board that fits is shown whole, wherever the user has scrolled to.
+  // Framing on the viewport alone cuts expressions in half: a user
+  // working at the right-hand end of an integral got back a capture
+  // starting mid-`e^x`, with the integral sign off the left edge, and
+  // the model answered the fragment it could see. Knowing that content
+  // continues left is not the same as being able to read it.
+  //
+  // Only once the board outgrows a legible capture does the viewport
+  // decide, because then something has to be left out and the least bad
+  // thing to keep is what the user is looking at.
+  const content = contentBounds(doc, services);
+  const fitsWhole =
+    content !== null &&
+    content.w <= MAX_CAPTURE_SPAN_W &&
+    content.h <= MAX_CAPTURE_SPAN_H;
+  // Either way the latest input is in shot, even if the user scrolled
+  // away after drawing it.
+  const base = union(fitsWhole ? content : around, latest) as Rect;
+
   const cx = base.x + base.w / 2;
   const cy = base.y + base.h / 2;
-  const spanW = Math.max(base.w * (1 + CAPTURE_MARGIN * 2), MIN_CAPTURE_SPAN);
-  const spanH = Math.max(base.h * (1 + CAPTURE_MARGIN * 2), MIN_CAPTURE_SPAN);
+  // Floored so a single tick mark on a blank board still arrives with
+  // surroundings; capped so a long board still arrives legible.
+  const spanW = clamp(base.w, MIN_CAPTURE_SPAN, MAX_CAPTURE_SPAN_W);
+  const spanH = clamp(base.h, MIN_CAPTURE_SPAN, MAX_CAPTURE_SPAN_H);
 
-  // No clamp into a canvas rectangle: the canvas has no edges, so the
-  // capture is simply centred on what it needs to cover.
   const sourceRect: Rect = {
     x: cx - spanW / 2,
     y: cy - spanH / 2,
@@ -135,6 +253,214 @@ export function planAtlas(
       ),
     },
   };
+}
+
+/**
+ * Which cells of the capture already hold something.
+ *
+ * The model cannot be told to keep off existing work by looking: on a
+ * busy board its own earlier answers are a few pixels tall, and the user
+ * may have dragged, resized or deleted them since -- edits that exist
+ * only in the document, never in the transcript. So the transcript is
+ * not merely incomplete about the board, it is confidently out of date,
+ * and this is the correction.
+ *
+ * A grid rather than a list of rectangles because the cost has to stay
+ * flat: three objects and three hundred produce the same handful of
+ * cells, where a rectangle list grows with the board until it dwarfs
+ * everything else in the turn.
+ *
+ * Cells are returned as `[col, row]`, the same shape as
+ * {@link mapHotspots}, so the model reads one spatial vocabulary rather
+ * than two.
+ */
+/**
+ * What an object actually covers, for occupancy purposes.
+ *
+ * {@link objectBounds} reports a text object's width as its `maxWidth`,
+ * which is the wrap width the author asked for, not the ink it produced.
+ * A one-glyph answer written with `maxWidth: 800` would claim eight
+ * cells it does not use, and the model would then route around canvas
+ * that is free -- getting steadily worse as its own generous wrap widths
+ * accumulate.
+ *
+ * Estimated from the glyph count rather than measured: measuring needs a
+ * canvas context, and being a little wrong about the width of a word is
+ * cheaper than threading one through. The estimate is deliberately
+ * slightly wide, so it errs toward keeping clear.
+ *
+ * ponytail: 0.6em per glyph, near the average for a proportional face;
+ * swap for a real measure if a service ever carries one.
+ */
+function occupiedBounds(
+  obj: WbObject,
+  services: RenderServices,
+): Rect | null {
+  const b = objectBounds(obj, services);
+  if (!b || obj.kind !== "text") return b;
+  const longest = Math.max(
+    ...obj.text.split("\n").map((line) => line.length),
+    0,
+  );
+  const inked = Math.max(obj.fontSize, longest * obj.fontSize * 0.6);
+  return { ...b, w: Math.min(b.w, inked) };
+}
+
+export function occupancyCells(
+  doc: WbDoc,
+  sourceRect: Rect,
+  services: RenderServices,
+): number[][] {
+  if (sourceRect.w <= 0 || sourceRect.h <= 0) return [];
+  const seen = new Set<number>();
+  const cells: number[][] = [];
+  const cellW = sourceRect.w / OCCUPANCY_GRID;
+  const cellH = sourceRect.h / OCCUPANCY_GRID;
+
+  for (const obj of doc.objects) {
+    const b = occupiedBounds(obj, services);
+    if (!b) continue;
+    const c0 = Math.floor((b.x - sourceRect.x) / cellW);
+    const c1 = Math.floor((b.x + b.w - sourceRect.x) / cellW);
+    const r0 = Math.floor((b.y - sourceRect.y) / cellH);
+    const r1 = Math.floor((b.y + b.h - sourceRect.y) / cellH);
+    for (let r = Math.max(0, r0); r <= Math.min(OCCUPANCY_GRID - 1, r1); r++) {
+      for (let c = Math.max(0, c0); c <= Math.min(OCCUPANCY_GRID - 1, c1); c++) {
+        const key = r * OCCUPANCY_GRID + c;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        cells.push([c, r]);
+      }
+    }
+  }
+  // Reading order, so a run of free space is easy to spot.
+  cells.sort((a, b) => a[1] - b[1] || a[0] - b[0]);
+  return cells;
+}
+
+/** How many of the agent's own objects the turn note lists. */
+export const AGENT_OBJECT_LIMIT = 8;
+
+/** One of the agent's own objects, as the board holds it now. */
+export interface AgentObjectReport {
+  /** The `whiteboard_draw` call that produced it. */
+  origin: string;
+  label: string;
+  /** Where it sits now, or null when the user has deleted it. */
+  bounds: Rect | null;
+  /** New user ink lands on or around it: an edit to it, not new work. */
+  touched?: boolean;
+}
+
+/** A short, note-sized description of what an object is. */
+function objectLabel(obj: WbObject): string {
+  const raw =
+    obj.kind === "text"
+      ? obj.text
+      : obj.kind === "formula"
+        ? obj.latex
+        : obj.kind === "artifact"
+          ? `artifact ${obj.artifactId}`
+          : obj.kind;
+  const flat = String(raw).replace(/\s+/g, " ").trim();
+  return flat.length > 40 ? `${flat.slice(0, 39)}…` : flat;
+}
+
+/** *rect* grown by *margin* on every side. */
+function grow(rect: Rect, margin: number): Rect {
+  return {
+    x: rect.x - margin,
+    y: rect.y - margin,
+    w: rect.w + margin * 2,
+    h: rect.h + margin * 2,
+  };
+}
+
+function overlaps(a: Rect, b: Rect): boolean {
+  return (
+    a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y
+  );
+}
+
+/**
+ * What became of everything the agent has drawn.
+ *
+ * The transcript records where it *asked* for each object. It does not
+ * record what happened next, because what happens next is the user:
+ * dragging, resizing, deleting, or drawing something that changes what
+ * an object means. None of that reaches the conversation, so the
+ * agent's memory of its own work is confidently out of date.
+ *
+ * One real session ended with the agent's answer wrapped in
+ * hand-drawn brackets and squared. The board said one thing, the
+ * transcript another, and the agent answered the transcript.
+ *
+ * *newLocalIds* are the user's objects added since the last Ask; an
+ * agent object they land on is flagged `touched`, because ink drawn
+ * over or around an answer is an edit to it rather than a new question
+ * beside it. The margin is generous on purpose: a bracket is drawn
+ * just outside the thing it encloses, never across it.
+ */
+export function agentObjectReport(
+  doc: WbDoc,
+  services: RenderServices,
+  opts: { newLocalIds?: ReadonlySet<string>; limit?: number } = {},
+): AgentObjectReport[] {
+  const limit = opts.limit ?? AGENT_OBJECT_LIMIT;
+  const fresh: Rect[] = [];
+  if (opts.newLocalIds?.size) {
+    for (const obj of doc.objects) {
+      if (obj.origin !== "local" || !opts.newLocalIds.has(obj.id)) continue;
+      const b = objectBounds(obj, services);
+      if (b) fresh.push(b);
+    }
+  }
+  const reach = inkHeight(doc, services) ?? 0;
+
+  // Newest first: the recent ones are the ones still being worked on,
+  // and the cap has to fall on the oldest.
+  const origins = doc.folded.slice(-limit).reverse();
+  const report: AgentObjectReport[] = [];
+  for (const origin of origins) {
+    const mine = doc.objects.filter((o) => o.origin === origin);
+    if (mine.length === 0) {
+      report.push({ origin, label: "", bounds: null });
+      continue;
+    }
+    for (const obj of mine) {
+      const bounds = objectBounds(obj, services);
+      const near = bounds ? grow(bounds, reach * 0.75) : null;
+      report.push({
+        origin,
+        label: objectLabel(obj),
+        bounds,
+        touched: near ? fresh.some((f) => overlaps(near, f)) : false,
+      });
+    }
+  }
+  return report;
+}
+
+/**
+ * Which way the board continues past the capture.
+ *
+ * The capture is bounded, so its edge is not the edge of anything. Say
+ * so, or the model treats the empty margin as free canvas and places
+ * work into objects sitting just outside the frame.
+ */
+export function contentBeyond(
+  doc: WbDoc,
+  sourceRect: Rect,
+  services: RenderServices,
+): string[] {
+  const content = contentBounds(doc, services);
+  if (!content) return [];
+  const out: string[] = [];
+  if (content.y < sourceRect.y) out.push("above");
+  if (content.x + content.w > sourceRect.x + sourceRect.w) out.push("right");
+  if (content.y + content.h > sourceRect.y + sourceRect.h) out.push("below");
+  if (content.x < sourceRect.x) out.push("left");
+  return out;
 }
 
 /**
@@ -208,13 +534,75 @@ export function buildAtlas(
     plan.imageSize,
     services,
   );
+  paintGridOverlay(ctx, plan.imageSize);
   return canvas;
+}
+
+/**
+ * Draw the occupancy grid over the finished atlas, labelled.
+ *
+ * The cells are already described in the note as `[col, row]` pairs, but
+ * reading those means cross-referencing a list against a picture and
+ * doing arithmetic on `sourceRect` to place anything. Drawn on, the model
+ * can see which cells hold work and which are free, and name a
+ * destination by pointing rather than by calculating.
+ *
+ * Deliberately faint and cool-toned: it has to be legible enough to
+ * count but never mistakable for something the user drew. The note says
+ * so as well -- both, because either alone has been enough for a model
+ * to answer the scaffolding instead of the question.
+ *
+ * Image space only. `renderDoc` leaves a board-space transform behind,
+ * and the grid is a property of the picture, not of the canvas.
+ */
+function paintGridOverlay(
+  ctx: CanvasRenderingContext2D,
+  size: { w: number; h: number },
+): void {
+  const cellW = size.w / OCCUPANCY_GRID;
+  const cellH = size.h / OCCUPANCY_GRID;
+
+  ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.strokeStyle = "rgba(37, 99, 235, 0.18)";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  for (let i = 1; i < OCCUPANCY_GRID; i++) {
+    // The half-pixel keeps a 1px line on the pixel rather than across
+    // two, which otherwise renders as a 2px smear.
+    const x = Math.round(i * cellW) + 0.5;
+    const y = Math.round(i * cellH) + 0.5;
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, size.h);
+    ctx.moveTo(0, y);
+    ctx.lineTo(size.w, y);
+  }
+  ctx.stroke();
+
+  // Indices along the top and left edges only. One label per cell would
+  // put 256 numbers over the board.
+  ctx.fillStyle = "rgba(37, 99, 235, 0.55)";
+  ctx.font = "11px system-ui, sans-serif";
+  ctx.textBaseline = "top";
+  for (let i = 0; i < OCCUPANCY_GRID; i++) {
+    ctx.fillText(String(i), i * cellW + 3, 2);
+    if (i > 0) ctx.fillText(String(i), 3, i * cellH + 2);
+  }
+  ctx.restore();
 }
 
 export interface AtlasExtras {
   mode?: "sketch" | "deep";
   selection?: Rect | null;
   typedInput?: string;
+  /** See {@link inkHeight}. Omitted when the board carries no ink. */
+  inkHeight?: number | null;
+  /** See {@link occupancyCells}. */
+  occupied?: number[][];
+  /** See {@link contentBeyond}. */
+  beyond?: string[];
+  /** See {@link agentObjectReport}. */
+  agentObjects?: AgentObjectReport[];
 }
 
 /**
@@ -241,5 +629,36 @@ export function atlasMetadata(
   if (hotspots.length > 0) meta.hotspots = hotspots;
   if (extras.selection) meta.selection = extras.selection;
   if (extras.typedInput?.trim()) meta.typedInput = extras.typedInput.trim();
+  if (extras.inkHeight && extras.inkHeight > 0) {
+    meta.inkHeight = Math.round(extras.inkHeight);
+  }
+  if (extras.occupied?.length) {
+    meta.occupied = extras.occupied;
+    meta.occupancyGrid = OCCUPANCY_GRID;
+    // So a chosen cell converts to canvas coordinates without inverting
+    // the image formula by hand. Asked for the slot after an `x =`, the
+    // model converted the column correctly and left the row in image
+    // coordinates, landing the answer below the frame it was shown.
+    meta.cellSize = {
+      w: round2(plan.sourceRect.w / OCCUPANCY_GRID),
+      h: round2(plan.sourceRect.h / OCCUPANCY_GRID),
+    };
+  }
+  if (extras.beyond?.length) meta.beyond = extras.beyond;
+  if (extras.agentObjects?.length) {
+    meta.agentObjects = extras.agentObjects.map((o) => ({
+      origin: o.origin,
+      label: o.label,
+      ...(o.bounds
+        ? {
+            x: round2(o.bounds.x),
+            y: round2(o.bounds.y),
+            w: round2(o.bounds.w),
+            h: round2(o.bounds.h),
+          }
+        : { removed: true }),
+      ...(o.touched ? { touched: true } : {}),
+    }));
+  }
   return meta;
 }

--- a/sdk/agent-chat-react/src/components/whiteboard/doc.ts
+++ b/sdk/agent-chat-react/src/components/whiteboard/doc.ts
@@ -100,6 +100,20 @@ function nextId(origin: string): string {
   return `${origin}:${localCounter}`;
 }
 
+/**
+ * A size the model may have spelled `width`/`height`.
+ *
+ * The command vocabulary is mixed — `draw` has a stroke `width`,
+ * `write_text` has `maxWidth`, `erase` and `place_artifact` have `w`/`h`
+ * — so the long spelling turns up on the short-spelled commands. The
+ * validator accepts it, and this is the half that makes it draw: without
+ * it an aliased erase passes validation and then rubs out nothing.
+ */
+function size(cmd: Record<string, unknown>, key: "w" | "h"): unknown {
+  const alias = key === "w" ? "width" : "height";
+  return cmd[key] ?? cmd[alias];
+}
+
 /** Convert one command into an object, or null to skip it. */
 function toObject(
   cmd: Record<string, unknown>,
@@ -152,8 +166,8 @@ function toObject(
         mode: cmd.mode,
         x: cmd.x as number | undefined,
         y: cmd.y as number | undefined,
-        w: cmd.w as number | undefined,
-        h: cmd.h as number | undefined,
+        w: size(cmd, "w") as number | undefined,
+        h: size(cmd, "h") as number | undefined,
         points: cmd.points as number[][] | undefined,
         size: cmd.size as number | undefined,
       };
@@ -165,8 +179,8 @@ function toObject(
         artifactId: cmd.artifact_id,
         x: Number(cmd.x),
         y: Number(cmd.y),
-        w: Number(cmd.w),
-        h: Number(cmd.h),
+        w: Number(size(cmd, "w")),
+        h: Number(size(cmd, "h")),
       };
     default:
       return null;
@@ -192,21 +206,35 @@ export function applyCommands(
   if (!Array.isArray(commands)) return doc;
 
   const added: WbObject[] = [];
+  // Origins this call supersedes. The agent can only add objects, so
+  // without this a corrected answer is drawn on top of the wrong one —
+  // `erase` paints white, it does not delete. One turn stacked four
+  // answers on a single spot.
+  const superseded = new Set<string>();
   for (const cmd of commands) {
     if (typeof cmd !== "object" || cmd === null) continue;
-    const obj = toObject(cmd as Record<string, unknown>, origin);
+    const record = cmd as Record<string, unknown>;
+    const obj = toObject(record, origin);
     if (obj) added.push(obj);
+    // Honoured even when the command itself was unusable: the intent to
+    // retract is independent of whether the replacement could be drawn,
+    // and leaving the old one behind on a failed replace is the worse
+    // of the two outcomes.
+    if (typeof record.replaces === "string" && record.replaces) {
+      superseded.add(record.replaces);
+    }
   }
   // Advance the cursor even when nothing survived validation, or the
   // persistence tail replays the same dead call on every load.
-  if (added.length === 0) {
+  if (added.length === 0 && superseded.size === 0) {
     return { ...doc, lastEventId: nextEventId };
   }
+  const kept = doc.objects.filter((o) => !superseded.has(o.origin));
   return {
     ...doc,
     version: 1,
     objects: [
-      ...doc.objects.map((o) => (o.selected ? { ...o, selected: false } : o)),
+      ...kept.map((o) => (o.selected ? { ...o, selected: false } : o)),
       ...added,
     ],
     lastEventId: nextEventId,

--- a/sdk/agent-chat-react/src/components/whiteboard/persist.ts
+++ b/sdk/agent-chat-react/src/components/whiteboard/persist.ts
@@ -27,6 +27,20 @@ export const CANVAS_PATH = `${CANVAS_DIR}/${CANVAS_FILE}`;
 /** Debounce for autosave. Long enough to coalesce a burst of strokes. */
 export const SAVE_DEBOUNCE_MS = 1500;
 
+/**
+ * Saves that have not landed yet, per session.
+ *
+ * Switching the view unmounts the board and remounts it, so the unmount's
+ * save and the remount's load are in flight together — and the load wins,
+ * because a read beats an upload. It returns the board from before the
+ * strokes, and the remount's own debounce then writes that back, which is
+ * what makes the loss permanent.
+ *
+ * One writer means the file is still the document; it just has to be
+ * finished being written before it is read.
+ */
+const inFlightSaves = new Map<string, Promise<void>>();
+
 function decode(content: string, encoding: string): string {
   if (encoding !== "base64") return content;
   try {
@@ -49,6 +63,9 @@ export async function loadDoc(
   sessionId: string,
   messages: AgentChatMessage[],
 ): Promise<WbDoc> {
+  // Never rejects: saveDoc swallows its own failures.
+  await inFlightSaves.get(sessionId);
+
   let doc = emptyDoc();
   try {
     const file = await adapter.getWorkspaceFile({
@@ -88,22 +105,36 @@ export async function loadDoc(
  * carries the agent's objects, and surfacing an error here would put a
  * network hiccup in front of someone who is drawing.
  */
-export async function saveDoc(
+export function saveDoc(
   adapter: AgentChatAdapter,
   sessionId: string,
   doc: WbDoc,
 ): Promise<void> {
-  try {
-    const body = JSON.stringify(doc);
-    const file = new File([body], CANVAS_FILE, { type: "application/json" });
-    await adapter.uploadWorkspaceFile({
-      sessionId,
-      file,
-      directory: CANVAS_DIR,
-    });
-  } catch {
-    // Intentionally silent — see the docstring.
-  }
+  const done = (async () => {
+    try {
+      const body = JSON.stringify(doc);
+      const file = new File([body], CANVAS_FILE, {
+        type: "application/json",
+      });
+      await adapter.uploadWorkspaceFile({
+        sessionId,
+        file,
+        directory: CANVAS_DIR,
+      });
+    } catch {
+      // Intentionally silent — see the docstring.
+    }
+  })();
+  // Registered synchronously: the unmount flush and the remount load run
+  // in the same React commit, so a save that only published itself after
+  // its first await would not be visible to the load that has to wait
+  // for it.
+  inFlightSaves.set(sessionId, done);
+  return done.then(() => {
+    if (inFlightSaves.get(sessionId) === done) {
+      inFlightSaves.delete(sessionId);
+    }
+  });
 }
 
 /**

--- a/sdk/agent-chat-react/tests/whiteboard-atlas.test.ts
+++ b/sdk/agent-chat-react/tests/whiteboard-atlas.test.ts
@@ -4,8 +4,15 @@ import {
   MAX_ATLAS_HEIGHT,
   MAX_ATLAS_WIDTH,
   atlasMetadata,
+  buildAtlas,
+  AGENT_OBJECT_LIMIT,
+  OCCUPANCY_GRID,
+  agentObjectReport,
+  contentBeyond,
   contentBounds,
+  inkHeight,
   mapHotspots,
+  occupancyCells,
   planAtlas,
 } from "@/components/whiteboard/atlas";
 import { applyCommands, emptyDoc } from "@/components/whiteboard/doc";
@@ -101,9 +108,11 @@ describe("atlas planning", () => {
   it("captures negative regions without clamping them away", () => {
     // The canvas has no edges: a board drawn up and to the left of the
     // origin is ordinary, and clamping to 0 would crop it out entirely.
-    const latest = { x: -8000, y: -6000, w: 400, h: 300 };
+    // Framed from the viewport, so the user is looking at it.
+    const far = { x: -8000, y: -6000, zoom: 1 };
+    const latest = { x: -7900, y: -5900, w: 400, h: 300 };
     const { sourceRect } = planAtlas(
-      emptyDoc(), latest, view, viewport, services,
+      emptyDoc(), latest, far, viewport, services,
     );
     expect(sourceRect.x).toBeLessThanOrEqual(latest.x);
     expect(sourceRect.y).toBeLessThanOrEqual(latest.y);
@@ -255,5 +264,422 @@ describe("atlas metadata", () => {
       })),
     ).length;
     expect(size).toBeLessThan(65_536);
+  });
+});
+
+describe("keeping the board in shot", () => {
+  // From a real session: a finished sum, then `=` added to the right of
+  // it. The capture framed on the new stroke alone, so the model got two
+  // bare horizontal lines and answered "menu / list icon?".
+  const sum = {
+    tool: "write_text", x: 0, y: 0, text: "1 + 2",
+    fontSize: 32, maxWidth: 300,
+  };
+
+  function covers(rect: { x: number; y: number; w: number; h: number },
+                  inner: { x: number; y: number; w: number; h: number }) {
+    return (
+      rect.x <= inner.x &&
+      rect.y <= inner.y &&
+      rect.x + rect.w >= inner.x + inner.w &&
+      rect.y + rect.h >= inner.y + inner.h
+    );
+  }
+
+  it("keeps earlier content in frame when new ink lands far away", () => {
+    const doc = applyCommands(emptyDoc(), [sum], 1);
+    const latest = { x: 1200, y: 40, w: 16, h: 33 };
+    const { sourceRect } = planAtlas(doc, latest, view, viewport, services);
+
+    expect(covers(sourceRect, latest)).toBe(true);
+    // The sum itself must still be in the picture the model answers.
+    expect(covers(sourceRect, { x: 0, y: 0, w: 1, h: 1 })).toBe(true);
+  });
+
+  it("still covers a dirty region where content was erased", () => {
+    // Rubbing something out leaves a dirty rectangle with nothing in it,
+    // and the model should see where. The user erases what they are
+    // looking at, so it sits inside the viewport.
+    const doc = applyCommands(emptyDoc(), [sum], 1);
+    const erased = { x: 40, y: 30, w: 20, h: 20 };
+    const { sourceRect } = planAtlas(doc, erased, view, viewport, services);
+
+    expect(covers(sourceRect, erased)).toBe(true);
+  });
+
+  it("still falls back to the viewport on an empty canvas", () => {
+    const { sourceRect } = planAtlas(
+      emptyDoc(), null, view, viewport, services,
+    );
+    expect(sourceRect.w).toBeGreaterThan(0);
+    expect(sourceRect.h).toBeGreaterThan(0);
+  });
+});
+
+describe("telling the model how big the writing is", () => {
+  // Without it the model picks a font size blind: on a board of ~250-unit
+  // digits it chose 90, and the answer came out a quarter the size.
+  function inked(heights: number[]) {
+    return {
+      ...emptyDoc(),
+      objects: heights.map((h, i) => ({
+        id: `i${i}`, origin: "local", selected: false,
+        kind: "ink" as const,
+        pts: [0, 0, 10, h],
+        // Zero width so the bounds are exactly the point extent --
+        // inkBounds pads by the stroke width otherwise.
+        width: 0, color: "#000",
+      })),
+    };
+  }
+
+  it("is null for a board with no ink", () => {
+    expect(inkHeight(emptyDoc(), services)).toBeNull();
+    expect(inkHeight(applyCommands(emptyDoc(), [text], 1), services))
+      .toBeNull();
+  });
+
+  it("ignores the flat marks that carry no height", () => {
+    // The bars of an `=` are ~4 units tall; averaging them in drags the
+    // figure toward zero and the model writes too small again.
+    expect(inkHeight(inked([252, 4, 116, 198, 1, 4]), services)).toBe(198);
+  });
+
+  it("resists a single outsized stroke", () => {
+    // A max would follow a stray divider; the median does not.
+    expect(inkHeight(inked([200, 210, 220, 2000]), services)).toBe(215);
+  });
+
+  it("rides on the turn metadata, rounded", () => {
+    const plan = planAtlas(emptyDoc(), null, view, viewport, services);
+    const meta = atlasMetadata(plan, null, [], { inkHeight: 251.7 });
+    expect(meta.inkHeight).toBe(252);
+  });
+
+  it("is omitted when there is no ink to measure", () => {
+    const plan = planAtlas(emptyDoc(), null, view, viewport, services);
+    expect(atlasMetadata(plan, null, [], { inkHeight: null }))
+      .not.toHaveProperty("inkHeight");
+  });
+});
+
+describe("a bounded view of an unbounded board", () => {
+  const wide = { w: 1600, h: 900 };
+  const at = (x: number, y: number) => ({ x, y, zoom: 1 });
+
+  it("stops growing instead of shrinking the board to fit", () => {
+    // A 6800-unit board arrived at imageScale 0.30, where the model's own
+    // 55-unit answers render 16px tall and it places new work on top of
+    // old by squinting. The capture stops; the board does not.
+    const zoomedOut = { x: 0, y: 0, zoom: 0.05 };
+    const { sourceRect, imageScale } = planAtlas(
+      emptyDoc(), null, zoomedOut, wide, services,
+    );
+    expect(sourceRect.w).toBeLessThanOrEqual(MAX_ATLAS_WIDTH);
+    expect(sourceRect.h).toBeLessThanOrEqual(MAX_ATLAS_HEIGHT);
+    // Capped span means no downscale: the picture is always 1:1.
+    expect(imageScale).toBe(1);
+  });
+
+  it("frames what the user is looking at", () => {
+    const { sourceRect } = planAtlas(
+      emptyDoc(), null, at(5000, 4000), wide, services,
+    );
+    expect(sourceRect.x).toBeLessThanOrEqual(5000);
+    expect(sourceRect.x + sourceRect.w).toBeGreaterThanOrEqual(5000 + wide.w);
+  });
+
+  it("says which way the board continues past the frame", () => {
+    // Content too big to show whole, so the frame is a window onto it.
+    const doc = applyCommands(emptyDoc(), [
+      { tool: "write_text", x: 0, y: 0, text: "here",
+        fontSize: 32, maxWidth: 100 },
+      { tool: "write_text", x: 9000, y: 9000, text: "far",
+        fontSize: 32, maxWidth: 100 },
+    ], 1);
+    const { sourceRect } = planAtlas(doc, null, at(0, 0), wide, services);
+    expect(contentBeyond(doc, sourceRect, services)).toEqual(["right", "below"]);
+  });
+
+  it("says nothing when the frame holds everything", () => {
+    const doc = applyCommands(emptyDoc(), [
+      { tool: "write_text", x: 10, y: 10, text: "near",
+        fontSize: 32, maxWidth: 100 },
+    ], 1);
+    const { sourceRect } = planAtlas(doc, null, at(0, 0), wide, services);
+    expect(contentBeyond(doc, sourceRect, services)).toEqual([]);
+  });
+});
+
+describe("occupancy", () => {
+  const rect = { x: 0, y: 0, w: 1600, h: 1600 };   // 16x16 cells of 100
+
+  const textAt = (x: number, y: number) => ({
+    tool: "write_text", x, y, text: "a", fontSize: 40, maxWidth: 100,
+  });
+
+  it("marks the cells an object covers", () => {
+    const doc = applyCommands(emptyDoc(), [textAt(250, 350)], 1);
+    const cells = occupancyCells(doc, rect, services);
+    expect(cells).toContainEqual([2, 3]);
+  });
+
+  it("costs the same whatever the board holds", () => {
+    // The whole reason for a grid: a rectangle list would grow without
+    // bound, and these notes stay in the context for the rest of the
+    // session.
+    const many = Array.from({ length: 300 }, (_, i) =>
+      textAt((i % 16) * 100, Math.floor(i / 16) * 100));
+    const cells = occupancyCells(applyCommands(emptyDoc(), many, 1),
+      rect, services);
+    expect(cells.length).toBeLessThanOrEqual(OCCUPANCY_GRID * OCCUPANCY_GRID);
+  });
+
+  it("reports each cell once however many objects share it", () => {
+    const doc = applyCommands(emptyDoc(),
+      [textAt(10, 10), textAt(20, 20), textAt(30, 30)], 1);
+    const cells = occupancyCells(doc, rect, services);
+    expect(cells.filter(([c, r]) => c === 0 && r === 0)).toHaveLength(1);
+  });
+
+  it("ignores objects outside the frame", () => {
+    const doc = applyCommands(emptyDoc(), [textAt(50000, 50000)], 1);
+    expect(occupancyCells(doc, rect, services)).toEqual([]);
+  });
+
+  it("is empty for an empty board", () => {
+    expect(occupancyCells(emptyDoc(), rect, services)).toEqual([]);
+  });
+
+  it("rides on the turn metadata with its grid size", () => {
+    const plan = planAtlas(emptyDoc(), null, view, viewport, services);
+    const meta = atlasMetadata(plan, null, [], {
+      occupied: [[1, 2]], beyond: ["right"],
+    });
+    expect(meta.occupied).toEqual([[1, 2]]);
+    expect(meta.occupancyGrid).toBe(OCCUPANCY_GRID);
+    expect(meta.beyond).toEqual(["right"]);
+  });
+});
+
+describe("the grid drawn on the picture", () => {
+  /** A canvas that records what was drawn into it. */
+  function recording() {
+    const calls: unknown[][] = [];
+    const ctx = new Proxy({} as Record<string, unknown>, {
+      get: (_t, p) => {
+        if (p === "calls") return calls;
+        return (...args: unknown[]) => {
+          calls.push([p, ...args]);
+        };
+      },
+      set: (t, p, v) => {
+        calls.push(["set", p, v]);
+        t[p as string] = v;
+        return true;
+      },
+    });
+    return {
+      calls,
+      services: {
+        ...services,
+        createCanvas: (w: number, h: number) =>
+          ({ width: w, height: h, getContext: () => ctx }) as unknown as
+            HTMLCanvasElement,
+      },
+    };
+  }
+
+  it("draws the cell lines and the edge labels", () => {
+    // Reading `[col, row]` pairs means cross-referencing a list against a
+    // picture; drawn on, the model can see which cells are free.
+    const { calls, services: rec } = recording();
+    const plan = planAtlas(emptyDoc(), null, view, viewport, services);
+    buildAtlas(emptyDoc(), plan, rec);
+
+    const labels = calls.filter((c) => c[0] === "fillText").map((c) => c[1]);
+    expect(labels).toContain("0");
+    expect(labels).toContain(String(OCCUPANCY_GRID - 1));
+    expect(calls.some((c) => c[0] === "stroke")).toBe(true);
+  });
+
+  it("keeps the overlay off the board's own coordinate space", () => {
+    // renderDoc leaves a board-space transform behind. The grid belongs
+    // to the picture, so it resets first -- otherwise the lines land
+    // wherever the board happens to be panned to.
+    const { calls, services: rec } = recording();
+    const plan = planAtlas(emptyDoc(), null, view, viewport, services);
+    buildAtlas(emptyDoc(), plan, rec);
+
+    const firstLabel = calls.findIndex((c) => c[0] === "fillText");
+    const identity = calls.findIndex(
+      (c, i) =>
+        i < firstLabel && c[0] === "setTransform" &&
+        c[1] === 1 && c[2] === 0 && c[3] === 0 && c[4] === 1 &&
+        c[5] === 0 && c[6] === 0,
+    );
+    expect(identity).toBeGreaterThan(-1);
+  });
+});
+
+describe("never cropping an expression in half", () => {
+  const wide = { w: 1600, h: 900 };
+
+  it("shows the whole board when it fits, wherever the user scrolled", () => {
+    // The regression this replaces: working at the right-hand end of an
+    // integral, the capture began mid-`e^x` with the integral sign off
+    // the left edge, and the model answered the fragment it could see.
+    const doc = applyCommands(emptyDoc(), [
+      { tool: "write_text", x: -150, y: 0, text: "integral",
+        fontSize: 40, maxWidth: 200 },
+      { tool: "write_text", x: 700, y: 0, text: "tail",
+        fontSize: 40, maxWidth: 100 },
+    ], 1);
+    // Scrolled right, so the left end is off screen.
+    const scrolled = { x: 214, y: -329, zoom: 1 };
+    const { sourceRect } = planAtlas(doc, null, scrolled, wide, services);
+
+    expect(sourceRect.x).toBeLessThanOrEqual(-150);
+    expect(sourceRect.x + sourceRect.w).toBeGreaterThanOrEqual(800);
+  });
+
+  it("falls back to the viewport once the board outgrows the frame", () => {
+    // Something has to be left out; the least bad thing to keep is what
+    // the user is looking at.
+    const doc = applyCommands(emptyDoc(), [
+      { tool: "write_text", x: 0, y: 0, text: "a", fontSize: 40, maxWidth: 100 },
+      { tool: "write_text", x: 9000, y: 0, text: "b", fontSize: 40, maxWidth: 100 },
+    ], 1);
+    const scrolled = { x: 8500, y: 0, zoom: 1 };
+    const { sourceRect } = planAtlas(doc, null, scrolled, wide, services);
+
+    expect(sourceRect.w).toBeLessThanOrEqual(MAX_ATLAS_WIDTH);
+    expect(sourceRect.x).toBeGreaterThan(1000);
+    expect(contentBeyond(doc, sourceRect, services)).toContain("left");
+  });
+});
+
+describe("occupancy measures ink, not the wrap width", () => {
+  const rect = { x: 0, y: 0, w: 1600, h: 1600 };   // 100-unit cells
+
+  it("does not claim the whole wrap width for one glyph", () => {
+    // objectBounds reports maxWidth, the width the author asked to wrap
+    // at. A one-glyph answer with maxWidth 800 claimed eight cells it
+    // never touched, and the model routed around free canvas.
+    const doc = applyCommands(emptyDoc(), [{
+      tool: "write_text", x: 0, y: 0, text: "5", fontSize: 40, maxWidth: 800,
+    }], 1);
+    expect(occupancyCells(doc, rect, services).length).toBeLessThanOrEqual(2);
+  });
+
+  it("still covers a long line that really is wide", () => {
+    const doc = applyCommands(emptyDoc(), [{
+      tool: "write_text", x: 0, y: 0, text: "1222 + 5000 = 6222",
+      fontSize: 55, maxWidth: 800,
+    }], 1);
+    const cells = occupancyCells(doc, rect, services);
+    // ~18 glyphs at 0.6em of 55 is ~590 units: six cells, not one.
+    expect(cells.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("never claims more than the wrap width", () => {
+    const doc = applyCommands(emptyDoc(), [{
+      tool: "write_text", x: 0, y: 0, text: "wrapped onto several lines",
+      fontSize: 40, maxWidth: 100,
+    }], 1);
+    const cols = occupancyCells(doc, rect, services).map(([c]) => c);
+    expect(Math.max(...cols)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("what became of the agent's own work", () => {
+  const drawn = (origin: string, x: number, y: number, text: string) => ({
+    id: `${origin}:1`, origin, selected: false, kind: "text" as const,
+    x, y, text, fontSize: 40, maxWidth: 200, lineHeight: 1.35,
+  });
+  const ink = (id: string, x: number, y: number, h = 60) => ({
+    id, origin: "local", selected: false, kind: "ink" as const,
+    pts: [x, y, x + 10, y + h], width: 0, color: "#000",
+  });
+  const board = (objects: unknown[], folded: string[]) =>
+    ({ ...emptyDoc(), folded, objects }) as never;
+
+  it("reports where an object sits now", () => {
+    const doc = board([drawn("callA", 480, 390, "e^x + C")], ["callA"]);
+    const [entry] = agentObjectReport(doc, services);
+    expect(entry.origin).toBe("callA");
+    expect(entry.label).toBe("e^x + C");
+    expect(entry.bounds?.x).toBe(480);
+  });
+
+  it("reports a deleted object as gone", () => {
+    // The call is folded but nothing survives from it.
+    const [entry] = agentObjectReport(board([], ["callA"]), services);
+    expect(entry.bounds).toBeNull();
+  });
+
+  it("flags ink the user drew around it", () => {
+    // The real case: an answer wrapped in hand-drawn brackets and
+    // squared. The object never moved; what it means changed.
+    const doc = board(
+      [drawn("callA", 480, 390, "e^x + C"), ink("new1", 465, 380)],
+      ["callA"],
+    );
+    const [entry] = agentObjectReport(doc, services, {
+      newLocalIds: new Set(["new1"]),
+    });
+    expect(entry.touched).toBe(true);
+  });
+
+  it("does not flag ink that was already there", () => {
+    const doc = board(
+      [drawn("callA", 480, 390, "e^x + C"), ink("old1", 465, 380)],
+      ["callA"],
+    );
+    const [entry] = agentObjectReport(doc, services, {
+      newLocalIds: new Set(),
+    });
+    expect(entry.touched).toBe(false);
+  });
+
+  it("does not flag new ink drawn far away", () => {
+    const doc = board(
+      [drawn("callA", 480, 390, "e^x + C"), ink("new1", 5000, 5000)],
+      ["callA"],
+    );
+    const [entry] = agentObjectReport(doc, services, {
+      newLocalIds: new Set(["new1"]),
+    });
+    expect(entry.touched).toBe(false);
+  });
+
+  it("keeps the newest and drops the oldest past the cap", () => {
+    // These notes are permanent, so the list has to be bounded.
+    const folded = Array.from({ length: 20 }, (_, i) => `call${i}`);
+    const doc = board(
+      folded.map((o, i) => drawn(o, i * 10, 0, `t${i}`)),
+      folded,
+    );
+    const report = agentObjectReport(doc, services);
+    expect(report.length).toBe(AGENT_OBJECT_LIMIT);
+    expect(report[0].origin).toBe("call19");
+  });
+
+  it("is empty when the agent has drawn nothing", () => {
+    expect(agentObjectReport(emptyDoc(), services)).toEqual([]);
+  });
+
+  it("rides on the turn metadata", () => {
+    const plan = planAtlas(emptyDoc(), null, view, viewport, services);
+    const meta = atlasMetadata(plan, null, [], {
+      agentObjects: [
+        { origin: "c1", label: "five", bounds: null },
+        { origin: "c2", label: "six",
+          bounds: { x: 1, y: 2, w: 3, h: 4 }, touched: true },
+      ],
+    });
+    const rows = meta.agentObjects as Record<string, unknown>[];
+    expect(rows[0]).toMatchObject({ origin: "c1", removed: true });
+    expect(rows[1]).toMatchObject({ origin: "c2", x: 1, touched: true });
   });
 });

--- a/sdk/agent-chat-react/tests/whiteboard-component.test.tsx
+++ b/sdk/agent-chat-react/tests/whiteboard-component.test.tsx
@@ -1,8 +1,12 @@
 import { act, StrictMode, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { AgentWhiteboard } from "../src/components/whiteboard/agent-whiteboard";
+import {
+  AgentWhiteboard,
+  WhiteboardSurface,
+} from "../src/components/whiteboard/agent-whiteboard";
 import { applyCommands, emptyDoc } from "../src/components/whiteboard/doc";
+import { SAVE_DEBOUNCE_MS } from "../src/components/whiteboard/persist";
 import type { AgentChatAdapter } from "../src/types";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
@@ -860,5 +864,397 @@ describe("AgentWhiteboard", () => {
     );
     expect(byLabel(el, "Ask")).toHaveProperty("disabled", true);
     expect(byLabel(el, "Pen")).toHaveProperty("disabled", true);
+  });
+});
+
+describe("returning to the board after an agent reply", () => {
+  const agentDraw = {
+    id: "m1", role: "assistant" as const, content: "",
+    toolCalls: [{
+      id: "call1", toolName: "whiteboard_draw",
+      args: JSON.stringify({ commands: [{
+        tool: "write_text", x: 600, y: 40, text: "4",
+        fontSize: 48, maxWidth: 80,
+      }] }),
+      status: "complete",
+    }],
+  };
+
+  /** A runtime holding one finished agent turn, as on a remount. */
+  function stubRuntime(messages: unknown[]) {
+    return {
+      messages,
+      isRunning: false,
+      send: vi.fn(async () => undefined),
+    } as never;
+  }
+
+  it("does not save the replayed board before the stored one loads", async () => {
+    // The regression, from a real session: switching away and back
+    // remounts from emptyDoc(), the fold effect immediately replays the
+    // agent's objects onto it, and the autosave wrote that ink-less
+    // board over the stored one -- which the load then read back. It
+    // needed an agent reply to reproduce: with nothing to fold the
+    // document stays empty and the autosave already declines to write
+    // an empty one.
+    let release!: (v: unknown) => void;
+    const pending = new Promise((r) => { release = r; });
+    const ink = applyCommands(emptyDoc(), [
+      { tool: "write_text", x: 5, y: 5, text: "2 + 2 =", fontSize: 20,
+        maxWidth: 200 },
+    ], 1);
+    const { adapter } = makeAdapter({
+      getWorkspaceFile: vi.fn(async () => {
+        await pending;
+        return {
+          path: "_whiteboard/canvas.json",
+          content: JSON.stringify(ink),
+          size: 1,
+          encoding: "utf-8" as const,
+          truncated: false,
+        };
+      }),
+    });
+
+    await render(
+      <WhiteboardSurface
+        adapter={adapter}
+        sessionId="s1"
+        runtime={stubRuntime([agentDraw])}
+      />,
+    );
+    // Let the fold land and the autosave debounce elapse, with the load
+    // still outstanding.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, SAVE_DEBOUNCE_MS * 2));
+    });
+    expect(adapter.uploadWorkspaceFile).not.toHaveBeenCalled();
+
+    release(null);
+    await act(async () => { await Promise.resolve(); });
+
+    // And once it lands, what is on screen -- and so what any later save
+    // writes -- is the stored board plus the agent's objects.
+    await act(async () => {
+      root!.unmount();
+      root = null;
+    });
+    const calls = (adapter.uploadWorkspaceFile as unknown as {
+      mock: { calls: { file: File }[][] };
+    }).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const written = JSON.parse(await calls[calls.length - 1][0].file.text());
+    expect(written.objects).toHaveLength(2);
+  });
+});
+
+describe("the restoring indicator", () => {
+  function deferredAdapter(doc: unknown) {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const { adapter } = makeAdapter({
+      getWorkspaceFile: vi.fn(async () => {
+        await gate;
+        return {
+          path: "_whiteboard/canvas.json",
+          content: JSON.stringify(doc),
+          size: 1,
+          encoding: "utf-8" as const,
+          truncated: false,
+        };
+      }),
+    });
+    return { adapter, release };
+  }
+
+  const stored = () =>
+    applyCommands(emptyDoc(), [
+      { tool: "write_text", x: 5, y: 5, text: "mine", fontSize: 20,
+        maxWidth: 100 },
+    ], 1);
+
+  it("refuses strokes while the stored board is still loading", async () => {
+    // The point of the indicator: the load replaces the document
+    // wholesale, so a stroke drawn now is discarded without trace.
+    const { adapter } = deferredAdapter(stored());
+    const el = await render(
+      <AgentWhiteboard adapter={adapter} sessionId="s1" />,
+    );
+    const canvas = el.querySelector<HTMLElement>(
+      '[aria-label="Whiteboard canvas"]',
+    );
+    expect(canvas?.className).toContain("pointer-events-none");
+  });
+
+  it("blocks Ask until the board is restored", async () => {
+    const { adapter, release } = deferredAdapter(stored());
+    const el = await render(
+      <AgentWhiteboard adapter={adapter} sessionId="s1" />,
+    );
+    expect((byLabel(el, "Ask") as HTMLButtonElement).disabled).toBe(true);
+
+    release();
+    await act(async () => { await Promise.resolve(); });
+    expect((byLabel(el, "Ask") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("says nothing when the load is quick", async () => {
+    // A warm switch back resolves inside the delay; a spinner flashing
+    // on every toggle would be worse than silence.
+    const { adapter, release } = deferredAdapter(stored());
+    const el = await render(
+      <AgentWhiteboard adapter={adapter} sessionId="s1" />,
+    );
+    release();
+    await act(async () => { await Promise.resolve(); });
+    expect(el.textContent).not.toContain("Restoring board");
+  });
+
+  it("says so when the load drags", async () => {
+    const { adapter, release } = deferredAdapter(stored());
+    const el = await render(
+      <AgentWhiteboard adapter={adapter} sessionId="s1" />,
+    );
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 400));
+    });
+    expect(el.textContent).toContain("Restoring board");
+
+    release();
+    await act(async () => { await Promise.resolve(); });
+    expect(el.textContent).not.toContain("Restoring board");
+  });
+
+  it("does not veil a fresh board that has nothing to load", async () => {
+    // No session means no stored canvas: drawing must work instantly.
+    const { adapter } = makeAdapter();
+    const el = await render(
+      <AgentWhiteboard adapter={adapter} sessionId={null} />,
+    );
+    const canvas = el.querySelector<HTMLElement>(
+      '[aria-label="Whiteboard canvas"]',
+    );
+    expect(canvas?.className).not.toContain("pointer-events-none");
+    expect(el.textContent).not.toContain("Restoring board");
+  });
+});
+
+describe("what the board shows while it loads", () => {
+  it("paints nothing until the stored board lands", async () => {
+    // The agent's objects replay out of the message list instantly. Fold
+    // them onto the empty document a remount starts from and the user
+    // watches a board they never had -- the answer with none of their
+    // working -- until the fetch replaces it.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const ink = applyCommands(emptyDoc(), [
+      { tool: "write_text", x: 5, y: 5, text: "1 + 2 =", fontSize: 20,
+        maxWidth: 200 },
+    ], 1);
+    const { adapter } = makeAdapter({
+      getWorkspaceFile: vi.fn(async () => {
+        await gate;
+        return {
+          path: "_whiteboard/canvas.json",
+          content: JSON.stringify(ink),
+          size: 1,
+          encoding: "utf-8" as const,
+          truncated: false,
+        };
+      }),
+    });
+
+    sharedCalls.length = 0;
+    await render(
+      <WhiteboardSurface
+        adapter={adapter}
+        sessionId="s1"
+        runtime={{
+          messages: [{
+            id: "m1", role: "assistant", content: "",
+            toolCalls: [{
+              id: "call1", toolName: "whiteboard_draw",
+              // Not a bare digit: the grid overlay paints labels 0..15,
+              // and the assertion below must distinguish the agent's
+              // object from the scaffolding drawn around it.
+              args: JSON.stringify({ commands: [{
+                tool: "write_text", x: 600, y: 40, text: "ANSWER",
+                fontSize: 48, maxWidth: 200,
+              }] }),
+              status: "complete",
+            }],
+          }],
+          isRunning: false,
+          send: vi.fn(async () => undefined),
+        } as never}
+      />,
+    );
+    await act(async () => { await Promise.resolve(); });
+
+    const painted = () =>
+      sharedCalls.filter((c) => c[0] === "fillText").map((c) => c[1]);
+    expect(painted()).not.toContain("ANSWER");
+
+    release();
+    await act(async () => { await Promise.resolve(); });
+
+    // And once it lands, both are on the board together.
+    expect(painted()).toContain("ANSWER");
+    expect(painted()).toContain("1 + 2 =");
+  });
+});
+
+describe("panning with the middle button", () => {
+  async function board() {
+    const { adapter } = makeAdapter();
+    const el = await render(
+      <AgentWhiteboard adapter={adapter} sessionId={null} />,
+    );
+    const canvas = byLabel(el, "Whiteboard canvas") as HTMLCanvasElement;
+    canvas.setPointerCapture = () => undefined;
+    canvas.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 800, height: 600 }) as DOMRect;
+    return { el, canvas };
+  }
+
+  const drag = (canvas: HTMLCanvasElement, button: number) =>
+    act(async () => {
+      canvas.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          clientX: 400, clientY: 300, button, bubbles: true, cancelable: true,
+        }),
+      );
+      canvas.dispatchEvent(
+        new PointerEvent("pointermove", {
+          clientX: 460, clientY: 340, bubbles: true,
+        }),
+      );
+      canvas.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+    });
+
+  it("moves the board whatever tool is in hand", async () => {
+    // The pen is the default tool: without this, panning means reaching
+    // for the pan tool and back again mid-drawing.
+    const { canvas } = await board();
+    const before = lastViewTranslation();
+    await drag(canvas, 1);
+    const after = lastViewTranslation();
+
+    expect(after).not.toEqual(before);
+    // Dragged right and down, so the view origin moves left and up.
+    expect(after!.x).toBeGreaterThan(before!.x);
+    expect(after!.y).toBeGreaterThan(before!.y);
+  });
+
+  it("draws no ink while doing it", async () => {
+    const { el, canvas } = await board();
+    await drag(canvas, 1);
+    // A stroke would be an undoable edit; panning is not one.
+    expect(byLabel(el, "Undo")).toHaveProperty("disabled", true);
+  });
+
+  it("suppresses the browser's middle-click autoscroll", async () => {
+    const { canvas } = await board();
+    const down = new PointerEvent("pointerdown", {
+      clientX: 400, clientY: 300, button: 1, bubbles: true, cancelable: true,
+    });
+    await act(async () => { canvas.dispatchEvent(down); });
+    expect(down.defaultPrevented).toBe(true);
+  });
+
+  it("leaves the left button drawing", async () => {
+    const { el, canvas } = await board();
+    await drag(canvas, 0);
+    expect(byLabel(el, "Undo")).toHaveProperty("disabled", false);
+  });
+});
+
+describe("progress while the agent works", () => {
+  const runtimeWith = (over: Record<string, unknown>) =>
+    ({
+      messages: [], isRunning: false, send: vi.fn(async () => undefined),
+      ...over,
+    }) as never;
+
+  const summaryMessage = (summary: string) => ({
+    id: "m1", role: "assistant" as const, content: "",
+    iterationSummary: {
+      iterationIndex: 0, summary, toolCallIds: [],
+      startedAt: "", endedAt: "",
+    },
+  });
+
+  it("says nothing when idle", async () => {
+    const { adapter } = makeAdapter();
+    const el = await render(
+      <WhiteboardSurface adapter={adapter} sessionId="s1"
+        runtime={runtimeWith({})} />,
+    );
+    expect(el.textContent).not.toContain("Thinking");
+  });
+
+  it("shows it is working on an ordinary Ask", async () => {
+    const { adapter } = makeAdapter();
+    const el = await render(
+      <WhiteboardSurface adapter={adapter} sessionId="s1"
+        runtime={runtimeWith({ isRunning: true })} />,
+    );
+    expect(el.textContent).toContain("Thinking…");
+  });
+
+  it("reports the agent's own step once it has one", async () => {
+    // A deep turn is many round-trips; without its steps a minute of
+    // real work is indistinguishable from a hang.
+    const { adapter } = makeAdapter();
+    const el = await render(
+      <WhiteboardSurface adapter={adapter} sessionId="s1"
+        runtime={runtimeWith({
+          isRunning: true,
+          messages: [summaryMessage("Searching for the integral rule")],
+        })} />,
+    );
+    expect(el.textContent).toContain("Searching for the integral rule");
+  });
+
+  it("prefers the newest step", async () => {
+    const { adapter } = makeAdapter();
+    const el = await render(
+      <WhiteboardSurface adapter={adapter} sessionId="s1"
+        runtime={runtimeWith({
+          isRunning: true,
+          messages: [summaryMessage("first"), summaryMessage("second")],
+        })} />,
+    );
+    expect(el.textContent).toContain("second");
+    expect(el.textContent).not.toContain("first");
+  });
+
+  it("holds the board while the agent works", async () => {
+    // Ink added now is invisible to the agent: the atlas and the
+    // occupied cells it is answering were captured at Ask.
+    const { adapter } = makeAdapter();
+    const el = await render(
+      <WhiteboardSurface adapter={adapter} sessionId="s1"
+        runtime={runtimeWith({ isRunning: true })} />,
+    );
+    // The overlay never takes the pointer itself...
+    const overlay = Array.from(el.querySelectorAll("div")).find((d) =>
+      d.className.includes("pointer-events-none") &&
+      d.textContent?.includes("Thinking…"),
+    );
+    expect(overlay).toBeTruthy();
+
+    const canvas = byLabel(el, "Whiteboard canvas") as HTMLCanvasElement;
+    expect(canvas.className).toContain("pointer-events-none");
+  });
+
+  it("hands the board back once the turn ends", async () => {
+    const { adapter } = makeAdapter();
+    const el = await render(
+      <WhiteboardSurface adapter={adapter} sessionId="s1"
+        runtime={runtimeWith({})} />,
+    );
+    const canvas = byLabel(el, "Whiteboard canvas") as HTMLCanvasElement;
+    expect(canvas.className).not.toContain("pointer-events-none");
   });
 });

--- a/sdk/agent-chat-react/tests/whiteboard-doc.test.ts
+++ b/sdk/agent-chat-react/tests/whiteboard-doc.test.ts
@@ -255,3 +255,87 @@ describe("deleting an agent's object", () => {
     expect(foldToolCalls(emptyDoc(), [bad]).folded).toContain("m9");
   });
 });
+
+
+describe("width/height where the schema says w/h", () => {
+  // From a real session: the model wrote a wrong correction, tried twice
+  // to erase it with `width`/`height`, and was rejected. The validator
+  // now accepts that spelling, so the client has to draw it — otherwise
+  // the erase passes validation and rubs out nothing.
+  const erase = (extent: Record<string, unknown>) =>
+    message("e1", "whiteboard_draw", {
+      commands: [{ tool: "erase", mode: "rect", x: 460, y: 300, ...extent }],
+    });
+
+  it("applies an erase spelled width/height", () => {
+    const doc = foldToolCalls(emptyDoc(), [erase({ width: 460, height: 60 })]);
+    const obj = doc.objects[0] as { w: number; h: number };
+    expect([obj.w, obj.h]).toEqual([460, 60]);
+  });
+
+  it("prefers w/h when both are present", () => {
+    const doc = foldToolCalls(emptyDoc(), [
+      erase({ w: 10, h: 20, width: 999, height: 999 }),
+    ]);
+    const obj = doc.objects[0] as { w: number; h: number };
+    expect([obj.w, obj.h]).toEqual([10, 20]);
+  });
+
+  it("applies a place_artifact spelled width/height", () => {
+    const doc = foldToolCalls(emptyDoc(), [
+      message("a1", "whiteboard_draw", {
+        commands: [{
+          tool: "place_artifact", artifact_id: "art", x: 0, y: 0,
+          width: 100, height: 50,
+        }],
+      }),
+    ]);
+    const obj = doc.objects[0] as { w: number; h: number };
+    expect([obj.w, obj.h]).toEqual([100, 50]);
+  });
+});
+
+describe("superseding an earlier draw", () => {
+  const at = (x: number, text: string) => ({
+    tool: "write_text", x, y: 0, text, fontSize: 40, maxWidth: 100,
+  });
+
+  it("removes the objects the call supersedes", () => {
+    // Revising an answer used to mean drawing over the old one: `erase`
+    // paints white, it does not delete.
+    const first = applyCommands(emptyDoc(), [at(0, "wrong")], 1, "callA");
+    const next = applyCommands(
+      first, [{ ...at(0, "right"), replaces: "callA" }], 2, "callB",
+    );
+    expect(next.objects).toHaveLength(1);
+    expect((next.objects[0] as { text: string }).text).toBe("right");
+  });
+
+  it("leaves everything else alone", () => {
+    let doc = applyCommands(emptyDoc(), [at(0, "keep")], 1, "callA");
+    doc = applyCommands(doc, [at(50, "drop")], 2, "callB");
+    const next = applyCommands(
+      doc, [{ ...at(50, "new"), replaces: "callB" }], 3, "callC",
+    );
+    const texts = next.objects.map((o) => (o as { text: string }).text);
+    expect(texts).toEqual(["keep", "new"]);
+  });
+
+  it("retracts even when the replacement itself is unusable", () => {
+    // The intent to retract is independent of whether the new object
+    // could be drawn; leaving the old one behind is the worse outcome.
+    const first = applyCommands(emptyDoc(), [at(0, "wrong")], 1, "callA");
+    const next = applyCommands(
+      first, [{ tool: "nonsense", replaces: "callA" }], 2, "callB",
+    );
+    expect(next.objects).toHaveLength(0);
+  });
+
+  it("ignores a replaces that matches nothing", () => {
+    const first = applyCommands(emptyDoc(), [at(0, "keep")], 1, "callA");
+    const next = applyCommands(
+      first, [{ ...at(50, "add"), replaces: "callZ" }], 2, "callB",
+    );
+    expect(next.objects).toHaveLength(2);
+  });
+});

--- a/sdk/agent-chat-react/tests/whiteboard-persist.test.ts
+++ b/sdk/agent-chat-react/tests/whiteboard-persist.test.ts
@@ -308,3 +308,67 @@ describe("recognising a board session", () => {
     expect(isBoardSession(undefined)).toBe(false);
   });
 });
+
+
+describe("switching views and back", () => {
+  /**
+   * A workspace whose upload lands a tick later than a read, the way a
+   * real one does. The view switch unmounts the board and remounts it,
+   * so the unmount's save and the remount's load are in flight together.
+   */
+  function racingWorkspace(initial: unknown) {
+    let stored = initial;
+    return {
+      getWorkspaceFile: vi.fn(async () => {
+        if (stored === null) throw new Error("404");
+        return {
+          path: CANVAS_PATH,
+          content: JSON.stringify(stored),
+          size: 1,
+          encoding: "utf-8" as const,
+          truncated: false,
+        };
+      }),
+      uploadWorkspaceFile: vi.fn(async ({ file }: { file: File }) => {
+        stored = JSON.parse(await file.text());
+      }),
+    } as unknown as AgentChatAdapter;
+  }
+
+  it("keeps strokes drawn since the last debounce", async () => {
+    // Draw, then switch away before the 1500ms autosave fires: the only
+    // copy of those strokes is the one the unmount flush is uploading.
+    const adapter = racingWorkspace(null);
+    const drawn = applyCommands(emptyDoc(), [text], 0);
+
+    void saveDoc(adapter, "s1", drawn); // unmount flush, not awaited
+    const reloaded = await loadDoc(adapter, "s1", []); // remount load
+
+    expect(reloaded.objects).toHaveLength(1);
+  });
+
+  it("does not write the stale board back over the good one", async () => {
+    // What makes the loss permanent: the remount's own debounced save
+    // persists whatever the load returned.
+    const adapter = racingWorkspace(null);
+    const drawn = applyCommands(emptyDoc(), [text], 0);
+
+    void saveDoc(adapter, "s1", drawn);
+    const reloaded = await loadDoc(adapter, "s1", []);
+    await saveDoc(adapter, "s1", reloaded);
+
+    expect((await loadDoc(adapter, "s1", [])).objects).toHaveLength(1);
+  });
+
+  it("still folds agent draws that landed while away", async () => {
+    const adapter = racingWorkspace(null);
+    const drawn = applyCommands(emptyDoc(), [text], 0);
+
+    void saveDoc(adapter, "s1", drawn);
+    const reloaded = await loadDoc(adapter, "s1", [
+      drawMessage("while-away", [text]),
+    ]);
+
+    expect(reloaded.objects).toHaveLength(2);
+  });
+});

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -1111,9 +1111,12 @@ class AgentHarness(
             # see the user's first message.  Runs in parallel with context
             # engineering and the main LLM call, so the chat turn isn't
             # delayed waiting for the title.
+            # Titled from the raw events, not from ``messages``: the
+            # rebuilt messages carry the harness's injected notes folded
+            # onto the user's text.
             self._maybe_generate_title(
                 session=session,
-                messages=messages,
+                messages=_title_source_messages(all_events),
                 model=session.model or self._default_model,
             )
 
@@ -2662,6 +2665,28 @@ class AgentHarness(
                 await self._complete_session(
                     session, messages, lease,
                     reason="tool_loop_halt",
+                    cost_tracker=cost_tracker,
+                    turn_id=turn_id,
+                )
+                return
+
+            # A sketch turn that has drawn is finished.  Narrowing the
+            # catalogue to one tool was only ever a nudge -- nothing
+            # stopped the model calling it again, and with the image and
+            # the occupied-cell list both captured before its own draws,
+            # it had no evidence it had already answered.
+            if _whiteboard_sketch_turn_done(
+                tool_calls_raw,
+                tool_results,
+                _latest_whiteboard_metadata(all_events),
+                has_whiteboard=getattr(self._prompt, "has_whiteboard", False),
+            ):
+                logger.info(
+                    "Session %s: sketch turn drew; ending turn", session.id,
+                )
+                await self._complete_session(
+                    session, messages, lease,
+                    reason="whiteboard_sketch_drawn",
                     cost_tracker=cost_tracker,
                     turn_id=turn_id,
                 )
@@ -4437,6 +4462,36 @@ class AgentHarness(
 
 
 
+def _title_source_messages(events: list[Any] | None) -> list[dict]:
+    """The user's turns as the user actually wrote them.
+
+    ``_rebuild_messages`` folds the per-turn ephemeral notes -- canvas
+    geometry, view context, the attachment list -- onto the *front* of
+    the user's text, so titling its output titles the scaffolding rather
+    than the request.  The whiteboard made that unmissable: its question
+    box is optional, so with nothing typed the geometry note IS the
+    whole message and every board came out named after the coordinate
+    contract it explains.
+
+    Reading the durable event payload instead keeps the title about what
+    the user said, and leaves it unset when they said nothing -- which
+    is the honest answer, and better than the same wrong title on every
+    board.
+    """
+    messages: list[dict] = []
+    for event in events or []:
+        event_type = getattr(event, "type", None)
+        if (
+            getattr(event_type, "value", event_type)
+            != EventType.USER_MESSAGE.value
+        ):
+            continue
+        data = getattr(event, "data", None)
+        content = data.get("content") if isinstance(data, dict) else None
+        messages.append({"role": "user", "content": content or ""})
+    return messages
+
+
 def _latest_whiteboard_metadata(events: list[Any] | None) -> Any:
     """Return the newest ``user.message`` event's metadata, or ``None``.
 
@@ -4453,6 +4508,59 @@ def _latest_whiteboard_metadata(events: list[Any] | None) -> Any:
         data = getattr(event, "data", None)
         return data.get("metadata") if isinstance(data, dict) else None
     return None
+
+
+def _whiteboard_sketch_turn_done(
+    tool_calls_raw: list[dict],
+    tool_results: list[dict],
+    metadata: Any,
+    *,
+    has_whiteboard: bool,
+) -> bool:
+    """Whether a sketch turn has drawn and should stop there.
+
+    ``sketch`` is meant to be one round-trip -- see
+    :func:`_whiteboard_sketch_filter` -- but narrowing the catalogue to a
+    single tool never limited how many times the model could call it.
+    One real turn drew five objects, four at the same coordinates and two
+    byte-identical: the image and the occupied-cell list it was reasoning
+    from were both captured before its own draws, so nothing it could see
+    said it had already answered.
+
+    A *failed* draw does not end the turn.  The error message exists to
+    be acted on, and stopping on it would leave the board untouched and
+    the user with nothing.
+    """
+    if not has_whiteboard:
+        return False
+
+    from surogates.tools.builtin.whiteboard import WHITEBOARD_TOOL_NAMES
+    from surogates.whiteboard.session import (
+        MODE_SKETCH,
+        is_whiteboard_turn,
+        turn_mode,
+    )
+
+    # Keyed on the turn, like the filter: an ordinary chat message to a
+    # board-enabled agent is not a sketch turn and keeps its iterations.
+    if not is_whiteboard_turn(metadata):
+        return False
+    if turn_mode(metadata) != MODE_SKETCH:
+        return False
+
+    drew = {
+        call.get("id")
+        for call in tool_calls_raw
+        if call.get("function", {}).get("name") in WHITEBOARD_TOOL_NAMES
+    }
+    if not drew:
+        return False
+    for result in tool_results:
+        if result.get("tool_call_id") not in drew:
+            continue
+        if not str(result.get("content") or "").startswith("Error:"):
+            return True
+    return False
 
 
 def _whiteboard_sketch_filter(

--- a/surogates/harness/loop_messages.py
+++ b/surogates/harness/loop_messages.py
@@ -69,6 +69,9 @@ def _whiteboard_note_from_metadata(metadata: Any) -> str | None:
     if payload is None:
         return None
 
+    def _is_num(value: Any) -> bool:
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
     def _rect(value: Any) -> str | None:
         if not isinstance(value, dict):
             return None
@@ -113,6 +116,122 @@ def _whiteboard_note_from_metadata(metadata: Any) -> str | None:
             f"The user lassoed a selection ({selection}). Treat it as the "
             f"exclusive context for this turn."
         )
+
+    # The board continues past the capture, which is bounded so it stays
+    # legible.  Unsaid, the empty margin reads as free canvas and work
+    # lands on objects sitting just outside the frame.
+    beyond = payload.get("beyond")
+    if isinstance(beyond, list) and beyond:
+        where = ", ".join(str(d) for d in beyond if isinstance(d, str))
+        if where:
+            lines.append(
+                f"This is a view of a larger board: content continues "
+                f"{where}. Treat the edge of the image as a crop, not as "
+                f"the end of the canvas."
+            )
+
+    # Where the existing objects are, as of this turn.  The model cannot
+    # get this from the transcript: its own draw calls record where it
+    # *asked* for things, and the user's drags, resizes and deletions are
+    # never recorded at all, so the history is confidently out of date.
+    occupied = payload.get("occupied")
+    grid = payload.get("occupancyGrid")
+    if isinstance(occupied, list) and occupied and isinstance(grid, int):
+        # Phrased as a constraint, not as a placement rule.  Told to
+        # "place new objects in free cells", the model went shopping for
+        # any empty cell and wrote the answer to an integral below the
+        # working instead of after the "=" -- both cells were free, and
+        # it picked the one the grid mentioned rather than the one the
+        # content called for.
+        lines.append(
+            f"A faint {grid}x{grid} grid is drawn over the image, "
+            f"labelled along the top and left edges; it is an overlay to "
+            f"help you place things, not something the user drew. These "
+            f"cells already hold work, as of this turn, [col, row]: "
+            f"{occupied}. Put your answer where the content calls for it "
+            f"-- continuing the user's line, beside the thing it "
+            f"answers -- and use the grid only to keep off what is "
+            f"already there."
+        )
+        # Converting a chosen cell back to canvas coordinates means
+        # inverting the image formula above, once per axis.  Asked for
+        # the slot after an "x =", the model inverted the column and
+        # left the row in image coordinates, putting its answer below
+        # the frame it had been shown.  Given the cell size it can place
+        # by arithmetic that has no direction to get backwards.
+        def _num(value: Any) -> bool:
+            return isinstance(value, (int, float)) and not isinstance(
+                value, bool
+            )
+
+        cell = payload.get("cellSize")
+        if isinstance(cell, dict) and _num(cell.get("w")) and _num(cell.get("h")):
+            lines.append(
+                f"Cell (col, row) starts at canvas x = sourceRect.x + "
+                f"col*{cell['w']}, y = sourceRect.y + row*{cell['h']}. "
+                f"Every coordinate you return is a canvas coordinate, "
+                f"never a position measured off the image."
+            )
+
+    # Without this the model has no sense of scale: the note says where
+    # the capture is and what it covers, but nothing about how big the
+    # strokes inside it are.  Asked to answer a sum written in ~250-unit
+    # digits it picked fontSize 90, and its answer landed a quarter the
+    # size of the working it belonged to.
+    ink = payload.get("inkHeight")
+    if isinstance(ink, (int, float)) and not isinstance(ink, bool) and ink > 0:
+        # The second sentence is not padding.  Given only the first, the
+        # model set fontSize 75 to match 80-unit handwriting, left
+        # maxWidth at 400, and turned a one-sentence answer into nine
+        # lines and 877 units of tower down the middle of the board.
+        lines.append(
+            f"The user's handwriting is about {int(ink)} canvas units "
+            f"tall. Size a short answer -- a number, a formula -- to sit "
+            f"with it. A sentence of prose at that size is enormous: use "
+            f"a smaller fontSize and a maxWidth wide enough that it reads "
+            f"across rather than down (a line holds roughly "
+            f"maxWidth/(fontSize*0.6) characters)."
+        )
+
+    # What became of the agent's own work.  The transcript records where
+    # it *asked* for each object and nothing after that, because what
+    # comes after is the user: dragging, resizing, deleting, or drawing
+    # something that changes what an object means.  None of it reaches
+    # the conversation, so the agent's memory of its own output is
+    # confidently out of date -- one session ended with its answer
+    # wrapped in hand-drawn brackets and squared, and it answered the
+    # transcript rather than the board.
+    mine = payload.get("agentObjects")
+    if isinstance(mine, list) and mine:
+        rows: list[str] = []
+        for entry in mine:
+            if not isinstance(entry, dict):
+                continue
+            label = str(entry.get("label") or "").strip()
+            named = f'"{label}"' if label else "an object"
+            if entry.get("removed"):
+                rows.append(f"- {named}: no longer on the board")
+                continue
+            if not all(_is_num(entry.get(k)) for k in ("x", "y", "w", "h")):
+                continue
+            where = (
+                f"- {named} is at ({entry['x']}, {entry['y']}), "
+                f"{entry['w']}x{entry['h']}"
+            )
+            if entry.get("touched"):
+                where += (
+                    " -- the user has since drawn on or around it. Read "
+                    "that ink as changing what it means, not as separate "
+                    "work beside it"
+                )
+            rows.append(where)
+        if rows:
+            joined = "\n".join(rows)
+            lines.append(
+                f"What you drew earlier, as the board holds it now (your "
+                f"own draw calls record where you asked for these, not "
+                f"what the user did to them afterwards):\n{joined}"
+            )
 
     typed = payload.get("typedInput")
     if isinstance(typed, str) and typed.strip():

--- a/surogates/harness/prompts/guidance/whiteboard.md
+++ b/surogates/harness/prompts/guidance/whiteboard.md
@@ -31,12 +31,39 @@ unless the latest input visually refers to them.
 
 `hotspots` contains only the current unconsumed writing segment, ordered
 oldest to newest. Use it to refine reading order inside `latestInput`,
-nothing more. Its absence is not evidence that there is no new input.
+nothing more. It is a coarse grid path traced by the pen, not a
+transcription: never read characters or symbols out of it. What was
+written is in the image and nowhere else. Its absence is not evidence
+that there is no new input.
 
 Handwriting in a logographic script needs deliberate character-by-
 character inspection: examine stroke groups, radicals, spacing and
 punctuation, and resolve a genuinely ambiguous character from the
 surrounding phrase rather than silently changing the sentence's topic.
+
+### Reading handwritten mathematics
+
+Transcribe the whole expression before you answer any part of it, and
+resolve each symbol from the structure of the expression rather than from
+the glyph alone. Handwritten maths is systematically ambiguous, and the
+same few confusions cause almost every misreading:
+
+- a cross is the variable `x` far more often than `×` — inside a term
+  (`2x`), next to a `dx`, or on either side of an `=` with an unknown to
+  solve for, it is the variable;
+- `+` misread as `4` or `÷`; `1` as `l` or `/`; `0` as `O`;
+- an elongated `S` is `∫`, especially with limits above and below it or a
+  `dx` after it;
+- a superscript is an exponent, not a separate factor.
+
+Then check that your transcription is a well-formed expression. If it is
+not — an operator with nothing to operate on, a stray `?`, an equation
+with no unknown — you have misread it. Read it again rather than
+answering the malformed version.
+
+`2x + 1 = 7` read as `2×4 ÷ 1` produces a confident answer to a question
+the user never asked, drawn onto their board. Being unsure and asking is
+always cheaper than being wrong in ink.
 
 ### Extending, not reproducing
 

--- a/surogates/tools/builtin/whiteboard.py
+++ b/surogates/tools/builtin/whiteboard.py
@@ -47,6 +47,12 @@ _DESCRIPTION = (
     "richer, or interactive than a simple sketch -- a chart, a diagram, a "
     "table, an interactive widget -- create an artifact and place it "
     "rather than approximating it with many draw commands.\n\n"
+    "Any command may carry `replaces`: the id of an earlier "
+    "whiteboard_draw call whose objects it supersedes. Use it to correct "
+    "or update something you drew before -- the old objects are removed "
+    "as the new one lands, so a revised answer replaces the previous one "
+    "instead of piling on top of it. The turn note lists what you drew "
+    "and where it now sits.\n\n"
     f"At most {MAX_COMMANDS} commands per call. Do not redraw content "
     "that is already on the canvas: add only the continuation, answer, or "
     "annotation that is missing."
@@ -127,7 +133,45 @@ async def _whiteboard_draw_handler(
     count = len(commands)
     logger.info("whiteboard_draw accepted %d command(s)", count)
     return (
-        f"Drew {count} object{'s' if count != 1 else ''} on the canvas. "
+        f"Drew {count} object{'s' if count != 1 else ''} on the canvas"
+        f"{_placement_summary(commands)}. "
         f"They are now the user's active selection, so they can move, "
-        f"resize or delete them."
+        f"resize or delete them. "
+        f"The attached image and the occupied-cell list were captured "
+        f"before this call and do not show it. Anything else you draw "
+        f"this turn must keep clear of the position above, and if this "
+        f"was the answer, stop -- do not draw it again."
     )
+
+
+def _placement_summary(commands: list[Any]) -> str:
+    """Where the commands landed, for the model's own benefit.
+
+    The image and the occupancy list both date from before the call, so
+    without this a second iteration has no evidence its first draw
+    happened: same picture, same free cells, same acknowledgement. One
+    real turn drew the same formula at the same coordinates twice and
+    piled four answers on one spot.
+    """
+    spots: list[str] = []
+    for cmd in commands:
+        if not isinstance(cmd, dict):
+            continue
+        x, y = cmd.get("x"), cmd.get("y")
+        if not (_is_number(x) and _is_number(y)):
+            continue
+        what = cmd.get("text") or cmd.get("latex") or cmd.get("tool") or ""
+        label = str(what).strip().replace("\n", " ")
+        if len(label) > 40:
+            label = f"{label[:39]}…"
+        # Quoted plainly, not with repr: repr doubles every backslash,
+        # which turns a LaTeX command into something the model has to
+        # unescape before it can recognise its own output.
+        spots.append(f'"{label}" at ({x}, {y})' if label else f"({x}, {y})")
+    if not spots:
+        return ""
+    return f": {'; '.join(spots)}"
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)

--- a/surogates/whiteboard/commands.py
+++ b/surogates/whiteboard/commands.py
@@ -11,6 +11,7 @@ drops.
 """
 from __future__ import annotations
 
+import math
 from typing import Any
 
 #: The canvas is infinite: it has no edges, the origin is the middle of
@@ -51,6 +52,37 @@ _POSITION_KEYS = frozenset({"x", "y"})
 #: Keys holding an extent.  A negative width is meaningless however
 #: infinite the canvas is, and silently renders nothing.
 _SIZE_KEYS = frozenset({"w", "h", "maxWidth"})
+
+#: ``width``/``height`` accepted where the schema says ``w``/``h``.
+#:
+#: The size vocabulary is mixed across commands -- ``draw`` has a stroke
+#: ``width``, ``write_text`` has ``maxWidth``, these two have ``w``/``h``
+#: -- so reaching for the long spelling is an easy slip, and it cost a
+#: real session its erase: the model wrote a wrong correction, tried
+#: twice to rub it out with ``width``/``height``, was rejected both
+#: times, and left the mistake on the user's canvas.  Aliased rather
+#: than rejected for the same reason the handler recovers a JSON-string
+#: command array: the intent is unambiguous and a retry buys nothing.
+#: The client applies the same aliases.
+_SIZE_ALIASES = {"w": "width", "h": "height"}
+
+#: Commands whose schema uses ``w``/``h``, and so honour the aliases.
+#: ``draw`` is deliberately absent: its ``width`` is a stroke weight, not
+#: an extent, and aliasing it would silently change what it draws.
+_ALIASING_TOOLS = frozenset({"erase", "place_artifact"})
+
+
+def _with_size_aliases(cmd: dict[str, Any]) -> dict[str, Any]:
+    """*cmd* with ``w``/``h`` filled in from ``width``/``height``.
+
+    Returns a copy: validation is pure, and the durable command in the
+    event log stays exactly as the model wrote it.
+    """
+    resolved = dict(cmd)
+    for key, alias in _SIZE_ALIASES.items():
+        if key not in resolved and alias in resolved:
+            resolved[key] = resolved[alias]
+    return resolved
 
 
 def _is_number(value: Any) -> bool:
@@ -171,6 +203,116 @@ def _validate_erase(cmd: dict[str, Any], idx: int) -> str | None:
     )
 
 
+#: Average glyph advance as a fraction of font size, for a proportional
+#: face. Only ever used to predict *whether* text wraps, never to lay it
+#: out -- the client measures for real at paint time.
+_GLYPH_ADVANCE = 0.6
+
+
+def _wrapped_lines(cmd: dict[str, Any]) -> int:
+    """How many lines a ``write_text`` is likely to occupy."""
+    text = str(cmd.get("text") or "")
+    font = cmd.get("fontSize")
+    max_width = cmd.get("maxWidth")
+    if not (_is_number(font) and _is_number(max_width)) or max_width <= 0:
+        return 1
+    lines = 0
+    for paragraph in text.split("\n"):
+        width = len(paragraph) * font * _GLYPH_ADVANCE
+        lines += max(1, math.ceil(width / max_width))
+    return max(1, lines)
+
+
+def _text_tower(commands: list[Any]) -> str | None:
+    """Reject prose wrapped into a column taller than it is wide.
+
+    ``fontSize`` and ``maxWidth`` are chosen independently, and nothing
+    connects them: told to match handwriting of 80 units, the model set
+    fontSize 75 and left maxWidth at 400, which is about six characters
+    a line. Its one-sentence answer became nine lines and 877 units of
+    tower -- taller than the whole captured board -- straight down the
+    middle of the user's working.
+
+    Matching handwriting is right for a short answer and wrong for a
+    sentence; what actually matters is that the block ends up shaped
+    like text. Four lines is the floor so a genuine short paragraph is
+    never touched.
+    """
+    for idx, cmd in enumerate(commands):
+        if not isinstance(cmd, dict) or cmd.get("tool") != "write_text":
+            continue
+        lines = _wrapped_lines(cmd)
+        if lines < 4:
+            continue
+        font, max_width = cmd["fontSize"], cmd["maxWidth"]
+        line_height = cmd.get("lineHeight")
+        step = font * (line_height if _is_number(line_height) else 1.35)
+        height = lines * step
+        if height <= max_width:
+            continue
+        fits = math.ceil(len(str(cmd.get("text") or "")) * font * _GLYPH_ADVANCE)
+        return (
+            f"command[{idx}] (write_text) wraps onto {lines} lines at "
+            f"fontSize={font:g} and maxWidth={max_width:g}, a block "
+            f"{height:g} tall and only {max_width:g} wide -- a tower, not "
+            f"a paragraph. A line holds about maxWidth/(fontSize*0.6) "
+            f"characters. Either set maxWidth near {fits} so it reads "
+            f"across, or use a smaller fontSize: handwriting scale suits "
+            f"a short answer, not a sentence."
+        )
+    return None
+
+
+def _wrap_collision(commands: list[Any]) -> str | None:
+    """Reject a call whose wrapped text would land on its own next command.
+
+    The model picks ``maxWidth`` and ``fontSize`` but cannot measure the
+    result, so it spaces the next command as if the text were one line.
+    A real call left "Yes, we can factor it a bit:" wrapping onto two
+    lines 90 units apart from a formula, and the second line printed
+    straight through it.
+
+    Deliberately narrow: it fires only when text is predicted to wrap
+    *and* a later command sits inside the extra lines. Everything else is
+    left to the model's judgement, because the estimate is too rough to
+    police general overlap.
+    """
+    for idx, cmd in enumerate(commands):
+        if not isinstance(cmd, dict) or cmd.get("tool") != "write_text":
+            continue
+        lines = _wrapped_lines(cmd)
+        if lines < 2:
+            continue
+        font = cmd["fontSize"]
+        line_height = cmd.get("lineHeight")
+        step = font * (line_height if _is_number(line_height) else 1.35)
+        top, left = cmd.get("y"), cmd.get("x")
+        if not (_is_number(top) and _is_number(left)):
+            continue
+        bottom = top + lines * step
+        right = left + cmd["maxWidth"]
+
+        for other_idx, other in enumerate(commands):
+            if other_idx == idx or not isinstance(other, dict):
+                continue
+            ox, oy = other.get("x"), other.get("y")
+            if not (_is_number(ox) and _is_number(oy)):
+                continue
+            # From the second line down, and inclusive on the left edge:
+            # stacked commands share an x, which is exactly the case
+            # this exists to catch.
+            if top + step <= oy < bottom and left <= ox < right:
+                return (
+                    f"command[{idx}] (write_text) wraps onto {lines} lines "
+                    f"at maxWidth={cmd['maxWidth']} and would run through "
+                    f"command[{other_idx}] at y={oy}. Text occupies "
+                    f"fontSize*lineHeight ({step:g}) per line: leave "
+                    f"{lines * step:g} below y={top}, or raise maxWidth so "
+                    f"it fits on one line."
+                )
+    return None
+
+
 def validate_commands(commands: Any) -> str | None:
     """Return an error message, or ``None`` when *commands* is valid."""
     if not isinstance(commands, list):
@@ -195,6 +337,23 @@ def validate_commands(commands: Any) -> str | None:
                 f"command[{idx}] has unknown tool {tool!r}. "
                 f"Valid tools: {valid}."
             )
+
+        # Optional on any drawing command: the id of an earlier
+        # ``whiteboard_draw`` call whose objects this one supersedes.
+        # Without it the model can only add, so revising an answer means
+        # drawing over the old one -- ``erase`` paints white, it does not
+        # delete. One turn stacked four answers on a single spot.
+        replaces = cmd.get("replaces")
+        if replaces is not None and not (
+            isinstance(replaces, str) and replaces.strip()
+        ):
+            return (
+                f"command[{idx}] ({tool}): replaces must be the id of an "
+                f"earlier whiteboard_draw call."
+            )
+
+        if tool in _ALIASING_TOOLS:
+            cmd = _with_size_aliases(cmd)
 
         missing = [k for k in _REQUIRED[tool] if k not in cmd]
         if missing:
@@ -231,4 +390,4 @@ def validate_commands(commands: Any) -> str | None:
                     f"non-empty string."
                 )
 
-    return None
+    return _text_tower(commands) or _wrap_collision(commands)

--- a/tests/test_title_generator.py
+++ b/tests/test_title_generator.py
@@ -15,7 +15,8 @@ from surogates.harness.title_generator import (
     generate_session_title,
     maybe_generate_session_title,
 )
-from surogates.harness.loop import AgentHarness
+from surogates.harness.loop import AgentHarness, _title_source_messages
+from surogates.session.events import EventType
 from surogates.session.models import Event, Session, SessionLease
 
 
@@ -544,3 +545,80 @@ async def test_wake_kicks_off_title_for_loop_command(monkeypatch) -> None:
     assert call_kwargs["messages"] == rebuilt_messages
     assert call_kwargs["model"] == "gpt-4o"
     assert harness._background_tasks == set()
+
+
+class TestTitleSourceMessages:
+    """The titler must see the user's words, not the harness's notes.
+
+    ``_rebuild_messages`` prepends the per-turn ephemeral notes to the
+    user's text.  Feeding that to the titler named every whiteboard
+    session after the canvas geometry note -- the board's question box is
+    optional, so with nothing typed the note is the entire message.
+    """
+
+    @staticmethod
+    def _user_event(content, **data):
+        return SimpleNamespace(
+            type=EventType.USER_MESSAGE.value,
+            data={"content": content, **data},
+        )
+
+    def test_uses_the_typed_question_not_the_canvas_note(self) -> None:
+        events = [
+            self._user_event(
+                "what is A + B?",
+                metadata={"whiteboard": {"sourceRect": {
+                    "x": 0, "y": 0, "w": 10, "h": 10,
+                }, "imageScale": 2}},
+            ),
+        ]
+        assert _title_source_messages(events) == [
+            {"role": "user", "content": "what is A + B?"},
+        ]
+
+    def test_a_silent_board_turn_carries_no_text_to_title(self) -> None:
+        # The regression: this used to arrive as the geometry note and
+        # every board was titled after it.
+        events = [
+            self._user_event(
+                "",
+                metadata={"whiteboard": {"mode": "sketch"}},
+            ),
+        ]
+        assert _title_source_messages(events) == [
+            {"role": "user", "content": ""},
+        ]
+
+    def test_a_silent_board_turn_produces_no_title(self) -> None:
+        # An empty first message is what makes the generator decline, so
+        # no title beats the same wrong title on every board.
+        import asyncio as _asyncio
+
+        events = [self._user_event("")]
+        store = SimpleNamespace(update_session_title_if_empty=AsyncMock())
+        title = _asyncio.run(
+            maybe_generate_session_title(
+                store=store,
+                llm_client=SimpleNamespace(),
+                session=SimpleNamespace(id=uuid4(), title=None),
+                messages=_title_source_messages(events),
+                model="m",
+            )
+        )
+        assert title is None
+        store.update_session_title_if_empty.assert_not_called()
+
+    def test_ignores_non_user_events(self) -> None:
+        events = [
+            SimpleNamespace(type="llm.response", data={"content": "hi"}),
+            self._user_event("real question"),
+        ]
+        assert _title_source_messages(events) == [
+            {"role": "user", "content": "real question"},
+        ]
+
+    def test_tolerates_a_missing_payload(self) -> None:
+        events = [SimpleNamespace(type=EventType.USER_MESSAGE.value, data=None)]
+        assert _title_source_messages(events) == [
+            {"role": "user", "content": ""},
+        ]

--- a/tests/test_whiteboard_commands.py
+++ b/tests/test_whiteboard_commands.py
@@ -158,3 +158,207 @@ def test_draw_formula_requires_latex():
 @pytest.mark.parametrize("bad", ["not a list", None, 42, {"tool": "write_text"}])
 def test_rejects_a_non_list_payload(bad):
     assert validate_commands(bad) is not None
+
+
+# ---------------------------------------------------------------------
+# width/height accepted where the schema says w/h
+#
+# From a real session: the model wrote a wrong correction on the user's
+# board, tried twice to rub it out, and was rejected both times for
+# spelling the extents ``width``/``height``.  The mistake stayed on the
+# canvas and the user paused the session.
+# ---------------------------------------------------------------------
+
+
+def test_erase_rect_accepts_width_and_height():
+    # Verbatim the call that failed.
+    assert validate_commands([
+        {"tool": "erase", "mode": "rect",
+         "x": 460, "y": 300, "width": 460, "height": 60},
+    ]) is None
+
+
+def test_erase_rect_still_rejects_no_extents_at_all():
+    error = validate_commands([
+        {"tool": "erase", "mode": "rect", "x": 460, "y": 300},
+    ])
+    assert error is not None
+    assert "w, h" in error
+
+
+def test_erase_rect_validates_an_aliased_extent():
+    # The alias is a spelling, not an escape from the range checks.
+    error = validate_commands([
+        {"tool": "erase", "mode": "rect",
+         "x": 0, "y": 0, "width": -5, "height": 60},
+    ])
+    assert error is not None
+
+
+def test_place_artifact_accepts_width_and_height():
+    assert validate_commands([
+        {"tool": "place_artifact", "artifact_id": "a1",
+         "x": 0, "y": 0, "width": 100, "height": 50},
+    ]) is None
+
+
+def test_the_short_spelling_still_wins():
+    # Both present: w/h is the schema, so it is what counts.
+    assert validate_commands([
+        {"tool": "erase", "mode": "rect", "x": 0, "y": 0,
+         "w": 10, "h": 10, "width": -999, "height": -999},
+    ]) is None
+
+
+def test_draw_width_is_a_stroke_weight_not_an_extent():
+    # ``draw`` must NOT alias: its width is a stroke weight bounded
+    # 2..200, and treating it as an extent would change what it draws.
+    error = validate_commands([
+        {"tool": "draw", "origin": [0, 0], "types": ["line"],
+         "items": [[0, 0, 10, 10]], "width": 500},
+    ])
+    assert error is not None
+    assert "stroke" in error or "2..200" in error
+
+
+# ---------------------------------------------------------------------
+# replaces: superseding an earlier draw
+#
+# The agent can only add objects, so revising an answer meant drawing
+# over the old one -- erase paints white, it does not delete. One turn
+# stacked four answers on a single spot.
+# ---------------------------------------------------------------------
+
+
+def test_accepts_a_replaces_id():
+    assert validate_commands([
+        {"tool": "write_text", "x": 0, "y": 0, "text": "3", "fontSize": 40,
+         "maxWidth": 100, "replaces": "toolu_01A"},
+    ]) is None
+
+
+def test_rejects_a_non_string_replaces():
+    error = validate_commands([
+        {"tool": "write_text", "x": 0, "y": 0, "text": "3", "fontSize": 40,
+         "maxWidth": 100, "replaces": 17},
+    ])
+    assert error is not None and "replaces" in error
+
+
+def test_rejects_an_empty_replaces():
+    error = validate_commands([
+        {"tool": "write_text", "x": 0, "y": 0, "text": "3", "fontSize": 40,
+         "maxWidth": 100, "replaces": "   "},
+    ])
+    assert error is not None and "replaces" in error
+
+
+def test_replaces_is_optional():
+    assert validate_commands([
+        {"tool": "write_text", "x": 0, "y": 0, "text": "3", "fontSize": 40,
+         "maxWidth": 100},
+    ]) is None
+
+
+# ---------------------------------------------------------------------
+# Wrapped text running through the next command
+#
+# The model picks maxWidth and fontSize but cannot measure the result,
+# so it spaces the next command as if the text were one line. A real
+# call left "Yes, we can factor it a bit:" wrapping onto two lines 90
+# units apart from a formula, and the second line printed through it.
+# ---------------------------------------------------------------------
+
+
+def _wrapping_pair(second_y):
+    return [
+        {"x": 1520, "y": 610, "text": "Yes, we can factor it a bit:",
+         "tool": "write_text", "fontSize": 65, "maxWidth": 700,
+         "lineHeight": 1.3},
+        {"x": 1520, "y": second_y, "tool": "draw_formula",
+         "latex": "e^{2x} + 2e^x(x + C)", "fontSize": 65},
+    ]
+
+
+def test_rejects_wrapped_text_running_through_the_next_command():
+    error = validate_commands(_wrapping_pair(700))
+    assert error is not None
+    assert "wraps onto 2 lines" in error
+    assert "y=700" in error
+
+
+def test_accepts_the_same_pair_spaced_for_the_wrap():
+    assert validate_commands(_wrapping_pair(790)) is None
+
+
+def test_accepts_it_when_maxWidth_avoids_the_wrap():
+    commands = _wrapping_pair(700)
+    commands[0]["maxWidth"] = 1200
+    assert validate_commands(commands) is None
+
+
+def test_short_text_never_trips_the_check():
+    assert validate_commands([
+        {"x": 0, "y": 0, "text": "5", "tool": "write_text",
+         "fontSize": 40, "maxWidth": 400},
+        {"x": 0, "y": 60, "tool": "draw_formula", "latex": "x", "fontSize": 40},
+    ]) is None
+
+
+def test_a_command_beside_the_text_is_not_a_collision():
+    # Wrapping only runs downward; something to the right is fine.
+    commands = _wrapping_pair(700)
+    commands[1]["x"] = 3000
+    assert validate_commands(commands) is None
+
+
+def test_the_check_survives_a_command_without_coordinates():
+    commands = _wrapping_pair(700)
+    commands[1] = {"tool": "erase", "mode": "path", "points": [[0, 0], [1, 1]]}
+    assert validate_commands(commands) is None
+
+
+# ---------------------------------------------------------------------
+# Prose wrapped into a tower
+#
+# fontSize and maxWidth are chosen independently. Told to match 80-unit
+# handwriting the model set fontSize 75 and left maxWidth at 400 -- six
+# characters a line -- turning a one-sentence answer into nine lines and
+# 877 units of tower, taller than the whole captured board.
+# ---------------------------------------------------------------------
+
+_SENTENCE = (
+    "Yes! The integral of e^x is e^x + C because the derivative of "
+    "e^x is e^x."
+)
+
+
+def _prose(**over):
+    return [{"x": 900, "y": 200, "tool": "write_text", "text": _SENTENCE,
+             "fontSize": 75, "maxWidth": 400, "lineHeight": 1.3, **over}]
+
+
+def test_rejects_a_tower_of_text():
+    error = validate_commands(_prose())
+    assert error is not None
+    assert "tower, not a paragraph" in error
+    assert "9 lines" in error
+
+
+def test_accepts_the_same_sentence_read_across():
+    assert validate_commands(_prose(maxWidth=3300)) is None
+
+
+def test_accepts_the_same_sentence_at_a_readable_size():
+    assert validate_commands(_prose(fontSize=28, maxWidth=700)) is None
+
+
+def test_a_short_answer_at_handwriting_scale_is_fine():
+    # The whole point of the inkHeight signal: a number or a formula
+    # should match the user's hand.
+    assert validate_commands(_prose(text="e^x + C")) is None
+
+
+def test_a_genuine_short_paragraph_is_untouched():
+    # Three lines never trips it, and a wide block never does either.
+    assert validate_commands(_prose(fontSize=30, maxWidth=900)) is None

--- a/tests/test_whiteboard_note.py
+++ b/tests/test_whiteboard_note.py
@@ -167,3 +167,166 @@ def test_pruning_does_not_mutate_the_input():
     messages = [_turn(1), _turn(2)]
     prune_superseded_canvas_images(messages)
     assert len(_images(messages)) == 2
+
+
+# --- how big the user writes ------------------------------------------
+
+def test_renders_the_handwriting_scale():
+    """Without it the model sizes its answer blind.
+
+    On a real board of ~250-unit digits it chose fontSize 90, and the
+    answer landed a quarter the size of the sum it belonged to.
+    """
+    note = _whiteboard_note_from_metadata(_meta(inkHeight=252))
+    assert "252 canvas units" in note
+    assert "fontSize" in note
+
+
+def test_omits_the_handwriting_scale_when_there_is_no_ink():
+    # A board holding only agent objects has nothing to measure; an
+    # invented number would be worse than silence.
+    note = _whiteboard_note_from_metadata(_meta())
+    assert "canvas units" not in note
+
+
+def test_ignores_a_nonsense_handwriting_scale():
+    for bad in (0, -5, "tall", None, True):
+        note = _whiteboard_note_from_metadata(_meta(inkHeight=bad))
+        assert "canvas units" not in (note or "")
+
+
+# --- what is already on the board -------------------------------------
+
+def test_renders_the_occupancy_grid():
+    """The model cannot get this from the transcript.
+
+    Its own draw calls record where it *asked* for things, and the user's
+    drags, resizes and deletions are never recorded at all -- so history
+    is not merely incomplete about the board, it is out of date.
+    """
+    note = _whiteboard_note_from_metadata(
+        _meta(occupied=[[0, 3], [1, 3]], occupancyGrid=16),
+    )
+    assert "16x16 grid" in note
+    assert "[[0, 3], [1, 3]]" in note
+    # The grid is drawn on the image too, and must not be read as ink.
+    assert "not something the user drew" in note
+
+
+def test_the_grid_is_a_constraint_not_a_placement_rule():
+    """Told to "place new objects in free cells", the model shopped.
+
+    On a real board it wrote the answer to an integral below the working
+    rather than after the "=" -- both cells were free, and it picked the
+    one the grid mentioned over the one the content called for.
+    """
+    note = _whiteboard_note_from_metadata(
+        _meta(occupied=[[0, 3]], occupancyGrid=16),
+    )
+    assert "where the content calls for it" in note
+    assert "only to keep off" in note
+
+
+def test_omits_occupancy_on_an_empty_board():
+    assert "grid over sourceRect" not in _whiteboard_note_from_metadata(_meta())
+
+
+def test_ignores_occupancy_without_a_grid_size():
+    # The cells are meaningless without the divisor.
+    note = _whiteboard_note_from_metadata(_meta(occupied=[[0, 3]]))
+    assert "grid over sourceRect" not in note
+
+
+def test_says_the_image_is_a_crop_of_a_larger_board():
+    # Unsaid, the empty margin reads as free canvas and work lands on
+    # objects sitting just outside the frame.
+    note = _whiteboard_note_from_metadata(_meta(beyond=["right", "below"]))
+    assert "continues right, below" in note
+    assert "crop" in note
+
+
+def test_omits_the_crop_note_when_the_frame_holds_everything():
+    assert "continues" not in _whiteboard_note_from_metadata(_meta())
+
+
+def test_gives_the_cell_to_canvas_mapping():
+    """Inverting the image formula by hand went wrong once per axis.
+
+    Asked for the slot after an "x =", the model converted the column
+    and left the row in image coordinates, landing its answer below the
+    frame it had been shown -- row 17 of a 16-row grid.
+    """
+    note = _whiteboard_note_from_metadata(
+        _meta(occupied=[[0, 3]], occupancyGrid=16,
+              cellSize={"w": 82.0, "h": 53.18}),
+    )
+    assert "col*82.0" in note
+    assert "row*53.18" in note
+    assert "never a position measured off the image" in note
+
+
+def test_omits_the_mapping_without_a_cell_size():
+    note = _whiteboard_note_from_metadata(
+        _meta(occupied=[[0, 3]], occupancyGrid=16),
+    )
+    assert "sourceRect.x + col" not in note
+
+
+def test_ignores_a_malformed_cell_size():
+    for bad in ({"w": "wide", "h": 10}, {"w": True, "h": 10}, {"w": 10}, 7):
+        note = _whiteboard_note_from_metadata(
+            _meta(occupied=[[0, 3]], occupancyGrid=16, cellSize=bad),
+        )
+        assert "sourceRect.x + col" not in (note or "")
+
+
+# --- what became of the agent's own work ------------------------------
+
+def test_reports_where_its_objects_sit_now():
+    note = _whiteboard_note_from_metadata(_meta(agentObjects=[
+        {"origin": "c1", "label": "e^x + C", "x": 480, "y": 390,
+         "w": 300, "h": 88},
+    ]))
+    assert '"e^x + C" is at (480, 390), 300x88' in note
+
+
+def test_reports_a_deleted_object():
+    note = _whiteboard_note_from_metadata(_meta(agentObjects=[
+        {"origin": "c1", "label": "gone", "removed": True},
+    ]))
+    assert "no longer on the board" in note
+
+
+def test_reports_ink_drawn_around_one_of_its_objects():
+    """The real case: an answer wrapped in brackets and squared.
+
+    The object never moved -- what it means changed -- so a report of
+    only what moved or vanished would have said nothing at all.
+    """
+    note = _whiteboard_note_from_metadata(_meta(agentObjects=[
+        {"origin": "c1", "label": "e^x + C", "x": 480, "y": 390,
+         "w": 300, "h": 88, "touched": True},
+    ]))
+    assert "drawn on or around it" in note
+    assert "not as separate work beside it" in note
+
+
+def test_omits_the_inventory_when_it_has_drawn_nothing():
+    assert "as the board holds it now" not in _whiteboard_note_from_metadata(
+        _meta(),
+    )
+
+
+def test_skips_a_malformed_inventory_entry():
+    note = _whiteboard_note_from_metadata(_meta(agentObjects=[
+        {"origin": "c1", "label": "bad", "x": "left", "y": 1, "w": 2, "h": 3},
+        {"origin": "c2", "label": "good", "x": 1, "y": 2, "w": 3, "h": 4},
+    ]))
+    assert "bad" not in note
+    assert "good" in note
+
+
+def test_tolerates_a_nonsense_inventory():
+    for bad in ("nope", [1, 2], [{"origin": "c1"}]):
+        note = _whiteboard_note_from_metadata(_meta(agentObjects=bad))
+        assert note is None or isinstance(note, str)

--- a/tests/test_whiteboard_prompt.py
+++ b/tests/test_whiteboard_prompt.py
@@ -110,3 +110,28 @@ def test_the_fragment_is_keyed_on_the_tool_not_the_session():
         available_tools={"whiteboard_draw"},
     ).build()
     assert "Whiteboard canvas" in prompt
+
+
+def test_guidance_covers_handwritten_maths_ambiguity():
+    """Three sessions in a row failed on the same misreadings.
+
+    `2x + 1 = 5` read as `2 x 1 = 5`, an integral sign read as `S`, and
+    `2x + 1 = 7` read as `2x4 / 1 = ?` -- every one the handwritten
+    variable taken for an operator. The guidance covered logographic
+    script in detail and said nothing about mathematics.
+    """
+    text = _library().get("guidance/whiteboard")
+    assert "Reading handwritten mathematics" in text
+    # The specific confusions, not just a vague instruction to be careful.
+    assert "the variable `x`" in text
+    assert "well-formed expression" in text
+
+
+def test_guidance_forbids_reading_symbols_from_the_hotspot_trail():
+    """The model said it was "reading from the hotspot trajectory".
+
+    That trail is a coarse grid path of the pen; characters cannot be
+    recovered from it, and trying produced an invented expression.
+    """
+    text = _library().get("guidance/whiteboard")
+    assert "never read characters or symbols out of it" in text

--- a/tests/test_whiteboard_tool.py
+++ b/tests/test_whiteboard_tool.py
@@ -92,3 +92,57 @@ def test_description_names_every_command_tool():
     for tool in ("write_text", "draw_formula", "draw", "erase",
                  "place_artifact"):
         assert tool in description
+
+
+# --- what the model learns back ---------------------------------------
+#
+# The image and the occupied-cell list are both captured at Ask time, so
+# a second iteration has no evidence its first draw happened. One real
+# sketch turn drew five objects, four at the same coordinates and two
+# byte-identical, because every acknowledgement read the same.
+
+
+def test_result_reports_where_the_object_landed():
+    out = _call(_registry(), {"commands": [
+        {"tool": "draw_formula", "x": 1310, "y": 338,
+         "latex": "= \\infty", "fontSize": 80},
+    ]})
+    assert "(1310, 338)" in out
+    assert "= \\infty" in out
+
+
+def test_result_warns_that_the_image_predates_the_call():
+    out = _call(_registry(), {"commands": [
+        {"tool": "write_text", "x": 0, "y": 0, "text": "hi",
+         "fontSize": 20, "maxWidth": 100},
+    ]})
+    assert "captured before this call" in out
+    assert "do not draw it again" in out
+
+
+def test_result_lists_every_command():
+    out = _call(_registry(), {"commands": [
+        {"tool": "write_text", "x": 10, "y": 20, "text": "a",
+         "fontSize": 20, "maxWidth": 100},
+        {"tool": "write_text", "x": 30, "y": 40, "text": "b",
+         "fontSize": 20, "maxWidth": 100},
+    ]})
+    assert "(10, 20)" in out and "(30, 40)" in out
+
+
+def test_result_truncates_a_long_label():
+    out = _call(_registry(), {"commands": [
+        {"tool": "write_text", "x": 0, "y": 0, "text": "z" * 200,
+         "fontSize": 20, "maxWidth": 100},
+    ]})
+    # The commands are already in the event log; echoing them whole
+    # would double their cost in the next turn's replay.
+    assert len(out) < 600
+
+
+def test_result_survives_a_command_without_coordinates():
+    # erase mode=path carries points, not x/y.
+    out = _call(_registry(), {"commands": [
+        {"tool": "erase", "mode": "path", "points": [[0, 0], [1, 1]]},
+    ]})
+    assert "Drew 1 object" in out

--- a/tests/test_whiteboard_turn_mode.py
+++ b/tests/test_whiteboard_turn_mode.py
@@ -149,3 +149,73 @@ def test_tolerates_a_non_dict_event_payload():
     assert _latest_whiteboard_metadata(
         [_event(EventType.USER_MESSAGE.value, None)],
     ) is None
+
+
+# --- sketch stops after it draws --------------------------------------
+#
+# Narrowing the catalogue to one tool was only ever a nudge. One real
+# sketch turn drew five objects, four at the same coordinates and two
+# byte-identical, because the image and the occupied-cell list it was
+# reasoning from both predated its own draws.
+
+from surogates.harness.loop import _whiteboard_sketch_turn_done
+
+
+def _sketch_meta(mode="sketch"):
+    return {"whiteboard": {"mode": mode, "sourceRect": {
+        "x": 0, "y": 0, "w": 100, "h": 100,
+    }}}
+
+
+def _drew(content="Drew 1 object on the canvas: \"5\" at (10, 20)."):
+    calls = [{"id": "c1", "function": {"name": "whiteboard_draw"}}]
+    results = [{"role": "tool", "tool_call_id": "c1", "content": content}]
+    return calls, results
+
+
+def test_a_sketch_turn_stops_once_it_has_drawn():
+    calls, results = _drew()
+    assert _whiteboard_sketch_turn_done(
+        calls, results, _sketch_meta(), has_whiteboard=True,
+    )
+
+
+def test_a_deep_turn_keeps_going():
+    # "Think harder" is many round-trips by design.
+    calls, results = _drew()
+    assert not _whiteboard_sketch_turn_done(
+        calls, results, _sketch_meta("deep"), has_whiteboard=True,
+    )
+
+
+def test_a_failed_draw_does_not_end_the_turn():
+    # The error exists to be acted on; stopping leaves the board
+    # untouched and the user with nothing.
+    calls, results = _drew("Error: command[0] (erase) is missing 'mode'.")
+    assert not _whiteboard_sketch_turn_done(
+        calls, results, _sketch_meta(), has_whiteboard=True,
+    )
+
+
+def test_other_tools_do_not_end_a_sketch_turn():
+    calls = [{"id": "c1", "function": {"name": "web_search"}}]
+    results = [{"role": "tool", "tool_call_id": "c1", "content": "ok"}]
+    assert not _whiteboard_sketch_turn_done(
+        calls, results, _sketch_meta(), has_whiteboard=True,
+    )
+
+
+def test_an_ordinary_chat_turn_is_untouched():
+    # The board is a view mode: a typed message on a board-enabled agent
+    # keeps its iterations.
+    calls, results = _drew()
+    assert not _whiteboard_sketch_turn_done(
+        calls, results, {"view_context": {}}, has_whiteboard=True,
+    )
+
+
+def test_an_agent_without_the_board_is_untouched():
+    calls, results = _drew()
+    assert not _whiteboard_sketch_turn_done(
+        calls, results, _sketch_meta(), has_whiteboard=False,
+    )


### PR DESCRIPTION
## Summary

One debugging campaign across a dozen real whiteboard sessions, fixing every failure they surfaced.

**Board resilience (client)**
- A view switch raced the unmount's save against the remount's load and wrote an ink-less board over the stored one; loads now wait for in-flight saves, the fold is held until the stored board lands, autosave is gated on that load committing, and a veil shows while it loads.
- Middle-button pan with any tool, a progress pill naming the agent's current step, the canvas held while a turn runs, the bottom bar kept clear of the host's copilot button.

**What the model is told (client → note)**
- Capture frames the whole board while it fits and the viewport once it cannot, so a wide board no longer arrives as a 30 % thumbnail.
- A labelled 16×16 grid on the atlas and the canvas; occupied cells, cell-to-canvas mapping, handwriting height, the directions content continues, and what became of the agent's own objects (moved, deleted, or drawn on by the user — none of which any event records).

**Reading, placing, stopping (harness)**
- Guidance for handwritten mathematics: the specific confusions (`x` vs `×`, `∫` vs `S`, `+` vs `4`) and a well-formedness check before answering. Three straight sessions had failed the same way.
- Occupancy phrased as a constraint, not a placement rule; the cell arithmetic handed over; prose sized separately from short answers (a nine-line tower otherwise).
- Validation catches text wrapping onto its own next command and prose taller than it is wide; `width`/`height` accepted for `w`/`h`; `replaces` supersedes an earlier draw instead of stacking on it.
- The tool result reports what landed where and that the image predates the call; a sketch turn ends once a draw succeeds — one round-trip was always the contract.
- Session titles come from the user's words, not the injected canvas note ("Whiteboard Canvas Coordinates" on every board).

## Test plan
- [x] `vitest`: 836 SDK tests
- [x] `pytest`: 5,775 harness tests
- [x] typecheck + biome clean
- [x] Verified against the sessions that motivated each fix (ids in the commit messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)