### PR TITLE
fix: context-window step-down, tool-result spilling, and KB pagination

### DIFF
--- a/benchmarks/gaia/RESULTS.md
+++ b/benchmarks/gaia/RESULTS.md
@@ -19,6 +19,7 @@ capability problem.
 | 2026-08-29 | `dev-018` | local harness, agent `gaia-h5iiol` | claude-sonnet-5 | 110 | 62 | **56.4%** |
 | 2026-08-29 | `dev-021` | local harness, agent `gaia-h5iiol` | claude-sonnet-5 | 110 | 66 | **60.0%** |
 | 2026-08-29 | `dev-022` | local harness, agent `gaia2-tbmpuz` | claude-sonnet-5 | 110 | 68 | **61.8%** |
+| 2026-08-29 | `dev-023` | local harness, agent `gaiaopus-xg75cy` | claude-opus-5 | 110 | 68 | **61.8%** |
 
 > **The 2026-08-27 run is `dev-001` in its own `report.md`.** Run ids auto-
 > increment from the contents of `runs/`, and it was produced against a fresh
@@ -113,6 +114,47 @@ Three touched the browser, and one of those was a real regression this run
 caught: navigate snapshots were not being pruned as superseded state, so a
 34-call session reached 324,700 input tokens against a 262,144 window. Fixed;
 not yet re-measured.
+
+## opus-5 vs sonnet-5: a tie at 4.6x the cost
+
+`dev-023` is the cleanest comparison in this file. `gaiaopus-xg75cy` differs
+from `gaia2-tbmpuz` in exactly one field — `model_id: surogate-pro` against
+`surogate` — so same tools, same flags, same project, no custom prompt, same
+harness commit. One variable.
+
+| | sonnet-5 (`dev-022`) | opus-5 (`dev-023`) |
+| --- | --- | --- |
+| Strict | 68/110 (61.8%) | 68/110 (61.8%) |
+| L1 / L2 / L3 | 23 / 37 / 8 | 22 / 39 / 7 |
+| `no_tool_use` | 8 | 9 |
+| `no_final_answer` | 5 | 5 |
+| `empty_llm_response` | 1 | 3 |
+| **Cost** | **$72.94** | **$335.75** |
+| LLM calls | 1,223 | 1,223 |
+| Input tokens | 123.9M (79% cached) | 408.0M (93% cached) |
+| Output tokens | 186,553 | 168,422 |
+
+Identical score. Eight tasks flipped each way, five of the eight regressions
+carrying no failure flag, and the two models agree on 94/110 (85%) — so the
+16 that differ read as coin-flips rather than capability.
+
+The cost is the result. Opus spent **3.3x the input tokens for the same
+number of calls**, meaning materially larger contexts per request, and landed
+at 4.6x the spend — well past the 2.5x its per-token rates imply, because
+token volume rose alongside the rate.
+
+A tie needs no statistical precision: the +/-3-point variance band that
+qualifies every other row here does not apply when the difference is zero.
+**On this benchmark, at this harness version, opus-5 buys nothing.**
+
+Two caveats. One run each, so opus could be a point either side. And the
+sentinel context-window problem below applies to `surogate-pro` too — opus
+ran much larger contexts, so it may be paying that mis-sizing harder than
+sonnet did, and fixing it could move opus more.
+
+(Both runs made exactly 1,223 LLM calls. Verified as coincidence, not a
+measurement artefact: the per-task distributions differ — 61 vs 65 max turns
+— and the token totals are nothing alike.)
 
 ## dev-021 → dev-022: snapshot pruning
 

--- a/benchmarks/gaia/RESULTS.md
+++ b/benchmarks/gaia/RESULTS.md
@@ -18,6 +18,7 @@ capability problem.
 | 2026-08-28 | `dev-007` | prod, agent `gaia-xi8anu` | Surogate Pro | 110 | 53 | **48.2%** |
 | 2026-08-29 | `dev-018` | local harness, agent `gaia-h5iiol` | claude-sonnet-5 | 110 | 62 | **56.4%** |
 | 2026-08-29 | `dev-021` | local harness, agent `gaia-h5iiol` | claude-sonnet-5 | 110 | 66 | **60.0%** |
+| 2026-08-29 | `dev-022` | local harness, agent `gaia2-tbmpuz` | claude-sonnet-5 | 110 | 68 | **61.8%** |
 
 > **The 2026-08-27 run is `dev-001` in its own `report.md`.** Run ids auto-
 > increment from the contents of `runs/`, and it was produced against a fresh
@@ -112,6 +113,41 @@ Three touched the browser, and one of those was a real regression this run
 caught: navigate snapshots were not being pruned as superseded state, so a
 34-call session reached 324,700 input tokens against a 262,144 window. Fixed;
 not yet re-measured.
+
+## dev-021 → dev-022: snapshot pruning
+
+Re-measured after pruning superseded `browser_navigate` snapshots and marking
+un-inlinable attachments. Ran on `gaia2-tbmpuz`, which differs from
+`gaia-h5iiol` only in `research_enabled` / `deep_research_enabled` — flags that
+gate the `/auto-research` and `/deep-research` slash commands, which the
+benchmark never sends. Same model, same tools.
+
+| | dev-021 | dev-022 |
+| --- | --- | --- |
+| Strict | 66/110 (60.0%) | **68/110 (61.8%)** |
+| L1 / L2 / L3 | 21 / 39 / 6 | 23 / 37 / 8 |
+| `no_tool_use` | 11 | 8 |
+| `no_final_answer` | 6 | 5 |
+| `empty_llm_response` | 3 | 1 |
+| `tool_error` | 4 | 4 |
+| Cost | $86.47 | $72.94 |
+
+Net +2 is 8 newly passing against 6 newly failing, four of which carry no
+flag — answered and wrong, i.e. variance. Treat +2 as "not worse", not as a
+measured gain.
+
+Pruning worked but did not rescue its target task. `d5141ca5` went 324,700 →
+274,386 peak input tokens and 34 → 21 browser calls, and still failed. It
+spent 58 turns and 9,995,161 input tokens, 92% of them cache reads, for
+$3.56.
+
+**The context window the harness plans against is wrong.** Sessions run under
+the `surogate` sentinel, which the catalog gives a 262,144-token window, but
+they are served by claude-sonnet-5 at 1,000,000. That 274,386-token request
+succeeded — the real model had room to spare. So compaction and browser-state
+pruning are sized against a limit ~3.8x smaller than the one that applies,
+discarding context that never needed discarding. Nothing overflows; the
+harness is just planning against the wrong number.
 
 ## The earlier regression
 

--- a/benchmarks/gaia/experiments/README.md
+++ b/benchmarks/gaia/experiments/README.md
@@ -1,0 +1,41 @@
+# Offline experiments
+
+Evaluations that run against stored run traces — no agent, no browser, no
+benchmark execution. A trace is a paid artefact; asking new questions of one
+should be free.
+
+## doubter_eval.py
+
+Would a critic model, shown the agent's action history before it answered,
+flag the runs that turned out wrong — and leave the correct ones alone?
+
+`runs/<id>/outcomes.json` gives the labels, `trajectory.md` the history. Both
+halves of the question matter: a doubter that catches every failure by
+objecting to everything costs a rerun on every task and makes the agent worse.
+
+```bash
+python experiments/doubter_eval.py dev-022                        # summary model
+python experiments/doubter_eval.py dev-022 --model google/gemini-3.1-pro-preview
+```
+
+Writes `runs/<id>/doubter_verdicts.json` so score thresholds can be swept
+without paying for the pass again.
+
+### Result on dev-022 (110 trajectories, 68 pass / 42 fail)
+
+| model | best precision | detection there | false positives | passed / failed median score |
+| --- | --- | --- | --- | --- |
+| deepseek-v4-flash (summary preset) | 59% @ score<=0 | 40% | 18% | 5.0 / 1.0 |
+| gemini-3.1-pro | **68% @ score<=3** | 64% | 19% | **10.0** / 2.0 |
+
+**The doubter needs a strong model.** Cross-family alone does not carry it:
+deepseek is a different family from the executor (claude-sonnet-5) and still
+scored *correct* runs a median 5 — it could not tell good work from bad. The
+pro model scores them 10 against 2 for failures.
+
+Against a 38% base rate, deepseek's 59% precision is barely better than
+chance. Do not wire in a cheap doubter on the theory that criticism is easier
+than generation; it was measured and it is not.
+
+Still untested: whether a rerun actually fixes a caught failure. The 68%
+precision figure is the ceiling on value, not the value.

