### PR TITLE
fix(channels): refresh the routing identifier when a session resumes

### DIFF
--- a/surogates/channels/identity.py
+++ b/surogates/channels/identity.py
@@ -429,6 +429,25 @@ async def get_or_create_channel_session(
                 await session_store.update_session_config_key(
                     existing_id, "workspace_boundary", incoming_boundary,
                 )
+        # The channel's routing identifier can change under a live session —
+        # an operator repoints the channel at a different WhatsApp number, and
+        # the old identifier is deactivated. The session's copy is a
+        # creation-time snapshot, but the outbox destination is built from it
+        # and delivery resolves credentials by it, so a stale value addresses
+        # every reply to the dead identifier and the delivery loop drops it as
+        # "channel deprovisioned". The session key carries no identifier, so
+        # such a session resumes forever and never self-heals. Refresh from the
+        # live routing the same way the boundaries above are backfilled.
+        # Absent (a caller that carries no routing) leaves the stored value
+        # alone: blanking it would strand a session that was working.
+        incoming_identifier = str(config.get("channel_identifier") or "").strip()
+        if (
+            incoming_identifier
+            and _existing_config.get("channel_identifier") != incoming_identifier
+        ):
+            await session_store.update_session_config_key(
+                existing_id, "channel_identifier", incoming_identifier,
+            )
         if existing_status in ("completed", "paused"):
             await session_store.resume_session(existing_id, source="channel_message")
             logger.info(

--- a/tests/test_channel_session_resume.py
+++ b/tests/test_channel_session_resume.py
@@ -120,6 +120,65 @@ async def test_no_backfill_when_multi_party_already_matches():
     assert store.config_updates == []
 
 
+async def test_refreshes_channel_identifier_on_resume():
+    # An operator repointing the channel at a different identifier (a new
+    # WhatsApp number) leaves live sessions pinned to the old one. Delivery
+    # builds the outbox destination from session config and resolves creds by
+    # that identifier, so every reply is dropped as "channel deprovisioned".
+    sid = uuid4()
+    store = _Store()
+    got = await _call_group(
+        store,
+        _SessionFactory(
+            SimpleNamespace(
+                id=sid, status="active",
+                config={"channel_identifier": "1326972397162150"},
+            )
+        ),
+        {"slack_channel_id": "C1", "channel_identifier": "1275764455611851"},
+    )
+    assert got == sid
+    assert store.config_updates == [
+        (sid, "channel_identifier", "1275764455611851"),
+    ]
+
+
+async def test_no_refresh_when_channel_identifier_matches():
+    sid = uuid4()
+    store = _Store()
+    got = await _call_group(
+        store,
+        _SessionFactory(
+            SimpleNamespace(
+                id=sid, status="active",
+                config={"channel_identifier": "A0"},
+            )
+        ),
+        {"slack_channel_id": "C1", "channel_identifier": "A0"},
+    )
+    assert got == sid
+    assert store.config_updates == []
+
+
+async def test_absent_incoming_identifier_never_clears_the_stored_one():
+    # Callers that do not carry routing (and any future one that forgets)
+    # must not blank a working destination.
+    sid = uuid4()
+    store = _Store()
+    got = await _call_group(
+        store,
+        _SessionFactory(
+            SimpleNamespace(
+                id=sid, status="active",
+                config={"channel_identifier": "A0"},
+            )
+        ),
+        {"slack_channel_id": "C1"},
+    )
+    assert got == sid
+    assert store.config_updates == []
+
+
 async def test_resumes_paused_session():
     # A paused session must also be re-activated on a new message — otherwise the
     # harness's paused branch is a hard stop and the message is stranded.


### PR DESCRIPTION
## Problem

Repointing a channel at a different identifier — in practice, switching an agent's WhatsApp number — permanently strands every session already open on it.

`channel_identifier` is stamped into the session config when the session is created. The outbox destination is built from that config, and `_deliver_item` resolves credentials by it. Once the old identifier is deactivated, `resolve_tenant` returns nothing and every reply is dropped:

```
[delivery] Outbox 23563 identifier '1275764455611851' not found in routing cache
           — channel may have been deprovisioned
Outbox 23563 failed: channel deprovisioned: 1275764455611851 (will retry)
```

The agent runs, produces an answer, and the answer never leaves. Nothing surfaces to the operator — it looks exactly like the agent ignoring the user.

It cannot self-heal: the session key carries no identifier (`agent:whatsapp:dm:<user>`), so the same stranded session resumes forever. Observed in PROD; the session had to be repaired by hand with a config UPDATE.

## Fix

Refresh `channel_identifier` from the live routing on resume, in the block that already backfills `multi_party` and the memory/workspace boundaries for the same reason — session config is a creation-time snapshot that drifts.

An absent incoming value leaves the stored one alone: blanking it would strand a session that was working.

## Tests

- `test_refreshes_channel_identifier_on_resume` — stale identifier is updated (failed before the change).
- `test_no_refresh_when_channel_identifier_matches` — no redundant write.
- `test_absent_incoming_identifier_never_clears_the_stored_one` — guards the blanking case.

1396 channel/session/identity/delivery/dispatch tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)