### PR TITLE
fix(browser): survive a viewer that leaves, and stop tab-push chatter

### DIFF
--- a/surogates/browser/shell.py
+++ b/surogates/browser/shell.py
@@ -278,6 +278,18 @@ class ShellSession:
         self._frames: asyncio.Queue[tuple[bytes, str]] = asyncio.Queue()
         self._pump: asyncio.Task | None = None
         self._dropped = 0
+        # Background pushes (tab lists, navigation updates) tracked so close()
+        # can cancel them. Target discovery makes Chrome announce every
+        # existing target at once, so a burst of these is typically in flight
+        # exactly when a viewer remounts and tears the session down.
+        self._tasks: set[asyncio.Task] = set()
+        # Last tab list actually sent, so identical ones can be skipped.
+        self._last_tabs: list[dict] | None = None
+        # The viewer's socket is unusable. Starlette raises on every send once
+        # one has failed, so the first failure has to stop the rest: a viewer
+        # leaving is routine (React remounts in dev, a closed pane in prod)
+        # and must not raise out of start().
+        self._gone = False
 
     async def start(self) -> None:
         pages = await self._cdp.targets()
@@ -299,9 +311,23 @@ class ShellSession:
         await self._push_tabs()
 
     async def close(self) -> None:
+        self._gone = True
         if self._pump is not None:
             self._pump.cancel()
             self._pump = None