--- a/benchmarks/gaia/experiments/doubter_eval.py
+++ b/benchmarks/gaia/experiments/doubter_eval.py
@@ -1,0 +1,210 @@
+"""Offline evaluation of a doubter (critic) against stored GAIA trajectories.
+
+The question this answers: if a critic model reviewed the agent's action
+history before it answered, would it flag the runs that turned out wrong --
+and would it leave the correct ones alone?
+
+Both halves matter. A doubter that catches every failure by objecting to
+everything costs a rerun on every task and makes the agent worse.
+
+Runs entirely on stored traces: no agent, no browser, no benchmark. A pass
+over 110 trajectories is ~722k tokens, which on deepseek-v4-flash is a few
+cents -- against $73+ for a live run.
+
+Usage:
+    python experiments/doubter_eval.py dev-022 [--limit N] [--model ID]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import pathlib
+import re
+import sys
+
+import httpx
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+CONFIG = pathlib.Path.home() / ".surogate" / "config.yaml"
+
+# Reasoning first, verdict last: guided decoding emits keys in declaration
+# order, so a leading score would be produced before the analysis that is
+# supposed to justify it.
+SCHEMA = {
+    "type": "object",
+    "properties": {
+        "flaws": {
+            "type": "string",
+            "description": (
+                "Concrete flaws in the action history: a missing step, an "
+                "unverified assumption, a question asked but not answered. "
+                "Empty string if the history is sound."
+            ),
+        },
+        "score": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10,
+            "description": "0 = illogical and full of errors, 10 = sound and complete.",
+        },
+        "rerun": {
+            "type": "boolean",
+            "description": "True if the agent should run again.",
+        },
+    },
+    "required": ["flaws", "score", "rerun"],
+    "additionalProperties": False,
+}
+
+INSTRUCTION = """You are reviewing the actions an agent took to answer a question.
+
+Look for a logical flaw or a missing step: a claim it never verified, a
+question it answered from memory when it had a tool available, a sub-question
+in the task it silently skipped, an answer that does not follow from what it
+actually found.
+
+Not every history is flawed. Many are sound, and saying so is the correct
+answer -- objecting to good work costs a wasted rerun. Judge only what the
+history shows.
+
+The history ends just before the agent commits to its answer, so the absence
+of a verification step at the end is expected. Do not report that as a flaw.
+"""
+
+
+def load_summary_endpoint() -> tuple[str, str, str]:
+    cfg = yaml.safe_load(CONFIG.read_text())
+    return (
+        cfg["summary_llm_endpoint"].rstrip("/"),
+        cfg["summary_llm_key"],
+        cfg["summary_llm_model"],
+    )
+
+
+async def review(client: httpx.AsyncClient, model: str, question: str,
+                 trajectory: str, sem: asyncio.Semaphore) -> dict | None:
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": INSTRUCTION},
+            {"role": "user", "content": f"Task:\n{question}\n\nAction history:\n{trajectory}"},
+        ],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "doubt", "strict": True, "schema": SCHEMA},
+        },
+    }
+    async with sem:
+        for attempt in range(3):
+            try:
+                r = await client.post("/chat/completions", json=body, timeout=180)
+                if r.status_code != 200:
+                    if attempt == 2:
+                        print(f"    HTTP {r.status_code}: {r.text[:160]}", file=sys.stderr)
+                    await asyncio.sleep(2 * (attempt + 1))
+                    continue
+                content = r.json()["choices"][0]["message"]["content"]
+                return json.loads(content)
+            except Exception as exc:  # noqa: BLE001 - one bad trace must not kill the sweep
+                if attempt == 2:
+                    print(f"    {type(exc).__name__}: {exc}", file=sys.stderr)
+                await asyncio.sleep(2 * (attempt + 1))
+    return None
+
+
+def question_of(task_dir: pathlib.Path) -> str:
+    """First user message, which carries the task text."""
+    events = task_dir / "events.jsonl"
+    if not events.exists():
+        return ""
+    for line in events.open():
+        e = json.loads(line)
+        if e.get("type") == "user.message" and isinstance(e.get("data"), dict):
+            c = e["data"].get("content") or ""
+            if isinstance(c, list):
+                c = " ".join(p.get("text", "") for p in c if isinstance(p, dict))
+            return c[:4000]
+    return ""
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_id")
+    ap.add_argument("--limit", type=int)
+    ap.add_argument("--model")
+    ap.add_argument("--concurrency", type=int, default=6)
+    args = ap.parse_args()
+
+    run = ROOT / "runs" / args.run_id
+    outcomes = {x["task_id"]: x for x in json.loads((run / "outcomes.json").read_text())}
+    base, key, model = load_summary_endpoint()
+    model = args.model or model
+
+    tasks = []
+    for tid, out in outcomes.items():
+        d = run / "tasks" / tid
+        traj = d / "trajectory.md"
+        if traj.exists():
+            tasks.append((tid, bool(out.get("strict_pass")), question_of(d),
+                          traj.read_text(errors="replace")))
+    if args.limit:
+        tasks = tasks[: args.limit]
+
+    print(f"{len(tasks)} trajectories from {args.run_id} | model={model}")
+    print(f"  {sum(1 for t in tasks if t[1])} passed / {sum(1 for t in tasks if not t[1])} failed\n")
+
+    sem = asyncio.Semaphore(args.concurrency)
+    async with httpx.AsyncClient(
+        base_url=base, headers={"Authorization": f"Bearer {key}"}
+    ) as client:
+        verdicts = await asyncio.gather(*[
+            review(client, model, q, tr, sem) for _, _, q, tr in tasks
+        ])
+
+    tp = fp = tn = fn = err = 0
+    rows = []
+    for (tid, passed, _, _), v in zip(tasks, verdicts):
+        if v is None:
+            err += 1
+            continue
+        flagged = bool(v.get("rerun"))
+        if not passed and flagged:
+            tp += 1
+        elif passed and flagged:
+            fp += 1
+        elif passed and not flagged:
+            tn += 1
+        else:
+            fn += 1
+        rows.append((tid[:8], passed, flagged, v.get("score"), (v.get("flaws") or "")[:90]))
+
+    print(f"{'task':9} {'truth':>7} {'doubter':>8} {'score':>5}  flaws")
+    for r in sorted(rows, key=lambda x: (x[1], x[2])):
+        print(f"{r[0]:9} {'pass' if r[1] else 'FAIL':>7} "
+              f"{'rerun' if r[2] else 'ok':>8} {str(r[3]):>5}  {r[4]!r}")
+
+    out_path = run / "doubter_verdicts.json"
+    out_path.write_text(json.dumps([
+        {"task_id": tid, "strict_pass": passed, "verdict": v}
+        for (tid, passed, _, _), v in zip(tasks, verdicts)
+    ], indent=1))
+    print(f"\n  verdicts written to {out_path}")
+
+    graded = tp + fp + tn + fn
+    print(f"\n  errors: {err}   graded: {graded}")
+    if graded:
+        print(f"  caught {tp}/{tp+fn} real failures     ({tp/(tp+fn)*100:.0f}% detection)"
+              if tp + fn else "  no failures in set")
+        print(f"  flagged {fp}/{fp+tn} correct runs      ({fp/(fp+tn)*100:.0f}% false positive)"
+              if fp + tn else "  no passes in set")
+        print(f"  a rerun triggered here is right {tp/(tp+fp)*100:.0f}% of the time"
+              if tp + fp else "  never triggered a rerun")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/surogates/config.py
+++ b/surogates/config.py
@@ -342,6 +342,12 @@ class LLMSettings(BaseSettings):
     prune_browser_state: bool = True
     browser_state_keep_last: int = 2
 
+    # Fraction of the model's context window at which compaction fires.
+    # The default deliberately leaves room for the response plus the
+    # compaction call itself; raise it to trade a larger working context
+    # for a tighter margin before an overflow.
+    compression_threshold: float = Field(default=0.50, gt=0.0, le=0.95)
+
     summary_model: str = ""  # cheap model for context compression summaries
     summary_base_url: str = ""  # optional auxiliary endpoint for summaries
     summary_api_key: str = ""  # optional auxiliary API key for summaries

--- a/surogates/harness/context.py
+++ b/surogates/harness/context.py
@@ -233,15 +233,8 @@ class ContextCompressor:
         self._prune_browser_state = prune_browser_state
         self._browser_state_keep_last = browser_state_keep_last
 
-        self.threshold_tokens = int(self.context_length * threshold_percent)
         self.compression_count = 0
-
-        # Derive token budgets: ratio is relative to the threshold, not total context.
-        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
-        self.tail_token_budget = target_tokens
-        self.max_summary_tokens = min(
-            int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
-        )
+        self._derive_budgets()
 
         if not quiet_mode:
             logger.info(
@@ -262,6 +255,34 @@ class ContextCompressor:
         # Stores the previous compaction summary for iterative updates.
         self._previous_summary: Optional[str] = None
         self._summary_failure_cooldown_until: float = 0.0
+
+    def _derive_budgets(self) -> None:
+        """Recompute every budget derived from the context window.
+
+        Called from ``__init__`` and again whenever the window is revised
+        downwards, so the threshold and summary budgets never keep
+        referring to a window the provider has already rejected.
+        """
+        self.threshold_tokens = int(self.context_length * self.threshold_percent)
+        # Ratio is relative to the threshold, not to total context.
+        self.tail_token_budget = int(self.threshold_tokens * self.summary_target_ratio)
+        self.max_summary_tokens = min(
+            int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
+        )
+
+    def set_context_length(self, context_length: int) -> bool:
+        """Shrink the assumed context window and re-derive budgets.
+
+        Returns ``True`` if the window actually moved.  Only shrinking is
+        allowed: the caller reaches here because the provider rejected a
+        request as too long, so a larger value would be the guess that
+        just failed.
+        """
+        if context_length <= 0 or context_length >= self.context_length:
+            return False
+        self.context_length = context_length
+        self._derive_budgets()
+        return True
 
     # ------------------------------------------------------------------
     # Token tracking

--- a/surogates/harness/llm_call.py
+++ b/surogates/harness/llm_call.py
@@ -92,6 +92,10 @@ def _stamp_turn_meta(
     return payload
 
 
+# Only used when no compressor is attached; a compressor always knows the
+# real window for its model.
+_FALLBACK_CONTEXT_WINDOW: int = 128_000
+
 # Retry constants
 MAX_LLM_RETRIES: int = 3
 
@@ -681,9 +685,9 @@ async def call_llm_with_retry(
                 if isinstance(m, dict)
             )
             context_window = int(
-                getattr(context_compressor, "_context_window", 200_000)
+                context_compressor.context_length
                 if context_compressor is not None
-                else 200_000
+                else _FALLBACK_CONTEXT_WINDOW
             )
             classified = classify_api_error(
                 exc,
@@ -772,9 +776,8 @@ async def call_llm_with_retry(
                     and compress_context is not None
                 ):
                     _reduced_ctx = 200_000
-                    old_ctx = getattr(context_compressor, "_context_window", 0)
-                    if old_ctx > _reduced_ctx:
-                        context_compressor._context_window = _reduced_ctx
+                    old_ctx = context_compressor.context_length
+                    if context_compressor.set_context_length(_reduced_ctx):
                         logger.warning(
                             "Anthropic long-context tier requires extra usage "
                             "-- reducing context: %d -> %d tokens",
@@ -930,18 +933,14 @@ async def call_llm_with_retry(
                 # Try to parse the actual limit from the error message
                 # and step down the context window.
                 if context_compressor is not None:
-                    old_ctx = getattr(
-                        context_compressor, "_context_window",
-                        128_000,
-                    )
+                    old_ctx = context_compressor.context_length
                     parsed_limit = parse_context_limit_from_error(error_msg)
                     if parsed_limit and parsed_limit < old_ctx:
                         new_ctx = parsed_limit
                     else:
                         new_ctx = get_next_probe_tier(old_ctx)
 
-                    if new_ctx and new_ctx < old_ctx:
-                        context_compressor._context_window = new_ctx
+                    if new_ctx and context_compressor.set_context_length(new_ctx):
                         logger.warning(
                             "Context length exceeded -- stepping down: "
                             "%d -> %d tokens",

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -330,18 +330,43 @@ def _slash_command_name(content: str | None) -> str | None:
     return None
 
 
-def _looks_unfinished(text: str) -> bool:
-    """True when *text* trails off mid-thought instead of concluding.
+#: A first-person intention to act, sitting at the very end of the message:
+#: "Let me take a screenshot to see the current state of the video."
+_TRAILING_INTENT = re.compile(
+    r"(?:^|[.!?]\s+)"
+    r"(?:let me|let'?s|i'?ll|i will|i'?m going to|now i|taking|checking|"
+    r"looking|trying)\b[^.!?]*[.!?\u2026]*\s*$",
+    re.IGNORECASE,
+)
 
