### PR TITLE
refactor(skills): drop the unevaluated platforms frontmatter field

### DIFF
--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -37,10 +37,9 @@ You are a code reviewer. When asked to review code:
 | `name` | string | yes | Unique skill name (lowercase, alphanumeric + hyphens) |
 | `description` | string | yes | Human-readable description |
 | `trigger` | string/list | no | Comma-separated keywords or phrases that activate a prompt-based skill or select an expert for routing |
-| `tools` | list | no | Tools the skill uses (for progressive disclosure) |
+| `tools` | list | no | For `type: expert`, the tools the expert may call in its mini-loop. On a regular skill it is author metadata only: the runtime does not read it. Use `requires_tools` to gate on tool availability. |
 | `type` | string | no | `skill` (default) or `expert` (see [Experts](../experts/index.md)) |
 | `tags` | list | no | Metadata tags for categorisation and discovery |
-| `platforms` | list | no | Restrict to specific platforms (e.g. `["linux", "macos"]`) |
 | `requires_tools` | list | no | Only activate when **all** listed tools are available |
 | `fallback_for_tools` | list | no | Only activate when **any** listed tool is unavailable |
 

--- a/surogates/tools/loader.py
+++ b/surogates/tools/loader.py
@@ -128,7 +128,6 @@ class SkillDef:
     category: str | None = None  # subdirectory grouping
     tags: list[str] | None = None  # metadata tags
     # Conditional activation fields (parsed from frontmatter).
-    platforms: list[str] | None = None  # e.g. ["linux", "macos"]
     fallback_for_tools: list[str] | None = None  # show only when these tools are unavailable
     requires_tools: list[str] | None = None  # show only when these tools ARE available
     trigger: str | None = None  # trigger description
@@ -773,7 +772,7 @@ def _skill_from_db_row(row: Any, source: str) -> SkillDef:
     """Convert a :class:`~surogates.db.models.Skill` ORM row to a :class:`SkillDef`.
 
     DB columns supply the primary fields.  Optional activation and expert
-    fields (``trigger``, ``tags``, ``platforms``, ``expert_tools``, etc.)
+    fields (``trigger``, ``tags``, ``requires_tools``, ``expert_tools``, etc.)
     are stored in the ``config`` JSONB column.
 
     The ``content`` column may contain the full ``SKILL.md`` text
@@ -796,7 +795,6 @@ def _skill_from_db_row(row: Any, source: str) -> SkillDef:
             "type": row.type or "skill",
             "category": cfg.get("category"),
             "tags": cfg.get("tags"),
-            "platforms": cfg.get("platforms"),
             "fallback_for_tools": cfg.get("fallback_for_tools"),
             "requires_tools": cfg.get("requires_tools"),
             "trigger": cfg.get("trigger"),
@@ -1002,7 +1000,6 @@ def _build_skill_def(
         category=category,
         category_description=category_description,
         tags=parsed.get("tags"),
-        platforms=parsed.get("platforms"),
         fallback_for_tools=parsed.get("fallback_for_tools"),
         requires_tools=parsed.get("requires_tools"),
         trigger=parsed.get("trigger"),
@@ -1023,8 +1020,8 @@ def _parse_skill_frontmatter(
     """Extract YAML frontmatter and body from a skill file.
 
     Returns a dict with keys: ``name``, ``description``, ``content``,
-    and optional ``platforms``, ``fallback_for_tools``, ``requires_tools``,
-    ``trigger``, ``tags``.
+    and optional ``fallback_for_tools``, ``requires_tools``, ``trigger``,
+    ``tags``.
     """
     result: dict[str, Any] = {
         "name": fallback_name,
@@ -1046,7 +1043,7 @@ def _parse_skill_frontmatter(
             result["description"] = fm.get("description", "")
 
             # Conditional activation fields.
-            for key in ("platforms", "fallback_for_tools", "requires_tools"):
+            for key in ("fallback_for_tools", "requires_tools"):
                 val = fm.get(key)
                 if val:
                     if isinstance(val, str):


### PR DESCRIPTION
## Summary

`platforms` was parsed into `SkillDef` and documented as a conditional activation field, but nothing ever evaluated it: visibility is decided solely by `requires_tools` / `fallback_for_tools` in the prompt builder. Remove the field from the parser, the dataclass and the DB-row mapping, and document that `tools:` is only read for experts.

Companion to the surogate-ops PR that lets Studio carry `requires_tools` / `fallback_for_tools`.

## Test plan

- [x] `tests/test_loader.py`, `test_loader_skills_system_bundle.py`, `test_skill_view_handler.py`, `test_expert.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
