### PR TITLE
feat(model-metadata): price the new base and pro tiers, and keep inspected deliverables in the summary

### DIFF
--- a/surogates/harness/loop_artifact_completion.py
+++ b/surogates/harness/loop_artifact_completion.py
@@ -15,6 +15,7 @@ from surogates.harness.loop_artifacts import (
     _coerce_modified_to_datetime,
     _coerce_tool_args,
     _derive_artifact_name,
+    _terminal_executes_file,
 )
 from surogates.harness.delivery_manifest import (
     check_terminal_claim,
@@ -539,19 +540,18 @@ class ArtifactCompletionMixin:
             workspace_candidates, entries_by_path = [], {}
         out.extend(workspace_candidates)
 
-        # Flag intermediate scripts: a file the agent wrote and then
-        # ran via terminal is almost always scaffolding (e.g. a python
-        # script used to generate the real deliverable), not a final
-        # artifact the user wanted. Annotate so the summarizer LLM can
-        # filter them out — we don't drop here because the user
-        # occasionally does ask for code, and the LLM gets to make
-        # that call against the user message.
+        # Reconciliation rejects executed helper scripts as scaffolding.
+        # Only execution counts: inspecting a PDF with pdfinfo or passing
+        # an output path to a generator must not discard the deliverable.
         annotated: list[TurnArtifact] = []
         for art in out:
             if art.kind != "file":
                 annotated.append(art)
                 continue
-            executed = any(art.ref in cmd for cmd in terminal_commands)
+            executed = any(
+                _terminal_executes_file(cmd, art.ref)
+                for cmd in terminal_commands
+            )
             if executed:
                 meta = dict(art.meta or {})
                 meta["executed_by_terminal"] = True

--- a/surogates/harness/loop_artifacts.py
+++ b/surogates/harness/loop_artifacts.py
@@ -3,9 +3,133 @@
 from __future__ import annotations
 
 import json
+import posixpath
 import re
+import shlex
 from datetime import datetime, timezone
 from typing import Any
+
+
+_TERMINAL_TOKEN_RE = re.compile(
+    r'''(?:[^\s;&|<>()'"\\]+|'[^']*'|"(?:\\.|[^"\\])*"|\\[^\n])+'''
+    r"|[;&|<>]+|[()\n]"
+)
+_PYTHON_COMMAND_RE = re.compile(r"(?:python|pypy)(?:\d+(?:\.\d+)*)?")
+_SHELL_COMMANDS = {"sh", "bash", "dash", "zsh", "ksh"}
+_SHELL_CONTROL_COMMANDS = {
+    "cd", "pushd", "popd", "if", "then", "else", "elif", "fi", "for",
+    "while", "until", "do", "done", "case", "esac", "select", "function",
+    "{", "}", "source", ".", "eval", "command", "builtin", "exec",
+    "exit", "return", "break", "continue",
+}
+
+
+def _terminal_executes_file(command: str, path: str) -> bool:
+    """Recognize a workspace file in an executable or interpreter-script slot.
+
+    This is deliberately a small, conservative shell recognizer: references in
+    inspection commands, output arguments, redirections, or inline code do not
+    make a file a generator script. Unsupported syntax returns False so a
+    possible deliverable stays visible. No shell command is evaluated.
+    """
+    if not command or not path or len(command) > 65536 or "$" in command or "`" in command:
+        return False
+
+    # Keep quotes until after splitting commands: a quoted ";" or "&&" is an
+    # argument, not a shell operator. shlex then decodes each individual word.
+    groups: list[list[str]] = [[]]
+    offset = 0
+    token_count = 0
+    while offset < len(command):
+        if command[offset] in " \t\r":
+            offset += 1
+            continue
+        if command[offset] == "#":
+            newline = command.find("\n", offset)
+            offset = newline if newline >= 0 else len(command)
+            continue
+        match = _TERMINAL_TOKEN_RE.match(command, offset)
+        if match is None:
+            return False
+        raw = match.group()
+        offset = match.end()
+        token_count += 1
+        if token_count > 4096:
+            return False
+        if raw in {";", "&&", "||", "|", "&", "\n"}:
+            groups.append([])
+        elif raw in {"(", ")"} or raw.startswith("<<"):
+            return False
+        else:
+            groups[-1].append(raw)
+
+    commands: list[list[str]] = []
+    for group in groups:
+        words: list[str] = []
+        index = 0
+        while index < len(group):
+            raw = group[index]
+            if raw in {">", ">>", "<", "<>", ">|", ">&", "<&", "&>"}:
+                if index + 1 >= len(group):
+                    return False
+                # A numeric word before a redirect may be a file descriptor.
+                # Discard it conservatively even when separated by whitespace.
+                if words and words[-1].isdigit():
+                    words.pop()
+                index += 2
+                continue
+            if raw[0] in ";&|<>":
+                return False
+            try:
+                decoded = shlex.split(raw)
+            except ValueError:
+                return False
+            if len(decoded) != 1:
+                return False
+            words.append(decoded[0])
+            index += 1
+        while words and re.fullmatch(r"[A-Za-z_][A-Za-z_0-9]*=.*", words[0], re.DOTALL):
+            words.pop(0)
+        # Directory changes and compound shell statements need execution state
+        # that this recognizer intentionally does not attempt to reconstruct.
+        if words and words[0] in _SHELL_CONTROL_COMMANDS:
+            return False
+        if words:
+            commands.append(words)
+
+    expected = posixpath.normpath(path)
+    for words in commands:
+        executable = words[0]
+        if "/" in executable and posixpath.normpath(executable) == expected:
+            return True
+        interpreter = posixpath.basename(executable)
+        is_python = _PYTHON_COMMAND_RE.fullmatch(interpreter) is not None
+        is_shell = interpreter in _SHELL_COMMANDS
+        if not is_python and not is_shell and interpreter not in {"node", "nodejs", "ruby", "perl"}:
+            continue
+        index = 1
+        while index < len(words) and words[index].startswith("-"):
+            option = words[index]
+            if option == "--":
+                index += 1
+                break
+            if is_python and option in {"-W", "-X"}:
+                index += 2
+            elif is_python and re.fullmatch(r"-[bBdEiIOPqRsSuv]+", option):
+                index += 1
+            elif is_shell and re.fullmatch(r"-[aefuvxC]+", option):
+                index += 1
+            elif is_shell and option == "-o" and index + 1 < len(words) and words[index + 1] == "pipefail":
+                index += 2
+            else:
+                # Includes Python -c/-m and shell -c/-s: subsequent words are
+                # inline code, module names, or arguments, not a script path.
+                break
+        if index < len(words) and not words[index].startswith("-"):
+            if posixpath.normpath(words[index]) == expected:
+                return True
+    return False
+
 
 def _coerce_modified_to_datetime(raw: Any) -> "datetime | None":
     """Normalize a storage backend's ``modified`` field to ``datetime``.

--- a/surogates/harness/model_metadata.py
+++ b/surogates/harness/model_metadata.py
@@ -119,6 +119,19 @@ MODEL_CATALOG: dict[str, ModelInfo] = {
         output_cost_per_1k=0.0012,
         supports_vision=True,
     ),
+    # --- Meta ---------------------------------------------------------------
+    # What ``pro_llm_model`` resolves the ``surogate-pro`` tier -- and the
+    # hidden advisor -- to.  Reasoning is MANDATORY on this model (OpenRouter
+    # reports no way to disable it) and its tokens are counted as completion,
+    # so the output rate is what a Pro turn actually pays.
+    "meta/muse-spark-1.3": ModelInfo(
+        id="meta/muse-spark-1.3",
+        context_window=1_048_576,
+        max_output_tokens=943_718,
+        input_cost_per_1k=0.00125,
+        output_cost_per_1k=0.00425,
+        supports_vision=True,
+    ),
     # --- Google ------------------------------------------------------------
     "google/gemini-3-flash-preview": ModelInfo(
         id="google/gemini-3-flash-preview",
@@ -331,6 +344,8 @@ _ALIASES: dict[str, str] = {
     "deepseek-v4-flash": "deepseek/deepseek-v4-flash-0731",
     "deepseek/deepseek-v4-flash-20260423": "deepseek/deepseek-v4-flash-0731",
     "deepseek-ai/DeepSeek-V4-Flash": "deepseek/deepseek-v4-flash-0731",
+    "muse-spark-1.3": "meta/muse-spark-1.3",
+    "meta/muse-spark-1.3-20260902": "meta/muse-spark-1.3",
     "gemini-3-flash-preview": "google/gemini-3-flash-preview",
     "google/gemini-3-flash-preview-20251217": "google/gemini-3-flash-preview",
     "gemini-3.5-flash": "google/gemini-3.5-flash",

--- a/surogates/harness/model_metadata.py
+++ b/surogates/harness/model_metadata.py
@@ -105,6 +105,20 @@ MODEL_CATALOG: dict[str, ModelInfo] = {
         input_cost_per_1k=8e-05,
         output_cost_per_1k=0.00018,
     ),
+    # The V4.1 Flash release, and what ``base_llm_model`` resolves the
+    # ``surogate`` tier to.  Rates are the WEEKDAY PEAK ones: DeepSeek
+    # halves them off-peak (weekends, and 00:00-01:00 / 04:00-06:00 /
+    # 10:00-24:00 UTC on weekdays), so a session priced here reads at or
+    # above what it actually cost.  Reasoning is on by default upstream
+    # and its tokens land in the completion count, priced as output.
+    "deepseek/deepseek-v4.1-flash": ModelInfo(
+        id="deepseek/deepseek-v4.1-flash",
+        context_window=1_048_576,
+        max_output_tokens=384_000,
+        input_cost_per_1k=0.0003,
+        output_cost_per_1k=0.0012,
+        supports_vision=True,
+    ),
     # --- Google ------------------------------------------------------------
     "google/gemini-3-flash-preview": ModelInfo(
         id="google/gemini-3-flash-preview",
@@ -308,6 +322,9 @@ _ALIASES: dict[str, str] = {
     "deepseek-v4-flash-0731": "deepseek/deepseek-v4-flash-0731",
     "deepseek/deepseek-v4-flash-20260731": "deepseek/deepseek-v4-flash-0731",
     "deepseek-ai/DeepSeek-V4-Flash-0731": "deepseek/deepseek-v4-flash-0731",
+    "deepseek-v4.1-flash": "deepseek/deepseek-v4.1-flash",
+    "deepseek/deepseek-v4.1-flash-20260910": "deepseek/deepseek-v4.1-flash",
+    "deepseek-ai/DeepSeek-V4.1-Flash": "deepseek/deepseek-v4.1-flash",
     # Undated Flash ids point at the current release rather than the older
     # 0423 build they originally named.
     "deepseek/deepseek-v4-flash": "deepseek/deepseek-v4-flash-0731",

--- a/surogates/harness/turn_summarizer.py
+++ b/surogates/harness/turn_summarizer.py
@@ -382,7 +382,9 @@ def _is_internal_workspace_path(path: str) -> bool:
     """True for workspace paths that are never user deliverables.
 
     Any hidden path segment marks agent-internal state (``.agents/``
-    skill context files, ``.claude/`` config, ``.cache/`` …),
+    skill context files, ``.claude/`` config, ``.cache/`` …). Python's
+    ``__pycache__/`` directories and bytecode files are generated runtime
+    state, including when they live below a user output directory.
     ``uploads/`` holds user-provided attachments — inputs, not
     outputs — and the underscore directories above are storage for a
     surface the chat already renders. Filtered deterministically so they
