### PR TITLE
fix(sdk): finish the browserLiveViewUrl to browserShellUrl rename

### DIFF
--- a/sdk/agent-chat-react/tests/agent-chat.test.tsx
+++ b/sdk/agent-chat-react/tests/agent-chat.test.tsx
@@ -440,7 +440,7 @@ describe("AgentChat", () => {
       const adapter = {
         ...createAdapter(stream),
         async getBrowserState() {
-          return { status: "live" as const, controlOwner: null };
+          return { status: "live" as const, controlOwner: null, liveViewPath: "" };
         },
       };
       container = document.createElement("div");

--- a/sdk/example-chat-app/src/client/adapter.ts
+++ b/sdk/example-chat-app/src/client/adapter.ts
@@ -102,7 +102,7 @@ export function createExampleChatAdapter(baseUrl = "/api"): AgentChatAdapter {
     async releaseBrowserControl() {
       // The example app does not provision browser sessions.
     },
-    browserLiveViewUrl() {
+    browserShellUrl() {
       return "";
     },
   };


### PR DESCRIPTION
The release build failed at `sdk/example-chat-app`: the browser shell replaced the VNC live view and renamed the adapter's URL method to `browserShellUrl`, but the example app still implemented `browserLiveViewUrl` and no longer compiled against the published type.

A second error surfaced only under `tsc --noEmit`: the `getBrowserState` stub in the runtime test omitted `liveViewPath`, which is still a required field on `AgentChatBrowserStateResponse`. `tsup` emits declarations for `src/` only, so the package build never typechecks the test tree — the typecheck script is what catches it.

## Verified before committing
Ran the exact CI steps plus everything they don't cover:

| Check | Result |
|---|---|
| `pnpm install --frozen-lockfile` (CI step 1) | pass |
| `pnpm -r --filter './sdk/*' run build` (CI step 2) | all 3 packages pass |
| `pnpm -r --filter './sdk/*' run typecheck` | all 3 pass |
| SDK test suites | 949 + 55 + 22 pass |
| `web/` SPA typecheck | pass |
| `docker build --target web-build` (`--no-cache`) | pass, `npm ci` genuinely re-ran |

Note for follow-up, not fixed here: `web/package-lock.json` still lists `@novnc/novnc` (both in web's own deps and in its mirror of the SDK manifest). The uncached image build proves `npm ci` tolerates it, so it is dead weight in the image rather than a broken build — worth cleaning when `web/` deps are next touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)