### PR TITLE
test(kb): check reference prompts for grounding directives

### DIFF
--- a/tests/test_prompt_kb_section.py
+++ b/tests/test_prompt_kb_section.py
@@ -66,7 +66,8 @@ def test_reference_kb_gets_soft_header_and_tree(tmp_path: Path):
     )
     section = builder._kb_section()
     assert "when relevant" in section.lower()
-    assert "authoritative" not in section.lower()
+    assert "## Authoritative (consult first)" not in section
+    assert "These knowledge bases are your authoritative source" not in section
     assert "Extra Notes" in section
     assert "notes.md" in section
 


### PR DESCRIPTION
The reference-mode prompt test rejected any occurrence of `authoritative`, including the warning that a reviewed preference does not make a whole document authoritative. Check for the actual grounding-mode header and directive instead, preserving coverage that reference knowledge remains optional.

Validation: runtime KB, prompt, and worker checks passed (164 tests); the focused `tests/test_prompt_kb_section.py` suite passed again (11 tests).