+        for task in list(self._tasks):
+            task.cancel()
+        self._tasks.clear()
+
+    def _spawn(self, coro) -> None:
+        """Run a background update, tracked so :meth:`close` can cancel it."""
+
+        if self._gone:
+            coro.close()  # never awaited; closing it avoids a warning
+            return
+        task = asyncio.create_task(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
 
     async def handle(self, raw: str | bytes) -> None:
         """Act on one client frame. Never raises for bad input — drops it."""
@@ -412,18 +438,22 @@ class ShellSession:
 
     async def _push_tabs(self) -> None:
         pages = await self._cdp.targets()
-        await self._send({
-            "t": "tabs",
-            "tabs": [
-                {
-                    "id": page.get("targetId"),
-                    "title": page.get("title", ""),
-                    "url": page.get("url", ""),
-                    "active": page.get("targetId") == self._target,
-                }
-                for page in pages
-            ],
-        })
+        tabs = [
+            {
+                "id": page.get("targetId"),
+                "title": page.get("title", ""),
+                "url": page.get("url", ""),
+                "active": page.get("targetId") == self._target,
+            }
+            for page in pages
+        ]
+        # Discovery reports every title, favicon and loading-state change, so
+        # a single busy tab pushes dozens of identical lists a minute. Send
+        # only what actually differs -- each push is a client re-render.
+        if tabs == self._last_tabs:
+            return
+        self._last_tabs = tabs
+        await self._send({"t": "tabs", "tabs": tabs})
 
     def _on_frame(self, params: dict) -> None:
         try:
@@ -436,10 +466,10 @@ class ShellSession:
         frame = params.get("frame") or {}
         if frame.get("parentId"):
             return  # a subframe navigating is not the address bar's business
-        asyncio.create_task(self._after_navigation(frame))
+        self._spawn(self._after_navigation(frame))
 
     def _on_targets_changed(self, _params: dict) -> None:
-        asyncio.create_task(self._push_tabs())
+        self._spawn(self._push_tabs())
 
     async def _after_navigation(self, frame: dict) -> None:
         try:
@@ -455,8 +485,19 @@ class ShellSession:
     async def _pump_frames(self) -> None:
         while True:
             payload, screencast_session = await self._frames.get()
+            if self._gone:
+                continue
             try:
                 await self._client.send_bytes(payload)
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 - the viewer left mid-stream
+                # Every later send would fail the same way; stop rather than
+                # spinning once per frame for the life of the session.
+                self._gone = True
+                logger.debug("browser shell viewer went away", exc_info=True)
+                return
+            try:
                 # An unacked stream stalls by design.
                 await self._cdp.call(
                     "Page.screencastFrameAck",
@@ -465,15 +506,24 @@ class ShellSession:
                 )
             except asyncio.CancelledError:
                 raise
-            except Exception:  # noqa: BLE001 - a dropped frame is not fatal
-                logger.debug("browser shell frame forward failed", exc_info=True)
+            except Exception:  # noqa: BLE001 - a dropped ack is not fatal
+                logger.debug("browser shell frame ack failed", exc_info=True)
 
     def _drain_frames(self) -> None:
         while not self._frames.empty():
             self._frames.get_nowait()
 
     async def _send(self, message: dict[str, Any]) -> None:
-        await self._client.send_text(json.dumps(message))
+        if self._gone:
+            return
+        # Serialized before the send so a genuine encoding bug still raises;
+        # only the write to the viewer is treated as survivable.
+        payload = json.dumps(message)
+        try:
+            await self._client.send_text(payload)
+        except Exception:  # noqa: BLE001 - the viewer left; that is not an error
+            self._gone = True
+            logger.debug("browser shell viewer went away", exc_info=True)
 
     def _drop(self, reason: str) -> None:
         self._dropped += 1

--- a/tests/test_browser_shell_session.py
+++ b/tests/test_browser_shell_session.py
@@ -189,13 +189,32 @@ class TestTabs:
         assert ("Target.setDiscoverTargets", {"discover": True}, None) in cdp.calls
         await _session_obj.close()
 
-    async def test_target_changes_push_a_fresh_tab_list(self) -> None:
+    async def test_an_unchanged_tab_list_is_not_resent(self) -> None:
+        # Target discovery fires targetInfoChanged for every title, favicon
+        # and loading-state change, which on a live page is constant: a
+        # single tab produced ~57 pushes in 20s, each a getTargets round
+        # trip and a client re-render. Only real changes are worth sending.
         session, cdp, client = await _session()
         client.text.clear()
+        for _ in range(5):
+            cdp.emit("Target.targetInfoChanged", {"targetInfo": {"targetId": "t1"}})
+        await asyncio.sleep(0.05)
+        assert client.text == []
+        await session.close()
+
+    async def test_a_changed_tab_list_is_still_pushed(self) -> None:
+        session, cdp, client = await _session()
+        client.text.clear()
+        cdp._results["__targets__"] = [
+            {"targetId": "t1", "url": "u"},
+            {"targetId": "t2", "url": "u2"},
+        ]
         cdp.emit("Target.targetCreated", {"targetInfo": {"targetId": "t2"}})
         await asyncio.sleep(0.05)
-        assert any(msg.get("t") == "tabs" for msg in client.text)
+        assert [m["t"] for m in client.text] == ["tabs"]
+        assert len(client.text[0]["tabs"]) == 2
         await session.close()
+
 
 
 class TestCloseTab:
@@ -245,3 +264,56 @@ class TestCloseTab:
         # stream and nothing for the agent to come back to.
         assert "Target.closeTarget" not in cdp.methods()
         await session.close()
+
+
+class TestVanishedViewer:
+    """A viewer that goes away mid-startup is routine, not an error.
+
+    React StrictMode double-mounts in dev, so the first socket is opened and
+    closed immediately; a user closing the pane during startup does the same
+    in production. Starlette flips the socket to DISCONNECTED after one failed
+    send and raises on every send after that, so the session must notice and
+    fall silent instead of raising through start().
+    """
+
+    class DeadClient:
+        """Starlette's behaviour once the peer is gone."""
+
+        def __init__(self) -> None:
+            self.sends = 0
+
+        async def send_bytes(self, payload: bytes) -> None:
+            self.sends += 1
+            raise RuntimeError(
+                'Cannot call "send" once a close message has been sent.'
+            )
+
+        async def send_text(self, payload: str) -> None:
+            self.sends += 1
+            raise RuntimeError(
+                'Cannot call "send" once a close message has been sent.'
+            )
+
+    async def test_start_survives_a_client_that_already_went_away(self) -> None:
+        cdp = FakeCdp({"Page.getLayoutMetrics": _layout()})
+        client = self.DeadClient()
+
+        async def lease_held() -> bool:
+            return True
+
+        session = ShellSession(cdp, client, lease_held=lease_held)
+        # The viewer is already gone; startup must complete quietly rather
+        # than raising a traceback out of the route handler.
+        await session.start()
+        await session.close()
+
+    async def test_background_pushes_stop_after_close(self) -> None:
+        # setDiscoverTargets makes Chrome announce every existing target at
+        # once, so a burst of _push_tabs tasks is in flight exactly when a
+        # StrictMode remount tears the session down. None may outlive it.
+        session, cdp, client = await _session()
+        cdp.emit("Target.targetCreated", {"targetInfo": {"targetId": "t2"}})
+        await session.close()
+        client.text.clear()
+        await asyncio.sleep(0.05)
+        assert client.text == []


### PR DESCRIPTION
Opening the browser pane logged an ERROR traceback on every mount:

```
RuntimeError: Cannot call "send" once a close message has been sent.
  ... shell.py, in _push_tabs -> _send
```

## Why

React StrictMode double-mounts in dev, so the first socket is opened and closed the instant it appears. Starlette flips a connection to `DISCONNECTED` after the **first** failed send and raises on every send after that — so the frame pump swallowed the real failure (it logs at debug), and the tab push inside `start()` was the one that blew up. Production hits the same path whenever a pane is closed during startup.

A viewer leaving is routine, not an error. The session now falls silent once its socket is unusable, and the frame pump stops rather than spinning once per frame for the life of the session.

## Two adjacent problems this exposed

**Orphaned background pushes.** `_on_targets_changed` / `_on_navigated` spawned bare `asyncio.create_task`, untracked and uncancelled, so they outlived the session that spawned them. Target discovery makes Chrome announce every existing target at once, putting a burst of them in flight at exactly the moment a remount tears the session down. They are tracked and cancelled by `close()` now.

**Tab-push chatter.** `targetInfoChanged` fires for every title, favicon and loading-state change — measured at **57 pushes in 20s for a single tab**, each one a `Target.getTargets` round trip plus a client re-render. Identical lists are no longer resent.

## Verified live

Against session `fc96dbd0-…` with a real browser, simulating the StrictMode pair (throwaway mount, then the real one):

| | before | after |
|---|---|---|
| server ERROR tracebacks | one per mount | **0** |
| tab pushes / 20s | 57 | **1** |
| JPEG frames / 20s | 466 | 462 (≈23fps, unchanged) |

432 browser tests pass, ruff clean. The superseded `test_target_changes_push_a_fresh_tab_list` is replaced by a sharper pair: an unchanged list is not resent, a changed one still is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)