-    Answers end; intentions trail off.  Every instance observed on GAIA
-    dev-018 ended in an ellipsis -- "Let me check the page directly via the
-    browser...." -- while the model had been calling tools successfully up
-    to that turn.  Kept to that one structural signal on purpose: judging
-    "is this an answer?" from prose would misfire on short legitimate
-    replies, and the caller bounds the cost of a false positive to a single
-    extra turn.
+#: An intention is stated briefly; a real answer that happens to end on a
+#: forward-looking sentence is usually longer.  Length is what separates
+#: them, and it is what keeps this off turns that did answer.
+_UNFINISHED_MAX_CHARS = 200
+
+
+def _looks_unfinished(text: str) -> bool:
+    """True when *text* states an intention instead of concluding.
+
+    Two signals, measured over 444 stored turns across five GAIA runs
+    (44 that produced no answer, 400 that did):
+
+        trailing ellipsis      catches 52%, fires on 19% of answered turns
+        trailing intent        catches 45%, fires on  2%
+        either, under 200 chars catches 61%, fires on  5%
+
+    The ellipsis alone was the first version of this, fitted to a single run
+    where every instance happened to end in one.  It cost a wasted turn on
+    nearly a fifth of turns that had answered perfectly well, which is why
+    both signals and the length bound are here.
     """
-    return text.rstrip().endswith(("...", "\u2026"))
+    stripped = text.strip()
+    if len(stripped) > _UNFINISHED_MAX_CHARS:
+        return False
+    return (
+        stripped.endswith(("...", "\u2026"))
+        or bool(_TRAILING_INTENT.search(stripped))
+    )
 
 
 def _carries_information(text: str) -> bool:

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -114,6 +114,7 @@ from surogates.harness.loop_attachments import (
     _attachments_note,  # noqa: F401
     _render_inlined_attachments,  # noqa: F401
 )