@@ -390,10 +392,12 @@ def _is_internal_workspace_path(path: str) -> bool:
     download card.
     """
     segments = [s for s in path.split("/") if s]
-    if any(s.startswith(".") for s in segments):
+    if any(s.startswith(".") or s == "__pycache__" for s in segments):
         return True
     if not segments:
         return False
+    if segments[-1].lower().endswith((".pyc", ".pyo")):
+        return True
     return (
         segments[0] == "uploads"
         or segments[0] in _INTERNAL_WORKSPACE_PREFIXES

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -45,3 +45,11 @@ def test_sentinel_session_prices_against_the_served_model() -> None:
     )
     assert priced == "deepseek/deepseek-v4.1-flash"
     assert cost > 0
+
+
+def test_pro_sentinel_session_prices_against_the_served_model() -> None:
+    cost, priced = estimate_call_cost(
+        "surogate-pro", "meta/muse-spark-1.3", 1_000, 1_000,
+    )
+    assert priced == "meta/muse-spark-1.3"
+    assert cost > 0

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -1,0 +1,47 @@
+"""Catalog invariants for :mod:`surogates.harness.model_metadata`.
+
+The module docstring already claims these are pinned; until now nothing
+checked them. An alias pointing at a missing catalog key resolves to
+``None`` and the caller silently falls back to a default context window
+and zero pricing, with no error anywhere -- exactly the failure mode
+:func:`estimate_call_cost` was written to stop hiding.
+"""
+
+from __future__ import annotations
+
+from surogates.harness.model_metadata import (
+    _ALIASES,
+    MODEL_CATALOG,
+    estimate_call_cost,
+    get_model_info,
+)
+
+
+def test_every_alias_resolves_to_a_catalog_entry() -> None:
+    dangling = {a: t for a, t in _ALIASES.items() if t not in MODEL_CATALOG}
+    assert not dangling, f"aliases point at missing catalog keys: {dangling}"
+
+
+def test_catalog_ids_match_their_keys() -> None:
+    mismatched = {k: v.id for k, v in MODEL_CATALOG.items() if v.id != k}
+    assert not mismatched, f"catalog id/key mismatch: {mismatched}"
+
+
+def test_tier_sentinels_carry_no_rate() -> None:
+    # Pricing a sentinel would bill every platform session at the wrong
+    # rate; estimate_call_cost must fall through to the served model.
+    for sentinel in ("surogate", "surogate-pro"):
+        info = get_model_info(sentinel)
+        assert info is not None
+        assert info.input_cost_per_1k == 0.0
+        assert info.output_cost_per_1k == 0.0
+
+
+def test_sentinel_session_prices_against_the_served_model() -> None:
+    # What the base tier resolves to in PROD: the sentinel rides the
+    # request, OpenRouter reports the concrete model back in usage.
+    cost, priced = estimate_call_cost(
+        "surogate", "deepseek/deepseek-v4.1-flash", 1_000, 1_000,
+    )
+    assert priced == "deepseek/deepseek-v4.1-flash"
+    assert cost > 0

--- a/tests/test_pdf_delivery_summary.py
+++ b/tests/test_pdf_delivery_summary.py
@@ -1,0 +1,70 @@
+"""A generated PDF survives inspection and Python's incidental cache files."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from surogates.harness.loop_artifact_completion import ArtifactCompletionMixin
+from surogates.session.events import EventType
+
+
+async def test_pdf_summary_keeps_inspected_pdf_and_excludes_generator_and_cache():
+    session_id = uuid4()
+    turn_id = str(uuid4())
+    started = datetime(2026, 9, 10, 9, 43, 54, tzinfo=timezone.utc)
+    modified = datetime(2026, 9, 10, 9, 44, 54, tzinfo=timezone.utc)
+    pdf = "stirile-zilei-hotnews-2026-09-10.pdf"
+    script = "make_stiri_pdf.py"
+    events = [
+        SimpleNamespace(type=EventType.LLM_REQUEST, data={"turn_id": turn_id}),
+        SimpleNamespace(type=EventType.TOOL_CALL, data={
+            "name": "write_file", "arguments": {"path": script},
+        }),
+        SimpleNamespace(type=EventType.TOOL_CALL, data={
+            "name": "terminal", "arguments": {"command": (
+                f"python3 {script} && pdfinfo {pdf} 2>/dev/null | head -12; "
+                f'pdftotext -layout {pdf} - | grep -n "Diverse" -A3'
+            )},
+        }),
+        SimpleNamespace(type=EventType.TOOL_CALL, data={
+            "name": "terminal", "arguments": {"command": (
+                f"pdfinfo {pdf} | grep -i pages; "
+                f"pdftoppm -png -r 70 {pdf} preview && ls preview*"
+            )},
+        }),
+    ]
+    session = SimpleNamespace(
+        id=session_id, channel="studio", config={"storage_bucket": "workspace"},
+    )
+    harness = ArtifactCompletionMixin()
+    harness._turn_started_at = started
+    harness._pending_iteration_summary_tasks = {}
+    harness._turn_summarizer = None
+    harness._store = AsyncMock()
+    harness._store.get_session.return_value = session
+    harness._store.get_events.side_effect = [[], events]
+    harness._storage = AsyncMock()
+    harness._storage.list_entries.return_value = [
+        {"key": f"{session_id}/{path}", "size": size, "modified": modified}
+        for path, size in [
+            (script, 6785),
+            (pdf, 68847),
+            ("__pycache__/make_stiri_pdf.cpython-312.pyc", 7100),
+        ]
+    ]
+
+    await harness._drain_and_emit_turn_summary(
+        session_id=session_id, turn_id=turn_id,
+        user_message="scrie-le intr-un pdf",
+        final_message=f"Gata. Am făcut PDF-ul: {pdf}",
+    )
+
+    harness._store.emit_event.assert_awaited_once_with(
+        session_id, EventType.TURN_SUMMARY, {
+            "turn_id": turn_id,
+            "recap": "",
+            "rejected": [{"ref": script, "reason": "scaffolding"}],
+            "artifacts": [{"kind": "file", "label": pdf, "ref": pdf}],
+        },
+    )

