### PR TITLE
fix(browser): let the page snapshot see inside iframes

### DIFF
--- a/surogates/browser/client.py
+++ b/surogates/browser/client.py
@@ -69,7 +69,7 @@ class KernelBrowserClient:
 
     _SNAPSHOT_SCRIPT = """
 const __surogatesSelector = __SUROGATES_SELECTOR__;
-const __surogatesSnapshot = await page.evaluate((selector) => {
+const __surogatesCollect = ({selector, base}) => {
 function roleOf(el) {
   const explicit = el.getAttribute('role');
   if (explicit) return explicit;
@@ -168,7 +168,8 @@ for (const el of __els) {
   if (style.visibility === 'hidden' || style.display === 'none') continue;
   const bbox = el.getBoundingClientRect();
   if (!bbox || bbox.width <= 0 || bbox.height <= 0) continue;
-  el.setAttribute('data-sg-i', String(out.length));
+  const idx = base + out.length;
+  el.setAttribute('data-sg-i', String(idx));
   const role = roleOf(el);
   let textBlock = '';
   if (__INTERACTIVE.has(role)) {
@@ -195,7 +196,7 @@ for (const el of __els) {
     height: Math.round(bbox.height),
     depth: depthOf(el),
     children_count: el.children ? el.children.length : 0,
-    idx: out.length,
+    idx: idx,
     text_block: textBlock,
   };
   if (role === 'heading') entry.heading_level = headingLevelOf(el);
@@ -205,17 +206,52 @@ return {
   viewport: {width: window.innerWidth, height: window.innerHeight},
   nodes: out,
 };
-}, __surogatesSelector);
+};
+// One collector run per frame.  Every frame measures in its own viewport, so
+// each result carries the frame's origin in root space -- page.mouse and the
+// screenshot overlay only ever speak root coordinates.  A selector narrows the
+// main document to one subtree, so that mode stays single-frame.
+const __mainFrame = page.mainFrame();
+const __targets = __surogatesSelector === null ? page.frames() : [__mainFrame];
+const __frames = [];
+let __viewport = null;
+let __base = 0;
+for (const __f of __targets) {
+  let __ox = 0, __oy = 0;
+  if (__f !== __mainFrame) {
+    // frameElement() is a Playwright-side lookup, so it resolves across
+    // origins where window.frameElement would be blocked, and boundingBox()
+    // already accumulates the offsets of every ancestor frame.
+    let __box = null;
+    try {
+      const __fe = await __f.frameElement();
+      __box = __fe ? await __fe.boundingBox() : null;
+    } catch (e) { __box = null; }
+    // Detached, display:none or zero-size frame: nothing clickable inside.
+    if (!__box) continue;
+    __ox = Math.round(__box.x); __oy = Math.round(__box.y);
+  }
+  let __r = null;
+  try {
+    __r = await __f.evaluate(__surogatesCollect, {
+      selector: __f === __mainFrame ? __surogatesSelector : null,
+      base: __base,
+    });
+  } catch (e) { continue; }
+  if (__f === __mainFrame) __viewport = __r.viewport;
+  __base += __r.nodes.length;
+  __frames.push({x: __ox, y: __oy, nodes: __r.nodes});
+}
 const __cdp = await page.context().newCDPSession(page);
 const __doc = await __cdp.send('DOM.getDocument', {depth: -1, pierce: true});
 const __map = {};
 (function walk(n){ if(!n) return; const a=n.attributes||[]; for(let i=0;i<a.length;i+=2){ if(a[i]==='data-sg-i'){ __map[a[i+1]] = n.backendNodeId; } } for(const c of (n.children||[])) walk(c); if(n.contentDocument) walk(n.contentDocument); })(__doc.root);
-for (const node of __surogatesSnapshot.nodes) { node.backend_node_id = (node.idx!=null && __map[String(node.idx)]!=null) ? __map[String(node.idx)] : null; }
+for (const __fr of __frames) { for (const node of __fr.nodes) { node.backend_node_id = (node.idx!=null && __map[String(node.idx)]!=null) ? __map[String(node.idx)] : null; } }
 return {
   url: page.url(),
   title: await page.title(),
-  viewport: page.viewportSize() || __surogatesSnapshot.viewport,
-  nodes: __surogatesSnapshot.nodes,
+  viewport: page.viewportSize() || __viewport || {width: 0, height: 0},
+  frames: __frames,
 };
 """
 