+from surogates.harness.loop_conclusion import conclude_from_transcript
 from surogates.harness.loop_constants import (
     _DYNAMIC_LOOP_EXCLUDED_TOOLS,
     _EMPTY_RESPONSE_NUDGE,
@@ -2313,29 +2314,47 @@ class AgentHarness(
                             )
                             continue
 
-                        logger.error(
-                            "Session %s: LLM returned empty response %d "
-                            "times; emitting session.fail",
-                            session.id, _MAX_EMPTY_RESPONSE_RETRIES,
+                        # Before failing: the model stopped producing text,
+                        # but the turn may already contain the finding. A
+                        # recovered conclusion ends the turn properly; a
+                        # NOT_FOUND leaves the failure exactly as it was.
+                        concluded = await conclude_from_transcript(
+                            self._summary_client, self._summary_model,
+                            question=_latest_user_event_text(all_events or []),
+                            messages=messages,
                         )
-                        await self._store.emit_event(
-                            session.id,
-                            EventType.SESSION_FAIL,
-                            {
-                                "reason": "empty_llm_response",
-                                "attempts": _MAX_EMPTY_RESPONSE_RETRIES,
-                            },
-                        )
-                        try:
-                            await self._store.update_session_status(
-                                session.id, "failed",
+                        if concluded:
+                            logger.info(
+                                "Session %s: recovered a conclusion from the "
+                                "transcript after %d empty responses",
+                                session.id, _MAX_EMPTY_RESPONSE_RETRIES,
                             )
-                        except Exception:
-                            logger.warning(
-                                "Failed to update session status to failed "
-                                "for %s", session.id, exc_info=True,
+                            assistant_message["content"] = concluded
+                            visible_content = concluded
+                        else:
+                            logger.error(
+                                "Session %s: LLM returned empty response %d "
+                                "times; emitting session.fail",
+                                session.id, _MAX_EMPTY_RESPONSE_RETRIES,
                             )
-                        return
+                            await self._store.emit_event(
+                                session.id,
+                                EventType.SESSION_FAIL,
+                                {
+                                    "reason": "empty_llm_response",
+                                    "attempts": _MAX_EMPTY_RESPONSE_RETRIES,
+                                },
+                            )
+                            try:
+                                await self._store.update_session_status(
+                                    session.id, "failed",
+                                )
+                            except Exception:
+                                logger.warning(
+                                    "Failed to update session status to "
+                                    "failed for %s", session.id, exc_info=True,
+                                )
+                            return
 
                 # The model announced an action, made no tool call, and its
                 # text trails off ("Let me check the page directly via the
@@ -2366,6 +2385,26 @@ class AgentHarness(
                         "content": _UNFINISHED_RESPONSE_NUDGE,
                     })
                     continue
+
+                # The nudge is spent and the model is still trailing off. Its
+                # own text is not an answer, but the work it did may contain
+                # one -- ask the cheap model for the conclusion the transcript
+                # supports, and keep the original text if there is none.
+                if _looks_unfinished(visible_content):
+                    concluded = await conclude_from_transcript(
+                        self._summary_client, self._summary_model,
+                        question=_latest_user_event_text(all_events or []),
+                        messages=messages,
+                    )
+                    if concluded:
+                        logger.info(
+                            "Session %s: recovered a conclusion from the "
+                            "transcript after the turn trailed off",
+                            session.id,
+                        )
+                        assistant_message["content"] = concluded
+                        final_content = concluded
+                        visible_content = concluded
 
                 # Pop thinking-only prefill message(s) before appending
                 # the final response.  This avoids consecutive assistant

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -2773,8 +2773,14 @@ class AgentHarness(
                 )
             else:
                 _spill_writer = None
+            # A tool result message carries no tool name, so hand the
+            # budget the id -> name map or it cannot honour the pins.
+            _tc_names = {
+                tc.get("id"): tc.get("function", {}).get("name", "")
+                for tc in (tool_calls_raw or [])
+            }
             tool_results = await enforce_turn_budget(
-                tool_results, writer=_spill_writer,
+                tool_results, writer=_spill_writer, tool_names=_tc_names,
             )
 
             # 7c. Budget pressure warning -- inject into the last tool result.

--- a/surogates/harness/loop.py
+++ b/surogates/harness/loop.py
@@ -2696,8 +2696,22 @@ class AgentHarness(
                     self._iters_since_skill = 0
 
             # 7b. Layer 3: enforce aggregate turn budget -- persist oversized results.
-            from surogates.tools.utils.tool_result_storage import enforce_turn_budget
-            tool_results = enforce_turn_budget(tool_results)
+            #     Spills go through the sandbox when tools run there, so the
+            #     path handed to the model is one ``read_file`` can open.
+            from surogates.tools.utils.tool_result_storage import (
+                enforce_turn_budget,
+                make_sandbox_writer,
+            )
+            if self._sandbox_pool is not None:
+                from surogates.sandbox.pool import sandbox_session_key
+                _spill_writer = make_sandbox_writer(
+                    self._sandbox_pool, sandbox_session_key(session),
+                )
+            else:
+                _spill_writer = None
+            tool_results = await enforce_turn_budget(
+                tool_results, writer=_spill_writer,
+            )
 
             # 7c. Budget pressure warning -- inject into the last tool result.
             tool_results = inject_budget_warning(tool_results, self._budget)

--- a/surogates/harness/loop_attachments.py
+++ b/surogates/harness/loop_attachments.py
@@ -30,6 +30,36 @@ _ATTACHMENT_SKIP_HINTS: dict[str, str] = {
         " when you actually need this file's content"
     ),
 }
+#: Attachment kinds the platform cannot turn into text, keyed by mime prefix.
+#: The generic note tells the agent its file tools can read the attachment;
+#: for these that is false, and the agent has no way to discover it except by
+#: trying. On GAIA dev-021 an mp3 task did try -- ``whisper: not installed``
+#: -- and then answered anyway, inventing a shopping list from the question's
+#: wording. A capability we do not have must be stated, not discovered, or the
+#: model fills the gap with plausible invention.
+_UNREADABLE_ATTACHMENT_KINDS: dict[str, str] = {
+    "audio/": (
+        "audio — this platform has NO transcription capability. You cannot"
+        " learn what is spoken or played in this file, and no tool or package"
+        " will give you that. Say plainly that you cannot access the audio;"
+        " never infer its contents from the filename or the request."
+    ),
+    "video/": (
+        "video — this platform has NO transcription or frame-extraction"
+        " capability. Say plainly that you cannot access it; never infer its"
+        " contents."
+    ),
+}
+
+
+def _unreadable_kind_note(mime: str) -> str | None:
+    """Return the capability note for *mime*, or ``None`` when readable."""
+    for prefix, note in _UNREADABLE_ATTACHMENT_KINDS.items():
+        if mime.startswith(prefix):
+            return note
+    return None
+
+
 def _attachments_note(events: list[Any]) -> str | None:
     """Return a per-turn system note describing path-only attachments.
 
@@ -66,11 +96,8 @@ def _attachments_note_from_data(data: Any) -> str | None:
     attachments_section: str | None = None
     attachments = data.get("attachments")
     if isinstance(attachments, list) and attachments:
-        lines = [
-            "The user attached the following files to this message. They are"
-            " available in the workspace and you can read them with your file"
-            " tools:",
-        ]
+        lines: list[str] = []          # header prepended once the kinds are known
+        any_unreadable = False
         for item in attachments:
             if not isinstance(item, dict):
                 continue
@@ -89,14 +116,32 @@ def _attachments_note_from_data(data: Any) -> str | None:
             else:
                 size_str = "unknown size"
             line = f"- {path} ({mime}, {size_str}) — \"{filename}\""
-            skip_reason = item.get("inline_skip_reason")
-            if skip_reason:
-                hint = _ATTACHMENT_SKIP_HINTS.get(skip_reason, "use read_file")
-                line += f" (inline skipped: {skip_reason} — {hint})"
+            unreadable = _unreadable_kind_note(mime)
+            if unreadable:
+                any_unreadable = True
+                line += f"\n  CANNOT BE READ: {unreadable}"
+            else:
+                skip_reason = item.get("inline_skip_reason")
+                if skip_reason:
+                    hint = _ATTACHMENT_SKIP_HINTS.get(skip_reason, "use read_file")
+                    line += f" (inline skipped: {skip_reason} — {hint})"
             lines.append(line)
 
-        if len(lines) > 1:
-            attachments_section = "\n".join(lines)
+        if lines:
+            # The caveat is only mentioned when something actually carries it;
+            # otherwise every ordinary attachment pays for prose about a case
+            # that does not apply to it.
+            header = (
+                "The user attached the following files to this message. They"
+                " are in the workspace and readable with your file tools,"
+                " EXCEPT any marked CANNOT BE READ — for those the content is"
+                " unavailable to you and no tool will change that:"
+                if any_unreadable else
+                "The user attached the following files to this message. They"
+                " are available in the workspace and you can read them with"
+                " your file tools:"
+            )
+            attachments_section = "\n".join([header, *lines])
 
     # Section 2: channel file ids from source.files (additive, never raises).
     files_section: str | None = None

--- a/surogates/harness/loop_conclusion.py
+++ b/surogates/harness/loop_conclusion.py
@@ -1,0 +1,147 @@
+"""Last-resort conclusion for a turn that ended without answering.
+
+The loop's guards catch a turn that produces nothing (empty or punctuation-only
+content) or that trails off mid-intent, and give the model another chance. When
+that chance is used up the turn still has to end, and today it ends with
+whatever the model last said -- an empty string, an ellipsis, or "Let me check
+the page directly via the browser....".
+
+That is a bad ending for a benchmark and a worse one for a person: the work was
+done, the finding is somewhere in the transcript, and the reply concludes
+nothing. This module asks the cheap summary model for the conclusion the
+transcript already supports.
+
+**It extracts; it never invents.** A model told to produce an answer will
+produce one whether or not the evidence is there -- that is how a missing audio
+transcription became a confidently fabricated shopping list. So the prompt
+demands a verbatim-grounded answer and reserves an explicit NOT_FOUND, and a
+NOT_FOUND is returned to the caller as ``None``: no conclusion is strictly
+better than an invented one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: The model must be able to decline. Without a reserved token for "the
+#: transcript does not contain this", the only shape available to it is an
+#: answer, and it will supply one.
+_NOT_FOUND = "NOT_FOUND"
+
+_CONCLUSION_PROMPT = (
+    "You are reading the transcript of an agent that worked on a task and "
+    "then stopped without stating its conclusion.\n\n"
+    "Report the conclusion the transcript ALREADY supports. Every fact you "
+    "state must be visible in the transcript.\n\n"
+    "Do not solve the task yourself. Do not reason past what was found. Do "
+    "not fill a gap with what is likely or plausible.\n\n"
+    f"If the transcript does not contain the answer, reply with exactly "
+    f"{_NOT_FOUND} and nothing else. Replying {_NOT_FOUND} is the correct "
+    "answer whenever the work did not get there -- a wrong answer is far "
+    "worse than none.\n\n"
+    "Otherwise reply with the conclusion alone, in the form the task asked "
+    "for, with no preamble."
+)
+
+#: The turn is already over and the user is waiting on it, so this is a tail
+#: cost on an already-failed turn.  Short enough that a stalled summary model
+#: cannot make the ending worse than the one it is replacing.
+CONCLUSION_TIMEOUT_SECONDS: float = 20.0
+
+_MAX_TRANSCRIPT_CHARS = 24_000
+_MAX_CONCLUSION_TOKENS = 400
+
+
+def _render_transcript(messages: list[dict[str, Any]]) -> str:
+    """Flatten the turn into text, keeping the most recent content.
+
+    Truncates from the front: a conclusion is supported by what the agent
+    found most recently, and the opening of a long session is setup.
+    """
+    parts: list[str] = []
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role")
+        if role == "system":
+            continue
+        content = m.get("content")
+        if isinstance(content, list):
+            content = " ".join(
+                p.get("text", "") for p in content if isinstance(p, dict)
+            )
+        if not content:
+            # An assistant turn that only made tool calls still carries the
+            # intent behind them, which is context for the conclusion.
+            calls = m.get("tool_calls") or []
+            names = [
+                (c.get("function") or {}).get("name")
+                for c in calls if isinstance(c, dict)
+            ]
+            if names:
+                parts.append(f"[{role}] called: {', '.join(n for n in names if n)}")
+            continue
+        parts.append(f"[{role}] {content}")
+    text = "\n".join(parts)
+    if len(text) > _MAX_TRANSCRIPT_CHARS:
+        text = "...\n" + text[-_MAX_TRANSCRIPT_CHARS:]
+    return text
+
+
+async def conclude_from_transcript(
+    client: Any,
+    model: str,
+    *,
+    question: str,
+    messages: list[dict[str, Any]],
+) -> str | None:
+    """Return the conclusion the transcript supports, or ``None``.
+
+    ``None`` covers every uncertain case -- no summary model configured, the
+    call failed or timed out, the model declined with NOT_FOUND, or it
+    returned nothing usable. The caller keeps its existing ending in all of
+    them, so this can only add a conclusion, never replace a good one with a
+    worse one.
+    """
+    if client is None or not model:
+        return None
+    transcript = _render_transcript(messages)
+    if not transcript.strip():
+        return None
+
+    try:
+        resp = await asyncio.wait_for(
+            client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": _CONCLUSION_PROMPT},
+                    {
+                        "role": "user",
+                        "content": f"Task:\n{question}\n\nTranscript:\n{transcript}",
+                    },
+                ],
+                max_tokens=_MAX_CONCLUSION_TOKENS,
+                temperature=0.0,
+                stream=False,
+            ),
+            timeout=CONCLUSION_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        logger.debug("Conclusion fallback failed", exc_info=True)
+        return None
+
+    try:
+        content = (resp.choices[0].message.content or "").strip()
+    except (AttributeError, IndexError):
+        return None
+
+    # Accept the decline in whatever wrapping the model gives it -- some
+    # models answer "NOT_FOUND." or quote it -- but only when it is the whole
+    # reply, so a conclusion that happens to mention the token still counts.
+    if not content or content.strip(" .\"'`").upper() == _NOT_FOUND:
+        return None
+    return content

--- a/surogates/harness/prompt.py
+++ b/surogates/harness/prompt.py
@@ -239,6 +239,23 @@ class PromptBuilder:
         """
         parts: list[str] = []
 
+        # The streaming executor already fans concurrency-safe tools out
+        # and even dispatches them during the LLM stream, but nothing ever
+        # asked the model to emit a batch: measured over 30 days of DEV
+        # traffic, 74% of iterations carried exactly one tool call and
+        # only 11% carried more, while ~24% of all calls sat in runs of
+        # consecutive read-only lookups that had no need to be serial.
+        # Gated on two or more of the parallel set being present, since
+        # with one such tool there is nothing to batch it with.
+        #
+        # Imported here, not at module scope: tool_exec transitively
+        # imports this module, so a top-level import closes a cycle and
+        # leaves whichever module loses the race half-initialised. It
+        # surfaced as unrelated tests failing on import order.
+        from surogates.harness.tool_exec import CONCURRENCY_SAFE_TOOLS
+
+        if len(CONCURRENCY_SAFE_TOOLS & self._available_tools) >= 2:
+            parts.append(self._prompts.get("guidance/parallel_tools"))
         if "memory" in self._available_tools:
             parts.append(self._prompts.get("guidance/memory"))
         if "session_search" in self._available_tools:

--- a/surogates/harness/prompts/guidance/parallel_tools.md
+++ b/surogates/harness/prompts/guidance/parallel_tools.md
@@ -1,0 +1,25 @@
+---
+name: parallel_tools
+description: Injected when two or more concurrency-safe read tools are loaded; teaches the agent to batch independent lookups into one round-trip instead of one call per turn.
+applies_when: at least two of read_file / search_files / list_files / web_search / web_extract / skill_view / session_search are available
+---
+# Batching independent lookups
+
+You can put **several tool calls in one response**. They run at the same time and all their results come back together, so a batch of five costs the same wait as one.
+
+Do it whenever the next steps do not depend on each other. Three files to read, two searches to run, a file and a web page to fetch — those are one response with three calls, not three responses with one call each.
+
+## When to batch
+- **Several files.** Reading `a.py`, `b.py` and `c.py` — one response, three `read_file` calls.
+- **Several searches.** Looking for two different patterns, or the same pattern under different paths.
+- **Orientation.** At the start of a task you usually need the layout *and* a couple of likely files: `list_files` and the `read_file` calls you already know you want, together.
+- **A file plus a lookup.** A local config and the upstream docs page have nothing to do with each other; fetch both at once.
+- **Over-fetching a little.** If you are fairly sure you will want a file, read it in the current batch rather than paying another round-trip for it later. A read you did not need costs a few tokens; a read you deferred costs a whole turn.
+
+## When not to batch
+- **The next call's arguments come from this call's result.** Searching for a symbol and then reading the file the search names is two steps, and it has to be. Do not guess the path to save a round-trip.
+- **Anything that writes.** `write_file`, `patch`, `terminal` and the other acting tools stay one at a time, in order — you need to see each result before deciding the next.
+- **Asking the user.** `ask_user_question` is never part of a batch.
+
+## The habit
+Before you send a single lookup, ask what else you already know you will need, and send those together. Most turns should open with one batched round of reading rather than a chain of single calls.

--- a/surogates/harness/tool_exec.py
+++ b/surogates/harness/tool_exec.py
@@ -1642,13 +1642,25 @@ async def execute_single_tool(
         if hints:
             result_content += hints
 
-    # Layer 2: persist oversized results to disk instead of truncating.
-    from surogates.tools.utils.tool_result_storage import maybe_persist_tool_result
+    # Layer 2: persist oversized results instead of truncating.  The spill
+    # must land where ``read_file`` will run -- in the sandbox when there is
+    # one, otherwise on this filesystem.
+    from surogates.tools.utils.tool_result_storage import (
+        make_sandbox_writer,
+        maybe_persist_tool_result,
+    )
 
-    result_content = maybe_persist_tool_result(
+    if sandbox_pool is not None:
+        from surogates.sandbox.pool import sandbox_session_key
+        spill_writer = make_sandbox_writer(sandbox_pool, sandbox_session_key(session))
+    else:
+        spill_writer = None
+
+    result_content = await maybe_persist_tool_result(
         content=result_content,
         tool_name=tool_name,
         tool_use_id=tool_call_id,
+        writer=spill_writer,
     )
 
     # Sanitise the event payload — frontend SSE consumers must not see

--- a/surogates/orchestrator/worker.py
+++ b/surogates/orchestrator/worker.py
@@ -1689,6 +1689,7 @@ async def run_worker(settings: Settings) -> None:
         )
         compressor = ContextCompressor(
             model_id,
+            threshold_percent=settings.llm.compression_threshold,
             base_url=settings.llm.base_url,
             api_key=settings.llm.api_key,
             model_overrides=settings.llm.models,

--- a/surogates/tools/builtin/kb_tools.py
+++ b/surogates/tools/builtin/kb_tools.py
@@ -94,11 +94,6 @@ _HUB_WIKI_PREFIX = "wiki/"
 # to ``main``, so reading any other branch would always 404.
 _HUB_BRANCH = "main"
 
-# Cap returned content per call. Wiki pages are typically small (a few
-# KB), but a malformed compile could produce a huge index page. The
-# cap protects the LLM context window from accidental flooding.
-_MAX_PAGE_BYTES = 200_000
-
 
 def _agent_id_from_kwargs(kwargs: dict[str, Any]) -> str:
     """Resolve the per-session agent_id from the tool-dispatch context.
@@ -333,6 +328,61 @@ async def _kb_list_pages_handler(
     )
 
 
+# One kb_read_page call returns at most this many characters.  Sized to
+# sit well under the layer-2 persistence threshold so a page read never
+# needs spilling to disk -- the agent pages through with ``offset``
+# instead, which is retrievable where a spill file was not.
+_PAGE_LIMIT_DEFAULT = 50_000
+_PAGE_LIMIT_MAX = 80_000
+
+
+def _clamp_offset(raw: Any) -> int:
+    """Coerce a caller-supplied offset to a non-negative int."""
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _clamp_page_limit(raw: Any) -> int:
+    """Coerce a caller-supplied limit into the allowed window size."""
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _PAGE_LIMIT_DEFAULT
+    if value <= 0:
+        return _PAGE_LIMIT_DEFAULT
+    return min(value, _PAGE_LIMIT_MAX)
+
+
+def _format_page_window(
+    title: str, content: str, offset: int, limit: int,
+) -> str:
+    """Render one window of a page, telling the agent how to get the rest.
+
+    A page that fits whole is returned exactly as before -- no note, so
+    the common case reads identically to an unpaginated tool.
+    """
+    total = len(content)
+    if total and offset >= total:
+        return (
+            f"# {title}\n\n"
+            f"_Error: offset {offset} is past the end of this page "
+            f"({total} characters)._"
+        )
+
+    window = content[offset:offset + limit]
+    end = offset + len(window)
+    if offset == 0 and end == total:
+        return f"# {title}\n\n{content}"
+
+    note = f"_Showing characters {offset}-{end} of {total}."
+    note += (
+        f" Continue with offset={end}._" if end < total else " End of page._"
+    )
+    return f"# {title}\n\n{note}\n\n{window}"
+
+
 async def _kb_read_page_handler(
     arguments: dict[str, Any], **kwargs: Any,
 ) -> str:
@@ -346,6 +396,9 @@ async def _kb_read_page_handler(
     path = (arguments.get("path") or "").strip()
     if not kb_id or not path:
         return "Error: both kb_id and path are required."
+
+    offset = _clamp_offset(arguments.get("offset"))
+    limit = _clamp_page_limit(arguments.get("limit"))
 
     agent_id = _agent_id_from_kwargs(kwargs)
     denied = _kb_plan_denied(kb_id, kwargs)
@@ -409,17 +462,9 @@ async def _kb_read_page_handler(
     except KBHubError as exc:
         return f"Error reading wiki page: {exc}"
 
-    if len(raw) > _MAX_PAGE_BYTES:
-        truncated = raw[:_MAX_PAGE_BYTES].decode("utf-8", errors="replace")
-        return (
-            f"# {page.title}\n\n"
-            f"_Note: page truncated to {_MAX_PAGE_BYTES} bytes (full "
-            f"size {page.size_bytes} bytes)._\n\n"
-            f"{truncated}"
-        )
-
-    content = raw.decode("utf-8", errors="replace")
-    return f"# {page.title}\n\n{content}"
+    return _format_page_window(
+        page.title, raw.decode("utf-8", errors="replace"), offset, limit,
+    )
 
 
 # Ranked-search caps. The result is a triage list, not a corpus: 10
@@ -657,6 +702,21 @@ _KB_READ_PAGE_PARAMS = {
                 "and slash-sensitive."
             ),
         },
+        "offset": {
+            "type": "integer",
+            "description": (
+                "Character offset to start reading from. Omit for the "
+                "start of the page. A long page reports the offset to "
+                "pass to read the next section."
+            ),
+        },
+        "limit": {
+            "type": "integer",
+            "description": (
+                f"Maximum characters to return (default "
+                f"{_PAGE_LIMIT_DEFAULT}, max {_PAGE_LIMIT_MAX})."
+            ),
+        },
     },
     "required": ["kb_id", "path"],
 }