--- a/tests/test_terminal_artifact_execution.py
+++ b/tests/test_terminal_artifact_execution.py
@@ -1,0 +1,84 @@
+"""Only executing a workspace file should classify it as a generator script."""
+
+import pytest
+
+from surogates.harness.loop_artifacts import _terminal_executes_file
+
+
+@pytest.mark.parametrize(
+    ("command", "path"),
+    [
+        ("python3 make_stiri_pdf.py", "make_stiri_pdf.py"),
+        ("/usr/bin/python3.12 -u -B ./make.py", "make.py"),
+        ("python -W ignore -X utf8 make.py output.pdf", "make.py"),
+        ("python -- 'scripts/my report.py'", "scripts/my report.py"),
+        ('python "scripts/my"\' report.py\'', "scripts/my report.py"),
+        ("bash -eu script.sh", "script.sh"),
+        ("bash -o pipefail script.sh", "script.sh"),
+        ("./scripts/run.sh input.pdf > result.pdf", "scripts/run.sh"),
+        ("node 'make report.js' result.pdf", "make report.js"),
+        ("python make.py > output.pdf && echo done", "make.py"),
+        ("python 2>/dev/null make.py", "make.py"),
+        ("echo ready; python make.py | head -12", "make.py"),
+        ("echo ready\npython make.py", "make.py"),
+        ("LANG=C python3 make.py", "make.py"),
+        ("echo ready # python ignored.py\npython make.py", "make.py"),
+    ],
+)
+def test_recognizes_script_execution(command: str, path: str) -> None:
+    assert _terminal_executes_file(command, path)
+
+
+@pytest.mark.parametrize(
+    ("command", "path"),
+    [
+        ("pdfinfo report.pdf", "report.pdf"),
+        ("pdftotext -layout report.pdf - | head", "report.pdf"),
+        ("python make.py report.pdf", "report.pdf"),
+        ("python make.py --output report.pdf", "report.pdf"),
+        ("python make.py > report.pdf", "report.pdf"),
+        ("python >report.pdf make.py", "report.pdf"),
+        ("python make.py 2>report.pdf", "report.pdf"),
+        ("python make.py 2>&1", "1"),
+        ("python -c 'print(\"report.pdf\")' report.pdf", "report.pdf"),
+        ("python -c '&&' ./script.sh", "script.sh"),
+        ("bash -c './script.sh' script.sh", "script.sh"),
+        ("bash -n script.sh", "script.sh"),
+        ("bash -o noexec script.sh", "script.sh"),
+        ("python -m py_compile make.py", "make.py"),
+        ("python -unknown make.py", "make.py"),
+        ("python remake.py", "make.py"),
+        ("python subdir/make.py", "make.py"),
+        ("python make.py.backup", "make.py"),
+        ('python "make".py', "make"),
+        ("echo ';' ./script.sh", "script.sh"),
+        ("echo ready # python make.py", "make.py"),
+        ("cat <<EOF\npython make.py\nEOF", "make.py"),
+        ("cat <<< 'python make.py'", "make.py"),
+        ("echo $(python make.py)", "make.py"),
+        ("echo `python make.py`", "make.py"),
+        ("cd subdir && python make.py", "make.py"),
+        ("source change_directory.sh; python make.py", "make.py"),
+        ("eval 'cd subdir'; python make.py", "make.py"),
+        ("if true; then python make.py; fi", "make.py"),
+        ("(python make.py)", "make.py"),
+        ("python 'make.py", "make.py"),
+        ("python make.py >", "make.py"),
+        ("python make.py", ""),
+        ("", "make.py"),
+        ("echo " + "x" * 65536 + "; python make.py", "make.py"),
+    ],
+)
+def test_keeps_arguments_and_unsupported_syntax_as_deliverables(command: str, path: str) -> None:
+    assert not _terminal_executes_file(command, path)
+
+
+def test_production_pdf_inspection_does_not_mark_pdf_as_executed() -> None:
+    command = (
+        "python3 make_stiri_pdf.py && "
+        "pdfinfo stirile-zilei-hotnews-2026-09-10.pdf 2>/dev/null | head -12; "
+        "pdftotext -layout stirile-zilei-hotnews-2026-09-10.pdf - | "
+        'grep -n "Diverse" -A3'
+    )
+    assert _terminal_executes_file(command, "make_stiri_pdf.py")
+    assert not _terminal_executes_file(command, "stirile-zilei-hotnews-2026-09-10.pdf")