@@ -345,7 +381,7 @@ return {
         """Return a DOM-derived page tree with stable refs and cached centers."""
 
         raw = await self._playwright_execute(self._snapshot_script(selector))
-        nodes = raw.get("nodes", [])
+        nodes = self._merge_frame_nodes(raw.get("frames", []))
         full_tree, new_cache = self._build_tree_and_cache(nodes)
         tree = [
             entry
@@ -705,7 +741,7 @@ const probe = await cdp.send('Runtime.callFunctionOn', {{
         + (hit.id ? '#' + hit.id : '')
         + (cls ? '.' + cls : '');
     }}
-    return {{ok: true, cx: cx, cy: cy, cover: cover}};
+    return {{ok: true, cover: cover}};
   }}.toString(),
 }});
 const res = (probe && probe.result && probe.result.value) ? probe.result.value : {{ok: false}};
@@ -715,10 +751,53 @@ if (!res.ok) {{
 if (res.cover) {{
   throw new Error("ref click blocked: covered by <" + res.cover + ">. Dismiss that element, then browser_get_state and retry.");
 }}
-await page.mouse.click(res.cx, res.cy, {click_opts});
+// The probe measured inside the node's own frame, which is right for
+// elementFromPoint and wrong for the mouse: DOM.resolveNode on a node in an
+// iframe resolves into that frame's context, so its rect is frame-relative
+// while page.mouse dispatches in root space. getBoxModel returns the quad
+// already in root coordinates. Read it after scrollIntoView, not before.
+let box = null;
+try {{
+  box = await cdp.send('DOM.getBoxModel', {{objectId: objectId}});
+}} catch (e) {{ box = null; }}
+const quad = (box && box.model && box.model.content) ? box.model.content : null;
+if (!quad) {{
+  throw new Error("ref element not measurable; call browser_get_state to refresh refs");
+}}
+const cx = Math.round((quad[0] + quad[2] + quad[4] + quad[6]) / 4);
+const cy = Math.round((quad[1] + quad[3] + quad[5] + quad[7]) / 4);
+await page.mouse.click(cx, cy, {click_opts});
 await page.waitForTimeout(150);
 return true;
 """
+
+    @staticmethod
+    def _merge_frame_nodes(
+        frames: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Flatten per-frame node lists into one root-space list.
+
+        Each frame measured its nodes against its own viewport and reports the
+        origin it sits at in the root frame; adding the two makes every
+        coordinate comparable, and clickable, because ``page.mouse`` dispatches
+        in root space only.
+
+        ponytail: ``depth`` stays frame-local, so ``max_depth`` treats each
+        frame as its own root and under-filters iframe content. Carry the
+        iframe element's own depth as a base if that ever matters.
+        """
+
+        merged: list[dict[str, Any]] = []
+        for frame in frames:
+            origin_x = int(frame.get("x", 0))
+            origin_y = int(frame.get("y", 0))
+            for node in frame.get("nodes", []):
+                merged.append({
+                    **node,
+                    "x": int(node.get("x", 0)) + origin_x,
+                    "y": int(node.get("y", 0)) + origin_y,
+                })
+        return merged
 
     def _build_tree_and_cache(
         self,

--- a/tests/integration/test_browser_e2e.py
+++ b/tests/integration/test_browser_e2e.py
@@ -10,6 +10,7 @@ Requires Docker and the kernel-images Chromium image.
 from __future__ import annotations
 
 import os
+from urllib.parse import quote
 
 import pytest
 
@@ -65,3 +66,50 @@ async def test_screenshot_returns_png(browser) -> None:
         result = await client.screenshot()
         assert result["png_bytes"].startswith(b"\x89PNG")
         assert len(result["png_bytes"]) > 1000
+
+
+# A control inside an iframe offset 300px down and 100px across -- the shape of
+# every embedded payment field and consent frame.  The frame reports the button
+# at its own (30, 20); only the frame's origin makes that clickable.
+IFRAME_PAGE = (
+    "<body style='margin:0'>"
+    "<h1 style='margin:0;height:100px'>Checkout</h1>"
+    "<iframe style='position:absolute;top:300px;left:100px;width:400px;"
+    "height:200px;border:0' srcdoc=\""
+    "<body style='margin:0'>"
+    "<button style='position:absolute;top:20px;left:30px;width:100px;"
+    "height:40px' onclick='this.textContent=&quot;Paid&quot;'>Pay now</button>"
+    "</body>\"></iframe>"
+    "</body>"
+)
+
+
+async def test_get_state_reaches_into_iframes(browser) -> None:
+    _browser_id, endpoint = browser
+    async with KernelBrowserClient(rest_url=endpoint.rest_url) as client:
+        await client.navigate("data:text/html," + quote(IFRAME_PAGE))
+
+        state = await client.get_state()
+        button = next(
+            (n for n in state["tree"] if n["name"] == "Pay now"), None
+        )
+        assert button is not None, "iframe content missing from the snapshot"
+        # Root-space centre: frame origin (100, 300) + local (30, 20) + half
+        # the 100x40 button.  Nothing here should be off by the frame origin.
+        assert button["x"] == pytest.approx(180, abs=2)
+        assert button["y"] == pytest.approx(340, abs=2)
+
+
+async def test_click_ref_lands_inside_an_iframe(browser) -> None:
+    _browser_id, endpoint = browser
+    async with KernelBrowserClient(rest_url=endpoint.rest_url) as client:
+        await client.navigate("data:text/html," + quote(IFRAME_PAGE))
+
+        state = await client.get_state()
+        ref = next(n["ref"] for n in state["tree"] if n["name"] == "Pay now")
+        await client.click_ref(ref)
+
+        # The button rewrites its own label, so a click measured in the frame's
+        # coordinates instead of the root's misses it and the label stands.
+        after = await client.get_state()
+        assert any(n["name"] == "Paid" for n in after["tree"])

--- a/tests/test_browser_client.py
+++ b/tests/test_browser_client.py
@@ -147,7 +147,7 @@ class TestGetState:
                             "url": "u",
                             "title": "t",
                             "viewport": {"width": 1, "height": 1},
-                            "nodes": [],
+                            "frames": [],
                         },
                     },
                 )