@@ -695,8 +755,9 @@ def register(registry: ToolRegistry) -> None:
             name="kb_read_page",
             description=(
                 "Read the markdown content of a single wiki page from "
-                "a knowledge base. Returns the page's title and full "
-                "content. Pages over 200KB are truncated."
+                "a knowledge base. Returns the page's title and content. "
+                "A page longer than the limit comes back in sections -- "
+                "the response reports the offset to pass for the next one."
             ),
             parameters=_KB_READ_PAGE_PARAMS,
         ),

--- a/surogates/tools/utils/budget_config.py
+++ b/surogates/tools/utils/budget_config.py
@@ -8,10 +8,13 @@ Per-tool resolution: pinned > config overrides > default.
 from dataclasses import dataclass, field
 from typing import Dict
 
-# Tools whose thresholds must never be overridden.
-# read_file=inf prevents infinite persist->read->persist loops.
+# Tools whose thresholds must never be overridden.  Both of these page
+# through their own output on request, so persisting a result would only
+# produce a file the model has to read back -- the persist -> read ->
+# persist loop.  Honoured by layer 2 and layer 3 alike.
 PINNED_THRESHOLDS: Dict[str, float] = {
     "read_file": float("inf"),
+    "kb_read_page": float("inf"),
 }
 
 # Defaults matching the current hardcoded values in tool_result_storage.py.

--- a/surogates/tools/utils/tool_result_storage.py
+++ b/surogates/tools/utils/tool_result_storage.py
@@ -206,23 +206,34 @@ async def enforce_turn_budget(
     tool_messages: list[dict],
     config: BudgetConfig = DEFAULT_BUDGET,
     writer: ResultWriter | None = None,
+    tool_names: dict[str, str] | None = None,
 ) -> list[dict]:
     """Layer 3: enforce aggregate budget across all tool results in a turn.
 
     If total chars exceed budget, persist the largest non-persisted results
-    first (via disk write) until under budget. Already-persisted results
-    are skipped.
+    first until under budget.  Already-persisted results are skipped, as are
+    tools pinned never to persist -- persisting a ``read_file`` result is
+    what creates the persist -> read -> persist loop the pin exists to
+    prevent, and layer 3 is just as capable of starting it as layer 2.
+
+    *tool_names* maps tool_call_id to tool name; without it the pins cannot
+    be honoured, because a tool result message carries no tool name.
 
     Mutates the list in-place and returns it.
     """
+    tool_names = tool_names or {}
     candidates = []
     total_size = 0
     for i, msg in enumerate(tool_messages):
         content = msg.get("content", "")
         size = len(content)
         total_size += size
-        if PERSISTED_OUTPUT_TAG not in content:
-            candidates.append((i, size))
+        if PERSISTED_OUTPUT_TAG in content:
+            continue
+        name = tool_names.get(msg.get("tool_call_id", ""), "")
+        if name and config.resolve_threshold(name) == float("inf"):
+            continue
+        candidates.append((i, size))
 
     if total_size <= config.turn_budget:
         return tool_messages
