### PR TITLE
fix(web): make "Close browser" actually close the browser

### DIFF
--- a/scripts/web-shared-chat-sdk.test.mjs
+++ b/scripts/web-shared-chat-sdk.test.mjs
@@ -106,7 +106,10 @@ for (const path of [
     "getBrowserState",
     "acquireBrowserControl",
     "releaseBrowserControl",
-    "browserLiveViewUrl",
+    "browserShellUrl",
+    // Optional on the adapter type, so its absence is silent: the SDK just
+    // skips the call and "Close browser" quietly becomes "hide the panel".
+    "closeBrowserSession",
   ]) {
     assert.match(
       adapterSource,
@@ -116,13 +119,8 @@ for (const path of [
   }
   assert.match(
     adapterSource,
-    /\/browser\/live\//,
-    "web chat adapter should point the browser iframe at the live-view root",
-  );
-  assert.match(
-    adapterSource,
-    /searchParams\.set\("pwd",\s*"admin"\)/,
-    "web chat adapter should pass Neko's auto-login password",
+    /\/browser\/shell/,
+    "web chat adapter should point the browser socket at the shell endpoint",
   );
 }
 

--- a/web/src/api/sessions.ts
+++ b/web/src/api/sessions.ts
@@ -320,6 +320,16 @@ export async function releaseBrowserControl(sessionId: string): Promise<void> {
   if (!response.ok) throw new Error("Failed to release browser control");
 }
 
+export async function closeBrowserSession(sessionId: string): Promise<void> {
+  // Idempotent server-side: 204 whether or not a browser was attached, so
+  // there is nothing to special-case when the pane is closed twice.
+  const response = await authFetch(
+    `/api/v1/sessions/${encodeURIComponent(sessionId)}/browser`,
+    { method: "DELETE" },
+  );
+  if (!response.ok) throw new Error("Failed to close browser session");
+}
+
 export async function getSessionTree(
   sessionId: string,
 ): Promise<SessionTreeResponse> {

--- a/web/src/features/chat/surogates-web-chat-adapter.ts
+++ b/web/src/features/chat/surogates-web-chat-adapter.ts
@@ -224,6 +224,13 @@ export const surogatesWebChatAdapter: AgentChatAdapter = {
     await sessionsApi.releaseBrowserControl(sessionId);
   },
 
+  // Without this the shell's "Close browser" only hides the panel — the
+  // sandbox keeps running, and the confirm dialog says so. Implementing it
+  // is what makes the button mean what it says.
+  async closeBrowserSession(sessionId) {
+    await sessionsApi.closeBrowserSession(sessionId);
+  },
+
   async getArtifact(input) {
     return await getArtifact(input.sessionId, input.artifactId);
   },


### PR DESCRIPTION
Confirming **Close browser** in the shell's ⋯ menu only hid the panel — the browser sandbox kept running.

## Why

`closeBrowserSession` is **optional** on `AgentChatAdapter`. The SDK calls it only if present, and the web SPA never implemented it, so the call was silently skipped and the confirm dialog fell back to its "this hides the browser panel, the sandbox stays running" wording. Ops has implemented the method all along — which is exactly why the button behaved correctly there and not in the SPA.

## The guard that should have caught it

`scripts/web-shared-chat-sdk.test.mjs` asserts the web adapter implements each browser method — but it was still VNC-era, requiring `browserLiveViewUrl`, a `/browser/live/` URL and Neko's auto-login password. It had been failing since the shell landed (`npm run test:shared-sdk` was red on master). Updated to the shell's reality and extended to require `closeBrowserSession`, whose absence is otherwise invisible because the type marks it optional.

## Verification

- `DELETE /api/v1/sessions/{id}/browser` against a live instance, at the exact URL the adapter builds: **204** with a valid token, **401** without. The idempotent no-browser path was used so no running browser was destroyed.
- `npm run test:shared-sdk` — red before, green after.
- `npx tsc --noEmit` and `npx vite build` (what the image actually builds) both clean.

Unrelated, pre-existing on master and left alone: `npm run build` in `web/` fails `tsc -b` with four errors — three `erasableSyntaxOnly` violations in the SDK's whiteboard sources and a missing `sidebar` prop in `whiteboard-page.tsx`. Confirmed identical on a clean tree. The image build is unaffected because its Dockerfile deliberately skips `tsc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)