### PR TITLE
feat(programs): scheduled WhatsApp check-in Programs in the runtime

### DIFF
--- a/surogates/channels/delivery.py
+++ b/surogates/channels/delivery.py
@@ -84,6 +84,17 @@ _PERMANENT_DELIVERY_ERRORS: frozenset[str] = frozenset({
                              # into the Phone Number ID field
     "graph error 131026 (",  # recipient not on WhatsApp / undeliverable
     "graph error 131047 (",  # 24-hour customer service window closed
+    # Template sends. All are configuration, not weather: the template
+    # does not exist, is paused, or its parameters do not match, and
+    # sixty retries over half an hour cannot change any of that.
+    "graph error 132000 (",  # parameter count mismatch
+    "graph error 132001 (",  # template name does not exist
+    "graph error 132005 (",  # hydrated text too long
+    "graph error 132007 (",  # format character policy violated
+    "graph error 132012 (",  # parameter format mismatch
+    "graph error 132015 (",  # template paused
+    "graph error 132016 (",  # template disabled
+    "template payload incomplete",  # ours: name or language missing
 })
 
 # Give up on an undelivered item once it is older than this, whatever the
@@ -286,6 +297,32 @@ class DeliveryService:
             outbox_id,
             provider_message_id,
         )
+        await self._report_to_invitation(
+            outbox_id, provider_message_id=provider_message_id, error=None,
+        )
+
+    async def _report_to_invitation(
+        self, outbox_id: int, *, provider_message_id: str | None, error: str | None,
+    ) -> None:
+        """Tell a check-in invitation, if one rides on this row, how it went.
+
+        This is the only point at which the provider's message id is known,
+        and therefore the only way a later status webhook can ever match the
+        invitation. Best-effort: a bookkeeping failure must not fail the
+        delivery that already happened.
+        """
+        from surogates.programs.delivery import record_outbox_result
+
+        try:
+            await record_outbox_result(
+                self._sf, outbox_id,
+                provider_message_id=provider_message_id, error=error,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "[programs] could not report outbox %d to its invitation",
+                outbox_id, exc_info=True,
+            )
 
     async def mark_failed(self, outbox_id: int, error: str) -> None:
         """Mark an outbox item as failed.
@@ -322,6 +359,12 @@ class DeliveryService:
             )
             await db.commit()
         logger.warning("Outbox %d dropped (no retry): %s", outbox_id, error)
+        # A check-in opener that died here was never seen by the patient. Say
+        # so on the invitation, or the deadline sweep later records them as a
+        # non-responder for a question they were never asked.
+        await self._report_to_invitation(
+            outbox_id, provider_message_id=None, error=error,
+        )
 
     # ------------------------------------------------------------------
     # Real-time notifications (Redis pub/sub)

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -744,6 +744,71 @@ class ChannelInboundPipeline:
             _content = f"{_content}\n{_att_note}" if _content else _att_note
 
         # ------------------------------------------------------------------
+        # Check-in Programs: is this message the reply to a scheduled opener?
+        #
+        # Ordering is the point. The instruction goes in BEFORE the patient's
+        # own message, so the agent reads what it is being asked to do and
+        # then reads the answer — not the other way round.
+        #
+        # The skill's *content* is deliberately not injected: the agent
+        # resolves it from its current bundle, so a doctor correcting a wrong
+        # question reaches check-ins already under way. The bundle version is
+        # recorded on the invitation for the record, not to pin behaviour.
+        # ------------------------------------------------------------------
+        try:
+            from surogates.programs.inbound import (
+                attach_reply,
+                get_occurrence,
+                open_invitation_for,
+            )
+
+            _invitation = await open_invitation_for(
+                deps.session_factory,
+                org_id=routing.org_id,
+                agent_id=routing.agent_id,
+                platform=routing.platform,
+                platform_user_id=msg.platform_user_id,
+            )
+            if _invitation is not None:
+                _occurrence = await get_occurrence(
+                    deps.session_factory, _invitation.occurrence_id,
+                )
+                _skill_ref = getattr(_occurrence, "skill_ref", "") or ""
+                await attach_reply(
+                    deps.session_factory,
+                    _invitation,
+                    session_id=session_id,
+                    bundle_version=getattr(
+                        getattr(deps, "runtime_config", None),
+                        "bundle_version",
+                        None,
+                    ),
+                )
+                await deps.session_store.emit_synthetic_user_message(
+                    session_id,
+                    content=(
+                        f"[Check-in] Run the '{_skill_ref}' skill with this "
+                        "person now. Record the result with checkin_outcome "
+                        "when the check-in ends; use checkin_escalate if "
+                        "anything needs the doctor's attention."
+                    ),
+                    synthetic="checkin",
+                    metadata={
+                        "program_id": str(_invitation.program_id),
+                        "occurrence_id": str(_invitation.occurrence_id),
+                        "skill_ref": _skill_ref,
+                    },
+                )
+        except Exception:  # noqa: BLE001
+            # A patient's message must still reach their agent even if the
+            # check-in bookkeeping fails; the alternative is dropping a reply
+            # that may be clinically urgent.
+            logger.warning(
+                "[programs] could not attach check-in for %s on %s",
+                msg.platform_user_id, routing.agent_id, exc_info=True,
+            )
+
+        # ------------------------------------------------------------------
         # Gate 7: Emit USER_MESSAGE event.
         # ------------------------------------------------------------------
         event_data: dict = {

--- a/surogates/channels/inbound.py
+++ b/surogates/channels/inbound.py
@@ -746,65 +746,26 @@ class ChannelInboundPipeline:
         # ------------------------------------------------------------------
         # Check-in Programs: is this message the reply to a scheduled opener?
         #
-        # Ordering is the point. The instruction goes in BEFORE the patient's
-        # own message, so the agent reads what it is being asked to do and
-        # then reads the answer — not the other way round.
-        #
-        # The skill's *content* is deliberately not injected: the agent
-        # resolves it from its current bundle, so a doctor correcting a wrong
-        # question reaches check-ins already under way. The bundle version is
-        # recorded on the invitation for the record, not to pin behaviour.
+        # Only the lookup happens here. The writes — marking the invitation
+        # replied and injecting the instruction — wait until the message has
+        # cleared every gate that can still drop it, because a check-in
+        # recorded as answered for a reply that was then dropped is a false
+        # record on a clinical timeline.
         # ------------------------------------------------------------------
+        _checkin_invitation = None
         try:
-            from surogates.programs.inbound import (
-                attach_reply,
-                get_occurrence,
-                open_invitation_for,
-            )
+            from surogates.programs.inbound import open_invitation_for
 
-            _invitation = await open_invitation_for(
+            _checkin_invitation = await open_invitation_for(
                 deps.session_factory,
                 org_id=routing.org_id,
                 agent_id=routing.agent_id,
                 platform=routing.platform,
                 platform_user_id=msg.platform_user_id,
             )
-            if _invitation is not None:
-                _occurrence = await get_occurrence(
-                    deps.session_factory, _invitation.occurrence_id,
-                )
-                _skill_ref = getattr(_occurrence, "skill_ref", "") or ""
-                await attach_reply(
-                    deps.session_factory,
-                    _invitation,
-                    session_id=session_id,
-                    bundle_version=getattr(
-                        getattr(deps, "runtime_config", None),
-                        "bundle_version",
-                        None,
-                    ),
-                )
-                await deps.session_store.emit_synthetic_user_message(
-                    session_id,
-                    content=(
-                        f"[Check-in] Run the '{_skill_ref}' skill with this "
-                        "person now. Record the result with checkin_outcome "
-                        "when the check-in ends; use checkin_escalate if "
-                        "anything needs the doctor's attention."
-                    ),
-                    synthetic="checkin",
-                    metadata={
-                        "program_id": str(_invitation.program_id),
-                        "occurrence_id": str(_invitation.occurrence_id),
-                        "skill_ref": _skill_ref,
-                    },
-                )
         except Exception:  # noqa: BLE001
-            # A patient's message must still reach their agent even if the
-            # check-in bookkeeping fails; the alternative is dropping a reply
-            # that may be clinically urgent.
             logger.warning(
-                "[programs] could not attach check-in for %s on %s",
+                "[programs] check-in lookup failed for %s on %s",
                 msg.platform_user_id, routing.agent_id, exc_info=True,
             )
 
@@ -906,6 +867,65 @@ class ChannelInboundPipeline:
                     exc_info=True,
                 )
                 return InboundOutcome.DROPPED
+
+        # ------------------------------------------------------------------
+        # Check-in Programs: attach the reply and inject the instruction.
+        #
+        # Past every gate that can drop the message, and BEFORE the patient's
+        # own message is emitted — the agent has to read what it is being
+        # asked to do, then read the answer, not the other way round.
+        #
+        # Only on the first reply. Every later message of the same check-in
+        # matches the same open invitation; re-injecting the instruction
+        # before each one told the agent to start the questionnaire "now"
+        # four times in a four-question check-in.
+        #
+        # The skill's *content* is deliberately not injected: the agent
+        # resolves it from its current bundle, so a doctor correcting a wrong
+        # question reaches check-ins already under way.
+        # ------------------------------------------------------------------
+        if (
+            _checkin_invitation is not None
+            and _checkin_invitation.response_state == "awaiting_reply"
+        ):
+            try:
+                from surogates.programs.inbound import attach_reply, get_occurrence
+
+                _occurrence = await get_occurrence(
+                    deps.session_factory, _checkin_invitation.occurrence_id,
+                )
+                _skill_ref = getattr(_occurrence, "skill_ref", "") or ""
+                await attach_reply(
+                    deps.session_factory,
+                    _checkin_invitation,
+                    session_id=session_id,
+                    # The runtime config carries no bundle version today, so
+                    # this stays None rather than recording a guess.
+                    bundle_version=None,
+                )
+                await deps.session_store.emit_synthetic_user_message(
+                    session_id,
+                    content=(
+                        f"[Check-in] Run the '{_skill_ref}' skill with this "
+                        "person now. Record the result with checkin_outcome "
+                        "when the check-in ends; use checkin_escalate if "
+                        "anything needs the doctor's attention."
+                    ),
+                    synthetic="checkin",
+                    metadata={
+                        "program_id": str(_checkin_invitation.program_id),
+                        "occurrence_id": str(_checkin_invitation.occurrence_id),
+                        "skill_ref": _skill_ref,
+                    },
+                )
+            except Exception:  # noqa: BLE001
+                # A patient's message must still reach their agent even if the
+                # check-in bookkeeping fails; the alternative is dropping a
+                # reply that may be clinically urgent.
+                logger.warning(
+                    "[programs] could not attach check-in for %s on %s",
+                    msg.platform_user_id, routing.agent_id, exc_info=True,
+                )
 
         await deps.session_store.emit_event(
             session_id,

--- a/surogates/channels/platforms/whatsapp.py
+++ b/surogates/channels/platforms/whatsapp.py
@@ -578,6 +578,15 @@ class WhatsAppPlatform:
             # conversation.  Free-form text here comes back 131047, which is
             # permanent, so the opener would be dropped with nothing surfaced
             # to the operator.
+            if not isinstance(template, dict) or not template.get("name") or not template.get("language"):
+                # Nothing to retry: the payload can never become sendable.
+                # The wording is in the permanent-error list so the dispatcher
+                # drops it now instead of posting sixty times over half an
+                # hour and then reporting only "'language'".
+                return SendResult(
+                    success=False,
+                    error="template payload incomplete: name and language required",
+                )
             wamid, error = await send_message(
                 self._http,
                 token=token,

--- a/surogates/channels/platforms/whatsapp.py
+++ b/surogates/channels/platforms/whatsapp.py
@@ -51,6 +51,7 @@ from surogates.channels.platforms.whatsapp_api import (
 from surogates.channels.platforms.whatsapp_format import render_whatsapp
 from surogates.channels.registry import ChannelDescriptor, VerificationResult
 from surogates.channels.text_split import split_text
+from surogates.programs.delivery import schedule_status_apply
 
 __all__ = [
     "WhatsAppPlatform",
@@ -203,6 +204,16 @@ def verify(
 # ---------------------------------------------------------------------------
 
 
+def _status_error_text(status: dict) -> str | None:
+    """Meta's own wording for a failed delivery, if it gave any."""
+    for error in status.get("errors") or []:
+        if isinstance(error, dict):
+            text = error.get("title") or error.get("message")
+            if text:
+                return str(text)
+    return None
+
+
 def _log_statuses(value: dict, *, identifier: str) -> None:
     """Log delivery statuses and inbound errors.
 
@@ -228,6 +239,16 @@ def _log_statuses(value: dict, *, identifier: str) -> None:
                 "[whatsapp] delivery %s pnid=%s wamid=%s",
                 state, identifier, status.get("id"),
             )
+        # A check-in opener's fate lives on its invitation, not only in this
+        # log line: without recording it, a patient we never reached would be
+        # marked a non-responder when the deadline sweep runs.  Fire-and-forget
+        # because parsing is synchronous and a raise here would answer Meta
+        # non-200 and start a retry loop.
+        schedule_status_apply(
+            provider_message_id=str(status.get("id") or ""),
+            status=str(state or ""),
+            reason=_status_error_text(status),
+        )
     for error in value.get("errors") or []:
         logger.warning("[whatsapp] inbound error pnid=%s error=%s", identifier, error)
 
@@ -549,6 +570,33 @@ class WhatsAppPlatform:
             return SendResult(
                 success=False, error="missing whatsapp credentials or destination",
             )
+
+        template = item.payload.get("template")
+        if template:
+            # A scheduled opener is business-initiated: outside the 24-hour
+            # service window only an approved template may open the
+            # conversation.  Free-form text here comes back 131047, which is
+            # permanent, so the opener would be dropped with nothing surfaced
+            # to the operator.
+            wamid, error = await send_message(
+                self._http,
+                token=token,
+                phone_number_id=phone_number_id,
+                payload={
+                    "messaging_product": "whatsapp",
+                    "recipient_type": "individual",
+                    "to": wa_id,
+                    "type": "template",
+                    "template": {
+                        "name": template["name"],
+                        "language": {"code": template["language"]},
+                    },
+                },
+                api_version=api_version,
+            )
+            if wamid is None:
+                return SendResult(success=False, error=error or "send failed")
+            return SendResult(success=True, message_id=wamid)
 
         if item.payload.get("input_prompt"):
             text = _render_input_prompt(item.payload)

--- a/surogates/channels/runner.py
+++ b/surogates/channels/runner.py
@@ -541,6 +541,13 @@ async def run_channels(settings: Any, kind: str | None = None) -> None:
 
     delivery_service = DeliveryService(session_factory=sf, redis_client=redis)
 
+    # Meta's delivery-status webhooks land in THIS process, and the parser
+    # that reads them is synchronous with no database handle. Registering
+    # anywhere else — the ticker, say — satisfies the check and silently
+    # discards every status.
+    from surogates.programs.delivery import register_status_applier
+    register_status_applier(sf)
+
     from surogates.storage.backend import create_backend
     storage = create_backend(settings)
 

--- a/surogates/config.py
+++ b/surogates/config.py
@@ -238,6 +238,16 @@ class WorkerSettings(BaseSettings):
     poll_timeout: int = 5
     api_base_url: str = "http://localhost:8000"
     use_api_for_harness_tools: bool = True
+    # Where the ops server lives, and a runtime-scoped API key for it. Used
+    # only by the check-in Program ticker, to mirror ops' active Programs.
+    #
+    # Both empty by default, and that is the honest default rather than a
+    # placeholder: with no ops endpoint configured the ticker still fires the
+    # schedules it already has, it simply never learns about new ones or
+    # notices a pause. Guessing a URL here would produce a worker that looks
+    # wired and silently reconciles nothing.
+    ops_base_url: str = ""
+    ops_runtime_key: str = ""
     # Per-iteration one-liners, written on the cheap summary model while
     # the turn is still running. They land during the turn rather than
     # after it, so they cost the tail little -- and they are what the

--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Optional
 
@@ -35,6 +35,8 @@ from sqlalchemy.orm import (
 )
 from sqlalchemy.types import TypeDecorator
 
+_UTC = timezone.utc
+
 
 class GUID(TypeDecorator):
     """Platform-independent UUID column.
@@ -61,6 +63,39 @@ class GUID(TypeDecorator):
         if value is None or isinstance(value, uuid.UUID):
             return value
         return uuid.UUID(str(value))
+
+
+class UTCDateTime(TypeDecorator):
+    """A ``timestamptz`` column that is always UTC-aware in Python.
+
+    Two things go wrong with a plain ``DateTime(timezone=True)`` and naive
+    values.  On write, asyncpg's timestamptz encoder interprets a naive
+    datetime as *system local* — so a pod with ``TZ=Europe/Bucharest`` in its
+    values file stores every check-in three hours off, and nothing in a
+    SQLite-backed test can see it.  On read, SQLite hands back naive values
+    while Postgres hands back aware ones, so the same comparison raises on one
+    backend and passes on the other.
+
+    This pins both ends: a naive value is bound as UTC (never local), and every
+    read comes back aware UTC on every backend.  Postgres DDL is unchanged.
+    """
+
+    impl = DateTime(timezone=True)
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return value
+        if value.tzinfo is None:
+            return value.replace(tzinfo=_UTC)
+        return value.astimezone(_UTC)
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return value
+        if value.tzinfo is None:
+            return value.replace(tzinfo=_UTC)
+        return value.astimezone(_UTC)
 
 
 class Base(DeclarativeBase):
@@ -921,14 +956,14 @@ class ProgramScheduleRow(Base):
         Boolean, nullable=False, default=True,
     )
     next_run_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), nullable=True,
+        UTCDateTime(), nullable=True,
     )
     last_run_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), nullable=True,
+        UTCDateTime(), nullable=True,
     )
     locked_by: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     locked_until: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), nullable=True,
+        UTCDateTime(), nullable=True,
     )
 
 
@@ -952,7 +987,7 @@ class ProgramOccurrenceRow(Base):
     org_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
     agent_id: Mapped[str] = mapped_column(Text, nullable=False)
     scheduled_for: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False,
+        UTCDateTime(), nullable=False,
     )
     #: Which skill — not its content.  The skill is read live at reply time so
     #: a doctor can correct a wrong question mid-check-in.
@@ -966,7 +1001,7 @@ class ProgramOccurrenceRow(Base):
         Text, nullable=False, server_default="fired",
     )
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now(),
+        UTCDateTime(), nullable=False, server_default=func.now(),
     )
 
 
@@ -1034,7 +1069,7 @@ class ProgramInvitationRow(Base):
         Text, nullable=False, server_default="none",
     )
     deadline_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), nullable=True,
+        UTCDateTime(), nullable=True,
     )
     session_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         GUID(), nullable=True,
@@ -1046,7 +1081,7 @@ class ProgramInvitationRow(Base):
     #: Why this row is in the state it is, in operator words.
     reason: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now(),
+        UTCDateTime(), nullable=False, server_default=func.now(),
     )
 
 

--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -1013,9 +1013,20 @@ class ProgramInvitationRow(Base):
     delivery_state: Mapped[str] = mapped_column(
         Text, nullable=False, server_default="queued",
     )
-    provider_message_id: Mapped[Optional[str]] = mapped_column(
-        Text, nullable=True,
+    #: The outbox row carrying this opener.  This is the join key the delivery
+    #: loop reports back through: the provider's message id does not exist
+    #: until the dispatcher has actually posted, minutes after enqueue.
+    outbox_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger, nullable=True, index=True,
     )
+    provider_message_id: Mapped[Optional[str]] = mapped_column(
+        Text, nullable=True, index=True,
+    )
+    #: The provider's own wording for a failed send.  Kept apart from
+    #: ``reason`` so a late status webhook can never overwrite the agent's
+    #: clinical note or a skip explanation — the three axes stay separate on
+    #: disk too.
+    delivery_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     response_state: Mapped[str] = mapped_column(
         Text, nullable=False, server_default="not_started",
     )

--- a/surogates/db/models.py
+++ b/surogates/db/models.py
@@ -882,6 +882,164 @@ class AmbientScheduleRow(Base):
 
 
 # ---------------------------------------------------------------------------
+# Check-in Programs
+# ---------------------------------------------------------------------------
+
+
+class ProgramScheduleRow(Base):
+    """The ticker's claim/lock for one active Program.
+
+    Mirrors an ops ``programs`` row.  Deliberately separate from the
+    configuration: the runtime does not read ops tables, and this row holds
+    only what ticking needs.
+    """
+
+    __tablename__ = "program_schedules"
+    __table_args__ = (
+        UniqueConstraint("program_id", name="uq_program_schedule_program"),
+        Index(
+            "idx_program_schedules_due", "active", "next_run_at",
+            postgresql_where=text("active"),
+        ),
+    )
+
+    # Portable Postgres types, as AmbientScheduleRow uses: UUID/JSONB on
+    # Postgres (prod), String/JSON on SQLite so this table is unit-testable
+    # in isolation.  The Postgres DDL is unchanged.
+    id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), primary_key=True, default=uuid.uuid4,
+    )
+    program_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
+    org_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
+    agent_id: Mapped[str] = mapped_column(Text, nullable=False)
+    #: The projected ops configuration, refreshed by reconcile.  The roster
+    #: travels here too, so a tick never calls back into ops.
+    config: Mapped[dict[str, Any]] = mapped_column(
+        JSONB().with_variant(JSON(), "sqlite"), nullable=False, default=dict,
+    )
+    active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True,
+    )
+    next_run_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    last_run_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    locked_by: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    locked_until: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+
+class ProgramOccurrenceRow(Base):
+    """One due time.  Carries what must not change once the check-in starts."""
+
+    __tablename__ = "program_occurrences"
+    __table_args__ = (
+        UniqueConstraint(
+            "program_id", "scheduled_for",
+            name="uq_program_occurrence_instant",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), primary_key=True, default=uuid.uuid4,
+    )
+    program_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), nullable=False, index=True,
+    )
+    org_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
+    agent_id: Mapped[str] = mapped_column(Text, nullable=False)
+    scheduled_for: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )
+    #: Which skill — not its content.  The skill is read live at reply time so
+    #: a doctor can correct a wrong question mid-check-in.
+    skill_ref: Mapped[str] = mapped_column(Text, nullable=False)
+    #: Pinned, unlike the skill: Meta approved this exact text.
+    template_name: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    template_language: Mapped[Optional[str]] = mapped_column(
+        Text, nullable=True,
+    )
+    status: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="fired",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(),
+    )
+
+
+class ProgramInvitationRow(Base):
+    """One patient, one occurrence.
+
+    The pending record the reply path matches on, the run-history row, and the
+    deadline timer — one object, because they are one fact.
+
+    Delivery, response and escalation are three independent axes and must
+    never be collapsed: a send that failed is not a patient who stayed silent.
+    """
+
+    __tablename__ = "program_invitations"
+    __table_args__ = (
+        UniqueConstraint(
+            "occurrence_id", "user_id",
+            name="uq_program_invitation_patient",
+        ),
+        # The inbound lookup.  agent_id is part of the key because
+        # channel_identities is org-scoped and one person can be bound to
+        # several agents — without it, one agent's Program would swallow
+        # another agent's reply.
+        Index(
+            "idx_program_invitations_open",
+            "org_id", "agent_id", "platform", "platform_user_id",
+            "response_state",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), primary_key=True, default=uuid.uuid4,
+    )
+    occurrence_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), nullable=False, index=True,
+    )
+    program_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
+    org_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
+    agent_id: Mapped[str] = mapped_column(Text, nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
+    platform: Mapped[str] = mapped_column(Text, nullable=False)
+    platform_user_id: Mapped[str] = mapped_column(Text, nullable=False)
+
+    delivery_state: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="queued",
+    )
+    provider_message_id: Mapped[Optional[str]] = mapped_column(
+        Text, nullable=True,
+    )
+    response_state: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="not_started",
+    )
+    escalation_state: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="none",
+    )
+    deadline_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    session_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        GUID(), nullable=True,
+    )
+    #: Which bundle version this turn ran against — recorded, not pinned.
+    skill_bundle_version: Mapped[Optional[str]] = mapped_column(
+        Text, nullable=True,
+    )
+    #: Why this row is in the state it is, in operator words.
+    reason: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Browser Profiles
 # ---------------------------------------------------------------------------
 