@@ -242,9 +253,14 @@ async def enforce_turn_budget(
 
         replacement = await maybe_persist_tool_result(
             content=content,
-            tool_name=_BUDGET_TOOL_NAME,
+            tool_name=tool_names.get(
+                msg.get("tool_call_id", ""), _BUDGET_TOOL_NAME,
+            ),
             tool_use_id=tool_use_id,
             config=config,
+            # Forced: the aggregate is over budget, so the per-tool
+            # threshold does not get a say.  Pinned tools were already
+            # excluded from the candidate list above.
             threshold=0,
             writer=writer,
         )

--- a/surogates/tools/utils/tool_result_storage.py
+++ b/surogates/tools/utils/tool_result_storage.py
@@ -10,10 +10,11 @@ Defense against context-window overflow operates at three levels:
 
 2. **Per-result persistence** (maybe_persist_tool_result): After a tool
    returns, if its output exceeds the tool's registered threshold
-   (config.resolve_threshold), the full output is written to disk at
-   /tmp/surogates-results/{tool_use_id}.txt.  The in-context content is
-   replaced with a preview + file path reference.  The model can read_file
-   to access the full output later.
+   (config.resolve_threshold), the full output is written out and the
+   in-context content is replaced with a preview + file path reference,
+   which the model can read_file later.  The write has to target whichever
+   filesystem read_file runs on: the session workspace via the sandbox
+   when tools execute in a pod, this process's /tmp when they do not.
 
 3. **Per-turn aggregate budget** (enforce_turn_budget): After all tool
    results in a single assistant turn are collected, if the total exceeds
@@ -22,9 +23,11 @@ Defense against context-window overflow operates at three levels:
    medium-sized results combine to overflow context.
 """
 
+import json
 import logging
 import os
 import uuid
+from typing import Any, Awaitable, Callable
 
 from surogates.tools.utils.budget_config import (
     DEFAULT_PREVIEW_SIZE_CHARS,
@@ -35,8 +38,52 @@ from surogates.tools.utils.budget_config import (
 logger = logging.getLogger(__name__)
 PERSISTED_OUTPUT_TAG = "<persisted-output>"
 PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
+
+# Where a spilled result lands when the harness process is also the one
+# that will read it back (no sandbox pool).
 STORAGE_DIR = "/tmp/surogates-results"
+
+# Where it lands when tools execute in a sandbox pod.  ``read_file`` runs
+# there, not here, and refuses any path outside the session workspace --
+# so the spill has to be workspace-relative and written through the same
+# sandbox, or the model is handed a path it cannot open.
+WORKSPACE_STORAGE_DIR = ".surogates-results"
+
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
+
+# (path, content) -> wrote successfully
+ResultWriter = Callable[[str, str], Awaitable[bool]]
+
+
+def make_sandbox_writer(sandbox_pool: Any, sandbox_owner: str) -> ResultWriter:
+    """Return a writer that spills through *sandbox_pool* into the workspace."""
+
+    async def _write(file_path: str, content: str) -> bool:
+        try:
+            output = await sandbox_pool.execute(
+                sandbox_owner,
+                "write_file",
+                json.dumps({"path": file_path, "content": content}),
+            )
+        except Exception as exc:
+            logger.warning("Sandbox spill write failed for %s: %s", file_path, exc)
+            return False
+        # The sandbox reports tool errors in-band as ``{"error": ...}``
+        # rather than raising, so a write can "succeed" and still be a
+        # refusal (protected path, blind overwrite).
+        try:
+            payload = json.loads(output)
+        except (TypeError, ValueError):
+            payload = None
+        if isinstance(payload, dict) and payload.get("error"):
+            logger.warning(
+                "Sandbox spill write rejected for %s: %s",
+                file_path, str(payload["error"])[:200],
+            )
+            return False
+        return True
+
+    return _write
 
 
 def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) -> tuple[str, bool]:
@@ -53,8 +100,9 @@ def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) 
 def _write_to_disk(content: str, file_path: str) -> bool:
     """Write content to a local file path. Returns True on success.
 
-    The worker IS the sandbox in Surogates, so we write directly to the
-    filesystem instead of going through an env.execute() indirection.
+    Only correct when tools execute in this process.  When they run in a
+    sandbox pod the spill must go through :func:`make_sandbox_writer`
+    instead -- a file written here is invisible there.
     """
     try:
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
@@ -91,17 +139,21 @@ def _build_persisted_message(
     return msg
 
 
-def maybe_persist_tool_result(
+async def maybe_persist_tool_result(
     content: str,
     tool_name: str,
     tool_use_id: str,
     config: BudgetConfig = DEFAULT_BUDGET,
     threshold: int | float | None = None,
+    writer: ResultWriter | None = None,
 ) -> str:
-    """Layer 2: persist oversized result to disk, return preview + path.
+    """Layer 2: persist oversized result, return preview + path.
 
-    Writes directly to the local filesystem since the Surogates worker IS
-    the sandbox. Falls back to inline truncation if write fails.
+    The spill has to land wherever ``read_file`` will run.  With a
+    *writer* (sandboxed tools) that means a workspace-relative path
+    written through the sandbox; without one, the harness process reads
+    its own filesystem.  Falls back to inline truncation if the write
+    fails.
 
     Args:
         content: Raw tool result string.
@@ -109,6 +161,8 @@ def maybe_persist_tool_result(
         tool_use_id: Unique ID for this tool call (used as filename).
         config: BudgetConfig controlling thresholds and preview size.
         threshold: Explicit override; takes precedence over config resolution.
+        writer: Sandbox writer from :func:`make_sandbox_writer`, when tools
+            execute in a sandbox pod.
 
     Returns:
         Original content if small, or <persisted-output> replacement.
@@ -121,10 +175,16 @@ def maybe_persist_tool_result(
     if len(content) <= effective_threshold:
         return content
 
-    file_path = f"{STORAGE_DIR}/{tool_use_id}.txt"
     preview, has_more = generate_preview(content, max_chars=config.preview_size)
 
-    if _write_to_disk(content, file_path):
+    if writer is None:
+        file_path = f"{STORAGE_DIR}/{tool_use_id}.txt"
+        persisted = _write_to_disk(content, file_path)
+    else:
+        file_path = f"{WORKSPACE_STORAGE_DIR}/{tool_use_id}.txt"
+        persisted = await writer(file_path, content)
+
+    if persisted:
         logger.info(
             "Persisted large tool result: %s (%s, %d chars -> %s)",
             tool_name, tool_use_id, len(content), file_path,
@@ -142,9 +202,10 @@ def maybe_persist_tool_result(
     )
 
 
-def enforce_turn_budget(
+async def enforce_turn_budget(
     tool_messages: list[dict],
     config: BudgetConfig = DEFAULT_BUDGET,
+    writer: ResultWriter | None = None,
 ) -> list[dict]:
     """Layer 3: enforce aggregate budget across all tool results in a turn.
 
@@ -173,14 +234,19 @@ def enforce_turn_budget(
             break
         msg = tool_messages[idx]
         content = msg["content"]
-        tool_use_id = msg.get("tool_call_id", f"budget_{idx}")
+        # The fallback id must stay unique across turns: the sandbox
+        # ``write_file`` refuses to overwrite a file it has not read.
+        tool_use_id = msg.get(
+            "tool_call_id", f"budget_{idx}_{uuid.uuid4().hex[:8]}",
+        )
 
-        replacement = maybe_persist_tool_result(
+        replacement = await maybe_persist_tool_result(
             content=content,
             tool_name=_BUDGET_TOOL_NAME,
             tool_use_id=tool_use_id,
             config=config,
             threshold=0,
+            writer=writer,
         )
         if replacement != content:
             total_size -= size

--- a/tests/test_chat_attachments_note.py
+++ b/tests/test_chat_attachments_note.py
@@ -360,3 +360,49 @@ def test_attachments_note_inserts_adjacent_to_user_when_view_context_also_presen
     ]
     assert api_messages[1]["content"] == view_note
     assert api_messages[2]["content"] == att_note
+
+
+class TestUnreadableAttachmentKinds:
+    """A capability we do not have must be stated, not discovered.
+
+    GAIA dev-021: an mp3 task tried `whisper` in the terminal, got
+    `openai-whisper: not installed`, and then answered anyway -- inventing a
+    shopping list from the question's wording. The note had told it the file
+    was readable with its file tools.
+    """
+
+    def test_audio_is_marked_unreadable(self) -> None:
+        from surogates.harness.loop_attachments import _attachments_note_from_data
+
+        note = _attachments_note_from_data({"attachments": [
+            {"path": "__WORKSPACE__/a.mp3", "filename": "a.mp3",
+             "mime_type": "audio/mpeg", "size": 1024},
+        ]})
+        assert "CANNOT BE READ" in note
+        assert "NO transcription capability" in note
+        # It must be told not to guess, which is the failure being prevented.
+        assert "never infer its contents" in note
+
+    def test_readable_kinds_are_untouched(self) -> None:
+        from surogates.harness.loop_attachments import _attachments_note_from_data
+
+        note = _attachments_note_from_data({"attachments": [
+            {"path": "__WORKSPACE__/a.png", "filename": "a.png",
+             "mime_type": "image/png", "size": 1024},
+            {"path": "__WORKSPACE__/b.csv", "filename": "b.csv",
+             "mime_type": "text/csv", "size": 1024},
+        ]})
+        assert "CANNOT BE READ" not in note
+        assert "a.png" in note and "b.csv" in note
+
+    def test_skip_reason_hint_still_shown_for_readable_files(self) -> None:
+        """The unreadable branch must not swallow the existing fallback hint."""
+        from surogates.harness.loop_attachments import _attachments_note_from_data
+
+        note = _attachments_note_from_data({"attachments": [
+            {"path": "__WORKSPACE__/c.pdf", "filename": "c.pdf",
+             "mime_type": "application/pdf", "size": 4096,
+             "inline_skip_reason": "oversize_output"},
+        ]})
+        assert "oversize_output" in note
+        assert "offset/limit" in note

--- a/tests/test_harness_resilience.py
+++ b/tests/test_harness_resilience.py
@@ -1693,16 +1693,43 @@ class TestUnfinishedFinalResponse:
     intention as the answer and completed.
     """
 
-    def test_trailing_ellipsis_looks_unfinished(self) -> None:
+    def test_trailing_intent_looks_unfinished(self) -> None:
+        """Both signals, taken from real finals across five GAIA runs.
+
+        The ellipsis-only version of this was fitted to dev-018, where every
+        instance happened to end in one. On dev-025 they ended in a full
+        stop instead and nothing fired.
+        """
         from surogates.harness.loop import _looks_unfinished
 
         for text in (
+            # ellipsis (dev-018)
             "Let me check the page directly via the browser....",
-            "I'll dismiss the consent banner and then navigate...",
             "Now let me look at the results…",
             "...",
+            # plain full stop (dev-025) -- missed by the first version
+            "Let me check the browser state after the search and also try "
+            "the PubChem classification API with a different endpoint.",
+            "Taking a screenshot of the expanded Dastardly Mash panel now.",
+            "Let me take a screenshot to see the current state of the video.",
         ):
             assert _looks_unfinished(text) is True, text
+
+    def test_long_answers_are_left_alone(self) -> None:
+        """Length is what separates an intention from an answer that happens
+        to close on a forward-looking sentence. Without the bound this fired
+        on 19% of turns that had answered."""
+        from surogates.harness.loop import _looks_unfinished
+
+        long_answer = (
+            "The enrollment count is 90, taken from the ClinicalTrials.gov "
+            "record rather than the abstract, which quotes the planned "
+            "figure of 100. I checked both the results section and the "
+            "study protocol to confirm the discrepancy is a recruitment "
+            "shortfall. Let me know if you need the protocol revision."
+        )
+        assert len(long_answer) > 200
+        assert _looks_unfinished(long_answer) is False
 
     def test_concluded_answers_are_left_alone(self) -> None:
         from surogates.harness.loop import _looks_unfinished

--- a/tests/test_kb_read_page_pagination.py
+++ b/tests/test_kb_read_page_pagination.py
@@ -1,0 +1,80 @@
+"""kb_read_page pages through a long page instead of being spilled.
+
+The tool used to cap itself at 200_000 bytes while layer 2 persisted
+anything over 100_000 characters, so every page in that band was
+guaranteed to be spilled to a file the model then could not open.  It
+now returns a window and reports the offset for the next one, and is
+pinned so the budget layers never persist it.
+"""
+
+from surogates.tools.builtin.kb_tools import (
+    _PAGE_LIMIT_DEFAULT,
+    _PAGE_LIMIT_MAX,
+    _clamp_offset,
+    _clamp_page_limit,
+    _format_page_window,
+)
+from surogates.tools.utils.budget_config import DEFAULT_BUDGET
+
+
+def test_short_page_is_returned_whole_with_no_note():
+    out = _format_page_window("Title", "hello", 0, _PAGE_LIMIT_DEFAULT)
+    assert out == "# Title\n\nhello"
+
+
+def test_long_page_reports_the_next_offset():
+    out = _format_page_window("Title", "x" * 1000, 0, 400)
+    assert "Showing characters 0-400 of 1000" in out
+    assert "Continue with offset=400" in out
+    assert out.endswith("x" * 400)
+
+
+def test_middle_and_final_windows_join_up():
+    content = "".join(str(i % 10) for i in range(1000))
+    first = _format_page_window("T", content, 0, 400)
+    second = _format_page_window("T", content, 400, 400)
+    final = _format_page_window("T", content, 800, 400)
+
+    assert "Continue with offset=400" in first
+    assert "Continue with offset=800" in second
+    assert "End of page" in final
+    assert "Continue with offset" not in final
+
+    # The windows must reconstruct the page exactly -- no gaps, no overlap.
+    rebuilt = "".join(
+        part.split("_\n\n", 1)[1] for part in (first, second, final)
+    )
+    assert rebuilt == content
+
+
+def test_offset_past_the_end_is_an_error_not_an_empty_page():
+    out = _format_page_window("T", "abc", 99, 10)
+    assert "past the end" in out
+
+
+def test_empty_page_is_not_an_error():
+    assert _format_page_window("T", "", 0, 10) == "# T\n\n"
+
+
+def test_limit_is_clamped_and_offset_coerced():
+    assert _clamp_page_limit(None) == _PAGE_LIMIT_DEFAULT
+    assert _clamp_page_limit("nonsense") == _PAGE_LIMIT_DEFAULT
+    assert _clamp_page_limit(0) == _PAGE_LIMIT_DEFAULT
+    assert _clamp_page_limit(-5) == _PAGE_LIMIT_DEFAULT
+    assert _clamp_page_limit(10**9) == _PAGE_LIMIT_MAX
+    assert _clamp_page_limit(1234) == 1234
+
+    assert _clamp_offset(None) == 0
+    assert _clamp_offset(-3) == 0
+    assert _clamp_offset("12") == 12
+
+
+def test_a_full_window_stays_under_the_spill_threshold():
+    """The whole point: a page read can never trip layer 2."""
+    threshold = DEFAULT_BUDGET.resolve_threshold("some_other_tool")
+    biggest = len(_format_page_window("T", "x" * 10**6, 0, _PAGE_LIMIT_MAX))
+    assert biggest < threshold
+
+
+def test_kb_read_page_is_pinned_against_persistence():
+    assert DEFAULT_BUDGET.resolve_threshold("kb_read_page") == float("inf")

--- a/tests/test_loop_conclusion.py
+++ b/tests/test_loop_conclusion.py
@@ -1,0 +1,108 @@
+"""The last-resort conclusion must extract, never invent."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from surogates.harness.loop_conclusion import (
+    _render_transcript,
+    conclude_from_transcript,
+)
+
+
+def _client(content: str) -> AsyncMock:
+    c = AsyncMock()
+    c.chat.completions.create.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+    return c
+
+
+MESSAGES = [
+    {"role": "system", "content": "ignored"},
+    {"role": "user", "content": "How many albums?"},
+    {"role": "assistant", "content": "Let me check the discography...."},
+]
+
+
+class TestNeverInvents:
+    """A model asked for an answer will produce one whether or not the
+    evidence exists -- that is how a missing transcription became a
+    fabricated shopping list. NOT_FOUND must survive to the caller as None."""
+
+    async def test_not_found_returns_none(self) -> None:
+        got = await conclude_from_transcript(
+            _client("NOT_FOUND"), "m", question="q", messages=MESSAGES,
+        )
+        assert got is None
+
+    @pytest.mark.parametrize("reply", ["NOT_FOUND.", ' "NOT_FOUND" ', "not_found"])
+    async def test_decline_is_recognised_however_wrapped(self, reply: str) -> None:
+        got = await conclude_from_transcript(
+            _client(reply), "m", question="q", messages=MESSAGES,
+        )
+        assert got is None
+
+    async def test_answer_mentioning_the_token_is_kept(self) -> None:
+        """Only a bare decline counts -- a real conclusion that happens to
+        discuss NOT_FOUND is still a conclusion."""
+        got = await conclude_from_transcript(
+            _client("The lookup returned NOT_FOUND for two of five rows; the count is 3"),
+            "m", question="q", messages=MESSAGES,
+        )
+        assert got is not None and got.endswith("3")
+
+
+class TestFailsQuietly:
+    """Every uncertain path must leave the caller's existing ending intact."""
+
+    async def test_no_client_configured(self) -> None:
+        assert await conclude_from_transcript(
+            None, "m", question="q", messages=MESSAGES) is None
+
+    async def test_no_model_configured(self) -> None:
+        assert await conclude_from_transcript(
+            _client("x"), "", question="q", messages=MESSAGES) is None
+
+    async def test_call_failure_is_swallowed(self) -> None:
+        c = AsyncMock()
+        c.chat.completions.create.side_effect = RuntimeError("upstream down")
+        assert await conclude_from_transcript(
+            c, "m", question="q", messages=MESSAGES) is None
+
+    async def test_empty_reply(self) -> None:
+        assert await conclude_from_transcript(
+            _client("   "), "m", question="q", messages=MESSAGES) is None
+
+    async def test_empty_transcript(self) -> None:
+        assert await conclude_from_transcript(
+            _client("42"), "m", question="q",
+            messages=[{"role": "system", "content": "sys"}]) is None
+
+
+class TestTranscript:
+    def test_system_dropped_and_roles_kept(self) -> None:
+        out = _render_transcript(MESSAGES)
+        assert "ignored" not in out
+        assert "[user] How many albums?" in out
+
+    def test_tool_only_turn_keeps_its_intent(self) -> None:
+        out = _render_transcript([
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"function": {"name": "web_search"}},
+                {"function": {"name": "read_file"}},
+            ]},
+        ])
+        assert "web_search" in out and "read_file" in out
+
+    def test_truncates_from_the_front(self) -> None:
+        """A conclusion rests on the most recent findings; the opening of a
+        long session is setup."""
+        msgs = [{"role": "assistant", "content": "x" * 40_000},
+                {"role": "assistant", "content": "THE FINDING"}]
+        out = _render_transcript(msgs)
+        assert out.startswith("...")
+        assert "THE FINDING" in out

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -305,3 +305,74 @@ class TestBoardSection:
         tenant = _make_tenant(tmp_path)
         prompt = PromptBuilder(tenant).build()
         assert "# Coordination Board" not in prompt
