### PR TITLE
fix(web): restore a clean typecheck

### DIFF
--- a/sdk/agent-chat-react/src/components/whiteboard/formula.ts
+++ b/sdk/agent-chat-react/src/components/whiteboard/formula.ts
@@ -143,7 +143,11 @@ export class FormulaCache {
   >();
   private readonly pending = new Set<string>();
 
-  constructor(private readonly onReady: () => void) {}
+  private readonly onReady: () => void;
+
+  constructor(onReady: () => void) {
+    this.onReady = onReady;
+  }
 
   get(latex: string, fontSize: number): RasterFormula | null {
     const hit = this.entries.get(latex);

--- a/sdk/agent-chat-react/src/components/whiteboard/input.ts
+++ b/sdk/agent-chat-react/src/components/whiteboard/input.ts
@@ -156,10 +156,13 @@ export class StrokeBuilder {
   private readonly pts: number[] = [];
   private started = false;
 
-  constructor(
-    private readonly color: string,
-    private readonly width: number,
-  ) {}
+  private readonly color: string;
+  private readonly width: number;
+
+  constructor(color: string, width: number) {
+    this.color = color;
+    this.width = width;
+  }
 
   begin(pt: Point): void {
     this.started = true;

--- a/web/src/features/whiteboard/whiteboard-page.tsx
+++ b/web/src/features/whiteboard/whiteboard-page.tsx
@@ -1,4 +1,5 @@
 import { AppShell } from "@/components/app-shell";
+import { SessionSidebar } from "@/components/navbar";
 import { useAppStore } from "@/stores/app-store";
 // Copyright (c) 2026, Invergent SA, developed by Flavius Burca
 // SPDX-License-Identifier: AGPL-3.0-only
@@ -40,7 +41,7 @@ export function WhiteboardPage() {
   }, [navigate]);
 
   return (
-    <AppShell>
+    <AppShell sidebar={<SessionSidebar />}>
       <div className="h-full w-full">
         <AgentWhiteboard
           adapter={whiteboardChatAdapter}


### PR DESCRIPTION
## Problem

`npm run typecheck` in `web/` failed on `master` with four errors. A check that is already red cannot tell a new regression from the standing noise.

```
sdk/agent-chat-react/src/components/whiteboard/formula.ts(146,15): TS1294
sdk/agent-chat-react/src/components/whiteboard/input.ts(160,5):   TS1294
sdk/agent-chat-react/src/components/whiteboard/input.ts(161,5):   TS1294
web/src/features/whiteboard/whiteboard-page.tsx(43,6):            TS2741
```

## Fixes

**TS1294 ×3 — parameter properties.** `erasableSyntaxOnly` rejects them because they emit runtime code instead of erasing. `FormulaCache` and `StrokeBuilder` declared their fields in the constructor signature; they now declare the fields and assign in the body. Behaviour is identical.

**TS2741 — missing `sidebar`.** `WhiteboardPage` rendered `<AppShell>` with no `sidebar`, which `AppShellProps` requires. Every other caller — inbox, missions, agents, settings, chat, skills — passes `sidebar={<SessionSidebar />}`. The whiteboard was the sole omission, so it gets the same sidebar rather than the prop being loosened to optional to accommodate one caller.

## Verification

```
$ npm run typecheck
> tsc -b --pretty false
$ npx biome check <the three files>
Lint: No issues found
```

Clean, and no lint regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)