### PR TITLE
fix(sdk): regenerate the lockfile after the noVNC removal

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   sdk/agent-chat-react:
     dependencies:
-      '@novnc/novnc':
-        specifier: ^1.7.0
-        version: 1.7.0
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -715,9 +712,6 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
-
-  '@novnc/novnc@1.7.0':
-    resolution: {integrity: sha512-ucEJOx4T2avIRCleodk7YobZj5O2Ga2AeLfQ69A/yjG9HHba2+PDgwSkN3FttrmG+70ZGx21sElNFouK13RzyA==}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -4372,8 +4366,6 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
-
-  '@novnc/novnc@1.7.0': {}
 
   '@opentelemetry/api@1.9.0': {}
 


### PR DESCRIPTION
The browser shell replaced the VNC live view and dropped `@novnc/novnc` from the SDK's `package.json`, but `pnpm-lock.yaml` still carried it — the release build installs with a frozen lockfile and refused the mismatch (`ERR_PNPM_OUTDATED_LOCKFILE`).

Regenerated with `pnpm install --lockfile-only` (8 lines removed, all noVNC) and verified `CI=true pnpm install --frozen-lockfile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)