### PR TITLE
feat(web): tell the user they can close the link page once linked

### DIFF
--- a/web/src/features/auth/link-channel-page.tsx
+++ b/web/src/features/auth/link-channel-page.tsx
@@ -299,6 +299,9 @@ export function LinkChannelPage() {
               You can now message the assistant on {platformLabel} and it will
               recognize you as the same person.
             </p>
+            <p className="text-sm text-muted-foreground">
+              You can now close this window.
+            </p>
           </div>
         ) : (
           <form


### PR DESCRIPTION
## Change

One line in the link page's success panel:

> {platform} account linked successfully!
> You can now message the assistant on {platform} and it will recognize you as the same person.
> **You can now close this window.**

The panel confirmed the link and explained what now works on the channel, but never said the page was done with. Someone who arrived from a WhatsApp pairing prompt has no other reason to be on it.

## Verification

`npm run typecheck` in `web/` reports the same four errors before and after this change (three `erasableSyntaxOnly` errors in `sdk/agent-chat-react/src/components/whiteboard/`, one missing `sidebar` prop in `whiteboard-page.tsx`). They are pre-existing on `master` and unrelated — worth a separate fix.

## Not included

The same panel renders `{platformLabel}`, and `PLATFORM_LABELS` has no `whatsapp` entry — so a WhatsApp user currently reads "whatsapp account linked successfully!" in lowercase. Left alone deliberately; this PR is the requested one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)