--- a/tests/test_turn_summarizer_internal_paths.py
+++ b/tests/test_turn_summarizer_internal_paths.py
@@ -1,0 +1,51 @@
+"""Runtime cache files must not appear as turn-summary deliverables."""
+
+import pytest
+
+from surogates.harness.turn_summarizer import _is_internal_workspace_path
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "__pycache__/make_stiri_pdf.cpython-312.pyc",
+        "reports/__pycache__/make_stiri_pdf.cpython-312.pyc",
+        "reports/__pycache__/cached-output.json",
+        "make_stiri_pdf.pyc",
+        "reports/make_stiri_pdf.pyo",
+        "reports/MAKE_STIRI_PDF.PYC",
+    ],
+)
+def test_python_runtime_files_are_internal(path: str) -> None:
+    assert _is_internal_workspace_path(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "stirile-zilei-hotnews-2026-09-10.pdf",
+        "reports/stirile-zilei-hotnews-2026-09-10.pdf",
+        "make_stiri_pdf.py",
+        "_posts/report.md",
+        "_config.yml",
+        "__init__.py",
+        "__pycache__-guide.md",
+        "reports/bytecode.pyc.md",
+    ],
+)
+def test_user_outputs_and_underscore_files_remain_candidates(path: str) -> None:
+    assert not _is_internal_workspace_path(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".cache/report.pdf",
+        "reports/.cache/report.pdf",
+        "uploads/input.pdf",
+        "_artifacts/report/v1.json",
+        "_whiteboard/canvas.json",
+    ],
+)
+def test_existing_internal_paths_remain_excluded(path: str) -> None:
+    assert _is_internal_workspace_path(path)


### PR DESCRIPTION
## Summary

- Price `deepseek-v4.1-flash` as the new base tier and `muse-spark-1.3` as the new pro tier in the harness model metadata.
- Keep inspected deliverables in the turn summary, and exclude Python caches from it.

## Test plan

- [x] `pytest tests/test_model_metadata.py tests/test_pdf_delivery_summary.py tests/test_terminal_artifact_execution.py tests/test_turn_summarizer_internal_paths.py` — 76 passed
- [x] Full suite run before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
