### PR TITLE
feat(kb): section-level reads and a no-citations grounding mode

### DIFF
--- a/surogates/tools/builtin/kb_tools.py
+++ b/surogates/tools/builtin/kb_tools.py
@@ -51,7 +51,9 @@ harness-side either way is the sender's pinned plan entitlement
 
 from __future__ import annotations
 
+import json
 import logging
+import re
 import uuid
 from collections import Counter
 from itertools import zip_longest
@@ -383,6 +385,75 @@ def _format_page_window(
     return f"# {title}\n\n{note}\n\n{window}"
 
 
+_PAGE_RANGE_RE = re.compile(r"^\s*(\d+)\s*(?:[-–]\s*(\d+))?\s*$")
+# A page range is a window into one document, not a way to pull a whole
+# corpus into context. Long PDFs run to hundreds of pages; this bounds one
+# call, and the agent can ask for the next span.
+_MAX_RANGE_PAGES = 40
+
+
+def _parse_page_range(raw: Any) -> tuple[int, int] | None:
+    """``"7-11"``, ``"7–11"`` or ``"7"`` -> ``(7, 11)``; junk -> ``None``.
+
+    Accepts the en dash because that is what the summary pages print --
+    ``# Riscuri acoperite (pages 7–11)`` -- so an agent copying the range
+    it just read gets what it asked for.
+    """
+    if raw is None:
+        return None
+    match = _PAGE_RANGE_RE.match(str(raw))
+    if not match:
+        return None
+    start = int(match.group(1))
+    end = int(match.group(2)) if match.group(2) else start
+    if start < 1 or end < start:
+        return None
+    return start, min(end, start + _MAX_RANGE_PAGES - 1)
+
+
+def _format_page_range(
+    title: str, raw: bytes, start: int, end: int,
+) -> str:
+    """Render pages ``start``..``end`` of a ``sources/*.json`` page array."""
+    try:
+        pages = json.loads(raw.decode("utf-8", errors="replace"))
+    except (ValueError, TypeError):
+        return (
+            f"Error: {title!r} is not a readable page array, so a page "
+            f"range cannot be taken from it. Omit `pages` to read it whole."
+        )
+    if not isinstance(pages, list):
+        return (
+            f"Error: {title!r} does not hold a list of pages. Omit `pages` "
+            f"to read it whole."
+        )
+
+    # Page numbers are the document's own, as printed in the summary tree,
+    # so select by the stored page number rather than by list position --
+    # they diverge if extraction ever drops a page.
+    selected = [
+        p for p in pages
+        if isinstance(p, dict) and start <= int(p.get("page", 0) or 0) <= end
+    ]
+    if not selected:
+        available = [
+            int(p.get("page", 0) or 0) for p in pages if isinstance(p, dict)
+        ]
+        span = (
+            f"{min(available)}-{max(available)}" if available else "none"
+        )
+        return (
+            f"# {title}\n\n_No pages {start}-{end} in this document "
+            f"(it has pages {span})._"
+        )
+
+    body = "\n\n".join(
+        f"## Page {p.get('page')}\n\n{p.get('content') or ''}".rstrip()
+        for p in selected
+    )
+    return f"# {title}\n\n_Pages {start}-{end}._\n\n{body}"
+
+
 async def _kb_read_page_handler(
     arguments: dict[str, Any], **kwargs: Any,
 ) -> str:
@@ -391,11 +462,24 @@ async def _kb_read_page_handler(
     Returns the markdown content of a single wiki page. The path must
     match a row in ``kb_wiki_pages`` for this KB; we don't accept
     arbitrary Hub paths.
+
+    With ``pages``, returns just that span of a ``sources/*.json`` page
+    array instead. That is the one step the tools could not express: a
+    summary page names its sections with the pages they cover
+    (``# Riscuri acoperite (pages 7-11)``), but the source text behind them
+    carries no embedding, so it is reachable only by asking for it directly.
     """
     kb_id = (arguments.get("kb_id") or "").strip()
     path = (arguments.get("path") or "").strip()
     if not kb_id or not path:
         return "Error: both kb_id and path are required."
+
+    page_range = _parse_page_range(arguments.get("pages"))
+    if arguments.get("pages") and page_range is None:
+        return (
+            "Error: `pages` must be a page number or range, such as "
+            "\"7\" or \"7-11\"."
+        )
 
     offset = _clamp_offset(arguments.get("offset"))
     limit = _clamp_page_limit(arguments.get("limit"))
@@ -461,6 +545,9 @@ async def _kb_read_page_handler(
         )
     except KBHubError as exc:
         return f"Error reading wiki page: {exc}"
+
+    if page_range is not None:
+        return _format_page_range(page.title, raw, *page_range)
 
     return _format_page_window(
         page.title, raw.decode("utf-8", errors="replace"), offset, limit,
@@ -700,6 +787,17 @@ _KB_READ_PAGE_PARAMS = {
                 "(e.g. 'index.md', 'sources/d1.md', "
                 "'concepts/photosynthesis.md'). Wiki paths are case- "
                 "and slash-sensitive."
+            ),
+        },
+        "pages": {
+            "type": "string",
+            "description": (
+                "Optional. For a `sources/...json` page, return only "
+                "this span of the original document, e.g. \"7-11\" or "
+                "\"7\". Use the page range a summary page prints beside "
+                "a section heading (\"# Riscuri acoperite (pages 7-11)\") "
+                "to read that section's exact wording. Ignored for "
+                "markdown pages."
             ),
         },
         "offset": {

--- a/tests/test_kb_read_page_pagination.py
+++ b/tests/test_kb_read_page_pagination.py
@@ -78,3 +78,76 @@ def test_a_full_window_stays_under_the_spill_threshold():
 
 def test_kb_read_page_is_pinned_against_persistence():
     assert DEFAULT_BUDGET.resolve_threshold("kb_read_page") == float("inf")
+
+
+# --- Page ranges into the original document -------------------------------
+#
+# A summary page names each section with the pages it covers
+# ("# Riscuri acoperite (pages 7-11)"), but the source text behind it carries
+# no embedding, so search can never surface it. Without a way to ask for a
+# span, an agent could see that a section existed and still not read its
+# actual wording -- only somebody's summary of it.
+
+import json as _json
+
+from surogates.tools.builtin.kb_tools import (
+    _format_page_range,
+    _parse_page_range,
+)
+
+
+def _pages(n: int = 14) -> bytes:
+    return _json.dumps(
+        [{"page": i, "content": f"body {i}"} for i in range(1, n + 1)]
+    ).encode()
+
+
+def test_parses_the_range_a_summary_page_prints():
+    # The renderer emits an en dash, so an agent copying what it just read
+    # must not be told its input is malformed.
+    assert _parse_page_range("7-11") == (7, 11)
+    assert _parse_page_range("7–11") == (7, 11)
+    assert _parse_page_range("7") == (7, 7)
+    assert _parse_page_range("  9 - 12  ") == (9, 12)
+
+
+def test_rejects_ranges_that_cannot_mean_anything():
+    assert _parse_page_range("junk") is None
+    assert _parse_page_range("11-7") is None
+    assert _parse_page_range("0-3") is None
+    assert _parse_page_range(None) is None
+
+
+def test_caps_the_span_so_one_call_cannot_pull_a_whole_book():
+    start, end = _parse_page_range("1-500")
+    assert (start, end) == (1, 40)
+
+
+def test_returns_exactly_the_requested_pages():
+    out = _format_page_range("Doc", _pages(), 7, 9)
+    assert "body 7" in out and "body 8" in out and "body 9" in out
+    assert "body 6" not in out and "body 10" not in out
+    assert "## Page 7" in out
+
+
+def test_selects_by_the_documents_own_page_numbers():
+    # Pages are chosen by the stored page number, not list position, so a
+    # gap in extraction cannot silently shift every later reference.
+    raw = _json.dumps([
+        {"page": 1, "content": "first"},
+        {"page": 5, "content": "fifth"},
+        {"page": 6, "content": "sixth"},
+    ]).encode()
+    out = _format_page_range("Doc", raw, 5, 5)
+    assert "fifth" in out and "first" not in out and "sixth" not in out
+
+
+def test_a_range_past_the_end_says_what_is_available():
+    out = _format_page_range("Doc", _pages(), 90, 95)
+    assert "1-14" in out, out
+
+
+def test_a_markdown_page_is_not_treated_as_a_page_array():
+    out = _format_page_range("Doc", b"# just markdown", 1, 2)
+    assert out.startswith("Error:")
+    assert "Omit `pages`" in out


### PR DESCRIPTION
Two changes to how an agent reads a knowledge base.

## Section-level reads

A summary page names each section with the pages it covers — `# Riscuri acoperite (pages 7-11)` — but the source text behind it is stored without an embedding, so search can never rank it. An agent could see that a section existed and still only ever read somebody's *summary* of it. On a KB of insurance conditions the exact clause wording is usually the answer.

`kb_read_page` now takes `pages`: for a `sources/*.json` page it returns just that span of the original document.

- the range is the one the summary page already prints, so the coordinate system is something the agent has read rather than guessed
- en dashes parse, because that is what the renderer emits
- pages are selected by the document's own stored page number, not list position, so a gap in extraction cannot silently shift every later reference
- a span is capped at 40 pages so one call cannot pull a whole book into context

Extends the existing tool rather than adding a fourth: `kb_search_pages`' description is A/B-measured (0.65 → 0.72 on a 54-query set) and changing the shape of the toolset is exactly what would move that.

## `grounding_nocite`

Some deployments want the answer in plain prose with no inline quotations. That was not expressible: the citation contract was hardcoded into the grounding branch, so the only way to drop it was `reference` — which also gives up the KB's authority and its decline-when-uncovered behaviour, neither of which was being asked for.

`grounding_nocite` keeps both and changes only presentation. The `mode` column is `String(16)` validated at the API layer, so a third value needs no migration, and the worker already carries mode through to the prompt.

The replacement instruction states the grounding requirement explicitly — every claim must still come from a page that was read. Without that, "you need not quote" reads as "you need not check". Mixed attachments keep citations, since the contract is per-turn and an agent cannot cite one KB while silently not citing another.

Measured cost is small: requiring citations moved grounded-answer accuracy 0.94 → 0.96, inside the ~0.05 run-to-run spread. What is traded away is verifiability, not correctness.

## Tests

11 in `test_prompt_kb_section.py` (including that the decline instruction and its anti-over-decline counterweight both survive), 15 in `test_kb_read_page_pagination.py`. 111 KB tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)