@@ -161,9 +161,13 @@ class TestGetState:
         await client.get_state()
 
         code = captured[0]["code"]
-        assert "await page.evaluate" in code
-        assert code.index("await page.evaluate") < code.index("document.querySelector")
-        assert code.index("await page.evaluate") < code.index("root.querySelectorAll")
+        # The DOM walk is a collector run once per frame, never a bare
+        # page.evaluate -- that form only ever sees the main document.
+        assert "await __f.evaluate(__surogatesCollect" in code
+        assert "for (const __f of __targets)" in code
+        assert "await page.evaluate(" not in code
+        assert code.index("__surogatesCollect") < code.index("document.querySelector")
+        assert code.index("__surogatesCollect") < code.index("root.querySelectorAll")
 
     async def test_get_state_returns_tree_with_refs(
         self, client_with_transport
@@ -180,7 +184,7 @@ class TestGetState:
                         "url": "https://example.com/",
                         "title": "Example",
                         "viewport": {"width": 1280, "height": 800},
-                        "nodes": [
+                        "frames": [{"nodes": [
                             {
                                 "role": "link",
                                 "name": "Settings",
@@ -197,7 +201,7 @@ class TestGetState:
                                 "width": 120,
                                 "height": 36,
                             },
-                        ],
+                        ]}],
                     },
                 },
             )
@@ -225,7 +229,7 @@ class TestGetState:
                         "url": "u",
                         "title": "t",
                         "viewport": {"width": 100, "height": 100},
-                        "nodes": [
+                        "frames": [{"nodes": [
                             {
                                 "role": "button",
                                 "name": "Go",
@@ -235,7 +239,7 @@ class TestGetState:
                                 "height": 30,
                                 "backend_node_id": 42,
                             }
-                        ],
+                        ]}],
                     },
                 },
             )
@@ -264,7 +268,7 @@ class TestGetState:
                         "url": "u",
                         "title": "t",
                         "viewport": {"width": 100, "height": 100},