+
+
+class TestParallelToolsGuidance:
+    """Batching guidance loads only when there is something to batch.
+
+    The streaming executor already fans CONCURRENCY_SAFE_TOOLS out, but
+    nothing asked the model for a batch: over 30 days of DEV traffic 74%
+    of iterations carried exactly one tool call while ~24% of all calls
+    sat in runs of consecutive independent lookups.
+    """
+
+    @staticmethod
+    def _tenant():
+        from uuid import uuid4
+
+        from surogates.tenant.context import TenantContext
+
+        return TenantContext(
+            org_id=uuid4(),
+            user_id=uuid4(),
+            org_config={"default_model": "gpt-4o"},
+            user_preferences={},
+            permissions=frozenset(),
+            asset_root="/tmp/test_assets",
+        )
+
+    def _section(self, tools):
+        from surogates.harness.prompt import PromptBuilder
+
+        return PromptBuilder(
+            tenant=self._tenant(), available_tools=set(tools),
+        )._tool_guidance_section()
+
+    @property
+    def _guidance(self):
+        from surogates.harness.prompt_library import default_library
+
+        return default_library().get("guidance/parallel_tools")
+
+    def test_injected_with_two_concurrency_safe_tools(self):
+        assert self._guidance in self._section({"read_file", "search_files"})
+
+    def test_injected_for_a_research_pairing(self):
+        assert self._guidance in self._section({"web_search", "web_extract"})
+
+    def test_not_injected_with_only_one(self):
+        """Nothing to batch a lone tool with."""
+        assert self._guidance not in self._section({"read_file"})
+
+    def test_not_injected_with_no_parallel_tools(self):
+        assert self._guidance not in self._section({"terminal", "write_file"})
+
+    def test_write_tools_do_not_count_toward_the_pair(self):
+        """write_file/patch/terminal are never dispatched concurrently, so
+        they must not trip the gate on their own."""
+        assert self._guidance not in self._section(
+            {"read_file", "write_file", "patch", "terminal"},
+        )
+
+    def test_gate_matches_the_executor_parallel_set(self):
+        """The guidance promises what the executor actually does; if the
+        two drift, the prompt starts advertising a concurrency the
+        harness will not deliver."""
+        from surogates.harness.tool_exec import CONCURRENCY_SAFE_TOOLS
+
+        for tool in CONCURRENCY_SAFE_TOOLS:
+            # Pair with a *different* member so the set really has two.
+            partner = "session_search" if tool != "session_search" else "read_file"
+            assert self._guidance in self._section({tool, partner}), (
+                f"{tool} is dispatched in parallel but does not arm the guidance"
+            )

