### PR TITLE
chore(benchmarks): consolidate ignores into one benchmarks-wide gitig…

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,12 @@
+# Shared ignores for every benchmark directory: local credentials,
+# virtualenvs, run traces, vendored upstream checkouts and derived data.
+# Patterns without a leading slash apply at every depth below benchmarks/.
+.env
+.venv/
+runs/
+vendor/
+task-data/
+answer_key.json
+__pycache__/
+.pytest_cache/
+*.pyc


### PR DESCRIPTION
…nore

Every benchmark ignores the same local artifacts (.env, .venv, runs, vendored checkouts, caches); one tracked file at benchmarks/ covers all of them on every branch, so standing on any branch no longer un-hides another benchmark's local files and branch switches stop colliding with untracked per-directory stopgaps.