-                        "nodes": [
+                        "frames": [{"nodes": [
                             {
                                 "role": "button",
                                 "name": "Add",
@@ -291,7 +295,7 @@ class TestGetState:
                                 "width": 10,
                                 "height": 10,
                             },
-                        ],
+                        ]}],
                     },
                 },
             )
@@ -326,7 +330,7 @@ class TestGetState:
                         "url": "u",
                         "title": "t",
                         "viewport": {"width": 1, "height": 1},
-                        "nodes": [
+                        "frames": [{"nodes": [
                             {
                                 "role": "button",
                                 "name": "fresh",
@@ -335,7 +339,7 @@ class TestGetState:
                                 "width": 0,
                                 "height": 0,
                             }
-                        ],
+                        ]}],
                     },
                 },
             )
@@ -343,6 +347,133 @@ class TestGetState:
         await client.get_state()
         assert "@e9" not in client._snapshot_cache
         assert "@e1" in client._snapshot_cache
+
+
+class TestGetStateFrames:
+    """Iframe content is collected per frame and merged into one root-space tree."""
+
+    async def test_iframe_nodes_are_offset_into_root_coordinates(
+        self, client_with_transport
+    ) -> None:
+        client, handlers = client_with_transport
+        # A checkout page whose card field lives in a payment iframe mounted
+        # 400px down the page.  getBoundingClientRect inside that frame reports
+        # y=10 -- relative to the frame -- but page.mouse dispatches in root
+        # space, so an unoffset center clicks 400px too high.
+        handlers.append(
+            (
+                "POST",
+                "/playwright/execute",
+                200,
+                {
+                    "success": True,
+                    "result": {
+                        "url": "https://shop.example/checkout",
+                        "title": "Checkout",
+                        "viewport": {"width": 1280, "height": 800},
+                        "frames": [
+                            {
+                                "x": 0,
+                                "y": 0,
+                                "nodes": [
+                                    {
+                                        "role": "heading",
+                                        "name": "Checkout",
+                                        "x": 40,
+                                        "y": 20,
+                                        "width": 200,
+                                        "height": 40,
+                                    }
+                                ],
+                            },
+                            {
+                                "x": 100,
+                                "y": 400,
+                                "nodes": [
+                                    {
+                                        "role": "textbox",
+                                        "name": "Card number",
+                                        "x": 8,
+                                        "y": 10,
+                                        "width": 200,
+                                        "height": 40,
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                },
+            )
+        )
+        state = await client.get_state()
+
+        card = next(e for e in state["tree"] if e["name"] == "Card number")
+        assert card["x"] == 100 + 8 + 200 // 2
+        assert card["y"] == 400 + 10 + 40 // 2
+        # The main frame is its own origin and must not be shifted.
+        heading = next(e for e in state["tree"] if e["name"] == "Checkout")
+        assert heading["x"] == 40 + 200 // 2
+        assert heading["y"] == 20 + 40 // 2
+
+    async def test_refs_stay_unique_across_frames(
+        self, client_with_transport
+    ) -> None:
+        client, handlers = client_with_transport
+        # Both frames number their own nodes from zero; without a global
+        # renumber the second frame's first node overwrites @e1.
+        handlers.append(
+            (
+                "POST",
+                "/playwright/execute",
+                200,
+                {
+                    "success": True,
+                    "result": {
+                        "url": "u",
+                        "title": "t",
+                        "viewport": {"width": 1280, "height": 800},
+                        "frames": [
+                            {
+                                "x": 0,
+                                "y": 0,
+                                "nodes": [
+                                    {
+                                        "role": "button",
+                                        "name": "Outer",
+                                        "x": 0,
+                                        "y": 0,
+                                        "width": 10,
+                                        "height": 10,
+                                        "backend_node_id": 11,
+                                    }
+                                ],
+                            },
+                            {
+                                "x": 0,
+                                "y": 300,
+                                "nodes": [
+                                    {
+                                        "role": "button",
+                                        "name": "Inner",
+                                        "x": 0,
+                                        "y": 0,
+                                        "width": 10,
+                                        "height": 10,
+                                        "backend_node_id": 22,
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                },
+            )
+        )
+        state = await client.get_state()
+
+        assert [e["ref"] for e in state["tree"]] == ["@e1", "@e2"]
+        assert client._snapshot_cache["@e1"]["backend_node_id"] == 11
+        assert client._snapshot_cache["@e2"]["backend_node_id"] == 22
+        assert client._snapshot_cache["@e2"]["y"] == 300 + 10 // 2
 
 
 class TestGetStateFilters:
@@ -354,7 +485,7 @@ class TestGetStateFilters:
                 "url": "u",
                 "title": "t",
                 "viewport": {"width": 1, "height": 1},
-                "nodes": [
+                "frames": [{"nodes": [
                     {
                         "role": "generic",
                         "name": "",
@@ -387,7 +518,7 @@ class TestGetStateFilters:
                         "width": 1,
                         "height": 1,
                     },
-                ],
+                ]}],
             },
         }
 
@@ -418,12 +549,12 @@ class TestGetStateFilters:
             "success": True,
             "result": {
                 **deep_response["result"],
-                "nodes": [
+                "frames": [{"nodes": [
                     {**node, "depth": depth}
                     for node, depth in zip(
-                        deep_response["result"]["nodes"], [0, 1, 1, 3]
+                        deep_response["result"]["frames"][0]["nodes"], [0, 1, 1, 3]
                     )
-                ],
+                ]}],
             },
         }
         handlers.append(("POST", "/playwright/execute", 200, deep_response))
@@ -446,7 +577,7 @@ class TestGetStateFilters:
                         "url": "https://example.test/",
                         "title": "Example",
                         "viewport": {"width": 1280, "height": 720},
-                        "nodes": [
+                        "frames": [{"nodes": [
                             {
                                 "role": "link",
                                 "name": "Economy",
@@ -474,7 +605,7 @@ class TestGetStateFilters:
                                 "height": 40,
                                 "depth": 14,
                             },
-                        ],
+                        ]}],
                     },
                 },
             )
@@ -542,7 +673,7 @@ class TestClickType:
         assert "314" in code
         assert "Accessibility.getFullAXTree" in code
         assert "elementFromPoint" in code
-        assert "page.mouse.click(res.cx, res.cy" in code
+        assert "page.mouse.click(cx, cy" in code
         # The ref path must not invalidate the cache so a follow-up type works.
         assert "@e3" in client._snapshot_cache
 
@@ -613,6 +744,40 @@ class TestClickType:
         client, _ = client_with_transport
         with pytest.raises(KeyError, match="@e99"):
             await client.click_ref("@e99")
+
+    async def test_click_ref_measures_click_point_in_root_coordinates(
+        self, client_with_transport
+    ) -> None:
+        client, _handlers = client_with_transport
+        client._snapshot_cache["@e1"] = {
+            "x": 150,
+            "y": 420,
+            "role": "textbox",
+            "name": "Card number",
+            "backend_node_id": 77,
+            "nth": 0,
+        }
+        captured: list[dict[str, Any]] = []
+
+        class CapturingTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(
+                self, request: httpx.Request
+            ) -> httpx.Response:
+                captured.append(json.loads(request.content))
+                return httpx.Response(200, json={"success": True, "result": True})
+
+        client._http = httpx.AsyncClient(
+            base_url=client.rest_url, transport=CapturingTransport()
+        )
+        await client.click_ref("@e1")
+        code = captured[0]["code"]
+        # DOM.resolveNode on a node inside an iframe resolves into that frame's
+        # execution context, so getBoundingClientRect there is frame-relative
+        # while page.mouse dispatches in root space.  DOM.getBoxModel returns
+        # the quad already in root space, which is the only measurement the
+        # mouse may use.
+        assert "DOM.getBoxModel" in code
+        assert "page.mouse.click(res.cx, res.cy" not in code
 
     async def test_click_waits_for_network_after_request(
         self, client_with_transport
@@ -1056,6 +1221,51 @@ class TestSnapshotScriptShape:
         assert KernelBrowserClient._SNAPSHOT_SCRIPT.count(
             "window.getComputedStyle"
         ) == 1
+
+    @pytest.mark.parametrize("script_name", ["snapshot", "click"])
+    def test_injected_js_parses(self, tmp_path, script_name: str) -> None:
+        """Parse the injected JS with node, since only the browser ever runs it.
+
+        A syntax error in either string is invisible to Python and breaks every
+        browser session at runtime, which is the most expensive place to find
+        out.  Both are async function bodies, so they are wrapped to parse.
+        """
+
+        import shutil
+        import subprocess
+
+        node = shutil.which("node")
+        if node is None:
+            pytest.skip("node is not installed")
+
+        from surogates.browser.client import KernelBrowserClient
+
+        if script_name == "snapshot":
+            body = KernelBrowserClient._SNAPSHOT_SCRIPT.replace(
+                "__SUROGATES_SELECTOR__", "null"
+            )
+        else:
+            body = KernelBrowserClient(
+                rest_url="http://browser-test:10001"
+            )._build_ref_click_js(
+                {
+                    "backend_node_id": 1,
+                    "role": "button",
+                    "name": "Go",
+                    "nth": 0,
+                    "ref": "@e1",
+                },
+                "left",
+                1,
+            )
+        source = tmp_path / f"{script_name}.mjs"
+        source.write_text(f"async function __check(page) {{{body}}}")
+        result = subprocess.run(
+            [node, "--check", str(source)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
 
 
 class TestEvaluate:


### PR DESCRIPTION
## The gap

`browser_get_state` ran one `page.evaluate` against the main document, so every iframe was a blank box in the tree. Payment fields, consent frames and embedded editors were simply invisible to the agent — grepping `iframe|frame` across `client.py`, `resolver.py` and `serialize.py` returned nothing but an unrelated framebuffer comment.

## The change

**Snapshot** — the collector now runs once per frame via `page.frames()` and the results merge in root coordinates. Each frame's origin comes from `frameElement().boundingBox()`: a Playwright-side lookup, so it resolves across origins where `window.frameElement` is blocked, and it already accumulates the offsets of nested frames. A `selector` still narrows the main document to one subtree, so that mode stays single-frame.

**Click** — the same gap, one layer down. `DOM.resolveNode` on a node inside an iframe resolves into *that frame's* execution context, so its `getBoundingClientRect` is frame-relative while `page.mouse` dispatches in root space. Adding iframe content without this would have clicked hundreds of pixels off. The probe keeps measuring locally for `elementFromPoint`, which is correct there, and `DOM.getBoxModel` supplies the click point in root space. `click_ref` and `type_into_ref` both route through `_act_click_on_entry`, so one fix covers both.

## Verification

| Check | Result |
|---|---|
| `browser_e2e` vs real Chromium, on `master` | **2 failed** — `iframe content missing from the snapshot` |
| `browser_e2e` vs real Chromium, on this branch | 4 passed — content found at root coords, ref click lands inside the offset frame |
| Unit suite (`-k browser`) | 350 passed |
| `node --check` on both generated JS strings | passes; mutation-checked that it catches an unbalanced brace |

The two new e2e cases drive a `data:` page with a control in an iframe offset 300px down and 100px across — the shape of every embedded payment field. The click case has the button rewrite its own label, so a click measured in the wrong coordinate space misses and the assertion fails.

`TestSnapshotScriptShape` also gains a `node --check` parse test for both injected JS strings. Nothing else type-checks them, and a syntax error there breaks every browser session at runtime.

## Known ceilings

- iframe `depth` stays frame-local, so `max_depth` treats each frame as its own root and under-filters iframe content. Marked with a `ponytail:` comment.
- For a **cross-origin** frame, `backend_node_id` may come back null (`DOM.getDocument` pierce from the root session), dropping ref-clicks to the role/name healing tier. Coordinates are correct either way, so coordinate clicks always work. The e2e fixture uses a `srcdoc` frame, which is same-process — a real OOPIF case would need a two-origin fixture.

## Provenance

The idea came from auditing `opencue/agenticbrowser` (MIT) as a possible replacement for our browser engine. It is not one — it is a single-user desktop CLI with no multi-tenancy, provisioning, billing or live view — but its `snapshot.mjs` pierces iframes, which showed up this gap. Implemented natively here rather than vendored: `page.frames()` is smaller than their `DOMSnapshot.captureSnapshot` rebuild and reaches cross-origin OOPIFs, which that approach cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)