--- a/tests/test_tool_result_spill.py
+++ b/tests/test_tool_result_spill.py
@@ -6,6 +6,8 @@ outside the session workspace, so ``read_file`` refused it and the model
 lost the output it was told it could page through.
 """
 
+import json
+
 import pytest
 
 from surogates.harness.context import ContextCompressor
@@ -122,3 +124,45 @@ def test_compression_threshold_is_configurable():
     assert LLMSettings(compression_threshold=0.8).compression_threshold == 0.8
     with pytest.raises(ValueError):
         LLMSettings(compression_threshold=1.5)
+
+
+async def test_turn_budget_never_spills_a_pinned_tool():
+    """The persist -> read -> persist loop the pin exists to stop.
+
+    ``read_file`` is pinned so its result is never persisted -- otherwise
+    reading a spill file produces a large result, which gets spilled to a
+    new file, which the model reads again.  Layer 2 honoured the pin;
+    layer 3 could not see it, because a tool result carries no tool name.
+    """
+    pool = _FakePool()
+    writer = make_sandbox_writer(pool, "owner-3")
+    messages = [
+        {"tool_call_id": "r1", "content": "r" * 300_000},   # read_file: pinned
+        {"tool_call_id": "k1", "content": "k" * 300_000},   # kb_read_page: pinned
+        {"tool_call_id": "s1", "content": "s" * 300_000},   # spillable
+    ]
+    tool_names = {
+        "r1": "read_file",
+        "k1": "kb_read_page",
+        "s1": "search_files",
+    }
+
+    await enforce_turn_budget(messages, writer=writer, tool_names=tool_names)
+
+    # Only the unpinned result may be spilled, even though all three are
+    # over budget and the pinned ones are the largest candidates.
+    written = [json.loads(c[2])["path"] for c in pool.calls]
+    assert written == [f"{WORKSPACE_STORAGE_DIR}/s1.txt"]
+    assert messages[0]["content"] == "r" * 300_000
+    assert messages[1]["content"] == "k" * 300_000
+
+
+async def test_turn_budget_without_names_still_spills():
+    """Absent a name map the pins cannot apply; budget must still hold."""
+    pool = _FakePool()
+    writer = make_sandbox_writer(pool, "owner-4")
+    messages = [{"tool_call_id": "x", "content": "x" * 300_000}]
+
+    await enforce_turn_budget(messages, writer=writer)
+
+    assert len(pool.calls) == 1

--- a/tests/test_tool_result_spill.py
+++ b/tests/test_tool_result_spill.py
@@ -1,0 +1,124 @@
+"""Spilled tool results must land where ``read_file`` will look for them.
+
+The spill previously always wrote to a local ``/tmp`` path.  With tools
+executing in a sandbox pod that path is both on the wrong machine and
+outside the session workspace, so ``read_file`` refused it and the model
+lost the output it was told it could page through.
+"""
+
+import pytest
+
+from surogates.harness.context import ContextCompressor
+from surogates.tools.utils.tool_result_storage import (
+    STORAGE_DIR,
+    WORKSPACE_STORAGE_DIR,
+    enforce_turn_budget,
+    make_sandbox_writer,
+    maybe_persist_tool_result,
+)
+
+
+class _FakePool:
+    """Records what the harness asks the sandbox to write."""
+
+    def __init__(self, output: str = "ok") -> None:
+        self.calls: list[tuple[str, str, str]] = []
+        self._output = output
+
+    async def execute(self, session_id: str, name: str, input: str) -> str:
+        self.calls.append((session_id, name, input))
+        return self._output
+
+
+async def test_sandboxed_spill_is_workspace_relative():
+    pool = _FakePool()
+    writer = make_sandbox_writer(pool, "owner-1")
+
+    result = await maybe_persist_tool_result(
+        content="x" * 5000,
+        tool_name="kb_read_page",
+        tool_use_id="toolu_abc",
+        threshold=100,
+        writer=writer,
+    )
+
+    assert len(pool.calls) == 1
+    session_id, tool, _payload = pool.calls[0]
+    assert (session_id, tool) == ("owner-1", "write_file")
+    # The advertised path must be the one read_file can resolve: relative to
+    # the workspace, never an absolute /tmp path outside it.
+    assert f"{WORKSPACE_STORAGE_DIR}/toolu_abc.txt" in result
+    assert STORAGE_DIR not in result
+
+
+async def test_spill_falls_back_to_truncation_when_sandbox_write_fails():
+    # The sandbox reports tool failures in-band as a JSON error body.
+    pool = _FakePool(output='{"error": "Write denied"}')
+    writer = make_sandbox_writer(pool, "owner-1")
+
+    result = await maybe_persist_tool_result(
+        content="y" * 5000,
+        tool_name="kb_read_page",
+        tool_use_id="toolu_def",
+        threshold=100,
+        writer=writer,
+    )
+
+    assert "could not be saved" in result
+    # Never advertise a path that was not written.
+    assert WORKSPACE_STORAGE_DIR not in result
+
+
+async def test_local_spill_used_when_no_sandbox(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "surogates.tools.utils.tool_result_storage.STORAGE_DIR", str(tmp_path),
+    )
+    result = await maybe_persist_tool_result(
+        content="z" * 5000,
+        tool_name="kb_read_page",
+        tool_use_id="toolu_ghi",
+        threshold=100,
+    )
+    assert str(tmp_path / "toolu_ghi.txt") in result
+    assert (tmp_path / "toolu_ghi.txt").read_text() == "z" * 5000
+
+
+async def test_turn_budget_spill_routes_through_the_writer():
+    pool = _FakePool()
+    writer = make_sandbox_writer(pool, "owner-2")
+    messages = [
+        {"tool_call_id": "a", "content": "a" * 300_000},
+        {"tool_call_id": "b", "content": "b" * 10},
+    ]
+
+    await enforce_turn_budget(messages, writer=writer)
+
+    assert [c[1] for c in pool.calls] == ["write_file"]
+    assert f"{WORKSPACE_STORAGE_DIR}/a.txt" in messages[0]["content"]
+
+
+def test_context_window_step_down_moves_the_compaction_threshold():
+    c = ContextCompressor("gpt-4o", quiet_mode=True, threshold_percent=0.5)
+    c.context_length = 200_000
+    c._derive_budgets()
+    assert c.threshold_tokens == 100_000
+
+    # A provider rejecting the request as too long steps the window down,
+    # and every derived budget must follow it.
+    assert c.set_context_length(64_000) is True
+    assert c.context_length == 64_000
+    assert c.threshold_tokens == 32_000
+    assert c.should_compress(33_000) is True
+
+    # Growing is the guess that just failed; refuse it.
+    assert c.set_context_length(500_000) is False
+    assert c.context_length == 64_000
+
+
+def test_compression_threshold_is_configurable():
+    from surogates.config import LLMSettings
+
+    assert LLMSettings().compression_threshold == 0.50
+    assert LLMSettings(compression_threshold=0.8).compression_threshold == 0.8
+    with pytest.raises(ValueError):
+        LLMSettings(compression_threshold=1.5)


### PR DESCRIPTION
Three related defects in the context/tool-result budget path, plus in-flight harness work from a parallel session that shared this branch.

## Context-window step-down never took effect

`llm_call` read and wrote `context_compressor._context_window` — an attribute `ContextCompressor` has never had; it stores the window as `context_length`. Three silent consequences:

- the error classifier got a hardcoded 200k window for every model;
- the Anthropic long-context branch read `old_ctx` defaulting to `0`, so `if old_ctx > 200_000` was never true and the reduction never fired;
- the overflow step-down probed down from a hardcoded 128k, then wrote the phantom attribute, so nothing changed.

Writing the real attribute would not have sufficed either — `threshold_tokens` and the summary budgets are derived once in `__init__`. Adds `set_context_length()`, which shrinks the window and re-derives every dependent budget.

## Spilled tool results were unreadable

Oversized results were written to `/tmp/surogates-results` on the harness process, justified by a comment claiming the worker is the sandbox. That stopped being true once tools began executing in a sandbox pod: the file lands on the worker, while `read_file` runs in the pod and refuses any path outside the session workspace.

Observed in PROD — the single occurrence in 30 days:

```
Blocked: Workspace sandbox violation: '/tmp/surogates-results/...'
resolves outside the session workspace.
```

182KB of knowledge-base content lost and a turn burned on the failed read. The mechanism had never worked in a sandboxed session. Spills now route through the same sandbox the reader runs in, to a workspace-relative path; a refused write falls back to inline truncation rather than advertising a path that was never written.

## Never-persist pins were unreachable from the turn-budget layer

`PINNED_THRESHOLDS` maps `read_file` to infinity to prevent the persist → read → persist loop. Layer 2 honoured it; layer 3 could not, for two independent reasons — it passed `_BUDGET_TOOL_NAME` rather than the real tool, so a pin lookup could never match, and it passed `threshold=0`, which short-circuits `resolve_threshold` entirely. The loop now passes the `tool_call_id → name` map it already has.

## kb_read_page paginates

It capped itself at 200_000 bytes while layer 2 persisted anything over 100_000 characters — the tool's cap sat *above* the point where the next layer intervenes, so every page in that band was guaranteed to be spilled. That is what produced the 186,693-character page above.

It now takes `offset`/`limit` and reports where to continue. A page that fits whole is returned unchanged. `kb_read_page` joins `read_file` in `PINNED_THRESHOLDS`: a tool that pages through its own output should never be persisted.

## Also on this branch

Committed by a parallel session sharing this checkout: an unreadable-attachment notice, turn-conclusion recovery, an offline doubter evaluation, and benchmark records for dev-022/023.

## Configuration

New `llm.compression_threshold` (default unchanged at 0.50). It was hardcoded, with one construction site that never passed it and no config key anywhere.

## Tests

24 new tests across `tests/test_tool_result_spill.py` and `tests/test_kb_read_page_pagination.py`, covering modules that previously had none. One asserts a maximum page window stays under the persistence threshold, so the two caps cannot silently drift apart again.

Full suite on this tree: **6733 passed, 11 skipped, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)