--- a/surogates/harness/tool_schemas.py
+++ b/surogates/harness/tool_schemas.py
@@ -59,6 +59,9 @@ _KB_TOOLS: frozenset[str] = frozenset({
 })
 _CHANNEL_TOOLS: frozenset[str] = frozenset({
     "fetch_channel_messages", "fetch_channel_file", "mate_ambient_post",
+    # Check-ins only ever run on a channel session; the tools look the
+    # invitation up by session and have nothing to find elsewhere.
+    "checkin_outcome", "checkin_escalate",
 })
 _CRON_TOOLS: frozenset[str] = frozenset({
     "cron_create", "cron_list", "cron_delete",

--- a/surogates/programs/__init__.py
+++ b/surogates/programs/__init__.py
@@ -1,0 +1,1 @@
+"""Scheduled check-in Programs: cadence, scheduling, delivery and replies."""

--- a/surogates/programs/cadence.py
+++ b/surogates/programs/cadence.py
@@ -35,12 +35,17 @@ def next_occurrences(
 ) -> list[datetime]:
     """The next *count* fire instants strictly after *after*.
 
-    *after* and the returned instants are naive UTC.  Returns fewer than
+    The returned instants are **aware UTC**.  *after* may be aware or naive;
+    a naive value is taken as UTC, never as local time.  Returns fewer than
     *count* — possibly none — when the cadence is empty or cannot be
     satisfied within the scan window.
     """
     if not weekdays or not times_local:
         return []
+    if after.tzinfo is None:
+        after = after.replace(tzinfo=_UTC)
+    else:
+        after = after.astimezone(_UTC)
 
     tz = ZoneInfo(timezone)
     wanted = {_WEEKDAYS[d] for d in weekdays if d in _WEEKDAYS}
@@ -53,7 +58,7 @@ def next_occurrences(
     )
 
     found: list[datetime] = []
-    day = after.replace(tzinfo=_UTC).astimezone(tz).date()
+    day = after.astimezone(tz).date()
     for _ in range(_MAX_DAYS_SCANNED):
         if day.weekday() in wanted:
             # Resolve every slot to a real instant BEFORE ordering them.
@@ -68,9 +73,7 @@ def next_occurrences(
             # it fires once. `set` collapses two slots that a sub-hour shift
             # maps onto the same instant.
             for utc in sorted({
-                datetime.combine(day, slot, tzinfo=tz)
-                .astimezone(_UTC)
-                .replace(tzinfo=None)
+                datetime.combine(day, slot, tzinfo=tz).astimezone(_UTC)
                 for slot in parsed
             }):
                 if utc > after and utc not in found:

--- a/surogates/programs/cadence.py
+++ b/surogates/programs/cadence.py
@@ -1,0 +1,70 @@
+"""Turn a Program's cadence into UTC instants.
+
+A cadence is a weekday set plus local times in a named zone.  Not cron: the
+operator UI has to preview the next occurrences and explain DST, and both are
+near-impossible to express over a cron string.
+
+"Every 12 hours" is expressed as two times of day, never as an interval.  An
+interval anchored to a start instant drifts, and eventually asks a patient for
+their blood pressure at 03:00.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+_UTC = ZoneInfo("UTC")
+
+_WEEKDAYS = {
+    "mon": 0, "tue": 1, "wed": 2, "thu": 3, "fri": 4, "sat": 5, "sun": 6,
+}
+
+#: A year of any weekday set fits comfortably; the bound only stops an empty
+#: or unsatisfiable cadence from looping forever.
+_MAX_DAYS_SCANNED = 400
+
+
+def next_occurrences(
+    after: datetime,
+    *,
+    weekdays: list[str],
+    times_local: list[str],
+    timezone: str,
+    count: int = 1,
+) -> list[datetime]:
+    """The next *count* fire instants strictly after *after*.
+
+    *after* and the returned instants are naive UTC.  Returns fewer than
+    *count* — possibly none — when the cadence is empty or cannot be
+    satisfied within the scan window.
+    """
+    if not weekdays or not times_local:
+        return []
+
+    tz = ZoneInfo(timezone)
+    wanted = {_WEEKDAYS[d] for d in weekdays if d in _WEEKDAYS}
+    if not wanted:
+        return []
+
+    parsed = sorted(
+        time(int(hh), int(mm))
+        for hh, _, mm in (t.partition(":") for t in times_local)
+    )
+
+    found: list[datetime] = []
+    day = after.replace(tzinfo=_UTC).astimezone(tz).date()
+    for _ in range(_MAX_DAYS_SCANNED):
+        if day.weekday() in wanted:
+            for slot in parsed:
+                local = datetime.combine(day, slot, tzinfo=tz)
+                # A nonexistent local time (spring forward) resolves to a
+                # real instant rather than raising; a repeated one (autumn
+                # back) resolves to its first occurrence, so it fires once.
+                utc = local.astimezone(_UTC).replace(tzinfo=None)
+                if utc > after and utc not in found:
+                    found.append(utc)
+                    if len(found) == count:
+                        return found
+        day += timedelta(days=1)
+    return found

--- a/surogates/programs/cadence.py
+++ b/surogates/programs/cadence.py
@@ -56,12 +56,23 @@ def next_occurrences(
     day = after.replace(tzinfo=_UTC).astimezone(tz).date()
     for _ in range(_MAX_DAYS_SCANNED):
         if day.weekday() in wanted:
-            for slot in parsed:
-                local = datetime.combine(day, slot, tzinfo=tz)
-                # A nonexistent local time (spring forward) resolves to a
-                # real instant rather than raising; a repeated one (autumn
-                # back) resolves to its first occurrence, so it fires once.
-                utc = local.astimezone(_UTC).replace(tzinfo=None)
+            # Resolve every slot to a real instant BEFORE ordering them.
+            # Local time-of-day is not monotone across a spring-forward gap:
+            # a nonexistent 02:30 resolves with the pre-transition offset and
+            # lands *after* a real 03:00, so ordering by the typed string
+            # returns them backwards and, at count=1, hands back the later
+            # instant while the earlier slot is never fired at all.
+            #
+            # A nonexistent local time still resolves rather than raising; a
+            # repeated one (autumn back) resolves to its first occurrence, so
+            # it fires once. `set` collapses two slots that a sub-hour shift
+            # maps onto the same instant.
+            for utc in sorted({
+                datetime.combine(day, slot, tzinfo=tz)
+                .astimezone(_UTC)
+                .replace(tzinfo=None)
+                for slot in parsed
+            }):
                 if utc > after and utc not in found:
                     found.append(utc)
                     if len(found) == count:

--- a/surogates/programs/delivery.py
+++ b/surogates/programs/delivery.py
@@ -1,0 +1,105 @@
+"""Apply WhatsApp delivery-status callbacks to check-in invitations.
+
+Meta reports send failures asynchronously: the ``POST /messages`` call returns
+200 with a message id, and only a later status webhook says the message was
+never delivered.  The channel parser logs those and drops them, so without this
+a patient we never reached would sit at ``awaiting_reply`` until the deadline
+sweep marked them a non-responder — blaming the patient for our failure to
+reach them.
+
+This touches the **delivery** axis only.  Response and escalation are separate
+facts and must never move because of a delivery status.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import sqlalchemy as sa
+
+from surogates.db.models import ProgramInvitationRow
+
+logger = logging.getLogger(__name__)
+
+#: Meta status values worth recording.  Anything else (``read``, ``sent``)
+#: tells us nothing the invitation does not already know.
+_DELIVERY_STATES = {"delivered", "failed", "undelivered"}
+
+#: Set once at worker startup by :func:`register_status_applier`.  The channel
+#: parser is synchronous and holds no database handle, so it cannot apply a
+#: status itself; this is the seam that lets it hand one over.
+_session_factory: Any | None = None
+
+
+def register_status_applier(session_factory: Any) -> None:
+    """Give the channel parser a database handle for delivery statuses."""
+    global _session_factory
+    _session_factory = session_factory
+
+
+def schedule_status_apply(
+    *, provider_message_id: str, status: str, reason: str | None,
+) -> None:
+    """Fire-and-forget a status update from synchronous parsing code.
+
+    Deliberately non-blocking and failure-tolerant: a status webhook that
+    raises would be answered non-200, and Meta would retry it in a loop.  A
+    lost status costs one stale delivery_state; a retry loop costs the channel.
+    """
+    if _session_factory is None or status not in _DELIVERY_STATES:
+        return
+    try:
+        asyncio.get_running_loop().create_task(
+            apply_status_callback(
+                _session_factory,
+                provider_message_id=provider_message_id,
+                status=status,
+                reason=reason,
+            )
+        )
+    except RuntimeError:
+        # Parsed outside an event loop (a unit test, a CLI). Nothing to do.
+        pass
+
+
+async def apply_status_callback(
+    session_factory: Any,
+    *,
+    provider_message_id: str,
+    status: str,
+    reason: str | None,
+) -> bool:
+    """Record *status* against the invitation carrying *provider_message_id*.
+
+    Returns ``True`` when an invitation matched.  Most statuses belong to
+    ordinary replies with no invitation behind them, so ``False`` is the common
+    case and is not an error.
+    """
+    if not provider_message_id:
+        return False
+
+    async with session_factory() as db:
+        row = (
+            await db.execute(
+                sa.select(ProgramInvitationRow)
+                .where(
+                    ProgramInvitationRow.provider_message_id
+                    == provider_message_id
+                )
+            )
+        ).scalar_one_or_none()
+        if row is None:
+            return False
+
+        row.delivery_state = status
+        if reason:
+            row.reason = reason[:500]
+        await db.commit()
+
+    logger.info(
+        "[programs] delivery %s for invitation carrying %s",
+        status, provider_message_id,
+    )
+    return True

--- a/surogates/programs/delivery.py
+++ b/surogates/programs/delivery.py
@@ -1,14 +1,21 @@
-"""Apply WhatsApp delivery-status callbacks to check-in invitations.
+"""Keep an invitation's delivery axis in step with what actually happened.
 
-Meta reports send failures asynchronously: the ``POST /messages`` call returns
-200 with a message id, and only a later status webhook says the message was
-never delivered.  The channel parser logs those and drops them, so without this
-a patient we never reached would sit at ``awaiting_reply`` until the deadline
-sweep marked them a non-responder — blaming the patient for our failure to
-reach them.
+Two things feed it, both from the **channels** process — the one that runs the
+outbox dispatcher and receives Meta's webhooks:
 
-This touches the **delivery** axis only.  Response and escalation are separate
-facts and must never move because of a delivery status.
+* the dispatcher's own result, via :func:`record_outbox_result`, which is how
+  the invitation learns the provider's message id in the first place.  That
+  id does not exist until the dispatcher has posted, minutes after enqueue,
+  so the invitation is keyed on the outbox row and the dispatcher reports
+  back through it;
+* Meta's asynchronous status webhooks, via :func:`apply_status_callback`.
+  ``POST /messages`` returns 200 with an id and only a later webhook says
+  the message was never delivered.  Dropping that would leave a patient we
+  never reached at ``awaiting_reply`` until the sweep marked them a
+  non-responder — blaming the patient for our failure.
+
+This module touches the **delivery** axis only.  Response and escalation are
+separate facts and must never move because of a delivery event.
 """
 
 from __future__ import annotations
@@ -23,45 +30,80 @@ from surogates.db.models import ProgramInvitationRow
 
 logger = logging.getLogger(__name__)
 
-#: Meta status values worth recording.  Anything else (``read``, ``sent``)
-#: tells us nothing the invitation does not already know.
-_DELIVERY_STATES = {"delivered", "failed", "undelivered"}
+#: Delivery states in the order they may advance.  A status may move a row
+#: forward along this line, never back: Meta batches statuses and retries
+#: un-acknowledged webhooks, so a stale ``delivered`` can arrive after a
+#: ``failed`` and must not resurrect a send that was already known lost.
+_ORDER = {"queued": 0, "accepted": 1, "delivered": 2, "failed": 3, "undelivered": 3}
 
-#: Set once at worker startup by :func:`register_status_applier`.  The channel
-#: parser is synchronous and holds no database handle, so it cannot apply a
-#: status itself; this is the seam that lets it hand one over.
+#: Meta status values worth recording.  ``sent`` and ``read`` add nothing the
+#: invitation does not already know.
+_DELIVERY_STATES = frozenset({"delivered", "failed", "undelivered"})
+
+#: Set once at channels-process startup.  The webhook parser is synchronous
+#: and holds no database handle, so it hands statuses over through this.
 _session_factory: Any | None = None
+
+#: Strong references to in-flight status tasks.  asyncio keeps only a weak
+#: reference to a running task, so without this a status write could be
+#: garbage-collected mid-flight.
+_inflight: set[asyncio.Task] = set()
 
 
 def register_status_applier(session_factory: Any) -> None:
-    """Give the channel parser a database handle for delivery statuses."""
+    """Give the webhook parser a database handle for delivery statuses.
+
+    Must be called in the process that receives the webhooks.  Registering
+    it anywhere else satisfies the check and silently discards every status.
+    """
     global _session_factory
     _session_factory = session_factory
 
 
-def schedule_status_apply(
-    *, provider_message_id: str, status: str, reason: str | None,
-) -> None:
-    """Fire-and-forget a status update from synchronous parsing code.
+def _advance(row: ProgramInvitationRow, status: str) -> bool:
+    """Move the delivery axis forward to *status*; refuse to move it back."""
+    if _ORDER.get(status, -1) < _ORDER.get(row.delivery_state, -1):
+        return False
+    row.delivery_state = status
+    return True
 
-    Deliberately non-blocking and failure-tolerant: a status webhook that
-    raises would be answered non-200, and Meta would retry it in a loop.  A
-    lost status costs one stale delivery_state; a retry loop costs the channel.
+
+async def record_outbox_result(
+    session_factory: Any,
+    outbox_id: int,
+    *,
+    provider_message_id: str | None,
+    error: str | None,
+) -> bool:
+    """The dispatcher's verdict on the outbox row carrying an opener.
+
+    On success the invitation learns its provider id — the only key a later
+    status webhook can match on — and advances to ``accepted``.  On a
+    permanent failure it advances to ``failed`` with the provider's wording.
+
+    Returns ``True`` when an invitation was keyed on *outbox_id*.  Almost every
+    outbox row is an ordinary reply with no invitation behind it, so ``False``
+    is the common case and not an error.
     """
-    if _session_factory is None or status not in _DELIVERY_STATES:
-        return
-    try:
-        asyncio.get_running_loop().create_task(
-            apply_status_callback(
-                _session_factory,
-                provider_message_id=provider_message_id,
-                status=status,
-                reason=reason,
+    async with session_factory() as db:
+        row = (
+            await db.execute(
+                sa.select(ProgramInvitationRow)
+                .where(ProgramInvitationRow.outbox_id == outbox_id)
             )
-        )
-    except RuntimeError:
-        # Parsed outside an event loop (a unit test, a CLI). Nothing to do.
-        pass
+        ).scalar_one_or_none()
+        if row is None:
+            return False
+
+        if error:
+            _advance(row, "failed")
+            row.delivery_error = error[:500]
+        else:
+            if provider_message_id:
+                row.provider_message_id = provider_message_id
+            _advance(row, "accepted")
+        await db.commit()
+    return True
 
 
 async def apply_status_callback(
@@ -71,13 +113,12 @@ async def apply_status_callback(
     status: str,
     reason: str | None,
 ) -> bool:
-    """Record *status* against the invitation carrying *provider_message_id*.
+    """Record a Meta status against the invitation carrying *provider_message_id*.
 
     Returns ``True`` when an invitation matched.  Most statuses belong to
-    ordinary replies with no invitation behind them, so ``False`` is the common
-    case and is not an error.
+    ordinary replies with no invitation behind them.
     """
-    if not provider_message_id:
+    if not provider_message_id or status not in _DELIVERY_STATES:
         return False
 
     async with session_factory() as db:
@@ -93,13 +134,51 @@ async def apply_status_callback(
         if row is None:
             return False
 
-        row.delivery_state = status
-        if reason:
-            row.reason = reason[:500]
+        moved = _advance(row, status)
+        if moved and reason and status in ("failed", "undelivered"):
+            row.delivery_error = reason[:500]
         await db.commit()
 
-    logger.info(
-        "[programs] delivery %s for invitation carrying %s",
-        status, provider_message_id,
-    )
+    if moved:
+        logger.info(
+            "[programs] delivery %s for invitation carrying %s",
+            status, provider_message_id,
+        )
     return True
+
+
+def schedule_status_apply(
+    *, provider_message_id: str, status: str, reason: str | None,
+) -> None:
+    """Fire-and-forget a status update from synchronous parsing code.
+
+    Deliberately non-blocking and failure-tolerant: a webhook that raises is
+    answered non-200 and Meta retries it in a loop.  A lost status costs one
+    stale ``delivery_state``; a retry loop costs the channel.
+    """
+    if _session_factory is None or status not in _DELIVERY_STATES:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return  # parsed outside an event loop (a unit test, a CLI)
+
+    task = loop.create_task(
+        apply_status_callback(
+            _session_factory,
+            provider_message_id=provider_message_id,
+            status=status,
+            reason=reason,
+        )
+    )
+    _inflight.add(task)
+
+    def _done(t: asyncio.Task) -> None:
+        _inflight.discard(t)
+        if not t.cancelled() and t.exception() is not None:
+            logger.warning(
+                "[programs] status %s for %s was not recorded",
+                status, provider_message_id, exc_info=t.exception(),
+            )
+
+    task.add_done_callback(_done)

--- a/surogates/programs/delivery.py
+++ b/surogates/programs/delivery.py
@@ -98,6 +98,11 @@ async def record_outbox_result(
         if error:
             _advance(row, "failed")
             row.delivery_error = error[:500]
+            if row.response_state == "awaiting_reply":
+                # Nobody was asked, so nobody is awaited.  Left at
+                # ``awaiting_reply`` the row counts as an open check-in and
+                # suppresses this patient's next occurrence for good.
+                row.response_state = "not_started"
         else:
             if provider_message_id:
                 row.provider_message_id = provider_message_id

--- a/surogates/programs/inbound.py
+++ b/surogates/programs/inbound.py
@@ -1,0 +1,82 @@
+"""Recognise an inbound message as the reply to a check-in.
+
+The match is on ``(org_id, agent_id, platform, platform_user_id)`` and an open
+response state.  ``agent_id`` is part of the key because ``channel_identities``
+is org-scoped and one person can be bound to several agents: without it, one
+agent's Program would swallow another agent's reply.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import sqlalchemy as sa
+
+from surogates.db.models import ProgramInvitationRow, ProgramOccurrenceRow
+
+#: An invitation is still "open" while the patient has been asked and the
+#: agent has not recorded an outcome.  A completed or declined check-in is
+#: finished: the patient's next message is ordinary conversation.
+_OPEN_STATES = ("awaiting_reply", "replied", "in_progress")
+
+
+async def open_invitation_for(
+    session_factory: Any,
+    *,
+    org_id: uuid.UUID,
+    agent_id: str,
+    platform: str,
+    platform_user_id: str,
+) -> ProgramInvitationRow | None:
+    """The newest open invitation this sender is answering, if any."""
+    async with session_factory() as db:
+        return (
+            await db.execute(
+                sa.select(ProgramInvitationRow)
+                .where(ProgramInvitationRow.org_id == org_id)
+                .where(ProgramInvitationRow.agent_id == agent_id)
+                .where(ProgramInvitationRow.platform == platform)
+                .where(
+                    ProgramInvitationRow.platform_user_id == platform_user_id
+                )
+                .where(ProgramInvitationRow.response_state.in_(_OPEN_STATES))
+                .order_by(ProgramInvitationRow.created_at.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+
+async def get_occurrence(
+    session_factory: Any, occurrence_id: uuid.UUID,
+) -> ProgramOccurrenceRow | None:
+    async with session_factory() as db:
+        return await db.get(ProgramOccurrenceRow, occurrence_id)
+
+
+async def attach_reply(
+    session_factory: Any,
+    invitation: ProgramInvitationRow,
+    *,
+    session_id: uuid.UUID,
+    bundle_version: str | None,
+) -> None:
+    """Bind this check-in to the session the reply is being handled in.
+
+    Stamping ``session_id`` is what makes the outcome tools unspoofable: they
+    find the invitation *by session*, so an agent in an ordinary conversation
+    cannot close or escalate a check-in it is not part of.
+
+    ``skill_bundle_version`` is recorded, not pinned — the skill itself is
+    resolved live, so a doctor correcting a wrong question reaches check-ins
+    already under way.
+    """
+    async with session_factory() as db:
+        row = await db.get(ProgramInvitationRow, invitation.id)
+        if row is None:
+            return
+        row.response_state = "replied"
+        row.session_id = session_id
+        if bundle_version:
+            row.skill_bundle_version = str(bundle_version)
+        await db.commit()

--- a/surogates/programs/materialize.py
+++ b/surogates/programs/materialize.py
@@ -10,7 +10,7 @@ the record instead of being the thing the operator needs to see.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 import sqlalchemy as sa
@@ -20,11 +20,15 @@ from surogates.db.models import (
     ChannelIdentity,
     ProgramInvitationRow,
     ProgramOccurrenceRow,
+    ProgramScheduleRow,
 )
 
 #: Response states meaning "this person is mid-check-in".  A patient in one of
 #: these must not be handed a second opener.
 _OPEN_RESPONSE_STATES = ("replied", "in_progress")
+
+#: Used when a Program's projected config carries no deadline of its own.
+_DEFAULT_DEADLINE_HOURS = 24
 
 
 def _permission(identity: Any) -> str:
@@ -135,6 +139,93 @@ async def materialize_occurrence(
             )
         await db.commit()
         return occ.id
+
+
+async def send_queued_openers(
+    session_factory: Any,
+    *,
+    identity_lookup: Any,
+    now: datetime,
+    enqueue: Any = None,
+) -> int:
+    """Re-check permission on every queued opener, then hand on the survivors.
+
+    The permission re-check is not belt-and-braces.  It is the only mechanism
+    by which a withdrawal reaches an opener that is already queued — ops never
+    calls into the runtime to cancel anything — and it closes the race where
+    permission is withdrawn between materialising the occurrence and sending.
+
+    *enqueue* is ``async (invitation) -> str | None`` returning the provider
+    message id.  It is optional so the cancellation pass can be exercised on
+    its own; when it is absent, survivors stay queued for the next tick rather
+    than being silently marked sent.
+
+    Returns the number of invitations cancelled.
+    """
+    cancelled = 0
+    async with session_factory() as db:
+        rows = (
+            await db.execute(
+                sa.select(ProgramInvitationRow)
+                .where(ProgramInvitationRow.delivery_state == "queued")
+                .order_by(ProgramInvitationRow.created_at)
+            )
+        ).scalars().all()
+
+        survivors = []
+        for row in rows:
+            identity = await identity_lookup(
+                row.org_id, row.platform, row.user_id,
+            )
+            if identity is None or _permission(identity) != "granted":
+                row.delivery_state = "canceled"
+                row.reason = "Permission withdrawn before the opener was sent"
+                cancelled += 1
+                continue
+            survivors.append(row)
+        await db.commit()
+
+        if enqueue is None:
+            return cancelled
+
+        deadlines = await _deadline_hours_by_program(
+            db, {row.program_id for row in survivors},
+        )
+        for row in survivors:
+            provider_message_id = await enqueue(row)
+            if provider_message_id is None:
+                # The opener was not accepted; leave it queued so the next
+                # tick retries rather than starting a deadline nobody was
+                # asked to meet.
+                continue
+            row.provider_message_id = provider_message_id
+            row.delivery_state = "accepted"
+            row.response_state = "awaiting_reply"
+            row.deadline_at = now + timedelta(
+                hours=deadlines.get(row.program_id, _DEFAULT_DEADLINE_HOURS),
+            )
+        await db.commit()
+
+    return cancelled
+
+
+async def _deadline_hours_by_program(db, program_ids: set) -> dict:
+    """Each Program's response deadline, read from its projected config."""
+    if not program_ids:
+        return {}
+    rows = (
+        await db.execute(
+            sa.select(ProgramScheduleRow.program_id, ProgramScheduleRow.config)
+            .where(ProgramScheduleRow.program_id.in_(program_ids))
+        )
+    ).all()
+    return {
+        program_id: int(
+            (config or {}).get("response_deadline_hours")
+            or _DEFAULT_DEADLINE_HOURS
+        )
+        for program_id, config in rows
+    }
 
 
 def identity_lookup_from(session_factory: Any):

--- a/surogates/programs/materialize.py
+++ b/surogates/programs/materialize.py
@@ -25,7 +25,15 @@ from surogates.db.models import (
 
 #: Response states meaning "this person is mid-check-in".  A patient in one of
 #: these must not be handed a second opener.
-_OPEN_RESPONSE_STATES = ("replied", "in_progress")
+#
+#: ``awaiting_reply`` belongs here.  The canonical cadence is twice a day and
+#: the default response deadline is a full day, so the next occurrence arrives
+#: while the first opener is still live: without it the patient is asked two
+#: questions at once and whichever they do not answer is later swept as a
+#: non-response.  The deadline sweep is what eventually clears these — it runs
+#: first in the tick precisely so an expired opener does not suppress the next
+#: check-in.
+_OPEN_RESPONSE_STATES = ("awaiting_reply", "replied", "in_progress")
 
 #: Used when a Program's projected config carries no deadline of its own.
 _DEFAULT_DEADLINE_HOURS = 24
@@ -50,10 +58,10 @@ async def _existing_occurrence(db, program_id, scheduled_for) -> uuid.UUID:
 async def _has_open_invitation(db, schedule, identity) -> bool:
     """Is this patient already mid-check-in with this agent?
 
-    Deliberately does not filter on ``awaiting_reply``: an unanswered opener is
-    closed by the deadline sweep before the next tick evaluates the roster, so
-    by the time this runs an ``awaiting_reply`` row is either expired or from
-    this same occurrence.
+    Counts an unanswered opener too.  The sweep runs first in the tick, so an
+    ``awaiting_reply`` row still here is one whose deadline has not passed —
+    a live question the patient has yet to answer, and not something to talk
+    over with a second one.
     """
     return (
         await db.execute(

--- a/surogates/programs/materialize.py
+++ b/surogates/programs/materialize.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import sqlalchemy as sa
@@ -191,63 +191,129 @@ async def send_queued_openers(
     failure on the k-th enqueue rolled back the first k-1, whose openers
     were already in the outbox — and the next tick sent them all again.
 
+    Each row is **claimed before** it is handed over: a conditional update
+    flips it to ``awaiting_reply`` and only the worker whose update took
+    effect calls *enqueue*.  The outbox row is committed inside *enqueue* and
+    the invitation learns its id in a later commit; a process that dies in
+    between used to leave a row that looked untouched, and the next tick sent
+    the patient a second approved template.  Now it leaves a claimed row with
+    no outbox id, which the deadline sweep records as a failed delivery — one
+    patient missed and visible, rather than one patient messaged twice.  The
+    same claim is what keeps two replicas from sending the same opener when
+    the leader lease lapses mid-pass.
+
     Returns the number of invitations cancelled.
     """
     cancelled = 0
     async with session_factory() as db:
         rows = (
             await db.execute(
-                sa.select(ProgramInvitationRow)
+                sa.select(ProgramInvitationRow, ProgramOccurrenceRow.scheduled_for)
+                .join(
+                    ProgramOccurrenceRow,
+                    ProgramOccurrenceRow.id == ProgramInvitationRow.occurrence_id,
+                )
                 .where(ProgramInvitationRow.delivery_state == "queued")
                 .where(ProgramInvitationRow.outbox_id.is_(None))
+                .where(ProgramInvitationRow.response_state == "not_started")
                 .order_by(ProgramInvitationRow.created_at)
             )
-        ).scalars().all()
+        ).all()
         deadlines = await _deadline_hours_by_program(
-            db, {row.program_id for row in rows},
+            db, {row.program_id for row, _ in rows},
         )
 
-    for pending in rows:
+    for pending, scheduled_for in rows:
+        window = timedelta(
+            hours=deadlines.get(pending.program_id, _DEFAULT_DEADLINE_HOURS),
+        )
         async with session_factory() as db:
-            row = await db.get(ProgramInvitationRow, pending.id)
-            if row is None or row.delivery_state != "queued" or row.outbox_id is not None:
-                continue  # another worker got here first
+            if scheduled_for is not None and _as_utc(scheduled_for) + window <= now:
+                # The slot's own response window has already closed.  A
+                # "how are you this morning" sent two days late is wrong,
+                # and retrying it every tick forever is worse.
+                await db.execute(_unsent(pending.id).values(
+                    delivery_state="skipped",
+                    reason="Opener not sent within the response window",
+                ))
+                await db.commit()
+                continue
 
             try:
                 identity = await identity_lookup(
-                    row.org_id, row.platform, row.user_id,
+                    pending.org_id, pending.platform, pending.user_id,
                 )
             except Exception:  # noqa: BLE001 — one patient, not the fleet
                 logger.exception(
                     "[programs] identity lookup failed for invitation %s; "
-                    "leaving it queued", row.id,
+                    "leaving it queued", pending.id,
                 )
                 continue
 
             if identity is None or _permission(identity) != "granted":
-                row.delivery_state = "canceled"
-                row.reason = "Permission withdrawn before the opener was sent"
-                cancelled += 1
+                withdrawn = await db.execute(_unsent(pending.id).values(
+                    delivery_state="canceled",
+                    reason="Permission withdrawn before the opener was sent",
+                ))
+                cancelled += int(withdrawn.rowcount or 0)
                 await db.commit()
                 continue
 
             if enqueue is None:
                 continue
 
-            outbox_id = await enqueue(row)
+            claimed = await db.execute(_unsent(pending.id).values(
+                response_state="awaiting_reply", deadline_at=now + window,
+            ))
+            await db.commit()
+            if int(claimed.rowcount or 0) != 1:
+                continue  # another worker got here first
+
+            try:
+                outbox_id = await enqueue(pending)
+            except Exception:
+                await _release(db, pending.id)
+                raise
             if outbox_id is None:
-                # Nothing was handed over; leave it queued so the next tick
+                # Nothing was handed over; give it back so the next tick
                 # retries rather than starting a deadline nobody was asked
                 # to meet.
+                await _release(db, pending.id)
                 continue
-            row.outbox_id = int(outbox_id)
-            row.response_state = "awaiting_reply"
-            row.deadline_at = now + timedelta(
-                hours=deadlines.get(row.program_id, _DEFAULT_DEADLINE_HOURS),
+            await db.execute(
+                sa.update(ProgramInvitationRow)
+                .where(ProgramInvitationRow.id == pending.id)
+                .values(outbox_id=int(outbox_id))
             )
             await db.commit()
 
     return cancelled
+
+
+def _unsent(invitation_id: Any):
+    """An UPDATE that only takes effect while nobody has touched the row."""
+    return (
+        sa.update(ProgramInvitationRow)
+        .where(ProgramInvitationRow.id == invitation_id)
+        .where(ProgramInvitationRow.delivery_state == "queued")
+        .where(ProgramInvitationRow.outbox_id.is_(None))
+        .where(ProgramInvitationRow.response_state == "not_started")
+    )
+
+
+async def _release(db: Any, invitation_id: Any) -> None:
+    """Undo a claim whose enqueue handed nothing over."""
+    await db.execute(
+        sa.update(ProgramInvitationRow)
+        .where(ProgramInvitationRow.id == invitation_id)
+        .where(ProgramInvitationRow.outbox_id.is_(None))
+        .values(response_state="not_started", deadline_at=None)
+    )
+    await db.commit()
+
+
+def _as_utc(value: datetime) -> datetime:
+    return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
 
 
 async def _deadline_hours_by_program(db, program_ids: set) -> dict:

--- a/surogates/programs/materialize.py
+++ b/surogates/programs/materialize.py
@@ -1,0 +1,154 @@
+"""Turn one due instant into an occurrence and one invitation per patient.
+
+Every patient on the roster gets a row whatever the outcome, and a skip is
+recorded on that row rather than dropping it.  The roster is the denominator
+run history counts against: dropping an unreachable patient would quietly turn
+"12 of 14" into "12 of 13", and the two unreachable people would vanish from
+the record instead of being the thing the operator needs to see.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+
+from surogates.db.models import (
+    ChannelIdentity,
+    ProgramInvitationRow,
+    ProgramOccurrenceRow,
+)
+
+#: Response states meaning "this person is mid-check-in".  A patient in one of
+#: these must not be handed a second opener.
+_OPEN_RESPONSE_STATES = ("replied", "in_progress")
+
+
+def _permission(identity: Any) -> str:
+    meta = getattr(identity, "platform_meta", None) or {}
+    return (meta.get("contact_permission") or {}).get("status") or "none"
+
+
+async def _existing_occurrence(db, program_id, scheduled_for) -> uuid.UUID:
+    """The occurrence a racing tick already created for this instant."""
+    return (
+        await db.execute(
+            sa.select(ProgramOccurrenceRow.id)
+            .where(ProgramOccurrenceRow.program_id == program_id)
+            .where(ProgramOccurrenceRow.scheduled_for == scheduled_for)
+        )
+    ).scalar_one()
+
+
+async def _has_open_invitation(db, schedule, identity) -> bool:
+    """Is this patient already mid-check-in with this agent?
+
+    Deliberately does not filter on ``awaiting_reply``: an unanswered opener is
+    closed by the deadline sweep before the next tick evaluates the roster, so
+    by the time this runs an ``awaiting_reply`` row is either expired or from
+    this same occurrence.
+    """
+    return (
+        await db.execute(
+            sa.select(sa.func.count())
+            .select_from(ProgramInvitationRow)
+            .where(ProgramInvitationRow.agent_id == schedule.agent_id)
+            .where(
+                ProgramInvitationRow.platform_user_id
+                == identity.platform_user_id
+            )
+            .where(
+                ProgramInvitationRow.response_state.in_(_OPEN_RESPONSE_STATES)
+            )
+        )
+    ).scalar_one() > 0
+
+
+async def materialize_occurrence(
+    schedule: Any,
+    *,
+    session_factory: Any,
+    identity_lookup: Any,
+    now: datetime,
+) -> uuid.UUID:
+    """Create the occurrence and one invitation per patient.
+
+    Idempotent at both levels — ``(program_id, scheduled_for)`` and
+    ``(occurrence_id, user_id)`` — so a crashed or retried tick is harmless
+    rather than a second message to every patient.
+    """
+    config = schedule.config or {}
+    async with session_factory() as db:
+        occ = ProgramOccurrenceRow(
+            program_id=schedule.program_id,
+            org_id=schedule.org_id,
+            agent_id=schedule.agent_id,
+            scheduled_for=now,
+            skill_ref=config.get("skill_ref", ""),
+            template_name=config.get("template_name"),
+            template_language=config.get("template_language"),
+            status="fired",
+        )
+        db.add(occ)
+        try:
+            await db.flush()
+        except IntegrityError:
+            await db.rollback()
+            return await _existing_occurrence(db, schedule.program_id, now)
+
+        platform = config.get("channel", "whatsapp")
+        for user_id in config.get("patients", []):
+            reason: str | None = None
+            state = "queued"
+            identity = await identity_lookup(
+                schedule.org_id, platform, uuid.UUID(user_id),
+            )
+            if identity is None:
+                reason = f"No {platform} identity"
+                state = "skipped"
+            elif _permission(identity) != "granted":
+                reason = "No permission to message"
+                state = "skipped"
+            elif await _has_open_invitation(db, schedule, identity):
+                reason = "Previous check-in still open"
+                state = "skipped"
+
+            db.add(
+                ProgramInvitationRow(
+                    occurrence_id=occ.id,
+                    program_id=schedule.program_id,
+                    org_id=schedule.org_id,
+                    agent_id=schedule.agent_id,
+                    user_id=uuid.UUID(user_id),
+                    platform=platform,
+                    platform_user_id=(
+                        identity.platform_user_id if identity else ""
+                    ),
+                    delivery_state=state,
+                    response_state="not_started",
+                    escalation_state="none",
+                    reason=reason,
+                )
+            )
+        await db.commit()
+        return occ.id
+
+
+def identity_lookup_from(session_factory: Any):
+    """The production identity lookup: the patient's ``channel_identities`` row."""
+
+    async def _lookup(org_id, platform, user_id):
+        async with session_factory() as db:
+            return (
+                await db.execute(
+                    sa.select(ChannelIdentity)
+                    .where(ChannelIdentity.org_id == org_id)
+                    .where(ChannelIdentity.platform == platform)
+                    .where(ChannelIdentity.user_id == user_id)
+                )
+            ).scalar_one_or_none()
+
+    return _lookup

--- a/surogates/programs/materialize.py
+++ b/surogates/programs/materialize.py
@@ -9,6 +9,7 @@ the record instead of being the thing the operator needs to see.
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import datetime, timedelta
 from typing import Any
@@ -22,6 +23,8 @@ from surogates.db.models import (
     ProgramOccurrenceRow,
     ProgramScheduleRow,
 )
+
+logger = logging.getLogger(__name__)
 
 #: Response states meaning "this person is mid-check-in".  A patient in one of
 #: these must not be handed a second opener.
@@ -163,10 +166,16 @@ async def send_queued_openers(
     calls into the runtime to cancel anything — and it closes the race where
     permission is withdrawn between materialising the occurrence and sending.
 
-    *enqueue* is ``async (invitation) -> str | None`` returning the provider
-    message id.  It is optional so the cancellation pass can be exercised on
-    its own; when it is absent, survivors stay queued for the next tick rather
-    than being silently marked sent.
+    *enqueue* is ``async (invitation) -> int | None`` returning the **outbox
+    row id** — never a provider message id, which does not exist until the
+    dispatcher has posted.  The invitation is keyed on that row and the
+    dispatcher reports the provider id back through it.  It is optional so
+    the cancellation pass can be exercised alone; production always passes
+    it, and the ticker refuses to start without one.
+
+    Every row is committed on its own.  A single commit at the end meant a
+    failure on the k-th enqueue rolled back the first k-1, whose openers
+    were already in the outbox — and the next tick sent them all again.
 
     Returns the number of invitations cancelled.
     """
@@ -176,43 +185,53 @@ async def send_queued_openers(
             await db.execute(
                 sa.select(ProgramInvitationRow)
                 .where(ProgramInvitationRow.delivery_state == "queued")
+                .where(ProgramInvitationRow.outbox_id.is_(None))
                 .order_by(ProgramInvitationRow.created_at)
             )
         ).scalars().all()
+        deadlines = await _deadline_hours_by_program(
+            db, {row.program_id for row in rows},
+        )
 
-        survivors = []
-        for row in rows:
-            identity = await identity_lookup(
-                row.org_id, row.platform, row.user_id,
-            )
+    for pending in rows:
+        async with session_factory() as db:
+            row = await db.get(ProgramInvitationRow, pending.id)
+            if row is None or row.delivery_state != "queued" or row.outbox_id is not None:
+                continue  # another worker got here first
+
+            try:
+                identity = await identity_lookup(
+                    row.org_id, row.platform, row.user_id,
+                )
+            except Exception:  # noqa: BLE001 — one patient, not the fleet
+                logger.exception(
+                    "[programs] identity lookup failed for invitation %s; "
+                    "leaving it queued", row.id,
+                )
+                continue
+
             if identity is None or _permission(identity) != "granted":
                 row.delivery_state = "canceled"
                 row.reason = "Permission withdrawn before the opener was sent"
                 cancelled += 1
+                await db.commit()
                 continue
-            survivors.append(row)
-        await db.commit()
 
-        if enqueue is None:
-            return cancelled
-
-        deadlines = await _deadline_hours_by_program(
-            db, {row.program_id for row in survivors},
-        )
-        for row in survivors:
-            provider_message_id = await enqueue(row)
-            if provider_message_id is None:
-                # The opener was not accepted; leave it queued so the next
-                # tick retries rather than starting a deadline nobody was
-                # asked to meet.
+            if enqueue is None:
                 continue
-            row.provider_message_id = provider_message_id
-            row.delivery_state = "accepted"
+
+            outbox_id = await enqueue(row)
+            if outbox_id is None:
+                # Nothing was handed over; leave it queued so the next tick
+                # retries rather than starting a deadline nobody was asked
+                # to meet.
+                continue
+            row.outbox_id = int(outbox_id)
             row.response_state = "awaiting_reply"
             row.deadline_at = now + timedelta(
                 hours=deadlines.get(row.program_id, _DEFAULT_DEADLINE_HOURS),
             )
-        await db.commit()
+            await db.commit()
 
     return cancelled
 
@@ -241,13 +260,19 @@ def identity_lookup_from(session_factory: Any):
 
     async def _lookup(org_id, platform, user_id):
         async with session_factory() as db:
+            # Newest first, and never scalar_one: nothing unique guards
+            # (org, platform, user), so a patient whose new number was linked
+            # without removing the old one has two rows, and raising here
+            # would stop every opener in the fleet on this patient's account.
             return (
                 await db.execute(
                     sa.select(ChannelIdentity)
                     .where(ChannelIdentity.org_id == org_id)
                     .where(ChannelIdentity.platform == platform)
                     .where(ChannelIdentity.user_id == user_id)
+                    .order_by(ChannelIdentity.id.desc())
+                    .limit(1)
                 )
-            ).scalar_one_or_none()
+            ).scalars().first()
 
     return _lookup

--- a/surogates/programs/materialize.py
+++ b/surogates/programs/materialize.py
@@ -42,6 +42,15 @@ _OPEN_RESPONSE_STATES = ("awaiting_reply", "replied", "in_progress")
 _DEFAULT_DEADLINE_HOURS = 24
 
 
+def platform_of(identity: Any, schedule: Any) -> str:
+    """The channel this invitation is on — the identity's if it says, else the Program's."""
+    return (
+        getattr(identity, "platform", None)
+        or (schedule.config or {}).get("channel")
+        or "whatsapp"
+    )
+
+
 def _permission(identity: Any) -> str:
     meta = getattr(identity, "platform_meta", None) or {}
     return (meta.get("contact_permission") or {}).get("status") or "none"
@@ -70,7 +79,12 @@ async def _has_open_invitation(db, schedule, identity) -> bool:
         await db.execute(
             sa.select(sa.func.count())
             .select_from(ProgramInvitationRow)
+            # org_id leads the open-invitations index; without it this is a
+            # sequential scan of an append-only table, once per patient per
+            # occurrence, inside the claim lease.
+            .where(ProgramInvitationRow.org_id == schedule.org_id)
             .where(ProgramInvitationRow.agent_id == schedule.agent_id)
+            .where(ProgramInvitationRow.platform == platform_of(identity, schedule))
             .where(
                 ProgramInvitationRow.platform_user_id
                 == identity.platform_user_id

--- a/surogates/programs/opener.py
+++ b/surogates/programs/opener.py
@@ -1,0 +1,126 @@
+"""Hand a queued check-in opener to the outbox.
+
+Three things have to exist before an outbox row can: a session for the patient
+on this channel, an event on it, and the row itself.  The session is resolved
+with the **same key the inbound pipeline will compute for the reply** —
+``agent:whatsapp:dm:<wa_id>`` — so the patient's answer lands in the
+conversation that holds the opener, and the agent sees the question it is
+being answered to.  For a DM that key does not depend on any routing flag,
+which is what lets this run without the channel routing cache.
+
+The opener text is emitted as a synthetic user message first.  Without it the
+transcript shows a reply to a question that was never asked, and
+``delivery_outbox.event_id`` is NOT NULL regardless.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from surogates.channels.identity import get_or_create_channel_session
+from surogates.channels.memory_boundary import boundary_token
+from surogates.channels.source import SessionSource, build_session_key
+
+logger = logging.getLogger(__name__)
+
+
+def _opener_text(config: dict) -> str:
+    name = config.get("template_name") or "check-in"
+    return f"[Check-in opener sent: template '{name}']"
+
+
+def make_opener_enqueue(
+    *,
+    session_store: Any,
+    redis: Any,
+    session_factory: Any,
+    delivery_service: Any,
+    storage: Any = None,
+    settings: Any = None,
+    config_for_program: Any,
+):
+    """Build the ``enqueue`` callable ``send_queued_openers`` needs in production.
+
+    *config_for_program* is ``async (program_id) -> dict | None`` returning the
+    Program's projected config (the template name and language live there).
+    Returns ``async (invitation) -> int | None`` — the outbox row id, which is
+    the key the dispatcher later reports back through.
+    """
+
+    async def _enqueue(invitation: Any) -> int | None:
+        config = await config_for_program(invitation.program_id) or {}
+        template_name = config.get("template_name")
+        template_language = config.get("template_language")
+        if not template_name or not template_language:
+            # No approved template means no lawful way to open the
+            # conversation. Leave it queued; the activation gate should have
+            # refused this Program, and the operator will see it stuck.
+            logger.warning(
+                "[programs] program %s has no template; opener for %s not sent",
+                invitation.program_id, invitation.user_id,
+            )
+            return None
+
+        platform = invitation.platform
+        wa_id = invitation.platform_user_id
+        sender = str(config.get("channel_identifier") or "")
+
+        source = SessionSource(
+            platform=platform,
+            chat_id=wa_id,
+            chat_type="dm",
+            user_id=wa_id,
+            user_name="",
+            thread_id=None,
+            chat_name=wa_id,
+        )
+        session_key = build_session_key(source)
+
+        session_id: UUID = await get_or_create_channel_session(
+            session_store,
+            redis,
+            session_key=session_key,
+            user_id=invitation.user_id,
+            org_id=invitation.org_id,
+            agent_id=invitation.agent_id,
+            channel=platform,
+            config={
+                f"{platform}_channel_id": wa_id,
+                f"{platform}_thread_key": None,
+                "channel_identifier": sender,
+                "memory_boundary": boundary_token(
+                    platform=platform,
+                    channel_id=wa_id,
+                    visibility="dm",
+                    source="checkin",
+                    fallback_id=session_key,
+                ),
+                "multi_party": False,
+            },
+            session_factory=session_factory,
+            storage=storage,
+            settings=settings,
+        )
+
+        event_id = await session_store.emit_synthetic_user_message(
+            session_id,
+            content=_opener_text(config),
+            synthetic="checkin_opener",
+            metadata={
+                "program_id": str(invitation.program_id),
+                "occurrence_id": str(invitation.occurrence_id),
+                "template_name": template_name,
+            },
+        )
+
+        return await delivery_service.enqueue(
+            session_id,
+            event_id,
+            platform,
+            {"wa_id": wa_id, "phone_number_id": sender},
+            {"template": {"name": template_name, "language": template_language}},
+        )
+
+    return _enqueue

--- a/surogates/programs/opener.py
+++ b/surogates/programs/opener.py
@@ -94,7 +94,7 @@ def make_opener_enqueue(
                     platform=platform,
                     channel_id=wa_id,
                     visibility="dm",
-                    source="checkin",
+                    source={"chat_type": "private"},
                     fallback_id=session_key,
                 ),
                 "multi_party": False,
@@ -115,11 +115,14 @@ def make_opener_enqueue(
             },
         )
 
+        # Same three keys the reply path writes (``session/store.py``).  The
+        # dispatcher reads ``channel_identifier`` first and fails the row
+        # without it, before any adapter sees ``phone_number_id``.
         return await delivery_service.enqueue(
             session_id,
             event_id,
             platform,
-            {"wa_id": wa_id, "phone_number_id": sender},
+            {"wa_id": wa_id, "phone_number_id": sender, "channel_identifier": sender},
             {"template": {"name": template_name, "language": template_language}},
         )
 

--- a/surogates/programs/ops_projection.py
+++ b/surogates/programs/ops_projection.py
@@ -1,0 +1,67 @@
+"""Fetch ops' projection of active check-in Programs.
+
+The runtime does not read ops tables, so the only way it learns which
+Programs are active — and, just as importantly, which have stopped being
+active — is this runtime-scoped endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_PATH = "/api/programs/active"
+
+
+async def fetch_active_programs(
+    http_client: Any,
+    *,
+    base_url: str,
+    runtime_key: str,
+    timeout: float = 15.0,
+) -> list[dict] | None:
+    """Ops' active Programs, or ``None`` when the answer is not trustworthy.
+
+    The ``None``-versus-``[]`` distinction is the whole point of this
+    function's shape.  An empty list is ops saying "no Programs are active",
+    and reconcile answers that by deactivating every mirrored schedule.  A
+    failed, rejected, or malformed fetch must never be able to say that — one
+    unreachable ops server would otherwise silently stop every check-in in the
+    fleet.  Callers skip reconciliation entirely on ``None``.
+    """
+    if not base_url or not runtime_key:
+        return None
+
+    url = f"{base_url.rstrip('/')}{_PATH}"
+    try:
+        response = await http_client.get(
+            url,
+            headers={"Authorization": f"Bearer {runtime_key}"},
+            timeout=timeout,
+        )
+    except Exception:  # noqa: BLE001 — a tick must not die on a bad fetch
+        logger.warning(
+            "[programs] could not reach ops for the projection at %s",
+            url, exc_info=True,
+        )
+        return None
+
+    if not getattr(response, "is_success", False):
+        logger.warning(
+            "[programs] ops refused the projection at %s: %s",
+            url, getattr(response, "status_code", "?"),
+        )
+        return None
+
+    body = response.json()
+    if not isinstance(body, list):
+        # A proxy error page can answer 200 with an object; reading that as
+        # "no Programs are active" would pause the whole fleet.
+        logger.warning(
+            "[programs] ops returned a %s for the projection, expected a list",
+            type(body).__name__,
+        )
+        return None
+    return body

--- a/surogates/programs/ops_projection.py
+++ b/surogates/programs/ops_projection.py
@@ -55,7 +55,11 @@ async def fetch_active_programs(
         )
         return None
 
-    body = response.json()
+    try:
+        body = response.json()
+    except Exception:  # noqa: BLE001 — an HTML error page answering 200
+        logger.warning("[programs] ops answered the projection with a non-JSON body")
+        return None
     if not isinstance(body, list):
         # A proxy error page can answer 200 with an object; reading that as
         # "no Programs are active" would pause the whole fleet.

--- a/surogates/programs/reconcile.py
+++ b/surogates/programs/reconcile.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(timezone.utc)
 
 
 async def reconcile_programs(store: Any, *, projected: list[dict]) -> None:

--- a/surogates/programs/reconcile.py
+++ b/surogates/programs/reconcile.py
@@ -1,0 +1,47 @@
+"""Mirror ops' active Programs into the runtime's schedule table.
+
+Runs on a ``program_changed`` publish and, as a backstop, on a slow interval:
+a missed publish must not leave a paused Program messaging patients.
+
+The whole projected row is stored as the schedule's ``config`` — roster
+included — so a tick never has to call back into ops to find out who to
+message.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from surogates.programs.cadence import next_occurrences
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+async def reconcile_programs(store: Any, *, projected: list[dict]) -> None:
+    """Make the runtime's schedules match *projected* exactly."""
+    seen: set[uuid.UUID] = set()
+    now = _utcnow()
+
+    for row in projected:
+        program_id = uuid.UUID(row["id"])
+        seen.add(program_id)
+        upcoming = next_occurrences(
+            now,
+            weekdays=row.get("weekdays") or [],
+            times_local=row.get("times_local") or [],
+            timezone=row.get("timezone") or "UTC",
+            count=1,
+        )
+        await store.ensure(
+            program_id=program_id,
+            org_id=uuid.UUID(row["org_id"]),
+            agent_id=row["agent_id"],
+            config=row,
+            next_run_at=upcoming[0] if upcoming else None,
+        )
+
+    await store.deactivate_missing(seen)

--- a/surogates/programs/reconcile.py
+++ b/surogates/programs/reconcile.py
@@ -24,6 +24,15 @@ def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _warn_no_slot(program_id: uuid.UUID) -> None:
+    # Ops refuses to activate an empty cadence, so reaching this means the
+    # projection drifted.  Say so: a Program parked on NULL looks healthy.
+    logger.warning(
+        "[programs] program %s has no computable slot; it will not fire", program_id,
+    )
+    return None
+
+
 async def reconcile_programs(store: Any, *, projected: list[dict]) -> None:
     """Make the runtime's schedules match *projected* exactly.
 
@@ -65,7 +74,7 @@ async def reconcile_programs(store: Any, *, projected: list[dict]) -> None:
                 org_id=org_id,
                 agent_id=agent_id,
                 config=row,
-                next_run_at=upcoming[0] if upcoming else None,
+                next_run_at=upcoming[0] if upcoming else _warn_no_slot(program_id),
             )
         except Exception:  # noqa: BLE001
             logger.exception(

--- a/surogates/programs/reconcile.py
+++ b/surogates/programs/reconcile.py
@@ -10,11 +10,14 @@ message.
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import datetime, timezone
 from typing import Any
 
 from surogates.programs.cadence import next_occurrences
+
+logger = logging.getLogger(__name__)
 
 
 def _utcnow() -> datetime:
@@ -22,26 +25,55 @@ def _utcnow() -> datetime:
 
 
 async def reconcile_programs(store: Any, *, projected: list[dict]) -> None:
-    """Make the runtime's schedules match *projected* exactly."""
+    """Make the runtime's schedules match *projected* exactly.
+
+    Each row is handled on its own.  Nothing validates the projection before
+    it arrives here, and a single malformed field — a timezone this pod's
+    tzdata lacks, ``"9"`` for a time, a non-UUID id — used to raise out of
+    the loop.  That skipped every Program after the bad one **and** skipped
+    ``deactivate_missing``, so one bad row meant a Program the operator had
+    paused kept messaging patients indefinitely, fleet-wide, every tick.
+
+    A row that cannot be parsed is logged and left out of ``seen``, which
+    deactivates its schedule.  A Program we cannot understand must not fire.
+    """
     seen: set[uuid.UUID] = set()
     now = _utcnow()
 
     for row in projected:
-        program_id = uuid.UUID(row["id"])
+        try:
+            program_id = uuid.UUID(str(row["id"]))
+            org_id = uuid.UUID(str(row["org_id"]))
+            agent_id = str(row["agent_id"])
+            upcoming = next_occurrences(
+                now,
+                weekdays=list(row.get("weekdays") or []),
+                times_local=list(row.get("times_local") or []),
+                timezone=str(row.get("timezone") or "UTC"),
+                count=1,
+            )
+        except Exception:  # noqa: BLE001 — one bad row must not stop the rest
+            logger.exception(
+                "[programs] skipping unparseable projected program %r",
+                row.get("id") if isinstance(row, dict) else row,
+            )
+            continue
+
+        try:
+            await store.ensure(
+                program_id=program_id,
+                org_id=org_id,
+                agent_id=agent_id,
+                config=row,
+                next_run_at=upcoming[0] if upcoming else None,
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "[programs] could not mirror program %s; leaving its schedule "
+                "as it was", program_id,
+            )
+            # Keep it in `seen`: a transient store error is not a reason to
+            # deactivate a Program that is genuinely still active in ops.
         seen.add(program_id)
-        upcoming = next_occurrences(
-            now,
-            weekdays=row.get("weekdays") or [],
-            times_local=row.get("times_local") or [],
-            timezone=row.get("timezone") or "UTC",
-            count=1,
-        )
-        await store.ensure(
-            program_id=program_id,
-            org_id=uuid.UUID(row["org_id"]),
-            agent_id=row["agent_id"],
-            config=row,
-            next_run_at=upcoming[0] if upcoming else None,
-        )
 
     await store.deactivate_missing(seen)

--- a/surogates/programs/store.py
+++ b/surogates/programs/store.py
@@ -71,10 +71,16 @@ class ProgramScheduleStore:
     ) -> ProgramSchedule:
         """Create or refresh the schedule mirroring one active ops Program.
 
-        ``next_run_at`` is written only when the row is new or the cadence
-        changed.  Reconcile runs on every ``program_changed`` publish and on a
-        timer, so unconditionally resetting the clock would push a due Program
-        forward on every unrelated save — forever, and it would never fire.
+        ``next_run_at`` is written only when the row is new, the cadence
+        changed, or the Program is coming back from paused.  Reconcile runs on
+        every ``program_changed`` publish and on a timer, so unconditionally
+        resetting the clock would push a due Program forward on every
+        unrelated save — forever, and it would never fire.
+
+        Resuming is the third case because a Program paused past its slot
+        still carries that stale instant: without recomputing, resuming it on
+        Wednesday would immediately fire Monday's missed check-in at every
+        patient.
         """
         async with self._sf() as db:
             row = (
@@ -99,11 +105,12 @@ class ProgramScheduleStore:
                 cadence_changed = any(
                     old.get(k) != config.get(k) for k in _CADENCE_KEYS
                 )
+                resuming = not row.active
                 row.org_id = org_id
                 row.agent_id = agent_id
                 row.config = config
                 row.active = True
-                if cadence_changed:
+                if cadence_changed or resuming:
                     row.next_run_at = next_run_at
 
             await db.commit()

--- a/surogates/programs/store.py
+++ b/surogates/programs/store.py
@@ -21,7 +21,7 @@ import sqlalchemy as sa
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
-from surogates.db.models import ProgramScheduleRow
+from surogates.db.models import ProgramInvitationRow, ProgramScheduleRow
 from surogates.programs.cadence import next_occurrences
 
 __all__ = ["ProgramSchedule", "ProgramScheduleStore"]
@@ -245,6 +245,7 @@ class ProgramScheduleStore:
                 .where(ProgramScheduleRow.program_id == program_id)
                 .values(active=False, locked_by=None, locked_until=None)
             )
+            await _cancel_unsent(db, [program_id])
             await db.commit()
 
     async def deactivate_missing(self, keep: set[UUID]) -> None:
@@ -254,12 +255,38 @@ class ProgramScheduleStore:
         in ops would otherwise keep messaging patients on schedule.
         """
         async with self._sf() as db:
-            stmt = (
-                sa.update(ProgramScheduleRow)
-                .where(ProgramScheduleRow.active.is_(True))
-                .values(active=False, locked_by=None, locked_until=None)
+            active = sa.select(ProgramScheduleRow.program_id).where(
+                ProgramScheduleRow.active.is_(True)
             )
             if keep:
-                stmt = stmt.where(ProgramScheduleRow.program_id.notin_(keep))
-            await db.execute(stmt)
+                active = active.where(ProgramScheduleRow.program_id.notin_(keep))
+            stopping = list((await db.execute(active)).scalars().all())
+            if not stopping:
+                return
+            await db.execute(
+                sa.update(ProgramScheduleRow)
+                .where(ProgramScheduleRow.program_id.in_(stopping))
+                .values(active=False, locked_by=None, locked_until=None)
+            )
+            await _cancel_unsent(db, stopping)
             await db.commit()
+
+
+async def _cancel_unsent(db: Any, program_ids: list[UUID]) -> None:
+    """Withdraw openers that were materialised but never handed to the outbox.
+
+    Stopping the schedule alone is not enough: the send pass picks up every
+    queued opener regardless of whose Program it belongs to, so yesterday's
+    unsent opener would still go out after the operator paused the Program.
+    """
+    await db.execute(
+        sa.update(ProgramInvitationRow)
+        .where(ProgramInvitationRow.program_id.in_(program_ids))
+        .where(ProgramInvitationRow.delivery_state == "queued")
+        .where(ProgramInvitationRow.outbox_id.is_(None))
+        .values(
+            delivery_state="canceled",
+            response_state="not_started",
+            reason="Program stopped before the opener was sent",
+        )
+    )

--- a/surogates/programs/store.py
+++ b/surogates/programs/store.py
@@ -41,6 +41,20 @@ def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _cadence_value(value: Any) -> Any:
+    """Order-insensitive view of a cadence field.
+
+    Reconcile runs before claim_due in a tick. If ops ever projected
+    ``weekdays`` in an unstable order, a raw ``!=`` would recompute
+    ``next_run_at`` every tick — and the tick in which ``now`` first crossed
+    the due instant would move the clock past it before the claim ran, so the
+    Program would never fire.
+    """
+    if isinstance(value, list):
+        return sorted(str(v) for v in value)
+    return value
+
+
 class ProgramSchedule(BaseModel):
     model_config = {"from_attributes": True}
 
@@ -103,9 +117,21 @@ class ProgramScheduleStore:
             else:
                 old = row.config or {}
                 cadence_changed = any(
-                    old.get(k) != config.get(k) for k in _CADENCE_KEYS
+                    _cadence_value(old.get(k)) != _cadence_value(config.get(k))
+                    for k in _CADENCE_KEYS
                 )
                 resuming = not row.active
+                unchanged = (
+                    row.active
+                    and row.org_id == org_id
+                    and row.agent_id == agent_id
+                    and old == config
+                )
+                if unchanged:
+                    # Reconcile runs every tick. Rewriting an identical JSONB
+                    # blob for every Program each time is a write per Program
+                    # per tick for nothing.
+                    return ProgramSchedule.model_validate(row)
                 row.org_id = org_id
                 row.agent_id = agent_id
                 row.config = config

--- a/surogates/programs/store.py
+++ b/surogates/programs/store.py
@@ -1,0 +1,232 @@
+"""Store for ``program_schedules`` — one row per active check-in Program.
+
+Reuses the platform-ticker claim/lock pattern (``locked_by`` / ``locked_until``
++ ``SELECT FOR UPDATE SKIP LOCKED``), the same one ``surogates.ambient.store``
+uses.  Portable across SQLite (tests) and Postgres (prod): the claim is
+SQLAlchemy Core so it runs on both, and the SKIP LOCKED optimisation is applied
+opportunistically.
+
+Times here are **naive UTC**, matching what ``cadence.next_occurrences``
+returns.  Mixing naive and aware datetimes across this boundary is the kind of
+bug that only shows up an hour after a DST change.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID
+
+import sqlalchemy as sa
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from surogates.db.models import ProgramScheduleRow
+from surogates.programs.cadence import next_occurrences
+
+__all__ = ["ProgramSchedule", "ProgramScheduleStore"]
+
+#: Floor on how far a failed tick pushes its next run.  A Program whose
+#: cadence yields no computable instant must still come back eventually:
+#: parking it on ``next_run_at=NULL`` would drop it out of the ticker for good,
+#: because reconcile only rewrites the clock when the cadence itself changes.
+_MIN_FAILURE_BACKOFF_SECONDS: int = 300
+
+#: The cadence fields.  ``ensure`` rewrites ``next_run_at`` only when one of
+#: these moves — see its docstring for why that matters.
+_CADENCE_KEYS = ("weekdays", "times_local", "timezone")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class ProgramSchedule(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: UUID
+    program_id: UUID
+    org_id: UUID
+    agent_id: str
+    config: dict = {}
+    active: bool = True
+    next_run_at: datetime | None = None
+    last_run_at: datetime | None = None
+    locked_by: str | None = None
+    locked_until: datetime | None = None
+
+
+class ProgramScheduleStore:
+    def __init__(self, session_factory: async_sessionmaker) -> None:
+        self._sf = session_factory
+
+    async def ensure(
+        self,
+        *,
+        program_id: UUID,
+        org_id: UUID,
+        agent_id: str,
+        config: dict[str, Any],
+        next_run_at: datetime | None,
+    ) -> ProgramSchedule:
+        """Create or refresh the schedule mirroring one active ops Program.
+
+        ``next_run_at`` is written only when the row is new or the cadence
+        changed.  Reconcile runs on every ``program_changed`` publish and on a
+        timer, so unconditionally resetting the clock would push a due Program
+        forward on every unrelated save — forever, and it would never fire.
+        """
+        async with self._sf() as db:
+            row = (
+                await db.execute(
+                    sa.select(ProgramScheduleRow)
+                    .where(ProgramScheduleRow.program_id == program_id)
+                )
+            ).scalar_one_or_none()
+
+            if row is None:
+                row = ProgramScheduleRow(
+                    program_id=program_id,
+                    org_id=org_id,
+                    agent_id=agent_id,
+                    config=config,
+                    active=True,
+                    next_run_at=next_run_at,
+                )
+                db.add(row)
+            else:
+                old = row.config or {}
+                cadence_changed = any(
+                    old.get(k) != config.get(k) for k in _CADENCE_KEYS
+                )
+                row.org_id = org_id
+                row.agent_id = agent_id
+                row.config = config
+                row.active = True
+                if cadence_changed:
+                    row.next_run_at = next_run_at
+
+            await db.commit()
+            await db.refresh(row)
+            return ProgramSchedule.model_validate(row)
+
+    async def get(self, program_id: UUID) -> ProgramSchedule | None:
+        async with self._sf() as db:
+            row = (
+                await db.execute(
+                    sa.select(ProgramScheduleRow)
+                    .where(ProgramScheduleRow.program_id == program_id)
+                )
+            ).scalar_one_or_none()
+            return (
+                ProgramSchedule.model_validate(row) if row is not None else None
+            )
+
+    async def claim_due(
+        self, *, worker_id: str, limit: int, lease_seconds: int = 120,
+    ) -> list[ProgramSchedule]:
+        """Lease every active, due, unlocked schedule, up to *limit*."""
+        now = _utcnow()
+        async with self._sf() as db:
+            rows = (
+                await db.execute(
+                    sa.select(ProgramScheduleRow)
+                    .where(ProgramScheduleRow.active.is_(True))
+                    .where(ProgramScheduleRow.next_run_at.isnot(None))
+                    .where(ProgramScheduleRow.next_run_at <= now)
+                    .where(
+                        sa.or_(
+                            ProgramScheduleRow.locked_until.is_(None),
+                            ProgramScheduleRow.locked_until <= now,
+                        )
+                    )
+                    .order_by(ProgramScheduleRow.next_run_at.asc())
+                    .limit(limit)
+                    .with_for_update(skip_locked=True)
+                )
+            ).scalars().all()
+
+            claimed: list[ProgramSchedule] = []
+            for row in rows:
+                row.locked_by = worker_id
+                row.locked_until = now + timedelta(seconds=lease_seconds)
+                claimed.append(ProgramSchedule.model_validate(row))
+            await db.commit()
+            return claimed
+
+    async def mark_fired(
+        self, schedule: ProgramSchedule, *, next_run_at: datetime | None,
+    ) -> None:
+        now = _utcnow()
+        async with self._sf() as db:
+            await db.execute(
+                sa.update(ProgramScheduleRow)
+                .where(ProgramScheduleRow.id == schedule.id)
+                .values(
+                    last_run_at=now,
+                    next_run_at=next_run_at,
+                    locked_by=None,
+                    locked_until=None,
+                )
+            )
+            await db.commit()
+
+    async def mark_failed(self, schedule: ProgramSchedule) -> None:
+        """Advance a failed tick's clock and drop its lock.
+
+        Without this the row keeps ``next_run_at`` in the past while still
+        naming a worker that has already given up, so ``claim_due`` re-claims
+        it the moment the lease lapses — forever, at lease frequency, with no
+        backoff.  A failed tick waits a full cadence, like a skipped one.
+        """
+        now = _utcnow()
+        config = schedule.config or {}
+        upcoming = next_occurrences(
+            now,
+            weekdays=config.get("weekdays") or [],
+            times_local=config.get("times_local") or [],
+            timezone=config.get("timezone") or "UTC",
+            count=1,
+        )
+        # No computable instant (an empty or unsatisfiable cadence) still gets
+        # a clock, so the row stays in the ticker's world and a later reconcile
+        # can correct it.
+        floor = now + timedelta(seconds=_MIN_FAILURE_BACKOFF_SECONDS)
+        retry_at = max(upcoming[0], floor) if upcoming else floor
+
+        async with self._sf() as db:
+            await db.execute(
+                sa.update(ProgramScheduleRow)
+                .where(ProgramScheduleRow.id == schedule.id)
+                .values(
+                    next_run_at=retry_at, locked_by=None, locked_until=None,
+                )
+            )
+            await db.commit()
+
+    async def deactivate(self, program_id: UUID) -> None:
+        """Stop a Program firing, and release any lease it holds."""
+        async with self._sf() as db:
+            await db.execute(
+                sa.update(ProgramScheduleRow)
+                .where(ProgramScheduleRow.program_id == program_id)
+                .values(active=False, locked_by=None, locked_until=None)
+            )
+            await db.commit()
+
+    async def deactivate_missing(self, keep: set[UUID]) -> None:
+        """Stop every active Program that is no longer in the ops projection.
+
+        This is the whole reason reconcile exists: a Program paused or deleted
+        in ops would otherwise keep messaging patients on schedule.
+        """
+        async with self._sf() as db:
+            stmt = (
+                sa.update(ProgramScheduleRow)
+                .where(ProgramScheduleRow.active.is_(True))
+                .values(active=False, locked_by=None, locked_until=None)
+            )
+            if keep:
+                stmt = stmt.where(ProgramScheduleRow.program_id.notin_(keep))
+            await db.execute(stmt)
+            await db.commit()

--- a/surogates/programs/store.py
+++ b/surogates/programs/store.py
@@ -6,7 +6,7 @@ uses.  Portable across SQLite (tests) and Postgres (prod): the claim is
 SQLAlchemy Core so it runs on both, and the SKIP LOCKED optimisation is applied
 opportunistically.
 
-Times here are **naive UTC**, matching what ``cadence.next_occurrences``
+Times here are **aware UTC**, matching what ``cadence.next_occurrences``
 returns.  Mixing naive and aware datetimes across this boundary is the kind of
 bug that only shows up an hour after a DST change.
 """
@@ -38,7 +38,7 @@ _CADENCE_KEYS = ("weekdays", "times_local", "timezone")
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(timezone.utc)
 
 
 class ProgramSchedule(BaseModel):

--- a/surogates/programs/ticker.py
+++ b/surogates/programs/ticker.py
@@ -153,8 +153,22 @@ class ProgramTicker:
                     )
 
         # Kept outside the claim so the lease covers database work rather than
-        # provider round trips.
+        # provider round trips. Confirm we still lead before starting them:
+        # a backlog of openers is the one phase that can outlive the leader
+        # lock, and a second replica running the same pass over the same
+        # still-queued rows would message every patient twice.
         if self._send_openers is not None:
+            if self._lock is not None and hasattr(self._lock, "heartbeat"):
+                try:
+                    if not await self._lock.heartbeat():
+                        logger.warning(
+                            "program ticker lost the leader lock before the "
+                            "send pass; leaving queued openers for the leader",
+                        )
+                        return
+                except Exception:
+                    logger.exception("program ticker heartbeat failed")
+                    return
             try:
                 await self._send_openers()
             except Exception:

--- a/surogates/programs/ticker.py
+++ b/surogates/programs/ticker.py
@@ -27,22 +27,40 @@ logger = logging.getLogger(__name__)
 #: skipped, cancelled or rejected by the provider is our failure, not theirs.
 _REACHED_STATES = ("accepted", "delivered")
 
+#: The patient answered but the agent never recorded an outcome. Terminal
+#: at the deadline, so the next occurrence can reach them again.
+_STARTED_STATES = ("replied", "in_progress")
+
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 async def sweep_deadlines(session_factory: Any, *, now: datetime | None = None) -> int:
-    """Close check-ins whose deadline has passed unanswered.
+    """Close every check-in whose deadline has passed without finishing.
 
-    The ``delivery_state`` filter is the point: without it a failed or skipped
-    send would be recorded as a patient who stayed silent, which blames the
-    patient for our failure to reach them and hides the delivery problem the
-    operator actually needs to fix.
+    Two transitions, because two different things go wrong and the operator
+    needs to tell them apart:
+
+    * asked and never answered → ``no_reply_by_deadline``.  The
+      ``delivery_state`` filter is the point here: without it a failed or
+      skipped send would be recorded as a patient who stayed silent, blaming
+      the patient for our failure to reach them and hiding the delivery
+      problem that actually needs fixing.
+    * answered but never closed → ``incomplete``.  Only ``checkin_outcome``
+      moves a row out of ``replied``, so a patient who trails off mid-answer,
+      a session that errors, or a model that simply never calls the tool would
+      leave the row open forever.  That matters beyond the history: an open
+      check-in suppresses the patient's next one, so without this they drop
+      out of the Program silently and permanently.
+
+    Both are terminal, which is what lets the next occurrence reach that
+    patient again.
     """
     now = now or _utcnow()
+    swept = 0
     async with session_factory() as db:
-        result = await db.execute(
+        unanswered = await db.execute(
             sa.update(ProgramInvitationRow)
             .where(ProgramInvitationRow.response_state == "awaiting_reply")
             .where(ProgramInvitationRow.delivery_state.in_(_REACHED_STATES))
@@ -50,8 +68,19 @@ async def sweep_deadlines(session_factory: Any, *, now: datetime | None = None) 
             .where(ProgramInvitationRow.deadline_at <= now)
             .values(response_state="no_reply_by_deadline")
         )
+        swept += int(unanswered.rowcount or 0)
+
+        unfinished = await db.execute(
+            sa.update(ProgramInvitationRow)
+            .where(ProgramInvitationRow.response_state.in_(_STARTED_STATES))
+            .where(ProgramInvitationRow.deadline_at.isnot(None))
+            .where(ProgramInvitationRow.deadline_at <= now)
+            .values(response_state="incomplete")
+        )
+        swept += int(unfinished.rowcount or 0)
+
         await db.commit()
-        return int(result.rowcount or 0)
+        return swept
 
 
 class ProgramTicker:

--- a/surogates/programs/ticker.py
+++ b/surogates/programs/ticker.py
@@ -79,6 +79,38 @@ async def sweep_deadlines(session_factory: Any, *, now: datetime | None = None) 
         )
         swept += int(unfinished.rowcount or 0)
 
+        # Third case: the opener never reached them and the deadline came
+        # anyway.  A row still ``queued`` at that point had no dispatcher
+        # report at all (the outbox row was lost, or the process died between
+        # claiming and handing over): record the delivery failure so the
+        # operator sees it, rather than leaving a row that looks in flight.
+        unreported = await db.execute(
+            sa.update(ProgramInvitationRow)
+            .where(ProgramInvitationRow.response_state == "awaiting_reply")
+            .where(ProgramInvitationRow.delivery_state == "queued")
+            .where(ProgramInvitationRow.deadline_at.isnot(None))
+            .where(ProgramInvitationRow.deadline_at <= now)
+            .values(
+                delivery_state="failed",
+                delivery_error="No delivery report by the deadline",
+            )
+        )
+        swept += int(unreported.rowcount or 0)
+
+        # Whatever the delivery failure was, an ``awaiting_reply`` that was
+        # never delivered is not an open check-in.  Left as is it suppresses
+        # the patient's next occurrence forever; ``not_started`` says what
+        # happened (they were never asked) and lets the next one reach them.
+        never_asked = await db.execute(
+            sa.update(ProgramInvitationRow)
+            .where(ProgramInvitationRow.response_state == "awaiting_reply")
+            .where(ProgramInvitationRow.delivery_state.notin_(_REACHED_STATES))
+            .where(ProgramInvitationRow.deadline_at.isnot(None))
+            .where(ProgramInvitationRow.deadline_at <= now)
+            .values(response_state="not_started")
+        )
+        swept += int(never_asked.rowcount or 0)
+
         await db.commit()
         return swept
 
@@ -115,8 +147,8 @@ class ProgramTicker:
         self._stop.set()
 
     async def tick_once(self) -> None:
-        # Backstop for a missed program_changed publish: a Program paused in
-        # ops must stop firing even if the notification never arrived.
+        # The only way a change in ops reaches the runtime: nothing is
+        # pushed, so a pause takes effect on the next tick, not before.
         if self._reconcile is not None:
             try:
                 await self._reconcile()

--- a/surogates/programs/ticker.py
+++ b/surogates/programs/ticker.py
@@ -1,0 +1,148 @@
+"""Leader-locked ticker that fires due check-in Programs.
+
+Mirrors :class:`surogates.ambient.ticker.AmbientTicker`: acquire the leader
+lock, sweep expired check-ins, claim due schedules, materialise each one
+(isolating per-row failures), hand the queued openers on, sleep, repeat.
+
+The sweep runs **first**, and that ordering is load-bearing.  Materialisation
+skips a patient whose previous check-in is still open, so if expired
+invitations were not closed before the roster is evaluated, one unanswered
+opener would suppress that patient's check-ins for good.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+
+import sqlalchemy as sa
+
+from surogates.db.models import ProgramInvitationRow
+
+logger = logging.getLogger(__name__)
+
+#: Only a patient we actually reached can fail to reply.  A send that was
+#: skipped, cancelled or rejected by the provider is our failure, not theirs.
+_REACHED_STATES = ("accepted", "delivered")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+async def sweep_deadlines(session_factory: Any, *, now: datetime | None = None) -> int:
+    """Close check-ins whose deadline has passed unanswered.
+
+    The ``delivery_state`` filter is the point: without it a failed or skipped
+    send would be recorded as a patient who stayed silent, which blames the
+    patient for our failure to reach them and hides the delivery problem the
+    operator actually needs to fix.
+    """
+    now = now or _utcnow()
+    async with session_factory() as db:
+        result = await db.execute(
+            sa.update(ProgramInvitationRow)
+            .where(ProgramInvitationRow.response_state == "awaiting_reply")
+            .where(ProgramInvitationRow.delivery_state.in_(_REACHED_STATES))
+            .where(ProgramInvitationRow.deadline_at.isnot(None))
+            .where(ProgramInvitationRow.deadline_at <= now)
+            .values(response_state="no_reply_by_deadline")
+        )
+        await db.commit()
+        return int(result.rowcount or 0)
+
+
+class ProgramTicker:
+    def __init__(
+        self,
+        store: Any,
+        *,
+        session_factory: Any,
+        materialize: Callable[[Any], Awaitable[None]],
+        worker_id: str,
+        send_openers: Callable[[], Awaitable[None]] | None = None,
+        reconcile: Callable[[], Awaitable[None]] | None = None,
+        leader_lock: Any = None,
+        tick_interval_seconds: float = 60.0,
+        claim_limit: int = 50,
+    ) -> None:
+        self._store = store
+        self._sf = session_factory
+        self._materialize = materialize
+        self._send_openers = send_openers
+        #: Refreshes the mirrored schedules from ops' projection. Supplied by
+        #: the caller because fetching it needs an ops base URL and a
+        #: runtime-scoped key, neither of which this process configures today.
+        self._reconcile = reconcile
+        self._worker_id = worker_id
+        self._lock = leader_lock
+        self._interval = tick_interval_seconds
+        self._claim_limit = claim_limit
+        self._stop = asyncio.Event()
+
+    def request_stop(self) -> None:
+        self._stop.set()
+
+    async def tick_once(self) -> None:
+        # Backstop for a missed program_changed publish: a Program paused in
+        # ops must stop firing even if the notification never arrived.
+        if self._reconcile is not None:
+            try:
+                await self._reconcile()
+            except Exception:
+                logger.exception("program ticker failed to reconcile from ops")
+
+        # First, so the roster check below sees expired invitations as closed.
+        try:
+            await sweep_deadlines(self._sf, now=_utcnow())
+        except Exception:
+            logger.exception("program ticker failed to sweep deadlines")
+
+        rows = await self._store.claim_due(
+            worker_id=self._worker_id, limit=self._claim_limit,
+        )
+        for row in rows:
+            try:
+                await self._materialize(row)
+            except Exception:
+                logger.exception(
+                    "program ticker failed to materialize program %s",
+                    getattr(row, "program_id", "?"),
+                )
+                # A failed tick leaves the row past-due holding a lock nobody
+                # owns; tell the store or claim_due re-fires it every time the
+                # lease lapses, forever.
+                try:
+                    await self._store.mark_failed(row)
+                except Exception:
+                    logger.exception(
+                        "program ticker could not record the failed tick for "
+                        "program %s; it will retry when the lease lapses",
+                        getattr(row, "program_id", "?"),
+                    )
+
+        # Kept outside the claim so the lease covers database work rather than
+        # provider round trips.
+        if self._send_openers is not None:
+            try:
+                await self._send_openers()
+            except Exception:
+                logger.exception("program ticker failed to send queued openers")
+
+    async def run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                if self._lock is None or await self._lock.acquire():
+                    try:
+                        await self.tick_once()
+                    finally:
+                        if self._lock is not None:
+                            await self._lock.release()
+            except Exception:
+                logger.exception("program ticker tick failed")
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=self._interval)
+            except asyncio.TimeoutError:
+                pass

--- a/surogates/programs/ticker.py
+++ b/surogates/programs/ticker.py
@@ -33,7 +33,7 @@ _STARTED_STATES = ("replied", "in_progress")
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(timezone.utc)
 
 
 async def sweep_deadlines(session_factory: Any, *, now: datetime | None = None) -> int:

--- a/surogates/scheduled/platform_ticker.py
+++ b/surogates/scheduled/platform_ticker.py
@@ -400,6 +400,37 @@ async def main(
                 now=_program_now(),
             )
 
+        # Mirror ops' active Programs. Unconfigured by default: with no
+        # ops endpoint the ticker still fires the schedules it already has,
+        # it just never learns about new ones or notices a pause.
+        _ops_base = getattr(settings.worker, "ops_base_url", "") or ""
+        _ops_key = getattr(settings.worker, "ops_runtime_key", "") or ""
+        _program_reconcile = None
+        if _ops_base and _ops_key:
+            import httpx
+
+            from surogates.programs.ops_projection import fetch_active_programs
+            from surogates.programs.reconcile import reconcile_programs
+
+            _ops_http = httpx.AsyncClient()
+
+            async def _program_reconcile():  # pragma: no cover - prod path
+                projected = await fetch_active_programs(
+                    _ops_http, base_url=_ops_base, runtime_key=_ops_key,
+                )
+                if projected is None:
+                    # An unreachable or refused ops is not "no Programs are
+                    # active". Reconciling on that would deactivate every
+                    # schedule in the fleet, so skip this tick entirely.
+                    return
+                await reconcile_programs(program_store, projected=projected)
+        else:
+            logger.info(
+                "[programs] ops projection not configured "
+                "(worker.ops_base_url / worker.ops_runtime_key); schedules "
+                "will not be reconciled",
+            )
+
         program_lock = RedisLeaderLock(
             redis, key="surogates:program_ticker:leader",
             ttl_seconds=lock_ttl, holder_id=holder_id,
@@ -409,10 +440,7 @@ async def main(
             session_factory=_session_factory(),
             materialize=_program_run_one,
             send_openers=_program_send_openers,
-            # reconcile is left unwired: fetching ops' projection needs an ops
-            # base URL and a runtime-scoped key, neither of which this process
-            # configures yet. Until it is supplied, schedules are refreshed
-            # only by whatever calls reconcile_programs directly.
+            reconcile=_program_reconcile,
             worker_id=worker_id,
             leader_lock=program_lock,
             tick_interval_seconds=tick_interval,

--- a/surogates/scheduled/platform_ticker.py
+++ b/surogates/scheduled/platform_ticker.py
@@ -179,6 +179,26 @@ def _field(row: Any, name: str) -> Any:
     return getattr(row, name)
 
 
+def _program_now():
+    """Naive UTC, matching what the cadence module returns."""
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _next_occurrences_for(row):
+    """The next fire instant for a claimed schedule, from its own config."""
+    from surogates.programs.cadence import next_occurrences
+
+    config = getattr(row, "config", None) or {}
+    return next_occurrences(
+        _program_now(),
+        weekdays=config.get("weekdays") or [],
+        times_local=config.get("times_local") or [],
+        timezone=config.get("timezone") or "UTC",
+        count=1,
+    )
+
+
 async def main(
     *,
     settings: Any,
@@ -339,6 +359,66 @@ async def main(
             tick_interval_seconds=tick_interval, claim_limit=claim_limit,
         )
 
+    # Check-in Programs: a third ticker (its own leader lock) fires due
+    # Programs, expires unanswered check-ins, and hands queued openers to the
+    # outbox.
+    program_ticker = None
+    if not _run_one_injected:  # prod path only (session_store built above)
+        from surogates.programs.delivery import register_status_applier
+        from surogates.programs.materialize import (
+            identity_lookup_from,
+            materialize_occurrence,
+            send_queued_openers,
+        )
+        from surogates.programs.store import ProgramScheduleStore
+        from surogates.programs.ticker import ProgramTicker
+
+        program_store = ProgramScheduleStore(_session_factory())
+        _identity_lookup = identity_lookup_from(_session_factory())
+
+        # Lets the WhatsApp parser record delivery statuses. It is synchronous
+        # and holds no database handle, so this is how it gets one.
+        register_status_applier(_session_factory())
+
+        async def _program_run_one(row):  # pragma: no cover - prod path
+            fired_at = await materialize_occurrence(
+                row,
+                session_factory=_session_factory(),
+                identity_lookup=_identity_lookup,
+                now=_program_now(),
+            )
+            logger.debug("[programs] materialised occurrence %s", fired_at)
+            upcoming = _next_occurrences_for(row)
+            await program_store.mark_fired(
+                row, next_run_at=upcoming[0] if upcoming else None,
+            )
+
+        async def _program_send_openers():  # pragma: no cover - prod path
+            await send_queued_openers(
+                _session_factory(),
+                identity_lookup=_identity_lookup,
+                now=_program_now(),
+            )
+
+        program_lock = RedisLeaderLock(
+            redis, key="surogates:program_ticker:leader",
+            ttl_seconds=lock_ttl, holder_id=holder_id,
+        )
+        program_ticker = ProgramTicker(
+            program_store,
+            session_factory=_session_factory(),
+            materialize=_program_run_one,
+            send_openers=_program_send_openers,
+            # reconcile is left unwired: fetching ops' projection needs an ops
+            # base URL and a runtime-scoped key, neither of which this process
+            # configures yet. Until it is supplied, schedules are refreshed
+            # only by whatever calls reconcile_programs directly.
+            worker_id=worker_id,
+            leader_lock=program_lock,
+            tick_interval_seconds=tick_interval,
+            claim_limit=claim_limit,
+        )
+
     if install_signal_handlers:
         loop = asyncio.get_running_loop()
 
@@ -346,6 +426,8 @@ async def main(
             ticker.request_stop()
             if ambient_ticker is not None:
                 ambient_ticker.request_stop()
+            if program_ticker is not None:
+                program_ticker.request_stop()
 
         for sig in (signal.SIGTERM, signal.SIGINT):
             try:
@@ -354,10 +436,12 @@ async def main(
                 pass
 
     try:
+        runners = [ticker.run()]
         if ambient_ticker is not None:
-            await asyncio.gather(ticker.run(), ambient_ticker.run())
-        else:
-            await ticker.run()
+            runners.append(ambient_ticker.run())
+        if program_ticker is not None:
+            runners.append(program_ticker.run())
+        await asyncio.gather(*runners)
     finally:
         close = getattr(redis, "aclose", None) or getattr(
             redis, "close", None,

--- a/surogates/scheduled/platform_ticker.py
+++ b/surogates/scheduled/platform_ticker.py
@@ -364,21 +364,40 @@ async def main(
     # outbox.
     program_ticker = None
     if not _run_one_injected:  # prod path only (session_store built above)
-        from surogates.programs.delivery import register_status_applier
+        from surogates.channels.delivery import DeliveryService
         from surogates.programs.materialize import (
             identity_lookup_from,
             materialize_occurrence,
             send_queued_openers,
         )
+        from surogates.programs.opener import make_opener_enqueue
         from surogates.programs.store import ProgramScheduleStore
         from surogates.programs.ticker import ProgramTicker
 
         program_store = ProgramScheduleStore(_session_factory())
         _identity_lookup = identity_lookup_from(_session_factory())
 
-        # Lets the WhatsApp parser record delivery statuses. It is synchronous
-        # and holds no database handle, so this is how it gets one.
-        register_status_applier(_session_factory())
+        # The delivery-status applier is NOT registered here. Meta's status
+        # webhooks arrive in the channels process, and that is where the
+        # parser that reads them runs; registering it in this process would
+        # satisfy the check and silently discard every status. See
+        # channels/runner.py.
+
+        async def _config_for_program(program_id):  # pragma: no cover - prod
+            sched = await program_store.get(program_id)
+            return sched.config if sched is not None else None
+
+        _opener_enqueue = make_opener_enqueue(
+            session_store=session_store,
+            redis=redis,
+            session_factory=_session_factory(),
+            delivery_service=DeliveryService(
+                session_factory=_session_factory(), redis_client=redis,
+            ),
+            storage=storage,
+            settings=settings,
+            config_for_program=_config_for_program,
+        )
 
         async def _program_run_one(row):  # pragma: no cover - prod path
             # Stamp the occurrence with the instant it was DUE, never the wall
@@ -408,6 +427,7 @@ async def main(
                 _session_factory(),
                 identity_lookup=_identity_lookup,
                 now=_program_now(),
+                enqueue=_opener_enqueue,
             )
 
         # Mirror ops' active Programs. Unconfigured by default: with no

--- a/surogates/scheduled/platform_ticker.py
+++ b/surogates/scheduled/platform_ticker.py
@@ -180,9 +180,9 @@ def _field(row: Any, name: str) -> Any:
 
 
 def _program_now():
-    """Naive UTC, matching what the cadence module returns."""
+    """Aware UTC, matching what the cadence module returns."""
     from datetime import datetime, timezone
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(timezone.utc)
 
 
 def _next_occurrences_for(row):

--- a/surogates/scheduled/platform_ticker.py
+++ b/surogates/scheduled/platform_ticker.py
@@ -381,13 +381,23 @@ async def main(
         register_status_applier(_session_factory())
 
         async def _program_run_one(row):  # pragma: no cover - prod path
+            # Stamp the occurrence with the instant it was DUE, never the wall
+            # clock. The (program_id, scheduled_for) unique constraint is what
+            # makes a retried tick harmless — with a fresh clock per call it
+            # can never collide, and a pod rolled mid-tick double-messages the
+            # whole roster.
             fired_at = await materialize_occurrence(
                 row,
                 session_factory=_session_factory(),
                 identity_lookup=_identity_lookup,
-                now=_program_now(),
+                now=row.next_run_at or _program_now(),
             )
             logger.debug("[programs] materialised occurrence %s", fired_at)
+            # ponytail: the next run is computed from the wall clock, so slots
+            # missed during an outage are dropped rather than caught up. A
+            # burst of six openers after a three-day outage is worse than a
+            # gap; if catch-up is ever wanted, compute from row.next_run_at
+            # and cap the burst.
             upcoming = _next_occurrences_for(row)
             await program_store.mark_fired(
                 row, next_run_at=upcoming[0] if upcoming else None,

--- a/surogates/tools/builtin/checkin.py
+++ b/surogates/tools/builtin/checkin.py
@@ -13,6 +13,7 @@ import uuid
 from typing import Any
 
 import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
 
 from surogates.db.models import (
     Event,
@@ -136,7 +137,11 @@ async def handle_checkin_escalate(arguments: dict, **kwargs: Any) -> str:
         )
         row = await db.get(ProgramInvitationRow, inv.id)
 
-        if not target:
+        try:
+            target_id = uuid.UUID(str(target)) if target else None
+        except ValueError:
+            target_id = None
+        if target_id is None:
             # A visible failure, never a silent one: the agent saying it
             # escalated is not evidence that anyone was told.
             row.escalation_state = "failed"
@@ -162,7 +167,7 @@ async def handle_checkin_escalate(arguments: dict, **kwargs: Any) -> str:
                 # The designated operator, never the acting principal: an item
                 # raised against the patient reaches nobody but the patient.
                 user_id=None,
-                service_account_id=uuid.UUID(str(target)),
+                service_account_id=target_id,
                 session_id=inv.session_id,
                 source_event_id=event.id,
                 # An existing InboxKind. A new value would never pass the ops
@@ -180,7 +185,28 @@ async def handle_checkin_escalate(arguments: dict, **kwargs: Any) -> str:
         # Escalation is its own axis: raising a hand does not mean the patient
         # has finished answering, so response_state is deliberately untouched.
         row.escalation_state = "raised"
-        await db.commit()
+        try:
+            await db.commit()
+        except IntegrityError:
+            # The configured target is not a service account this database
+            # knows — a human's id pasted where a principal belongs, say. The
+            # insert rolled back, taking the event and the "raised" mark with
+            # it. Record the failure in its own transaction so the raised
+            # hand is not simply lost.
+            await db.rollback()
+            logger.warning(
+                "[programs] escalation target %s for program %s is not a "
+                "service account", target_id, inv.program_id,
+            )
+            async with sf() as db2:
+                row2 = await db2.get(ProgramInvitationRow, inv.id)
+                row2.escalation_state = "failed"
+                row2.reason = "Escalation target is not a valid service account"
+                await db2.commit()
+            return (
+                "Could not escalate: this Program's responsible operator is "
+                "not configured correctly."
+            )
 
     return "Escalated to the responsible operator."
 

--- a/surogates/tools/builtin/checkin.py
+++ b/surogates/tools/builtin/checkin.py
@@ -1,0 +1,201 @@
+"""Tools an agent uses to close or escalate a check-in.
+
+Neither tool takes an occurrence id.  The open invitation is found **by
+session**, because the inbound path stamped ``session_id`` on it when the
+patient replied.  That is what makes these unspoofable: an agent in an
+ordinary conversation cannot close or escalate a check-in it is not inside.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+import sqlalchemy as sa
+
+from surogates.db.models import (
+    Event,
+    InboxItem,
+    ProgramInvitationRow,
+    ProgramScheduleRow,
+)
+from surogates.tools.registry import ToolSchema
+
+logger = logging.getLogger(__name__)
+
+#: Response states a check-in can still be closed from.
+_OPEN = ("replied", "in_progress")
+
+_VALID_OUTCOMES = ("completed", "declined")
+
+CHECKIN_OUTCOME_SCHEMA = ToolSchema(
+    name="checkin_outcome",
+    description=(
+        "Record how a scheduled check-in ended. Call this once the person has "
+        "answered the check-in questions, or has clearly declined to. Use "
+        "'completed' when you got the answers, 'declined' when the person "
+        "refused or asked to be left alone. This closes the check-in; it does "
+        "not message anyone."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "outcome": {
+                "type": "string",
+                "enum": list(_VALID_OUTCOMES),
+                "description": "Whether the check-in was completed or declined.",
+            },
+            "note": {
+                "type": "string",
+                "description": (
+                    "Optional short note for the operator's run history."
+                ),
+            },
+        },
+        "required": ["outcome"],
+    },
+)
+
+CHECKIN_ESCALATE_SCHEMA = ToolSchema(
+    name="checkin_escalate",
+    description=(
+        "Raise a scheduled check-in to the responsible operator. Use this when "
+        "something in the person's answers needs a human's attention — a "
+        "worrying symptom, a reading outside safe bounds, distress. This does "
+        "not end the check-in; record the outcome separately when it ends."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "reason": {
+                "type": "string",
+                "description": (
+                    "What needs attention, in one or two sentences the "
+                    "operator can act on."
+                ),
+            },
+        },
+        "required": ["reason"],
+    },
+)
+
+
+async def _open_invitation_for_session(session_factory: Any, session_id: Any):
+    async with session_factory() as db:
+        return (
+            await db.execute(
+                sa.select(ProgramInvitationRow)
+                .where(ProgramInvitationRow.session_id == session_id)
+                .where(ProgramInvitationRow.response_state.in_(_OPEN))
+                .order_by(ProgramInvitationRow.created_at.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+
+async def handle_checkin_outcome(arguments: dict, **kwargs: Any) -> str:
+    outcome = str(arguments.get("outcome") or "").strip().lower()
+    if outcome not in _VALID_OUTCOMES:
+        return "outcome must be 'completed' or 'declined'."
+
+    sf = kwargs["session_factory"]
+    inv = await _open_invitation_for_session(sf, kwargs["session_id"])
+    if inv is None:
+        return "No check-in is open in this conversation."
+
+    async with sf() as db:
+        row = await db.get(ProgramInvitationRow, inv.id)
+        row.response_state = outcome
+        if arguments.get("note"):
+            row.reason = str(arguments["note"])[:500]
+        await db.commit()
+    return f"Check-in recorded as {outcome}."
+
+
+async def handle_checkin_escalate(arguments: dict, **kwargs: Any) -> str:
+    reason = str(arguments.get("reason") or "").strip()
+    if not reason:
+        return "reason is required — say what needs the operator's attention."
+
+    sf = kwargs["session_factory"]
+    inv = await _open_invitation_for_session(sf, kwargs["session_id"])
+    if inv is None:
+        return "No check-in is open in this conversation."
+
+    async with sf() as db:
+        sched = (
+            await db.execute(
+                sa.select(ProgramScheduleRow).where(
+                    ProgramScheduleRow.program_id == inv.program_id
+                )
+            )
+        ).scalar_one_or_none()
+        target = ((sched.config if sched else None) or {}).get(
+            "escalation_service_account_id"
+        )
+        row = await db.get(ProgramInvitationRow, inv.id)
+
+        if not target:
+            # A visible failure, never a silent one: the agent saying it
+            # escalated is not evidence that anyone was told.
+            row.escalation_state = "failed"
+            row.reason = "No escalation target configured on this Program"
+            await db.commit()
+            return (
+                "Could not escalate: this Program has no responsible operator."
+            )
+
+        # inbox_items.source_event_id is NOT NULL and unique, so the
+        # escalation is first an event on the patient's own session.
+        event = Event(
+            session_id=inv.session_id,
+            org_id=inv.org_id,
+            type="checkin.escalation",
+            data={"reason": reason, "occurrence_id": str(inv.occurrence_id)},
+        )
+        db.add(event)
+        await db.flush()
+        db.add(
+            InboxItem(
+                org_id=inv.org_id,
+                # The designated operator, never the acting principal: an item
+                # raised against the patient reaches nobody but the patient.
+                user_id=None,
+                service_account_id=uuid.UUID(str(target)),
+                session_id=inv.session_id,
+                source_event_id=event.id,
+                # An existing InboxKind. A new value would never pass the ops
+                # Inbox filter, which is a Literal over the known kinds.
+                kind="action_required",
+                title="Check-in needs your attention",
+                body=reason,
+                payload={
+                    "program_id": str(inv.program_id),
+                    "occurrence_id": str(inv.occurrence_id),
+                    "user_id": str(inv.user_id),
+                },
+            )
+        )
+        # Escalation is its own axis: raising a hand does not mean the patient
+        # has finished answering, so response_state is deliberately untouched.
+        row.escalation_state = "raised"
+        await db.commit()
+
+    return "Escalated to the responsible operator."
+
+
+def register(registry: Any) -> None:
+    """Register the checkin_outcome and checkin_escalate tools."""
+    registry.register(
+        name="checkin_outcome",
+        schema=CHECKIN_OUTCOME_SCHEMA,
+        handler=handle_checkin_outcome,
+        toolset="checkin",
+    )
+    registry.register(
+        name="checkin_escalate",
+        schema=CHECKIN_ESCALATE_SCHEMA,
+        handler=handle_checkin_escalate,
+        toolset="checkin",
+    )

--- a/surogates/tools/router.py
+++ b/surogates/tools/router.py
@@ -51,6 +51,10 @@ TOOL_LOCATIONS: dict[str, ToolLocation] = {
     # Reads users.memory_summary + the ops DB cohort cache — needs the
     # worker's DB access, never the sandbox.
     "user_reports": ToolLocation.HARNESS,
+    # Write invitation rows and operator inbox items — the worker's
+    # database, never a sandbox.
+    "checkin_outcome": ToolLocation.HARNESS,
+    "checkin_escalate": ToolLocation.HARNESS,
     "web_search": ToolLocation.HARNESS,
     "web_extract": ToolLocation.HARNESS,
     "web_crawl": ToolLocation.HARNESS,

--- a/surogates/tools/runtime.py
+++ b/surogates/tools/runtime.py
@@ -53,6 +53,7 @@ class ToolRuntime:
             browser,
             channel_files,
             channel_messages,
+            checkin,
             coding_agent,
             coordinator,
             cron,
@@ -111,6 +112,7 @@ class ToolRuntime:
             channel_files,  # fetch_channel_file (pull a shared channel file)
             channel_messages,  # fetch_channel_messages (read recent channel messages)
             whiteboard,  # whiteboard_draw (canvas chat surface)
+            checkin,  # checkin_outcome, checkin_escalate (Program check-ins)
         ]
 
         for mod in modules:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,7 @@ async def _make_program_invitation(
 
     from surogates.db.models import ProgramInvitationRow, ProgramOccurrenceRow
 
-    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    now = datetime.now(timezone.utc)
     async with sf() as db:
         occ = ProgramOccurrenceRow(
             org_id=uuid4(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from uuid import UUID, uuid4
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import BigInteger
 from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.ext.compiler import compiles
@@ -36,7 +37,8 @@ os.environ.setdefault("SUROGATES_DOCUMENT_PARSE_USE_SUBPROCESS", "0")
 #
 # Most of the metadata is Postgres-only: 26 columns are bare ``JSONB``, many
 # primary keys are bare ``postgresql.UUID``, and four tables carry a CHECK
-# constraint written with the Postgres-only ``::int`` cast.  The three hooks
+# constraint written with the Postgres-only ``::int`` cast, and BigInteger
+# identities do not autoincrement there.  The four hooks
 # below teach SQLite to render each of those, and ``sqlite_tables`` builds
 # only the tables a test names, because whole-metadata creation drags in
 # everything whether the test needs it or not.
@@ -54,6 +56,15 @@ def _jsonb_on_sqlite(type_, compiler, **kw):
 @compiles(PGUUID, "sqlite")
 def _uuid_on_sqlite(type_, compiler, **kw):
     return "CHAR(36)"
+
+
+@compiles(BigInteger, "sqlite")
+def _bigint_on_sqlite(type_, compiler, **kw):
+    # SQLite auto-assigns a rowid only for INTEGER PRIMARY KEY — a BIGINT one
+    # stays NULL and the insert fails. events.id and inbox_items.id are both
+    # BigInteger identities, so without this the escalation path cannot be
+    # tested at all. INTEGER is 64-bit in SQLite, so nothing is lost.
+    return "INTEGER"
 
 
 @compiles(CheckConstraint, "sqlite")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,12 +90,79 @@ async def sf():
     tables = sqlite_tables(
         "program_schedules", "program_occurrences", "program_invitations",
         "inbox_items", "events", "sessions", "orgs", "users",
-        "channel_identities",
+        "channel_identities", "delivery_outbox",
     )
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all, tables=tables)
     yield async_sessionmaker(engine, expire_on_commit=False)
     await engine.dispose()
+
+
+async def _make_program_invitation(
+    sf, *, delivery_state: str, response_state: str, **extra,
+):
+    """One occurrence carrying one invitation, for the delivery/sweep tests."""
+    from datetime import datetime, timezone
+
+    from surogates.db.models import ProgramInvitationRow, ProgramOccurrenceRow
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    async with sf() as db:
+        occ = ProgramOccurrenceRow(
+            org_id=uuid4(),
+            program_id=uuid4(),
+            agent_id="a1",
+            scheduled_for=now,
+            skill_ref="post-op",
+            template_name="daily",
+            template_language="en_US",
+            status="fired",
+        )
+        db.add(occ)
+        await db.flush()
+        row = ProgramInvitationRow(
+            occurrence_id=occ.id,
+            program_id=occ.program_id,
+            org_id=occ.org_id,
+            agent_id="a1",
+            user_id=uuid4(),
+            platform="whatsapp",
+            platform_user_id="40746148303",
+            delivery_state=delivery_state,
+            response_state=response_state,
+            escalation_state="none",
+            **extra,
+        )
+        db.add(row)
+        await db.commit()
+        return row
+
+
+async def _reload_program_invitation(sf, invitation_id):
+    from surogates.db.models import ProgramInvitationRow
+
+    async with sf() as db:
+        return await db.get(ProgramInvitationRow, invitation_id)
+
+
+@pytest.fixture
+def make_invitation(sf):
+    """``await make_invitation(delivery_state=..., response_state=..., ...)``."""
+
+    async def _make(**kwargs):
+        return await _make_program_invitation(sf, **kwargs)
+
+    return _make
+
+
+@pytest.fixture
+def reload_invitation(sf):
+    """``await reload_invitation(invitation_id)`` — re-read from the database."""
+
+    async def _reload(invitation_id):
+        return await _reload_program_invitation(sf, invitation_id)
+
+    return _reload
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,14 @@ from pathlib import Path
 from uuid import UUID, uuid4
 
 import pytest
+import pytest_asyncio
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.schema import CheckConstraint
 
+from surogates.db.models import Base
 from surogates.tenant.context import TenantContext
 
 
@@ -25,8 +32,71 @@ os.environ.setdefault("SUROGATES_DOCUMENT_PARSE_USE_SUBPROCESS", "0")
 
 
 # ---------------------------------------------------------------------------
+# Running the surogates schema on in-memory SQLite
+#
+# Most of the metadata is Postgres-only: 26 columns are bare ``JSONB``, many
+# primary keys are bare ``postgresql.UUID``, and four tables carry a CHECK
+# constraint written with the Postgres-only ``::int`` cast.  The three hooks
+# below teach SQLite to render each of those, and ``sqlite_tables`` builds
+# only the tables a test names, because whole-metadata creation drags in
+# everything whether the test needs it or not.
+#
+# These hooks are process-global, but they only ever ADD capability: before
+# them, compiling any of these constructs against SQLite raised outright, so
+# no previously-passing test can change behaviour.
+# ---------------------------------------------------------------------------
+
+@compiles(JSONB, "sqlite")
+def _jsonb_on_sqlite(type_, compiler, **kw):
+    return "JSON"
+
+
+@compiles(PGUUID, "sqlite")
+def _uuid_on_sqlite(type_, compiler, **kw):
+    return "CHAR(36)"
+
+
+@compiles(CheckConstraint, "sqlite")
+def _check_on_sqlite(element, compiler, **kw):
+    # SQLite has no ``::int`` cast and does not need one — a boolean there is
+    # already 0 or 1, so dropping the cast preserves the constraint's meaning.
+    return compiler.visit_check_constraint(element, **kw).replace("::int", "")
+
+
+def sqlite_tables(*names: str) -> list:
+    """The named tables, for ``create_all(tables=...)``.
+
+    A name that matches nothing is ignored, so callers may list tables
+    optimistically.
+    """
+    wanted = set(names)
+    return [t for name, t in Base.metadata.tables.items() if name in wanted]
+
+
+# ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def sf():
+    """Session factory over an in-memory SQLite database with the program tables.
+
+    StaticPool keeps every session on the one connection that owns the
+    database; without it each session would see a fresh, empty schema.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", poolclass=StaticPool,
+    )
+    tables = sqlite_tables(
+        "program_schedules", "program_occurrences", "program_invitations",
+        "inbox_items", "events", "sessions", "orgs", "users",
+        "channel_identities",
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all, tables=tables)
+    yield async_sessionmaker(engine, expire_on_commit=False)
+    await engine.dispose()
+
 
 @pytest.fixture()
 def tenant_context(tmp_path: Path) -> TenantContext:

--- a/tests/test_checkin_tools.py
+++ b/tests/test_checkin_tools.py
@@ -21,7 +21,7 @@ ESCALATION_SA = uuid.uuid4()
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(timezone.utc)
 
 
 async def _reload(sf, invitation_id):

--- a/tests/test_checkin_tools.py
+++ b/tests/test_checkin_tools.py
@@ -1,0 +1,197 @@
+"""The two tools an agent uses to close or escalate a check-in."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from surogates.db.models import (
+    InboxItem,
+    ProgramInvitationRow,
+    ProgramOccurrenceRow,
+    ProgramScheduleRow,
+)
+from surogates.tools.router import TOOL_LOCATIONS, ToolLocation
+
+ESCALATION_SA = uuid.uuid4()
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+async def _reload(sf, invitation_id):
+    async with sf() as db:
+        return await db.get(ProgramInvitationRow, invitation_id)
+
+
+async def _latest_inbox_item(sf):
+    async with sf() as db:
+        return (
+            await db.execute(
+                sa.select(InboxItem).order_by(InboxItem.id.desc()).limit(1)
+            )
+        ).scalar_one_or_none()
+
+
+@pytest_asyncio.fixture
+async def awaiting_invitation(sf):
+    """A check-in the patient replied to, attached to their session."""
+    program_id, org_id = uuid.uuid4(), uuid.uuid4()
+    async with sf() as db:
+        db.add(
+            ProgramScheduleRow(
+                program_id=program_id,
+                org_id=org_id,
+                agent_id="a1",
+                active=True,
+                config={"escalation_service_account_id": str(ESCALATION_SA)},
+            )
+        )
+        occ = ProgramOccurrenceRow(
+            program_id=program_id,
+            org_id=org_id,
+            agent_id="a1",
+            scheduled_for=_utcnow(),
+            skill_ref="post-op",
+            template_name="daily",
+            template_language="en_US",
+            status="fired",
+        )
+        db.add(occ)
+        await db.flush()
+        row = ProgramInvitationRow(
+            occurrence_id=occ.id,
+            program_id=program_id,
+            org_id=org_id,
+            agent_id="a1",
+            user_id=uuid.uuid4(),
+            platform="whatsapp",
+            platform_user_id="40746148303",
+            delivery_state="accepted",
+            response_state="replied",
+            escalation_state="none",
+            session_id=uuid.uuid4(),
+        )
+        db.add(row)
+        await db.commit()
+        return row
+
+
+def _kwargs(sf, invitation):
+    # Exactly what tools.dispatch passes its handlers.
+    return {
+        "session_id": invitation.session_id,
+        "session_factory": sf,
+        "tenant": None,
+        "api_client": None,
+        "session_config": {},
+    }
+
+
+def test_both_tools_route_to_the_harness():
+    # An unlisted tool falls through to the sandbox executor and fails as
+    # "Unknown tool" — these write invitation rows and operator inbox items
+    # and need the worker's database.
+    assert TOOL_LOCATIONS["checkin_outcome"] is ToolLocation.HARNESS
+    assert TOOL_LOCATIONS["checkin_escalate"] is ToolLocation.HARNESS
+
+
+@pytest.mark.asyncio
+async def test_checkin_outcome_records_completion(sf, awaiting_invitation):
+    from surogates.tools.builtin.checkin import handle_checkin_outcome
+
+    await handle_checkin_outcome(
+        {"outcome": "completed"}, **_kwargs(sf, awaiting_invitation),
+    )
+    assert (await _reload(sf, awaiting_invitation.id)).response_state == "completed"
+
+
+@pytest.mark.asyncio
+async def test_checkin_outcome_rejects_an_unknown_outcome(sf, awaiting_invitation):
+    from surogates.tools.builtin.checkin import handle_checkin_outcome
+
+    result = await handle_checkin_outcome(
+        {"outcome": "maybe"}, **_kwargs(sf, awaiting_invitation),
+    )
+    assert "completed" in result
+    assert (await _reload(sf, awaiting_invitation.id)).response_state == "replied"
+
+
+@pytest.mark.asyncio
+async def test_checkin_outcome_outside_a_check_in_writes_nothing(
+    sf, awaiting_invitation,
+):
+    # The invitation is found by session, so an agent in an ordinary
+    # conversation cannot close a check-in it is not part of.
+    from surogates.tools.builtin.checkin import handle_checkin_outcome
+
+    kwargs = _kwargs(sf, awaiting_invitation)
+    kwargs["session_id"] = uuid.uuid4()
+    result = await handle_checkin_outcome({"outcome": "completed"}, **kwargs)
+    assert "no check-in" in result.lower()
+    assert (await _reload(sf, awaiting_invitation.id)).response_state == "replied"
+
+
+@pytest.mark.asyncio
+async def test_escalation_targets_the_operator_not_the_patient(
+    sf, awaiting_invitation,
+):
+    # An item created against the acting principal lands in the patient's own
+    # inbox and reaches nobody else.
+    from surogates.tools.builtin.checkin import handle_checkin_escalate
+
+    await handle_checkin_escalate(
+        {"reason": "BP 180/110"}, **_kwargs(sf, awaiting_invitation),
+    )
+    item = await _latest_inbox_item(sf)
+    assert item is not None
+    assert item.service_account_id == ESCALATION_SA
+    assert item.user_id is None
+    # Must be an existing InboxKind — the ops Inbox filters on a Literal, and
+    # a new value would simply never be listed.
+    assert item.kind == "action_required"
+    assert item.session_id == awaiting_invitation.session_id
+    assert (await _reload(sf, awaiting_invitation.id)).escalation_state == "raised"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_escalation_is_visible(sf, awaiting_invitation):
+    # The agent saying it escalated is not evidence anyone was told.
+    from surogates.tools.builtin.checkin import handle_checkin_escalate
+
+    async with sf() as db:
+        sched = (
+            await db.execute(
+                sa.select(ProgramScheduleRow).where(
+                    ProgramScheduleRow.program_id == awaiting_invitation.program_id
+                )
+            )
+        ).scalar_one()
+        sched.config = {}  # no escalation target configured
+        await db.commit()
+
+    result = await handle_checkin_escalate(
+        {"reason": "x"}, **_kwargs(sf, awaiting_invitation),
+    )
+    row = await _reload(sf, awaiting_invitation.id)
+    assert row.escalation_state == "failed"
+    assert row.reason
+    assert "could not escalate" in result.lower()
+    assert await _latest_inbox_item(sf) is None
+
+
+@pytest.mark.asyncio
+async def test_escalation_does_not_close_the_check_in(sf, awaiting_invitation):
+    # Escalation and response are separate axes: raising a hand to the doctor
+    # does not mean the patient finished answering.
+    from surogates.tools.builtin.checkin import handle_checkin_escalate
+
+    await handle_checkin_escalate(
+        {"reason": "BP 180/110"}, **_kwargs(sf, awaiting_invitation),
+    )
+    assert (await _reload(sf, awaiting_invitation.id)).response_state == "replied"

--- a/tests/test_checkin_tools.py
+++ b/tests/test_checkin_tools.py
@@ -195,3 +195,33 @@ async def test_escalation_does_not_close_the_check_in(sf, awaiting_invitation):
         {"reason": "BP 180/110"}, **_kwargs(sf, awaiting_invitation),
     )
     assert (await _reload(sf, awaiting_invitation.id)).response_state == "replied"
+
+
+def test_the_checkin_tools_are_registered_with_the_other_builtins():
+    # ``tests`` above call the handlers directly, which passes while the
+    # tools are unreachable in production.  The synthetic instruction tells
+    # the agent to call them by name; they have to be in the registry.
+    from surogates.tools.registry import ToolRegistry
+    from surogates.tools.runtime import ToolRuntime
+
+    registry = ToolRegistry()
+    ToolRuntime(registry).register_builtins()
+    assert registry.has("checkin_outcome")
+    assert registry.has("checkin_escalate")
+
+
+def test_the_checkin_tools_are_only_offered_on_a_channel_session():
+    from surogates.harness.tool_schemas import drop_unusable_tools
+
+    schemas = [
+        {"function": {"name": n}}
+        for n in ("checkin_outcome", "checkin_escalate", "terminal")
+    ]
+    off_channel = drop_unusable_tools(
+        schemas, has_kbs=False, has_channel=False, is_scheduled=False,
+    )
+    assert {s["function"]["name"] for s in off_channel} == {"terminal"}
+    on_channel = drop_unusable_tools(
+        schemas, has_kbs=False, has_channel=True, is_scheduled=False,
+    )
+    assert len(on_channel) == 3

--- a/tests/test_program_cadence.py
+++ b/tests/test_program_cadence.py
@@ -46,6 +46,36 @@ def test_a_nonexistent_local_time_moves_to_the_first_valid_instant():
     assert got[0] is not None  # resolved, not skipped and not crashed
 
 
+def test_spring_forward_keeps_the_slots_in_order_and_fires_both():
+    # Sorting by local time-of-day is not monotone across the gap: 02:30 does
+    # not exist on this day, and resolving it with the pre-transition offset
+    # puts it AFTER 03:00 in real time. Sorting the resolved instants instead
+    # is what keeps the operator preview honest and stops a slot being lost.
+    got = next_occurrences(
+        datetime(2026, 3, 7, 23, 0),
+        weekdays=["sun"],
+        times_local=["02:30", "03:00"],
+        timezone="America/New_York",
+        count=2,
+    )
+    assert got == sorted(got)
+    # Both of Sunday's slots fire; neither is skipped to the following week.
+    assert all(d.date().isoformat() == "2026-03-08" for d in got), got
+
+
+def test_the_first_instant_after_a_spring_forward_is_the_earlier_slot():
+    got = next_occurrences(
+        datetime(2026, 3, 7, 23, 0),
+        weekdays=["sun"],
+        times_local=["02:30", "03:00"],
+        timezone="America/New_York",
+        count=1,
+    )
+    # 03:00 EST is 08:00 UTC; the nonexistent 02:30 resolves to 07:30 UTC.
+    # The earlier real instant must come first.
+    assert got[0].hour == 7
+
+
 def test_a_repeated_local_time_fires_once():
     # Autumn back: 03:00-04:00 happens twice on 2026-10-25 in Bucharest.
     got = next_occurrences(

--- a/tests/test_program_cadence.py
+++ b/tests/test_program_cadence.py
@@ -1,0 +1,60 @@
+"""Turning a Program's cadence into UTC instants, DST included."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from surogates.programs.cadence import next_occurrences
+
+
+def test_two_times_a_day_gives_two_occurrences():
+    # "Every 12 hours" is two times of day, not an interval — an interval
+    # anchored to a start instant drifts into the small hours.
+    # 2026-09-09 is a Wednesday. Start at 05:00 UTC, strictly before the
+    # first slot — 09:00 EEST is exactly 06:00 UTC, and "after" is strict,
+    # so starting at 06:00 would skip it and return [18, 6].
+    got = next_occurrences(
+        datetime(2026, 9, 9, 5, 0),
+        weekdays=["wed"],
+        times_local=["09:00", "21:00"],
+        timezone="Europe/Bucharest",
+        count=2,
+    )
+    assert [d.hour for d in got] == [6, 18]  # 09:00 and 21:00 EEST = UTC+3
+
+
+def test_it_skips_days_not_in_the_set():
+    got = next_occurrences(
+        datetime(2026, 9, 9, 12, 0),  # Wednesday
+        weekdays=["mon"],
+        times_local=["09:00"],
+        timezone="UTC",
+        count=1,
+    )
+    assert got[0].weekday() == 0  # the following Monday
+
+
+def test_a_nonexistent_local_time_moves_to_the_first_valid_instant():
+    # Spring forward: 03:00-04:00 does not exist on 2026-03-29 in Bucharest.
+    got = next_occurrences(
+        datetime(2026, 3, 28, 12, 0),
+        weekdays=["sun"],
+        times_local=["03:30"],
+        timezone="Europe/Bucharest",
+        count=1,
+    )
+    assert got[0] is not None  # resolved, not skipped and not crashed
+
+
+def test_a_repeated_local_time_fires_once():
+    # Autumn back: 03:00-04:00 happens twice on 2026-10-25 in Bucharest.
+    got = next_occurrences(
+        datetime(2026, 10, 24, 12, 0),
+        weekdays=["sun"],
+        times_local=["03:30"],
+        timezone="Europe/Bucharest",
+        count=2,
+    )
+    assert len(set(got)) == len(got)
+    # The second is the following week, not the repeated hour.
+    assert (got[1] - got[0]).days >= 6

--- a/tests/test_program_deadline_sweep.py
+++ b/tests/test_program_deadline_sweep.py
@@ -11,7 +11,7 @@ from surogates.programs.ticker import sweep_deadlines
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(timezone.utc)
 
 
 @pytest_asyncio.fixture

--- a/tests/test_program_deadline_sweep.py
+++ b/tests/test_program_deadline_sweep.py
@@ -42,15 +42,6 @@ async def skipped_invitation(make_invitation):
     )
 
 
-@pytest_asyncio.fixture
-async def replied_invitation(make_invitation):
-    return await make_invitation(
-        delivery_state="accepted",
-        response_state="replied",
-        deadline_at=_utcnow() + timedelta(hours=24),
-    )
-
-
 @pytest.mark.asyncio
 async def test_an_unanswered_invitation_expires(
     sf, awaiting_invitation, reload_invitation,
@@ -80,12 +71,37 @@ async def test_a_skipped_patient_is_not_a_non_responder(
     assert row.response_state != "no_reply_by_deadline"
 
 
+@pytest_asyncio.fixture
+async def replied_but_never_closed(make_invitation):
+    return await make_invitation(
+        delivery_state="accepted",
+        response_state="replied",
+        deadline_at=_utcnow() + timedelta(hours=24),
+    )
+
+
 @pytest.mark.asyncio
-async def test_a_replied_invitation_is_left_alone(
-    sf, replied_invitation, reload_invitation,
+async def test_a_check_in_the_agent_never_closed_expires(
+    sf, replied_but_never_closed, reload_invitation,
 ):
+    # Only checkin_outcome moves an invitation out of "replied". If the
+    # patient trails off mid-answer, or the session errors, or the model
+    # simply never calls the tool, the row would stay open forever — and
+    # because an open check-in suppresses the next one, that patient would
+    # silently drop out of the Program for good.
     await sweep_deadlines(sf, now=_utcnow() + timedelta(hours=25))
-    row = await reload_invitation(replied_invitation.id)
+    row = await reload_invitation(replied_but_never_closed.id)
+    assert row.response_state == "incomplete"
+    # Distinct from silence: they did answer, the check-in just never closed.
+    assert row.response_state != "no_reply_by_deadline"
+
+
+@pytest.mark.asyncio
+async def test_a_replied_invitation_inside_its_deadline_is_left_alone(
+    sf, replied_but_never_closed, reload_invitation,
+):
+    await sweep_deadlines(sf, now=_utcnow())
+    row = await reload_invitation(replied_but_never_closed.id)
     assert row.response_state == "replied"
 
 

--- a/tests/test_program_deadline_sweep.py
+++ b/tests/test_program_deadline_sweep.py
@@ -1,0 +1,101 @@
+"""Expiring check-ins nobody answered."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+
+from surogates.programs.ticker import sweep_deadlines
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+@pytest_asyncio.fixture
+async def awaiting_invitation(make_invitation):
+    return await make_invitation(
+        delivery_state="accepted",
+        response_state="awaiting_reply",
+        deadline_at=_utcnow() + timedelta(hours=24),
+    )
+
+
+@pytest_asyncio.fixture
+async def failed_invitation(make_invitation):
+    # Deadline set, never delivered.
+    return await make_invitation(
+        delivery_state="failed",
+        response_state="awaiting_reply",
+        deadline_at=_utcnow() + timedelta(hours=24),
+    )
+
+
+@pytest_asyncio.fixture
+async def skipped_invitation(make_invitation):
+    return await make_invitation(
+        delivery_state="skipped",
+        response_state="not_started",
+        deadline_at=_utcnow() + timedelta(hours=24),
+    )
+
+
+@pytest_asyncio.fixture
+async def replied_invitation(make_invitation):
+    return await make_invitation(
+        delivery_state="accepted",
+        response_state="replied",
+        deadline_at=_utcnow() + timedelta(hours=24),
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unanswered_invitation_expires(
+    sf, awaiting_invitation, reload_invitation,
+):
+    await sweep_deadlines(sf, now=_utcnow() + timedelta(hours=25))
+    row = await reload_invitation(awaiting_invitation.id)
+    assert row.response_state == "no_reply_by_deadline"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_delivery_is_not_a_non_responder(
+    sf, failed_invitation, reload_invitation,
+):
+    # They were never asked. Counting them as silent would blame the patient
+    # for our failure to reach them.
+    await sweep_deadlines(sf, now=_utcnow() + timedelta(hours=25))
+    row = await reload_invitation(failed_invitation.id)
+    assert row.response_state != "no_reply_by_deadline"
+
+
+@pytest.mark.asyncio
+async def test_a_skipped_patient_is_not_a_non_responder(
+    sf, skipped_invitation, reload_invitation,
+):
+    await sweep_deadlines(sf, now=_utcnow() + timedelta(hours=25))
+    row = await reload_invitation(skipped_invitation.id)
+    assert row.response_state != "no_reply_by_deadline"
+
+
+@pytest.mark.asyncio
+async def test_a_replied_invitation_is_left_alone(
+    sf, replied_invitation, reload_invitation,
+):
+    await sweep_deadlines(sf, now=_utcnow() + timedelta(hours=25))
+    row = await reload_invitation(replied_invitation.id)
+    assert row.response_state == "replied"
+
+
+@pytest.mark.asyncio
+async def test_the_deadline_is_not_reached_yet(
+    sf, awaiting_invitation, reload_invitation,
+):
+    # The negative control: the sweep must key on the deadline, not simply
+    # expire everything it finds awaiting a reply.
+    swept = await sweep_deadlines(sf, now=_utcnow())
+    assert swept == 0
+    row = await reload_invitation(awaiting_invitation.id)
+    assert row.response_state == "awaiting_reply"

--- a/tests/test_program_deadline_sweep.py
+++ b/tests/test_program_deadline_sweep.py
@@ -115,3 +115,62 @@ async def test_the_deadline_is_not_reached_yet(
     assert swept == 0
     row = await reload_invitation(awaiting_invitation.id)
     assert row.response_state == "awaiting_reply"
+
+
+@pytest.mark.asyncio
+async def test_the_send_pass_is_skipped_when_the_leader_lock_is_lost(sf):
+    # A backlog of openers is the one tick phase that can outlive the lease.
+    # A replica that is no longer leader must not run the same pass over the
+    # same still-queued rows — that is every patient messaged twice.
+    from surogates.programs.ticker import ProgramTicker
+
+    class _Store:
+        async def claim_due(self, **kw):
+            return []
+
+    class _LostLock:
+        async def heartbeat(self):
+            return False
+
+    sent = []
+
+    async def _send():
+        sent.append(1)
+
+    async def _materialize(row):  # pragma: no cover - no rows are claimed
+        raise AssertionError("nothing to materialise")
+
+    ticker = ProgramTicker(
+        _Store(), session_factory=sf, materialize=_materialize,
+        worker_id="w1", send_openers=_send, leader_lock=_LostLock(),
+    )
+    await ticker.tick_once()
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_the_send_pass_runs_while_the_leader_lock_holds(sf):
+    from surogates.programs.ticker import ProgramTicker
+
+    class _Store:
+        async def claim_due(self, **kw):
+            return []
+
+    class _HeldLock:
+        async def heartbeat(self):
+            return True
+
+    sent = []
+
+    async def _send():
+        sent.append(1)
+
+    async def _materialize(row):  # pragma: no cover
+        raise AssertionError("nothing to materialise")
+
+    ticker = ProgramTicker(
+        _Store(), session_factory=sf, materialize=_materialize,
+        worker_id="w1", send_openers=_send, leader_lock=_HeldLock(),
+    )
+    await ticker.tick_once()
+    assert sent == [1]

--- a/tests/test_program_deadline_sweep.py
+++ b/tests/test_program_deadline_sweep.py
@@ -97,6 +97,48 @@ async def test_a_check_in_the_agent_never_closed_expires(
 
 
 @pytest.mark.asyncio
+async def test_a_failed_send_left_awaiting_reply_is_released_at_the_deadline(
+    sf, failed_invitation, reload_invitation,
+):
+    # The send failed after the row was marked awaiting a reply.  Nobody is
+    # awaited: left open, the row suppresses this patient's next occurrence
+    # forever, with nothing terminal in the history to say why.
+    await sweep_deadlines(sf, now=_utcnow() + timedelta(hours=25))
+    row = await reload_invitation(failed_invitation.id)
+    assert row.delivery_state == "failed"
+    assert row.response_state == "not_started"
+
+
+@pytest.mark.asyncio
+async def test_an_opener_with_no_delivery_report_is_recorded_failed(
+    sf, make_invitation, reload_invitation,
+):
+    # Claimed, but no dispatcher verdict ever came — the outbox row was lost
+    # or the process died between claiming and handing over.  At the
+    # deadline that is a delivery failure the operator needs to see, not a
+    # row that looks in flight.
+    inv = await make_invitation(
+        delivery_state="queued", response_state="awaiting_reply",
+        deadline_at=_utcnow() + timedelta(hours=24),
+    )
+    await sweep_deadlines(sf, now=_utcnow() + timedelta(hours=25))
+    row = await reload_invitation(inv.id)
+    assert row.delivery_state == "failed"
+    assert row.delivery_error
+    assert row.response_state == "not_started"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_send_inside_its_deadline_is_left_alone(
+    sf, failed_invitation, reload_invitation,
+):
+    # The dispatcher may still be retrying; only the deadline settles it.
+    await sweep_deadlines(sf, now=_utcnow())
+    row = await reload_invitation(failed_invitation.id)
+    assert row.response_state == "awaiting_reply"
+
+
+@pytest.mark.asyncio
 async def test_a_replied_invitation_inside_its_deadline_is_left_alone(
     sf, replied_but_never_closed, reload_invitation,
 ):

--- a/tests/test_program_materialize.py
+++ b/tests/test_program_materialize.py
@@ -15,7 +15,7 @@ from surogates.programs.materialize import materialize_occurrence
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(timezone.utc)
 
 
 async def _invitations(sf, occurrence_id):

--- a/tests/test_program_materialize.py
+++ b/tests/test_program_materialize.py
@@ -1,0 +1,196 @@
+"""Turning one due instant into an occurrence and its per-patient invitations."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from surogates.db.models import ProgramInvitationRow
+from surogates.programs.materialize import materialize_occurrence
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+async def _invitations(sf, occurrence_id):
+    async with sf() as db:
+        return (
+            await db.execute(
+                sa.select(ProgramInvitationRow)
+                .where(ProgramInvitationRow.occurrence_id == occurrence_id)
+                .order_by(ProgramInvitationRow.created_at)
+            )
+        ).scalars().all()
+
+
+def _granted(platform_user_id):
+    return SimpleNamespace(
+        platform_user_id=platform_user_id,
+        platform_meta={"contact_permission": {"status": "granted"}},
+    )
+
+
+def _schedule(patients):
+    return SimpleNamespace(
+        program_id=uuid.uuid4(),
+        org_id=uuid.uuid4(),
+        agent_id="a1",
+        config={
+            "channel": "whatsapp",
+            "skill_ref": "post-op",
+            "template_name": "daily",
+            "template_language": "en_US",
+            "response_deadline_hours": 24,
+            "patients": [str(p) for p in patients],
+        },
+    )
+
+
+@pytest.fixture
+def schedule():
+    return _schedule([uuid.uuid4()])
+
+
+@pytest.fixture
+def schedule_with_three_patients():
+    return _schedule([uuid.uuid4(), uuid.uuid4(), uuid.uuid4()])
+
+
+@pytest.fixture
+def identity_lookup():
+    async def _lookup(org_id, platform, user_id):
+        return _granted(f"4074{str(user_id)[:7]}")
+    return _lookup
+
+
+@pytest.fixture
+def identity_lookup_missing_one(schedule_with_three_patients):
+    last = schedule_with_three_patients.config["patients"][-1]
+
+    async def _lookup(org_id, platform, user_id):
+        if str(user_id) == last:
+            return None
+        return _granted(f"4074{str(user_id)[:7]}")
+    return _lookup
+
+
+@pytest.fixture
+def identity_lookup_no_permission():
+    async def _lookup(org_id, platform, user_id):
+        ident = _granted(f"4074{str(user_id)[:7]}")
+        ident.platform_meta = {"contact_permission": {"status": "withdrawn"}}
+        return ident
+    return _lookup
+
+
+@pytest_asyncio.fixture
+async def open_invitation(sf, schedule, identity_lookup):
+    # A check-in from an earlier occurrence that the patient replied to and
+    # has not finished — the state the next tick must respect.
+    user_id = uuid.UUID(schedule.config["patients"][0])
+    ident = await identity_lookup(schedule.org_id, "whatsapp", user_id)
+    async with sf() as db:
+        row = ProgramInvitationRow(
+            occurrence_id=uuid.uuid4(),
+            program_id=schedule.program_id,
+            org_id=schedule.org_id,
+            agent_id=schedule.agent_id,
+            user_id=user_id,
+            platform="whatsapp",
+            platform_user_id=ident.platform_user_id,
+            delivery_state="accepted",
+            response_state="replied",
+            escalation_state="none",
+        )
+        db.add(row)
+        await db.commit()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_every_patient_gets_a_row_including_the_skipped(
+    sf, schedule_with_three_patients, identity_lookup_missing_one,
+):
+    # The history denominator is the roster. Dropping an unreachable patient
+    # would quietly shrink "12 of 14" to "12 of 13".
+    occ_id = await materialize_occurrence(
+        schedule_with_three_patients,
+        session_factory=sf,
+        identity_lookup=identity_lookup_missing_one,
+        now=_utcnow(),
+    )
+    rows = await _invitations(sf, occ_id)
+    assert len(rows) == 3
+    skipped = [r for r in rows if r.delivery_state == "skipped"]
+    assert len(skipped) == 1
+    assert "no whatsapp identity" in skipped[0].reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_a_patient_without_permission_is_skipped_not_messaged(
+    sf, schedule, identity_lookup_no_permission,
+):
+    occ_id = await materialize_occurrence(
+        schedule,
+        session_factory=sf,
+        identity_lookup=identity_lookup_no_permission,
+        now=_utcnow(),
+    )
+    rows = await _invitations(sf, occ_id)
+    assert rows[0].delivery_state == "skipped"
+    assert "permission" in rows[0].reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_firing_the_same_instant_twice_is_idempotent(
+    sf, schedule, identity_lookup,
+):
+    # A crashed or retried tick must not double-message a patient.
+    when = datetime(2026, 9, 9, 9, 0)
+    a = await materialize_occurrence(
+        schedule, session_factory=sf, identity_lookup=identity_lookup, now=when,
+    )
+    b = await materialize_occurrence(
+        schedule, session_factory=sf, identity_lookup=identity_lookup, now=when,
+    )
+    assert a == b
+    assert len(await _invitations(sf, a)) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_patient_with_an_open_check_in_is_skipped(
+    sf, schedule, identity_lookup, open_invitation,
+):
+    occ_id = await materialize_occurrence(
+        schedule,
+        session_factory=sf,
+        identity_lookup=identity_lookup,
+        now=_utcnow(),
+    )
+    rows = await _invitations(sf, occ_id)
+    assert rows[0].delivery_state == "skipped"
+    assert "still open" in rows[0].reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_a_reachable_patient_is_queued_not_skipped(
+    sf, schedule, identity_lookup,
+):
+    # The positive case, so the skip logic above cannot pass by skipping
+    # everyone unconditionally.
+    occ_id = await materialize_occurrence(
+        schedule,
+        session_factory=sf,
+        identity_lookup=identity_lookup,
+        now=_utcnow(),
+    )
+    rows = await _invitations(sf, occ_id)
+    assert rows[0].delivery_state == "queued"
+    assert rows[0].reason is None
+    assert rows[0].platform_user_id

--- a/tests/test_program_materialize.py
+++ b/tests/test_program_materialize.py
@@ -164,9 +164,88 @@ async def test_firing_the_same_instant_twice_is_idempotent(
 
 
 @pytest.mark.asyncio
+async def test_a_retried_tick_on_a_claimed_schedule_does_not_double_message(
+    sf, identity_lookup,
+):
+    # The production contract, end to end: the instant stamped on the
+    # occurrence is the schedule's due time. The earlier idempotence test
+    # passes one literal twice, which any caller can satisfy by accident —
+    # this one goes through a real claimed row, the way the ticker does, and
+    # fails if a fresh wall clock is ever substituted.
+    import asyncio
+    from datetime import timedelta
+
+    from surogates.programs.store import ProgramScheduleStore
+
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    await store.ensure(
+        program_id=pid, org_id=uuid.uuid4(), agent_id="a1",
+        config={"channel": "whatsapp", "skill_ref": "s",
+                "patients": [str(uuid.uuid4())]},
+        next_run_at=_utcnow() - timedelta(minutes=1),
+    )
+    claimed = (await store.claim_due(worker_id="w1", limit=1))[0]
+
+    first = await materialize_occurrence(
+        claimed, session_factory=sf, identity_lookup=identity_lookup,
+        now=claimed.next_run_at,
+    )
+    await asyncio.sleep(0.01)  # a fresh wall clock would differ here
+    second = await materialize_occurrence(
+        claimed, session_factory=sf, identity_lookup=identity_lookup,
+        now=claimed.next_run_at,
+    )
+    assert first == second
+    assert len(await _invitations(sf, first)) == 1
+
+
+@pytest.mark.asyncio
 async def test_a_patient_with_an_open_check_in_is_skipped(
     sf, schedule, identity_lookup, open_invitation,
 ):
+    occ_id = await materialize_occurrence(
+        schedule,
+        session_factory=sf,
+        identity_lookup=identity_lookup,
+        now=_utcnow(),
+    )
+    rows = await _invitations(sf, occ_id)
+    assert rows[0].delivery_state == "skipped"
+    assert "still open" in rows[0].reason.lower()
+
+
+@pytest_asyncio.fixture
+async def unanswered_invitation(sf, schedule, identity_lookup):
+    """An opener already sent, still inside its response deadline."""
+    user_id = uuid.UUID(schedule.config["patients"][0])
+    ident = await identity_lookup(schedule.org_id, "whatsapp", user_id)
+    async with sf() as db:
+        row = ProgramInvitationRow(
+            occurrence_id=uuid.uuid4(),
+            program_id=schedule.program_id,
+            org_id=schedule.org_id,
+            agent_id=schedule.agent_id,
+            user_id=user_id,
+            platform="whatsapp",
+            platform_user_id=ident.platform_user_id,
+            delivery_state="accepted",
+            response_state="awaiting_reply",
+            escalation_state="none",
+        )
+        db.add(row)
+        await db.commit()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_a_patient_with_an_unanswered_opener_is_skipped(
+    sf, schedule, identity_lookup, unanswered_invitation,
+):
+    # The canonical cadence is twice a day against a 24-hour deadline, so the
+    # next occurrence arrives while the first opener is still live. Sending a
+    # second one asks the same person two questions at once, and whichever
+    # they do not answer is later recorded as a non-response.
     occ_id = await materialize_occurrence(
         schedule,
         session_factory=sf,

--- a/tests/test_program_ops_projection.py
+++ b/tests/test_program_ops_projection.py
@@ -110,3 +110,21 @@ async def test_an_empty_projection_is_a_real_answer():
     assert await fetch_active_programs(
         client, base_url="http://ops:8888", runtime_key="rk",
     ) == []
+
+
+@pytest.mark.asyncio
+async def test_a_non_json_200_returns_none():
+    # A proxy error page answers 200 with HTML. Raising out of the fetch is
+    # caught by the tick, but the None-not-[] contract belongs to this
+    # function, not to whoever happens to call it.
+    class _HtmlResp:
+        status_code = 200
+        is_success = True
+
+        def json(self):
+            raise ValueError("Expecting value: line 1 column 1")
+
+    client = _Client(_HtmlResp())
+    assert await fetch_active_programs(
+        client, base_url="http://ops:8888", runtime_key="rk",
+    ) is None

--- a/tests/test_program_ops_projection.py
+++ b/tests/test_program_ops_projection.py
@@ -1,0 +1,112 @@
+"""Fetching ops' active-Program projection."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from surogates.programs.ops_projection import fetch_active_programs
+
+
+class _Resp:
+    def __init__(self, status_code, body):
+        self.status_code = status_code
+        self._body = body
+        self.is_success = 200 <= status_code < 300
+
+    def json(self):
+        return self._body
+
+
+class _Client:
+    def __init__(self, response=None, raises=None):
+        self._response = response
+        self._raises = raises
+        self.calls: list[tuple[str, dict]] = []
+
+    async def get(self, url, **kw):
+        self.calls.append((url, kw))
+        if self._raises is not None:
+            raise self._raises
+        return self._response
+
+
+def _row():
+    return {
+        "id": str(uuid.uuid4()),
+        "org_id": str(uuid.uuid4()),
+        "agent_id": "a1",
+        "skill_ref": "post-op",
+        "channel": "whatsapp",
+        "channel_identifier": "127",
+        "template_name": "daily",
+        "template_language": "en_US",
+        "weekdays": ["mon"],
+        "times_local": ["09:00"],
+        "timezone": "UTC",
+        "response_deadline_hours": 24,
+        "escalation_service_account_id": str(uuid.uuid4()),
+        "patients": [str(uuid.uuid4())],
+    }
+
+
+@pytest.mark.asyncio
+async def test_it_sends_the_runtime_key_and_returns_the_rows():
+    row = _row()
+    client = _Client(_Resp(200, [row]))
+    got = await fetch_active_programs(
+        client, base_url="http://ops:8888", runtime_key="rk_secret",
+    )
+    assert got == [row]
+
+    url, kw = client.calls[0]
+    assert url == "http://ops:8888/api/programs/active"
+    # The endpoint is runtime-scoped; without the bearer it answers 401 and
+    # every Program would silently stop being reconciled.
+    assert kw["headers"]["Authorization"] == "Bearer rk_secret"
+
+
+@pytest.mark.asyncio
+async def test_a_trailing_slash_does_not_double_up():
+    client = _Client(_Resp(200, []))
+    await fetch_active_programs(
+        client, base_url="http://ops:8888/", runtime_key="rk",
+    )
+    assert client.calls[0][0] == "http://ops:8888/api/programs/active"
+
+
+@pytest.mark.asyncio
+async def test_an_unreachable_ops_returns_none_not_an_empty_list():
+    # The distinction is the whole point. An empty list means "ops says no
+    # Programs are active", which reconcile answers by deactivating every
+    # schedule. A failed fetch must never be able to say that.
+    client = _Client(raises=RuntimeError("connection refused"))
+    assert await fetch_active_programs(
+        client, base_url="http://ops:8888", runtime_key="rk",
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_fetch_returns_none():
+    client = _Client(_Resp(401, {"detail": "unauthorized"}))
+    assert await fetch_active_programs(
+        client, base_url="http://ops:8888", runtime_key="rk",
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_a_non_list_body_returns_none():
+    # A proxy error page answering 200 must not be read as "no Programs".
+    client = _Client(_Resp(200, {"detail": "gateway"}))
+    assert await fetch_active_programs(
+        client, base_url="http://ops:8888", runtime_key="rk",
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_an_empty_projection_is_a_real_answer():
+    client = _Client(_Resp(200, []))
+    assert await fetch_active_programs(
+        client, base_url="http://ops:8888", runtime_key="rk",
+    ) == []

--- a/tests/test_program_reconcile.py
+++ b/tests/test_program_reconcile.py
@@ -150,3 +150,43 @@ async def test_resuming_does_not_fire_the_slot_that_was_missed(sf):
     assert resumed.active is True
     assert resumed.next_run_at > _utcnow()
     assert await store.claim_due(worker_id="w1", limit=10) == []
+
+
+@pytest.mark.asyncio
+async def test_one_malformed_program_does_not_stop_the_fleet(sf):
+    # Nothing validates the projection before it arrives. A single bad row
+    # used to raise out of the loop, skipping every Program after it AND
+    # skipping deactivate_missing — so a Program the operator had paused kept
+    # messaging patients indefinitely, every tick, because of someone else's
+    # typo.
+    store = ProgramScheduleStore(sf)
+    good_before, good_after, paused = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    await reconcile_programs(store, projected=[_projected(paused)])
+    assert (await store.get(paused)).active is True
+
+    await reconcile_programs(store, projected=[
+        _projected(good_before),
+        _projected(uuid.uuid4(), timezone="Mars/Olympus_Mons"),
+        _projected(uuid.uuid4(), times_local=["9"]),
+        {"id": "not-a-uuid", "org_id": str(uuid.uuid4()), "agent_id": "a1"},
+        _projected(good_after),
+    ])
+
+    assert (await store.get(good_before)).active is True
+    # The Program after the bad rows still got its schedule.
+    assert (await store.get(good_after)).active is True
+    # And the one that left the projection was deactivated despite the noise.
+    assert (await store.get(paused)).active is False
+
+
+@pytest.mark.asyncio
+async def test_a_program_that_cannot_be_parsed_does_not_fire(sf):
+    # A Program we cannot understand must not message anyone. Leaving it out
+    # of `seen` deactivates whatever schedule it had.
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    await reconcile_programs(store, projected=[_projected(pid)])
+    await reconcile_programs(
+        store, projected=[_projected(pid, timezone="Mars/Olympus_Mons")],
+    )
+    assert (await store.get(pid)).active is False

--- a/tests/test_program_reconcile.py
+++ b/tests/test_program_reconcile.py
@@ -1,0 +1,152 @@
+"""Mirroring ops' active Programs into the runtime's schedule table."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from surogates.programs.reconcile import reconcile_programs
+from surogates.programs.store import ProgramScheduleStore
+
+
+def _projected(program_id, **over):
+    row = {
+        "id": str(program_id),
+        "org_id": str(uuid.uuid4()),
+        "agent_id": "a1",
+        "skill_ref": "post-op",
+        "channel": "whatsapp",
+        "channel_identifier": "127",
+        "template_name": "daily",
+        "template_language": "en_US",
+        "weekdays": ["mon"],
+        "times_local": ["09:00"],
+        "timezone": "UTC",
+        "response_deadline_hours": 24,
+        "escalation_service_account_id": str(uuid.uuid4()),
+        "patients": [str(uuid.uuid4())],
+    }
+    row.update(over)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_a_program_missing_from_the_projection_is_deactivated(sf):
+    # This is the whole reason reconcile exists: a Program paused in ops
+    # would otherwise keep firing forever.
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    await reconcile_programs(store, projected=[_projected(pid)])
+    assert (await store.get(pid)).active is True
+
+    await reconcile_programs(store, projected=[])
+    assert (await store.get(pid)).active is False
+
+
+@pytest.mark.asyncio
+async def test_reconcile_does_not_push_a_due_program_forward(sf):
+    # Reconcile runs on every publish. If it reset next_run_at each time, a
+    # Program due in a minute would never fire while the operator kept
+    # saving unrelated changes.
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    rows = [_projected(pid)]
+    await reconcile_programs(store, projected=rows)
+    first = (await store.get(pid)).next_run_at
+
+    await reconcile_programs(store, projected=rows)
+    assert (await store.get(pid)).next_run_at == first
+
+
+@pytest.mark.asyncio
+async def test_a_changed_cadence_does_move_the_clock(sf):
+    # The other half of the rule above: when the cadence itself changes the
+    # old instant is wrong and must be recomputed, or an operator's edit
+    # would not take effect until the next fire.
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    await reconcile_programs(store, projected=[_projected(pid)])
+    first = (await store.get(pid)).next_run_at
+
+    await reconcile_programs(
+        store, projected=[_projected(pid, weekdays=["tue"], times_local=["17:00"])],
+    )
+    assert (await store.get(pid)).next_run_at != first
+
+
+@pytest.mark.asyncio
+async def test_reconcile_is_idempotent(sf):
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    rows = [_projected(pid)]
+    await reconcile_programs(store, projected=rows)
+    await reconcile_programs(store, projected=rows)
+    # One schedule, not two — uq_program_schedule_program guarantees it.
+    assert await store.get(pid) is not None
+
+
+@pytest.mark.asyncio
+async def test_the_roster_travels_on_the_schedule_config(sf):
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    patient = str(uuid.uuid4())
+    await reconcile_programs(
+        store, projected=[_projected(pid, patients=[patient])],
+    )
+    # The tick must not have to call back into ops for the roster.
+    sched = await store.get(pid)
+    assert sched is not None
+    assert patient in sched.config["patients"]
+
+
+@pytest.mark.asyncio
+async def test_a_returning_program_is_reactivated(sf):
+    # Pause then resume in ops. Without this the schedule stays inactive and
+    # the Program silently never fires again.
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    rows = [_projected(pid)]
+    await reconcile_programs(store, projected=rows)
+    await reconcile_programs(store, projected=[])
+    assert (await store.get(pid)).active is False
+
+    await reconcile_programs(store, projected=rows)
+    assert (await store.get(pid)).active is True
+
+
+@pytest.mark.asyncio
+async def test_resuming_does_not_fire_the_slot_that_was_missed(sf):
+    # A Program paused past its due time still carries that stale instant.
+    # Resuming must recompute it, or every patient gets the missed check-in
+    # the moment an operator un-pauses.
+    from datetime import timedelta
+
+    import sqlalchemy as sa
+
+    from surogates.db.models import ProgramScheduleRow
+    from surogates.programs.store import _utcnow
+
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    rows = [_projected(pid)]
+    await reconcile_programs(store, projected=rows)
+
+    # Let the stored instant go stale while the Program sits paused, without
+    # touching the cadence — a cadence change would recompute the clock by
+    # itself and this test would prove nothing.
+    async with sf() as db:
+        await db.execute(
+            sa.update(ProgramScheduleRow)
+            .where(ProgramScheduleRow.program_id == pid)
+            .values(next_run_at=_utcnow() - timedelta(hours=48))
+        )
+        await db.commit()
+    await reconcile_programs(store, projected=[])
+    assert (await store.get(pid)).active is False
+
+    await reconcile_programs(store, projected=rows)
+    resumed = await store.get(pid)
+    assert resumed.active is True
+    assert resumed.next_run_at > _utcnow()
+    assert await store.claim_due(worker_id="w1", limit=10) == []

--- a/tests/test_program_reply_match.py
+++ b/tests/test_program_reply_match.py
@@ -1,0 +1,146 @@
+"""Matching an inbound reply to the check-in invitation it answers."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+
+from surogates.db.models import ProgramInvitationRow, ProgramOccurrenceRow
+from surogates.programs.inbound import (
+    attach_reply,
+    get_occurrence,
+    open_invitation_for,
+)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+async def _seed(sf, *, agent_id="a1", response_state="awaiting_reply", org_id=None):
+    org_id = org_id or uuid.uuid4()
+    async with sf() as db:
+        occ = ProgramOccurrenceRow(
+            org_id=org_id,
+            program_id=uuid.uuid4(),
+            agent_id=agent_id,
+            scheduled_for=_utcnow(),
+            skill_ref="post-op",
+            template_name="daily",
+            template_language="en_US",
+            status="fired",
+        )
+        db.add(occ)
+        await db.flush()
+        row = ProgramInvitationRow(
+            occurrence_id=occ.id,
+            program_id=occ.program_id,
+            org_id=org_id,
+            agent_id=agent_id,
+            user_id=uuid.uuid4(),
+            platform="whatsapp",
+            platform_user_id="40746148303",
+            delivery_state="accepted",
+            response_state=response_state,
+            escalation_state="none",
+        )
+        db.add(row)
+        await db.commit()
+        return row
+
+
+@pytest_asyncio.fixture
+async def awaiting_invitation(sf):
+    return await _seed(sf)
+
+
+@pytest.mark.asyncio
+async def test_a_reply_matches_the_open_invitation(sf, awaiting_invitation):
+    found = await open_invitation_for(
+        sf,
+        org_id=awaiting_invitation.org_id,
+        agent_id=awaiting_invitation.agent_id,
+        platform="whatsapp",
+        platform_user_id=awaiting_invitation.platform_user_id,
+    )
+    assert found is not None
+    assert found.id == awaiting_invitation.id
+
+
+@pytest.mark.asyncio
+async def test_another_agents_invitation_is_not_matched(sf, awaiting_invitation):
+    # channel_identities is org-scoped and one person can be bound to several
+    # agents. Without agent_id in the key, one agent's Program would swallow
+    # another agent's reply.
+    found = await open_invitation_for(
+        sf,
+        org_id=awaiting_invitation.org_id,
+        agent_id="a-different-agent",
+        platform="whatsapp",
+        platform_user_id=awaiting_invitation.platform_user_id,
+    )
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_another_orgs_invitation_is_not_matched(sf, awaiting_invitation):
+    found = await open_invitation_for(
+        sf,
+        org_id=uuid.uuid4(),
+        agent_id=awaiting_invitation.agent_id,
+        platform="whatsapp",
+        platform_user_id=awaiting_invitation.platform_user_id,
+    )
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_message_matches_nothing(sf):
+    found = await open_invitation_for(
+        sf,
+        org_id=uuid.uuid4(),
+        agent_id="a1",
+        platform="whatsapp",
+        platform_user_id="40700000000",
+    )
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_a_finished_check_in_is_not_reopened_by_a_later_message(sf):
+    # Once the agent has recorded an outcome, the next message from that
+    # patient is an ordinary conversation, not more of the check-in.
+    await _seed(sf, response_state="completed")
+    found = await open_invitation_for(
+        sf,
+        org_id=uuid.uuid4(),
+        agent_id="a1",
+        platform="whatsapp",
+        platform_user_id="40746148303",
+    )
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_attach_reply_records_the_session_and_bundle(sf, awaiting_invitation):
+    # session_id is what makes the outcome tools unspoofable: they find the
+    # invitation by session, so an agent cannot close a check-in it is not in.
+    sid = uuid.uuid4()
+    await attach_reply(
+        sf, awaiting_invitation, session_id=sid, bundle_version="v7",
+    )
+    async with sf() as db:
+        row = await db.get(ProgramInvitationRow, awaiting_invitation.id)
+    assert row.response_state == "replied"
+    assert row.session_id == sid
+    assert row.skill_bundle_version == "v7"
+
+
+@pytest.mark.asyncio
+async def test_get_occurrence_carries_the_skill_reference(sf, awaiting_invitation):
+    occ = await get_occurrence(sf, awaiting_invitation.occurrence_id)
+    assert occ is not None
+    assert occ.skill_ref == "post-op"

--- a/tests/test_program_reply_match.py
+++ b/tests/test_program_reply_match.py
@@ -17,7 +17,7 @@ from surogates.programs.inbound import (
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(timezone.utc)
 
 
 async def _seed(sf, *, agent_id="a1", response_state="awaiting_reply", org_id=None):

--- a/tests/test_program_store.py
+++ b/tests/test_program_store.py
@@ -88,6 +88,47 @@ async def test_deactivate_stops_a_paused_program_firing(sf):
 
 
 @pytest.mark.asyncio
+async def test_deactivate_withdraws_openers_not_yet_handed_over(
+    sf, make_invitation, reload_invitation,
+):
+    # Stopping the schedule is not enough: the send pass picks up every
+    # queued opener whoever it belongs to, so yesterday's unsent opener would
+    # still go out after the operator paused the Program.
+    store = ProgramScheduleStore(sf)
+    unsent = await make_invitation(delivery_state="queued", response_state="not_started")
+    handed_over = await make_invitation(
+        delivery_state="queued", response_state="awaiting_reply", outbox_id=7,
+    )
+
+    await store.deactivate(unsent.program_id)
+    await store.deactivate(handed_over.program_id)
+
+    row = await reload_invitation(unsent.id)
+    assert row.delivery_state == "canceled"
+    assert row.reason
+    # Already in the outbox: the dispatcher owns it now, and its verdict
+    # is what the history should show.
+    assert (await reload_invitation(handed_over.id)).delivery_state == "queued"
+
+
+@pytest.mark.asyncio
+async def test_deactivate_missing_withdraws_the_unsent_openers_too(
+    sf, make_invitation, reload_invitation,
+):
+    store = ProgramScheduleStore(sf)
+    unsent = await make_invitation(delivery_state="queued", response_state="not_started")
+    await store.ensure(
+        program_id=unsent.program_id,
+        org_id=unsent.org_id,
+        agent_id="a1",
+        config={},
+        next_run_at=_utcnow() - timedelta(minutes=1),
+    )
+    await store.deactivate_missing(set())
+    assert (await reload_invitation(unsent.id)).delivery_state == "canceled"
+
+
+@pytest.mark.asyncio
 async def test_mark_fired_moves_the_clock_and_drops_the_lock(sf):
     store = ProgramScheduleStore(sf)
     pid = uuid.uuid4()

--- a/tests/test_program_store.py
+++ b/tests/test_program_store.py
@@ -128,3 +128,56 @@ async def test_deactivate_missing_stops_programs_that_left_the_projection(sf):
     assert [c.program_id for c in await store.claim_due(worker_id="w1", limit=10)] == [
         kept
     ]
+
+
+@pytest.mark.asyncio
+async def test_an_unchanged_reconcile_writes_nothing(sf):
+    # Reconcile runs every tick. Rewriting an identical config for every
+    # Program each time is a write per Program per tick for nothing.
+    from surogates.db.models import ProgramScheduleRow
+    import sqlalchemy as sa
+
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    cfg = {"weekdays": ["mon"], "times_local": ["09:00"], "timezone": "UTC"}
+    due = _utcnow() + timedelta(hours=1)
+    await store.ensure(program_id=pid, org_id=uuid.uuid4(), agent_id="a1", config=cfg, next_run_at=due)
+
+    # Plant a marker the no-op path must not disturb.
+    async with sf() as db:
+        await db.execute(
+            sa.update(ProgramScheduleRow)
+            .where(ProgramScheduleRow.program_id == pid)
+            .values(locked_by="marker")
+        )
+        await db.commit()
+
+    again = await store.ensure(
+        program_id=pid, org_id=(await store.get(pid)).org_id, agent_id="a1",
+        config=dict(cfg), next_run_at=_utcnow() + timedelta(days=3),
+    )
+    assert again.locked_by == "marker"
+    assert again.next_run_at == due
+
+
+@pytest.mark.asyncio
+async def test_a_reordered_weekday_list_does_not_move_the_clock(sf):
+    # Reconcile runs before claim_due. If an unstable ordering from ops were
+    # read as a cadence change, the tick in which `now` first crossed the due
+    # instant would move the clock past it before the claim ran — and the
+    # Program would never fire.
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    org = uuid.uuid4()
+    due = _utcnow() + timedelta(hours=1)
+    await store.ensure(
+        program_id=pid, org_id=org, agent_id="a1",
+        config={"weekdays": ["mon", "wed"], "times_local": ["09:00", "21:00"], "timezone": "UTC"},
+        next_run_at=due,
+    )
+    after = await store.ensure(
+        program_id=pid, org_id=org, agent_id="a1",
+        config={"weekdays": ["wed", "mon"], "times_local": ["21:00", "09:00"], "timezone": "UTC"},
+        next_run_at=_utcnow() + timedelta(days=3),
+    )
+    assert after.next_run_at == due

--- a/tests/test_program_store.py
+++ b/tests/test_program_store.py
@@ -1,0 +1,130 @@
+"""Claiming and leasing due program schedules."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from surogates.programs.store import ProgramScheduleStore
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_claim_due_takes_the_lease(sf):
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    await store.ensure(
+        program_id=pid,
+        org_id=uuid.uuid4(),
+        agent_id="a1",
+        config={"times_local": ["09:00"]},
+        next_run_at=_utcnow() - timedelta(minutes=1),
+    )
+    claimed = await store.claim_due(worker_id="w1", limit=10)
+    assert [c.program_id for c in claimed] == [pid]
+
+    # A second worker must not double-fire the same Program.
+    assert await store.claim_due(worker_id="w2", limit=10) == []
+
+
+@pytest.mark.asyncio
+async def test_a_failed_tick_waits_rather_than_spinning(sf):
+    # Leaving the row past-due while holding a dead lease makes claim_due
+    # re-fire it forever at lease frequency.
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    await store.ensure(
+        program_id=pid,
+        org_id=uuid.uuid4(),
+        agent_id="a1",
+        config={},
+        next_run_at=_utcnow() - timedelta(minutes=1),
+    )
+    claimed = (await store.claim_due(worker_id="w1", limit=10))[0]
+    await store.mark_failed(claimed)
+    assert await store.claim_due(worker_id="w2", limit=10) == []
+
+
+@pytest.mark.asyncio
+async def test_a_failed_tick_is_not_dead_forever(sf):
+    # A Program whose cadence yields no computable next instant must still
+    # come back: parking it on next_run_at=NULL would take it out of the
+    # ticker permanently, and reconcile only rewrites the clock when the
+    # cadence itself changes.
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    await store.ensure(
+        program_id=pid,
+        org_id=uuid.uuid4(),
+        agent_id="a1",
+        config={},
+        next_run_at=_utcnow() - timedelta(minutes=1),
+    )
+    claimed = (await store.claim_due(worker_id="w1", limit=10))[0]
+    await store.mark_failed(claimed)
+    again = await store.get(pid)
+    assert again.next_run_at is not None
+    assert again.next_run_at > _utcnow()
+
+
+@pytest.mark.asyncio
+async def test_deactivate_stops_a_paused_program_firing(sf):
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    await store.ensure(
+        program_id=pid,
+        org_id=uuid.uuid4(),
+        agent_id="a1",
+        config={},
+        next_run_at=_utcnow() - timedelta(minutes=1),
+    )
+    await store.deactivate(pid)
+    assert await store.claim_due(worker_id="w1", limit=10) == []
+
+
+@pytest.mark.asyncio
+async def test_mark_fired_moves_the_clock_and_drops_the_lock(sf):
+    store = ProgramScheduleStore(sf)
+    pid = uuid.uuid4()
+    await store.ensure(
+        program_id=pid,
+        org_id=uuid.uuid4(),
+        agent_id="a1",
+        config={},
+        next_run_at=_utcnow() - timedelta(minutes=1),
+    )
+    claimed = (await store.claim_due(worker_id="w1", limit=10))[0]
+    later = _utcnow() + timedelta(hours=12)
+    await store.mark_fired(claimed, next_run_at=later)
+
+    row = await store.get(pid)
+    assert row.locked_by is None
+    assert row.last_run_at is not None
+    # Still leased-free but not yet due, so nobody re-fires it.
+    assert await store.claim_due(worker_id="w2", limit=10) == []
+
+
+@pytest.mark.asyncio
+async def test_deactivate_missing_stops_programs_that_left_the_projection(sf):
+    store = ProgramScheduleStore(sf)
+    kept, dropped = uuid.uuid4(), uuid.uuid4()
+    for pid in (kept, dropped):
+        await store.ensure(
+            program_id=pid,
+            org_id=uuid.uuid4(),
+            agent_id="a1",
+            config={},
+            next_run_at=_utcnow() - timedelta(minutes=1),
+        )
+    await store.deactivate_missing({kept})
+
+    assert (await store.get(kept)).active is True
+    assert (await store.get(dropped)).active is False
+    assert [c.program_id for c in await store.claim_due(worker_id="w1", limit=10)] == [
+        kept
+    ]

--- a/tests/test_program_store.py
+++ b/tests/test_program_store.py
@@ -11,7 +11,7 @@ from surogates.programs.store import ProgramScheduleStore
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(timezone.utc)
 
 
 @pytest.mark.asyncio

--- a/tests/test_program_tables.py
+++ b/tests/test_program_tables.py
@@ -15,7 +15,7 @@ from surogates.db.models import (
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(timezone.utc)
 
 
 @pytest.mark.asyncio
@@ -67,3 +67,42 @@ async def test_delivery_and_response_are_independent(sf):
         await db.commit()
         assert inv.delivery_state == "failed"
         assert inv.response_state == "not_started"
+
+
+@pytest.mark.asyncio
+async def test_datetimes_come_back_aware_utc_whatever_went_in(sf):
+    # asyncpg interprets a naive datetime bound to timestamptz as SYSTEM
+    # LOCAL, so a pod with TZ set would store every check-in hours off — and
+    # SQLite returns naive values while Postgres returns aware ones, so the
+    # same comparison raises on one backend and passes on the other. The
+    # column type pins both ends: naive in means UTC, and reads are always
+    # aware UTC.
+    from datetime import timedelta, timezone as tz
+
+    naive = datetime(2026, 9, 9, 9, 0)
+    bucharest = tz(timedelta(hours=3))
+    aware_local = datetime(2026, 9, 9, 12, 0, tzinfo=bucharest)  # same instant
+
+    async with sf() as db:
+        a = ProgramScheduleRow(
+            program_id=uuid.uuid4(), org_id=uuid.uuid4(), agent_id="a1",
+            next_run_at=naive, active=True,
+        )
+        b = ProgramScheduleRow(
+            program_id=uuid.uuid4(), org_id=uuid.uuid4(), agent_id="a1",
+            next_run_at=aware_local, active=True,
+        )
+        db.add_all([a, b])
+        await db.commit()
+        a_id, b_id = a.id, b.id
+
+    async with sf() as db:
+        ra = await db.get(ProgramScheduleRow, a_id)
+        rb = await db.get(ProgramScheduleRow, b_id)
+
+    assert ra.next_run_at.tzinfo is not None
+    assert ra.next_run_at.utcoffset() == timedelta(0)
+    # The naive value was taken as UTC, not shifted by any local offset.
+    assert ra.next_run_at == datetime(2026, 9, 9, 9, 0, tzinfo=timezone.utc)
+    # The aware non-UTC value was normalised to the same instant in UTC.
+    assert rb.next_run_at == ra.next_run_at

--- a/tests/test_program_tables.py
+++ b/tests/test_program_tables.py
@@ -1,0 +1,69 @@
+"""The runtime's check-in program tables."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from surogates.db.models import (
+    ProgramInvitationRow,
+    ProgramOccurrenceRow,
+    ProgramScheduleRow,
+)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_the_tables_create_on_sqlite(sf):
+    # Portable column types are not optional: the whole runtime test suite
+    # builds its schema on in-memory SQLite.
+    async with sf() as db:
+        sched = ProgramScheduleRow(
+            program_id=uuid.uuid4(),
+            org_id=uuid.uuid4(),
+            agent_id="a1",
+            next_run_at=_utcnow() + timedelta(minutes=5),
+            active=True,
+        )
+        db.add(sched)
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_delivery_and_response_are_independent(sf):
+    # A failed send must never be able to read as a patient who did not
+    # reply; keeping the axes separate is what makes that impossible.
+    async with sf() as db:
+        occ = ProgramOccurrenceRow(
+            program_id=uuid.uuid4(),
+            org_id=uuid.uuid4(),
+            agent_id="a1",
+            scheduled_for=_utcnow(),
+            skill_ref="s",
+            template_name="t",
+            template_language="en_US",
+            status="fired",
+        )
+        db.add(occ)
+        await db.flush()
+        inv = ProgramInvitationRow(
+            occurrence_id=occ.id,
+            program_id=occ.program_id,
+            org_id=occ.org_id,
+            agent_id="a1",
+            user_id=uuid.uuid4(),
+            platform="whatsapp",
+            platform_user_id="40746148303",
+            delivery_state="failed",
+            response_state="not_started",
+            escalation_state="none",
+        )
+        db.add(inv)
+        await db.commit()
+        assert inv.delivery_state == "failed"
+        assert inv.response_state == "not_started"

--- a/tests/test_whatsapp_template_send.py
+++ b/tests/test_whatsapp_template_send.py
@@ -1,0 +1,214 @@
+"""Sending an approved template as a check-in opener, and the delivery axis."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from surogates.channels.platforms.whatsapp import WhatsAppPlatform
+from surogates.db.models import DeliveryOutbox
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _item(payload):
+    return type("Item", (), {
+        "destination": {"wa_id": "40746148303", "phone_number_id": "127"},
+        "payload": payload,
+    })()
+
+
+@pytest.mark.asyncio
+async def test_a_template_payload_sends_a_template_not_text(monkeypatch):
+    # Free-form text outside the 24h service window is rejected with 131047,
+    # which is a permanent error — the opener would be dropped with nothing
+    # surfaced to the operator.
+    sent = {}
+
+    async def _fake_send(client, *, token, phone_number_id, payload, api_version):
+        sent.update(payload)
+        return "wamid.1", None
+
+    monkeypatch.setattr(
+        "surogates.channels.platforms.whatsapp.send_message", _fake_send,
+    )
+    result = await WhatsAppPlatform().send(
+        _item({"template": {"name": "daily_checkin", "language": "en_US"}}),
+        creds={"access_token": "T", "api_version": "v23.0"},
+    )
+    assert result.success
+    assert sent["type"] == "template"
+    assert sent["template"]["name"] == "daily_checkin"
+    assert sent["template"]["language"] == {"code": "en_US"}
+    assert "text" not in sent
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_payload_still_sends_text(monkeypatch):
+    sent = {}
+
+    async def _fake_send(client, *, token, phone_number_id, payload, api_version):
+        sent.update(payload)
+        return "wamid.2", None
+
+    monkeypatch.setattr(
+        "surogates.channels.platforms.whatsapp.send_message", _fake_send,
+    )
+    await WhatsAppPlatform().send(
+        _item({"content": "hello"}), creds={"access_token": "T"},
+    )
+    assert sent["type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_template_send_is_reported_not_swallowed(monkeypatch):
+    async def _fake_send(client, *, token, phone_number_id, payload, api_version):
+        return None, "(#131047) Re-engagement message"
+
+    monkeypatch.setattr(
+        "surogates.channels.platforms.whatsapp.send_message", _fake_send,
+    )
+    result = await WhatsAppPlatform().send(
+        _item({"template": {"name": "daily_checkin", "language": "en_US"}}),
+        creds={"access_token": "T"},
+    )
+    assert result.success is False
+    assert "131047" in (result.error or "")
+
+
+class PermissionStub:
+    """An identity lookup whose answer the test can change mid-run.
+
+    The point under test is that ``send_queued_openers`` consults the lookup
+    *again* at send time, so the stub must be mutable after materialisation.
+    """
+
+    def __init__(self, status="granted"):
+        self.status = status
+
+    async def __call__(self, org_id, platform, user_id):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            platform_user_id=f"4074{str(user_id)[:7]}",
+            platform_meta={"contact_permission": {"status": self.status}},
+        )
+
+
+@pytest.fixture
+def identity_lookup():
+    return PermissionStub()
+
+
+@pytest_asyncio.fixture
+async def queued_invitation(make_invitation):
+    return await make_invitation(
+        delivery_state="queued", response_state="not_started",
+    )
+
+
+@pytest_asyncio.fixture
+async def accepted_invitation(make_invitation):
+    return await make_invitation(
+        delivery_state="accepted",
+        response_state="awaiting_reply",
+        provider_message_id="wamid.ACCEPTED",
+        deadline_at=_utcnow() + timedelta(hours=24),
+    )
+
+
+@pytest.mark.asyncio
+async def test_permission_is_rechecked_at_send_not_only_at_fire(
+    sf, queued_invitation, identity_lookup, reload_invitation,
+):
+    # This is how a withdrawal reaches an already-queued opener without ops
+    # calling into the runtime, and it closes the race where permission is
+    # withdrawn between materialising and sending.
+    from surogates.programs.materialize import send_queued_openers
+
+    identity_lookup.status = "withdrawn"
+    await send_queued_openers(sf, identity_lookup=identity_lookup, now=_utcnow())
+
+    row = await reload_invitation(queued_invitation.id)
+    assert row.delivery_state == "canceled"
+    assert "permission" in row.reason.lower()
+
+    # Cancelled means cancelled: nothing may have been handed to the outbox.
+    async with sf() as db:
+        assert (
+            await db.execute(sa.select(sa.func.count()).select_from(DeliveryOutbox))
+        ).scalar_one() == 0
+
+
+@pytest.mark.asyncio
+async def test_a_still_permitted_opener_is_left_for_delivery(
+    sf, queued_invitation, identity_lookup, reload_invitation,
+):
+    # The negative control for the test above: the cancel path must not be
+    # reachable for a patient who never withdrew.
+    from surogates.programs.materialize import send_queued_openers
+
+    await send_queued_openers(sf, identity_lookup=identity_lookup, now=_utcnow())
+    row = await reload_invitation(queued_invitation.id)
+    assert row.delivery_state != "canceled"
+
+
+@pytest.mark.asyncio
+async def test_a_delivery_status_callback_updates_the_invitation(
+    sf, accepted_invitation, reload_invitation,
+):
+    # _log_statuses logs these and drops them, so an asynchronous rejection
+    # would leave the patient looking like a non-responder.
+    from surogates.programs.delivery import apply_status_callback
+
+    applied = await apply_status_callback(
+        sf,
+        provider_message_id=accepted_invitation.provider_message_id,
+        status="failed",
+        reason="Message undeliverable",
+    )
+    assert applied is True
+
+    row = await reload_invitation(accepted_invitation.id)
+    assert row.delivery_state == "failed"
+    # The response axis must not move: they were never reached.
+    assert row.response_state == "awaiting_reply"
+    assert "undeliverable" in (row.reason or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_a_status_for_an_unknown_message_is_ignored(sf):
+    # Meta sends statuses for every message the number sends, most of which
+    # are ordinary replies with no invitation behind them.
+    from surogates.programs.delivery import apply_status_callback
+
+    assert await apply_status_callback(
+        sf, provider_message_id="wamid.NOTOURS", status="failed", reason=None,
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_a_delivered_status_does_not_downgrade_a_reply(
+    sf, make_invitation, reload_invitation,
+):
+    # Statuses arrive out of order. A late "delivered" must not walk back a
+    # patient who has already replied.
+    from surogates.programs.delivery import apply_status_callback
+
+    inv = await make_invitation(
+        delivery_state="accepted",
+        response_state="replied",
+        provider_message_id="wamid.LATE",
+    )
+    await apply_status_callback(
+        sf, provider_message_id="wamid.LATE", status="delivered", reason=None,
+    )
+    row = await reload_invitation(inv.id)
+    assert row.delivery_state == "delivered"
+    assert row.response_state == "replied"

--- a/tests/test_whatsapp_template_send.py
+++ b/tests/test_whatsapp_template_send.py
@@ -14,7 +14,7 @@ from surogates.db.models import DeliveryOutbox
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(timezone.utc)
 
 
 def _item(payload):

--- a/tests/test_whatsapp_template_send.py
+++ b/tests/test_whatsapp_template_send.py
@@ -275,9 +275,10 @@ async def test_a_dead_outbox_row_marks_the_invitation_failed(
     row = await reload_invitation(inv.id)
     assert row.delivery_state == "failed"
     assert "132001" in row.delivery_error
-    # Never asked, so the response axis is untouched — the sweep will not
-    # count them as silent.
-    assert row.response_state == "awaiting_reply"
+    # Never asked, so nobody is awaited.  ``awaiting_reply`` is an open
+    # check-in, and an open check-in suppresses the patient's next occurrence:
+    # left there, one failed send would drop them from the Program for good.
+    assert row.response_state == "not_started"
 
 
 @pytest.mark.asyncio
@@ -393,8 +394,118 @@ async def test_a_failure_mid_batch_does_not_resend_the_earlier_openers(
         )
 
     assert (await reload_invitation(first.id)).outbox_id == 101
-    # The one that failed is still queued for the next tick, not lost.
-    assert (await reload_invitation(second.id)).outbox_id is None
+    # The one that failed is still queued for the next tick, not lost — the
+    # claim taken before the enqueue is given back.
+    failed = await reload_invitation(second.id)
+    assert failed.outbox_id is None
+    assert failed.response_state == "not_started"
+    assert failed.deadline_at is None
+
+
+@pytest.mark.asyncio
+async def test_a_claimed_opener_with_no_outbox_id_is_not_sent_again(
+    sf, make_invitation, identity_lookup, reload_invitation,
+):
+    # The state a process leaves behind when it dies between the outbox
+    # commit and the invitation learning its id.  Before the claim existed
+    # this row looked untouched and the next tick sent a second template.
+    from surogates.programs.materialize import send_queued_openers
+
+    inv = await make_invitation(
+        delivery_state="queued", response_state="awaiting_reply",
+        deadline_at=_utcnow() + timedelta(hours=24),
+    )
+    calls = []
+
+    async def _enqueue(row):
+        calls.append(row.id)
+        return 5
+
+    await send_queued_openers(
+        sf, identity_lookup=identity_lookup, now=_utcnow(), enqueue=_enqueue,
+    )
+    assert calls == []
+    row = await reload_invitation(inv.id)
+    assert row.outbox_id is None
+    assert row.response_state == "awaiting_reply"
+
+
+@pytest.mark.asyncio
+async def test_an_opener_whose_window_closed_is_skipped_not_sent_late(
+    sf, queued_invitation, identity_lookup, reload_invitation,
+):
+    # The slot's own response deadline has passed: sending "how are you this
+    # morning" now is wrong, and retrying it every tick forever is worse.
+    from surogates.programs.materialize import send_queued_openers
+
+    calls = []
+
+    async def _enqueue(row):
+        calls.append(row.id)
+        return 5
+
+    await send_queued_openers(
+        sf, identity_lookup=identity_lookup,
+        now=_utcnow() + timedelta(hours=25), enqueue=_enqueue,
+    )
+    assert calls == []
+    row = await reload_invitation(queued_invitation.id)
+    assert row.delivery_state == "skipped"
+    assert row.reason
+    assert row.outbox_id is None
+
+
+@pytest.mark.asyncio
+async def test_the_opener_destination_carries_every_key_the_dispatcher_reads(
+    monkeypatch, queued_invitation,
+):
+    # ``dispatcher._deliver_item`` reads ``channel_identifier`` first and
+    # fails the row without it — before any adapter sees ``phone_number_id``.
+    # The reply path writes all three keys; the opener must too.
+    from surogates.programs import opener as opener_mod
+    from surogates.programs.opener import make_opener_enqueue
+
+    session_id = uuid.uuid4()
+
+    async def _session(*args, **kwargs):
+        return session_id
+
+    monkeypatch.setattr(opener_mod, "get_or_create_channel_session", _session)
+
+    class Store:
+        async def emit_synthetic_user_message(self, *args, **kwargs):
+            return 42
+
+    class Delivery:
+        def __init__(self):
+            self.calls = []
+
+        async def enqueue(self, session_id, event_id, channel, destination, payload):
+            self.calls.append((session_id, event_id, channel, destination, payload))
+            return 99
+
+    async def _config(program_id):
+        return {
+            "template_name": "daily",
+            "template_language": "en_US",
+            "channel_identifier": "127",
+        }
+
+    delivery = Delivery()
+    enqueue = make_opener_enqueue(
+        session_store=Store(), redis=None, session_factory=None,
+        delivery_service=delivery, config_for_program=_config,
+    )
+    assert await enqueue(queued_invitation) == 99
+
+    ((sid, event_id, channel, destination, payload),) = delivery.calls
+    assert (sid, event_id, channel) == (session_id, 42, "whatsapp")
+    assert destination == {
+        "wa_id": "40746148303",
+        "phone_number_id": "127",
+        "channel_identifier": "127",
+    }
+    assert payload == {"template": {"name": "daily", "language": "en_US"}}
 
 
 @pytest.mark.asyncio

--- a/tests/test_whatsapp_template_send.py
+++ b/tests/test_whatsapp_template_send.py
@@ -179,7 +179,10 @@ async def test_a_delivery_status_callback_updates_the_invitation(
     assert row.delivery_state == "failed"
     # The response axis must not move: they were never reached.
     assert row.response_state == "awaiting_reply"
-    assert "undeliverable" in (row.reason or "").lower()
+    # Provider wording has its own column, so a late status can never
+    # overwrite the agent's clinical note or a skip explanation in `reason`.
+    assert "undeliverable" in (row.delivery_error or "").lower()
+    assert row.reason is None
 
 
 @pytest.mark.asyncio
@@ -212,3 +215,206 @@ async def test_a_delivered_status_does_not_downgrade_a_reply(
     row = await reload_invitation(inv.id)
     assert row.delivery_state == "delivered"
     assert row.response_state == "replied"
+
+
+@pytest.mark.asyncio
+async def test_a_late_delivered_status_cannot_resurrect_a_failed_send(
+    sf, make_invitation, reload_invitation,
+):
+    # Meta batches statuses and retries un-acknowledged webhooks, so a stale
+    # "delivered" can land after "failed". Letting it win would put a send we
+    # know was lost back into the reached set, and the sweep would then mark
+    # a patient we never reached as a non-responder.
+    from surogates.programs.delivery import apply_status_callback
+
+    inv = await make_invitation(
+        delivery_state="failed",
+        response_state="awaiting_reply",
+        provider_message_id="wamid.LOST",
+    )
+    await apply_status_callback(
+        sf, provider_message_id="wamid.LOST", status="delivered", reason=None,
+    )
+    assert (await reload_invitation(inv.id)).delivery_state == "failed"
+
+
+@pytest.mark.asyncio
+async def test_the_dispatcher_result_gives_the_invitation_its_provider_id(
+    sf, make_invitation, reload_invitation,
+):
+    # The provider's id does not exist until the dispatcher has posted, so the
+    # invitation is keyed on the outbox row and learns its wamid from the
+    # dispatcher's report. Without this step no status webhook could ever
+    # match, and a failed send would sit at awaiting_reply until swept.
+    from surogates.programs.delivery import record_outbox_result
+
+    inv = await make_invitation(
+        delivery_state="queued", response_state="awaiting_reply", outbox_id=4242,
+    )
+    assert await record_outbox_result(
+        sf, 4242, provider_message_id="wamid.NEW", error=None,
+    ) is True
+    row = await reload_invitation(inv.id)
+    assert row.provider_message_id == "wamid.NEW"
+    assert row.delivery_state == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_a_dead_outbox_row_marks_the_invitation_failed(
+    sf, make_invitation, reload_invitation,
+):
+    from surogates.programs.delivery import record_outbox_result
+
+    inv = await make_invitation(
+        delivery_state="queued", response_state="awaiting_reply", outbox_id=4243,
+    )
+    await record_outbox_result(
+        sf, 4243, provider_message_id=None,
+        error="graph error 132001 (HTTP 400): Template name does not exist",
+    )
+    row = await reload_invitation(inv.id)
+    assert row.delivery_state == "failed"
+    assert "132001" in row.delivery_error
+    # Never asked, so the response axis is untouched — the sweep will not
+    # count them as silent.
+    assert row.response_state == "awaiting_reply"
+
+
+@pytest.mark.asyncio
+async def test_an_outbox_row_with_no_invitation_is_ignored(sf):
+    # Almost every outbox row is an ordinary reply.
+    from surogates.programs.delivery import record_outbox_result
+
+    assert await record_outbox_result(
+        sf, 999999, provider_message_id="wamid.X", error=None,
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_a_template_missing_its_language_fails_permanently(monkeypatch):
+    # A KeyError inside the send loop used to be recorded as the outbox error
+    # "'language'" and retried sixty times over half an hour. The payload can
+    # never become sendable, so it must fail in the permanent class.
+    from surogates.channels.delivery import is_permanent_delivery_error
+
+    called = False
+
+    async def _fake_send(client, *, token, phone_number_id, payload, api_version):
+        nonlocal called
+        called = True
+        return "wamid.NO", None
+
+    monkeypatch.setattr(
+        "surogates.channels.platforms.whatsapp.send_message", _fake_send,
+    )
+    result = await WhatsAppPlatform().send(
+        _item({"template": {"name": "daily_checkin"}}), creds={"access_token": "T"},
+    )
+    assert result.success is False
+    assert called is False
+    assert is_permanent_delivery_error(result.error)
+
+
+def test_template_graph_errors_are_permanent():
+    # A renamed or paused template fails every opener for the roster; retrying
+    # for thirty minutes cannot change that and only delays the failure the
+    # operator needs to see.
+    from surogates.channels.delivery import is_permanent_delivery_error
+
+    for code in ("132000", "132001", "132005", "132007", "132012", "132015", "132016"):
+        assert is_permanent_delivery_error(
+            f"graph error {code} (HTTP 400): whatever Meta said"
+        ), code
+
+
+@pytest.mark.asyncio
+async def test_a_sent_opener_is_keyed_on_its_outbox_row(
+    sf, queued_invitation, identity_lookup, reload_invitation,
+):
+    # The dispatcher reports back through the outbox id, and the deadline
+    # starts only once something was actually handed over.
+    from surogates.programs.materialize import send_queued_openers
+
+    async def _enqueue(inv):
+        return 777
+
+    await send_queued_openers(
+        sf, identity_lookup=identity_lookup, now=_utcnow(), enqueue=_enqueue,
+    )
+    row = await reload_invitation(queued_invitation.id)
+    assert row.outbox_id == 777
+    assert row.response_state == "awaiting_reply"
+    assert row.deadline_at is not None
+    # Still "queued" on the delivery axis: the dispatcher has not posted yet,
+    # and only its report moves this to accepted or failed.
+    assert row.delivery_state == "queued"
+
+
+@pytest.mark.asyncio
+async def test_an_enqueue_that_hands_nothing_over_starts_no_deadline(
+    sf, queued_invitation, identity_lookup, reload_invitation,
+):
+    from surogates.programs.materialize import send_queued_openers
+
+    async def _enqueue(inv):
+        return None
+
+    await send_queued_openers(
+        sf, identity_lookup=identity_lookup, now=_utcnow(), enqueue=_enqueue,
+    )
+    row = await reload_invitation(queued_invitation.id)
+    assert row.outbox_id is None
+    assert row.response_state == "not_started"
+    assert row.deadline_at is None
+
+
+@pytest.mark.asyncio
+async def test_a_failure_mid_batch_does_not_resend_the_earlier_openers(
+    sf, make_invitation, identity_lookup, reload_invitation,
+):
+    # One commit at the end meant a failure on the k-th enqueue rolled back
+    # the first k-1, whose openers were already in the outbox — and the next
+    # tick sent them all a second approved template.
+    from surogates.programs.materialize import send_queued_openers
+
+    first = await make_invitation(delivery_state="queued", response_state="not_started")
+    second = await make_invitation(delivery_state="queued", response_state="not_started")
+    calls = []
+
+    async def _enqueue(inv):
+        calls.append(inv.id)
+        if len(calls) == 2:
+            raise RuntimeError("provider hiccup")
+        return 100 + len(calls)
+
+    with pytest.raises(RuntimeError):
+        await send_queued_openers(
+            sf, identity_lookup=identity_lookup, now=_utcnow(), enqueue=_enqueue,
+        )
+
+    assert (await reload_invitation(first.id)).outbox_id == 101
+    # The one that failed is still queued for the next tick, not lost.
+    assert (await reload_invitation(second.id)).outbox_id is None
+
+
+@pytest.mark.asyncio
+async def test_an_already_handed_over_opener_is_not_enqueued_twice(
+    sf, make_invitation, identity_lookup,
+):
+    # A second worker, or the next tick, must not pick up a row that already
+    # has an outbox id even though its delivery_state is still "queued".
+    from surogates.programs.materialize import send_queued_openers
+
+    await make_invitation(
+        delivery_state="queued", response_state="awaiting_reply", outbox_id=555,
+    )
+    calls = []
+
+    async def _enqueue(inv):
+        calls.append(inv.id)
+        return 1
+
+    await send_queued_openers(
+        sf, identity_lookup=identity_lookup, now=_utcnow(), enqueue=_enqueue,
+    )
+    assert calls == []


### PR DESCRIPTION
## Summary

The runtime half of check-in Programs: an operator defines a Program in ops (skill, WhatsApp sender, roster, cadence) and the runtime mirrors it and does the sending.

- **Tables**: `program_schedules`, `program_occurrences`, `program_invitations` (aware-UTC columns via `UTCDateTime`; created by `create_all` like the rest).
- **Cadence** is a weekday set plus local times in a named zone, resolved to instants before sorting so DST cannot reorder slots.
- **Reconcile** mirrors the ops projection every tick; a Program learns it was paused by its absence. One malformed row never stops the fleet.
- **Materialise** one occurrence per due instant with a row per patient on the roster, skips recorded on the row, never dropped.
- **Openers** go out as an approved template through the outbox, keyed on the outbox id; each row is claimed with a conditional update before it is handed over, so neither a crash between commits nor a lapsed leader lease can send twice.
- **Delivery, response and escalation** are three independent axes. Meta status callbacks are applied in the channels process; a failed send is never recorded as a silent patient, and no longer suppresses the patient's next occurrence.
- **Replies** are matched to their open invitation before the allowance gate and the agent is told which skill to run; `checkin_outcome` / `checkin_escalate` close or escalate, and are registered with the other builtins.
- **Deadline sweep** closes unanswered check-ins as `no_reply_by_deadline`, answered-but-unfinished ones as `incomplete`, and unreached ones back to `not_started`.

Reviewed in three subagent passes; every finding is fixed or ruled on, every fix carries a mutation-probed test.

## Test plan

- [x] `pytest tests` — 15 failed / 6893 passed / 4 collection errors, identical to master's baseline set
- [ ] Manual: approve a template on a real WABA, enrol yourself with permission, activate a Program two minutes out, receive the template, reply, and let one occurrence lapse to `no_reply_by_deadline`

Ops side follows in invergent-ai/surogate-ops once a release carrying these models exists (ops imports them at module level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
